### PR TITLE
Add Docker-based test fixture

### DIFF
--- a/deps/cloudxr/Dockerfile.test
+++ b/deps/cloudxr/Dockerfile.test
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Test container for TeleopCore Python tests
+# This container installs dependencies and runs Python tests against CloudXR runtime
+
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libx11-6 \
+    libxext6 \
+    libvulkan1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create app directory
+WORKDIR /app
+
+# Install uv for fast Python package management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Copy the install directory (contains wheels, libs, etc.)
+COPY install/ /app/install/
+
+# Copy test files
+COPY examples/oxr/python/ /app/tests/
+
+# Install Python dependencies using uv
+WORKDIR /app/tests
+RUN uv venv /app/venv && \
+    . /app/venv/bin/activate && \
+    uv pip install --find-links=/app/install/wheels teleopcore numpy
+
+# Set environment variables
+ENV PATH="/app/venv/bin:$PATH"
+ENV PYTHONPATH="/app/install/lib:$PYTHONPATH"
+ENV XR_RUNTIME_JSON="/openxr/share/openxr/1/openxr_cloudxr.json"
+
+WORKDIR /app/tests
+
+# Default command runs the test script
+CMD ["python", "test_extensions.py"]

--- a/deps/cloudxr/docker-compose.test.yaml
+++ b/deps/cloudxr/docker-compose.test.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Test docker-compose file for running TeleopCore tests with CloudXR
+# Extends the base CloudXR compose and adds test runner service
+#
+# Note: Run with a different project name to isolate volumes from dev environment:
+#   docker compose -p teleopcore-test -f docker-compose.yaml -f docker-compose.test.yaml up
+#
+# This creates volumes like "teleopcore-test_openxr-volume" instead of "cloudxr_openxr-volume"
+#
+# NOTE: Must be used with -f docker-compose.yaml -f docker-compose.test.yaml
+# (Docker Compose's include: directive doesn't allow service overrides)
+
+services:
+  # Override cloudxr-runtime to always accept EULA in CI
+  cloudxr-runtime:
+    environment:
+      - ACCEPT_EULA=Y
+      - NV_CXR_ENABLE_PUSH_DEVICES=${NV_CXR_ENABLE_PUSH_DEVICES}
+
+  # Test runner container
+  # Build with: docker build -t teleopcore-tests:latest -f deps/cloudxr/Dockerfile.test .
+  teleopcore-tests:
+    image: teleopcore-tests:latest
+    pull_policy: never
+    network_mode: host
+    depends_on:
+      cloudxr-runtime:
+        condition: service_healthy
+    environment:
+      - XDG_RUNTIME_DIR=/openxr/run
+      - XR_RUNTIME_JSON=/openxr/share/openxr/1/openxr_cloudxr.json
+      - TEST_SCRIPTS=${TEST_SCRIPTS:-test_extensions.py}
+    volumes:
+      - openxr-volume:/openxr/:ro
+    working_dir: /app/tests
+    entrypoint: ["/bin/bash", "-c"]
+    command:
+      - |
+        set -e
+        echo "=========================================="
+        echo "TeleopCore Test Runner"
+        echo "=========================================="
+        echo ""
+        echo "XR_RUNTIME_JSON: $${XR_RUNTIME_JSON}"
+        echo ""
+
+        # Parse comma-separated test scripts
+        IFS=',' read -ra TESTS <<< "$${TEST_SCRIPTS}"
+
+        PASSED=0
+        FAILED=0
+        FAILED_TESTS=""
+
+        for test_script in "$${TESTS[@]}"; do
+            test_script=$$(echo "$$test_script" | xargs)  # trim whitespace
+            echo "----------------------------------------"
+            echo "Running: $$test_script"
+            echo "----------------------------------------"
+
+            if python "$$test_script"; then
+                echo "✅ PASSED: $$test_script"
+                PASSED=$((PASSED + 1))
+            else
+                echo "❌ FAILED: $$test_script"
+                FAILED=$((FAILED + 1))
+                FAILED_TESTS="$$FAILED_TESTS $$test_script"
+            fi
+            echo ""
+        done
+
+        echo "=========================================="
+        echo "Test Results Summary"
+        echo "=========================================="
+        echo "Passed: $$PASSED"
+        echo "Failed: $$FAILED"
+
+        if [ $$FAILED -gt 0 ]; then
+            echo "Failed tests:$$FAILED_TESTS"
+            exit 1
+        fi
+
+        echo "✅ All tests passed!"
+        exit 0

