### PR TITLE
Support creating  OpenXRSessionHandles in Python

### DIFF
--- a/src/core/oxr/python/oxr_bindings.cpp
+++ b/src/core/oxr/python/oxr_bindings.cpp
@@ -15,6 +15,17 @@ PYBIND11_MODULE(_oxr, m)
     // OpenXRSessionHandles structure (for sharing)
     py::class_<core::OpenXRSessionHandles>(m, "OpenXRSessionHandles")
         .def(py::init<>())
+        // Constructor from raw handle values (enables non-Kit usage and external runtime integration)
+        .def(py::init(
+                 [](uint64_t instance, uint64_t session, uint64_t space, uint64_t xr_get_instance_proc_addr)
+                 {
+                     return core::OpenXRSessionHandles(
+                         reinterpret_cast<XrInstance>(instance), reinterpret_cast<XrSession>(session),
+                         reinterpret_cast<XrSpace>(space),
+                         reinterpret_cast<PFN_xrGetInstanceProcAddr>(xr_get_instance_proc_addr));
+                 }),
+             py::arg("instance"), py::arg("session"), py::arg("space"), py::arg("xr_get_instance_proc_addr"),
+             "Create OpenXRSessionHandles from raw handle values (as integers)")
         .def_property_readonly(
             "instance", [](const core::OpenXRSessionHandles& self) { return reinterpret_cast<size_t>(self.instance); },
             "Get OpenXR instance handle as integer")
@@ -23,7 +34,11 @@ PYBIND11_MODULE(_oxr, m)
             "Get OpenXR session handle as integer")
         .def_property_readonly(
             "space", [](const core::OpenXRSessionHandles& self) { return reinterpret_cast<size_t>(self.space); },
-            "Get OpenXR space handle as integer");
+            "Get OpenXR space handle as integer")
+        .def_property_readonly(
+            "proc_addr",
+            [](const core::OpenXRSessionHandles& self) { return reinterpret_cast<size_t>(self.xrGetInstanceProcAddr); },
+            "Get xrGetInstanceProcAddr function pointer as integer");
 
     // OpenXRSession class (for creating sessions)
     py::class_<core::OpenXRSession, std::shared_ptr<core::OpenXRSession>>(m, "OpenXRSession")


### PR DESCRIPTION
Support creating  OpenXRSessionHandles in Python.
Also, add querying of proc_addr from handles in Python.