### PR TITLE
Switch the default size to match the camera resolution.

### DIFF
--- a/src/core/camera/inc/camera_core/camera_config.hpp
+++ b/src/core/camera/inc/camera_core/camera_config.hpp
@@ -11,8 +11,8 @@ namespace core
  */
 struct CameraConfig
 {
-    int width = 1280;
-    int height = 720;
+    int width = 1920;
+    int height = 1080;
     int fps = 30;
     int bitrate = 8'000'000;
     int quality = 80;


### PR DESCRIPTION
oakd will by default crop the frame instead of scaling so we lose fov