--- a/scripts/run_tests_with_cloudxr.sh
+++ b/scripts/run_tests_with_cloudxr.sh
@@ -1,0 +1,299 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Test Runner Script with CloudXR
+# Runs TeleopCore tests using docker-compose with CloudXR runtime
+#
+# Usage:
+#   ./scripts/run_tests_with_cloudxr.sh [--build]
+#
+# Options:
+#   --build    Force rebuild of test container (no cache)
+#   --help     Show this help message
+
+set -e
+
+#==============================================================================
+# Configuration - Edit this list to add/remove tests
+#==============================================================================
+TEST_SCRIPTS=(
+    "test_extensions.py"
+    "test_modular.py"
+)
+#==============================================================================
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Make sure to run this script from the root of the repository
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GIT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$GIT_ROOT" || exit 1
+
+# Default values
+FORCE_BUILD=false
+EXIT_CODE=0
+
+# Compose files and project name
+COMPOSE_BASE="deps/cloudxr/docker-compose.yaml"
+COMPOSE_TEST="deps/cloudxr/docker-compose.test.yaml"
+ENV_DEFAULT="deps/cloudxr/.env.default"
+ENV_LOCAL="deps/cloudxr/.env"
+# Use a different project name to isolate volumes from run_cloudxr.sh
+COMPOSE_PROJECT="teleopcore-test"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --build)
+            FORCE_BUILD=true
+            shift
+            ;;
+        --help)
+            echo "Test Runner Script with CloudXR"
+            echo ""
+            echo "Usage: $0 [--build]"
+            echo ""
+            echo "Options:"
+            echo "  --build    Force rebuild of test container (no cache)"
+            echo "  --help     Show this help message"
+            echo ""
+            echo "Tests to run (edit TEST_SCRIPTS in this script to modify):"
+            for test in "${TEST_SCRIPTS[@]}"; do
+                echo "  - $test"
+            done
+            exit 0
+            ;;
+        *)
+            echo -e "${RED}Unknown option: $1${NC}"
+            exit 1
+            ;;
+    esac
+done
+
+# Logging functions
+log_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+log_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+log_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+log_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Cleanup function - ensures containers are stopped
+cleanup() {
+    log_info "Cleaning up containers..."
+    docker compose \
+        -p "$COMPOSE_PROJECT" \
+        --env-file "$ENV_DEFAULT" \
+        ${ENV_LOCAL:+--env-file "$ENV_LOCAL"} \
+        -f "$COMPOSE_BASE" \
+        -f "$COMPOSE_TEST" \
+        down -v --remove-orphans 2>/dev/null || true
+    log_success "Cleanup complete"
+}
+
+# Set up trap to ensure cleanup on exit
+trap cleanup EXIT
+
+# Print banner
+echo ""
+echo -e "${BLUE}=========================================="
+echo "  TeleopCore Test Runner with CloudXR"
+echo -e "==========================================${NC}"
+echo ""
+
+# Check prerequisites
+log_info "Checking prerequisites..."
+
+if ! command -v docker &> /dev/null; then
+    log_error "Docker is not installed"
+    exit 1
+fi
+
+if ! docker compose version &> /dev/null; then
+    log_error "Docker Compose is not installed"
+    exit 1
+fi
+
+# Check if we have GPU support
+if docker info 2>/dev/null | grep -q "Runtimes.*nvidia"; then
+    log_success "NVIDIA Docker runtime detected"
+else
+    log_warning "NVIDIA Docker runtime not detected - GPU tests may fail"
+fi
+
+# Set up environment
+log_info "Setting up environment..."
+
+export CXR_HOST_VOLUME_PATH="${CXR_HOST_VOLUME_PATH:-/tmp/cloudxr-test}"
+export CXR_UID=$(id -u)
+export CXR_GID=$(id -g)
+
+# Create host volume path
+mkdir -p "$CXR_HOST_VOLUME_PATH"
+
+log_info "TEST_SCRIPTS:"
+for test in "${TEST_SCRIPTS[@]}"; do
+    log_info "  - $test"
+done
+
+# Join array into comma-separated string for docker-compose environment variable
+TEST_SCRIPTS_ENV=$(IFS=','; echo "${TEST_SCRIPTS[*]}")
+export TEST_SCRIPTS="$TEST_SCRIPTS_ENV"
+
+# Create .env file if it doesn't exist
+if [ ! -f "$ENV_LOCAL" ]; then
+    log_info "Creating $ENV_LOCAL..."
+    touch "$ENV_LOCAL"
+fi
+
+# In CI, auto-accept EULA
+if [ "${CI:-false}" = "true" ]; then
+    log_info "CI environment detected, auto-accepting CloudXR EULA"
+    echo "ACCEPT_CLOUDXR_EULA=Y" > "$ENV_LOCAL"
+fi
+
+# Verify install directory exists and has required artifacts
+log_info "Verifying build artifacts..."
+
+if [ ! -d "install/wheels" ]; then
+    log_error "install/wheels not found. Please build first:"
+    echo "  cmake -B build"
+    echo "  cmake --build build --parallel"
+    echo "  cmake --install build"
+    exit 1
+fi
+
+WHEEL_COUNT=$(find install/wheels -name "teleopcore-*.whl" | wc -l)
+if [ "$WHEEL_COUNT" -eq 0 ]; then
+    log_error "No teleopcore wheel found in install/wheels/"
+    exit 1
+elif [ "$WHEEL_COUNT" -gt 1 ]; then
+    log_error "Multiple teleopcore wheels found - consider cleaning install/wheels/"
+    ls -la install/wheels/teleopcore-*.whl
+    exit 1
+fi
+
+log_success "Found teleopcore wheel in install/wheels/"
+
+# Build test container
+log_info "Building test container..."
+
+BUILD_ARGS="-q"
+if [ "$FORCE_BUILD" = true ]; then
+    BUILD_ARGS="$BUILD_ARGS --no-cache"
+fi
+
+docker build \
+    $BUILD_ARGS \
+    -t teleopcore-tests:latest \
+    -f deps/cloudxr/Dockerfile.test \
+    .
+
+log_success "Test container built successfully"
+
+# Start CloudXR runtime services
+log_info "Starting CloudXR runtime services..."
+
+docker compose \
+    -p "$COMPOSE_PROJECT" \
+    --env-file "$ENV_DEFAULT" \
+    ${ENV_LOCAL:+--env-file "$ENV_LOCAL"} \
+    -f "$COMPOSE_BASE" \
+    -f "$COMPOSE_TEST" \
+    up -d cloudxr-runtime
+
+# Wait for CloudXR runtime to be healthy
+log_info "Waiting for CloudXR runtime to be healthy..."
+
+MAX_WAIT=60
+WAITED=0
+while [ $WAITED -lt $MAX_WAIT ]; do
+    if docker compose \
+        -p "$COMPOSE_PROJECT" \
+        --env-file "$ENV_DEFAULT" \
+        ${ENV_LOCAL:+--env-file "$ENV_LOCAL"} \
+        -f "$COMPOSE_BASE" \
+        -f "$COMPOSE_TEST" \
+        ps cloudxr-runtime 2>/dev/null | grep -q "healthy"; then
+        log_success "CloudXR runtime is healthy"
+        break
+    fi
+
+    sleep 2
+    WAITED=$((WAITED + 2))
+    echo -n "."
+done
+echo ""
+
+if [ $WAITED -ge $MAX_WAIT ]; then
+    log_error "CloudXR runtime failed to become healthy within ${MAX_WAIT}s"
+    log_info "Container logs:"
+    docker compose \
+        -p "$COMPOSE_PROJECT" \
+        --env-file "$ENV_DEFAULT" \
+        ${ENV_LOCAL:+--env-file "$ENV_LOCAL"} \
+        -f "$COMPOSE_BASE" \
+        -f "$COMPOSE_TEST" \
+        logs cloudxr-runtime
+    exit 1
+fi
+
+# Run tests
+log_info "Running tests..."
+echo ""
+
+if docker compose \
+    -p "$COMPOSE_PROJECT" \
+    --env-file "$ENV_DEFAULT" \
+    ${ENV_LOCAL:+--env-file "$ENV_LOCAL"} \
+    -f "$COMPOSE_BASE" \
+    -f "$COMPOSE_TEST" \
+    run --rm teleopcore-tests; then
+    log_success "All tests passed!"
+    EXIT_CODE=0
+else
+    log_error "Some tests failed"
+    EXIT_CODE=1
+fi
+
+# Output test results for CI
+if [ "${CI:-false}" = "true" ]; then
+    echo ""
+    echo "::group::Container Logs"
+    docker compose \
+        -p "$COMPOSE_PROJECT" \
+        --env-file "$ENV_DEFAULT" \
+        ${ENV_LOCAL:+--env-file "$ENV_LOCAL"} \
+        -f "$COMPOSE_BASE" \
+        -f "$COMPOSE_TEST" \
+        logs
+    echo "::endgroup::"
+fi
+
+echo ""
+echo -e "${BLUE}=========================================="
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}  ✅ Tests Completed Successfully${NC}"
+else
+    echo -e "${RED}  ❌ Tests Failed${NC}"
+fi
+echo -e "${BLUE}==========================================${NC}"
+echo ""
+
+exit $EXIT_CODE


### PR DESCRIPTION
This is mainly used for running TeleopCore tests against CloudXR runtime, both locally and in CI:

- Volume isolation via Docker Compose project name (teleopcore-test)
- Automatic cleanup on exit via trap handler
- Build artifact validation (checks for single teleopcore wheel)
- GPU runtime detection with warnings
- CI-friendly output with GitHub Actions log groups
- Configurable test list in script header
- Remove pull-cloudxr.yml workflow (now included in test-cloudxr.yml)