### PR TITLE
Add generic per-frame metadata in camera.fbs

### DIFF
--- a/src/core/schema/fbs/camera.fbs
+++ b/src/core/schema/fbs/camera.fbs
@@ -1,0 +1,14 @@
+include "timestamp.fbs";
+
+namespace core;
+
+// Minimum FrameMetadata needed for camera plugin.
+// All camera device plugins should provide below data for each frame.
+table FrameMetadata {
+  // Dual timestamp with device and runtime clock domains.
+  timestamp: Timestamp (id: 0);
+
+  sequence_number: int (id: 1);
+}
+
+root_type FrameMetadata;

--- a/src/core/schema/python/CMakeLists.txt
+++ b/src/core/schema/python/CMakeLists.txt
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 pybind11_add_module(schema_py
+    camera_bindings.h
     controller_bindings.h
     hand_bindings.h
     head_bindings.h

--- a/src/core/schema/python/camera_bindings.h
+++ b/src/core/schema/python/camera_bindings.h
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Python bindings for the Camera FlatBuffer schema.
+// Types: FrameMetadata (table with timestamp and sequence_number).
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <schema/camera_generated.h>
+
+#include <memory>
+
+namespace py = pybind11;
+
+namespace core
+{
+
+inline void bind_camera(py::module& m)
+{
+    // Bind FrameMetadata table using the native type (FrameMetadataT).
+    // This is the base metadata type for all camera frames.
+    py::class_<FrameMetadataT>(m, "FrameMetadata")
+        .def(py::init<>())
+        .def_property(
+            "timestamp", [](const FrameMetadataT& self) -> const Timestamp* { return self.timestamp.get(); },
+            [](FrameMetadataT& self, const Timestamp& ts) { self.timestamp = std::make_unique<Timestamp>(ts); },
+            "Get or set the dual timestamp (device and common time)")
+        .def_property(
+            "sequence_number", [](const FrameMetadataT& self) { return self.sequence_number; },
+            [](FrameMetadataT& self, int val) { self.sequence_number = val; }, "Get or set the frame sequence number")
+        .def("__repr__",
+             [](const FrameMetadataT& metadata)
+             {
+                 std::string result = "FrameMetadata(";
+                 if (metadata.timestamp)
+                 {
+                     result += "timestamp=Timestamp(device_time=" + std::to_string(metadata.timestamp->device_time()) +
+                               ", common_time=" + std::to_string(metadata.timestamp->common_time()) + ")";
+                 }
+                 else
+                 {
+                     result += "timestamp=None";
+                 }
+                 result += ", sequence_number=" + std::to_string(metadata.sequence_number);
+                 result += ")";
+                 return result;
+             });
+}
+
+} // namespace core

--- a/src/core/schema/python/schema_init.py
+++ b/src/core/schema/python/schema_init.py
@@ -35,6 +35,8 @@ from ._schema import (
     LocomotionCommand,
     # Pedals-related types.
     Generic3AxisPedalOutput,
+    # Camera-related types.
+    FrameMetadata,
 )
 
 __all__ = [
@@ -65,5 +67,7 @@ __all__ = [
     "LocomotionCommand",
     # Pedals types.
     "Generic3AxisPedalOutput",
+    # Camera types.
+    "FrameMetadata",
 ]
 

--- a/src/core/schema/python/schema_module.cpp
+++ b/src/core/schema/python/schema_module.cpp
@@ -6,6 +6,7 @@
 #include <pybind11/pybind11.h>
 
 // Include binding definitions.
+#include "camera_bindings.h"
 #include "controller_bindings.h"
 #include "hand_bindings.h"
 #include "head_bindings.h"
@@ -40,4 +41,7 @@ PYBIND11_MODULE(_schema, m)
 
     // Bind pedals types (Generic3AxisPedalOutput table).
     core::bind_pedals(m);
+
+    // Bind camera types (FrameMetadata table with timestamp and sequence_number).
+    core::bind_camera(m);
 }

--- a/src/core/schema_tests/cpp/CMakeLists.txt
+++ b/src/core/schema_tests/cpp/CMakeLists.txt
@@ -4,6 +4,7 @@
 cmake_minimum_required(VERSION 3.20)
 
 add_executable(schema_tests
+  test_camera.cpp
   test_tensor.cpp
   test_pose.cpp
   test_head.cpp

--- a/src/core/schema_tests/cpp/test_camera.cpp
+++ b/src/core/schema_tests/cpp/test_camera.cpp
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the generated Camera FlatBuffer types.
+
+#include <catch2/catch_test_macros.hpp>
+#include <flatbuffers/flatbuffers.h>
+
+// Include generated FlatBuffer headers.
+#include <schema/camera_generated.h>
+
+// =============================================================================
+// Compile-time verification of FlatBuffer field IDs for FrameMetadata table.
+// VT values are computed as: (field_id + 2) * 2.
+// =============================================================================
+#define VT(field) (field + 2) * 2
+
+static_assert(core::FrameMetadata::VT_TIMESTAMP == VT(0));
+static_assert(core::FrameMetadata::VT_SEQUENCE_NUMBER == VT(1));
+
+// =============================================================================
+// FrameMetadataT Tests (table native type)
+// =============================================================================
+TEST_CASE("FrameMetadataT default construction", "[camera][native]")
+{
+    core::FrameMetadataT metadata;
+
+    // Timestamp pointer should be null by default.
+    CHECK(metadata.timestamp == nullptr);
+    // Integer field should be zero by default.
+    CHECK(metadata.sequence_number == 0);
+}
+
+TEST_CASE("FrameMetadataT can store timestamp", "[camera][native]")
+{
+    core::FrameMetadataT metadata;
+
+    // Create timestamp.
+    metadata.timestamp = std::make_unique<core::Timestamp>(1000000000, 2000000000);
+
+    CHECK(metadata.timestamp != nullptr);
+    CHECK(metadata.timestamp->device_time() == 1000000000);
+    CHECK(metadata.timestamp->common_time() == 2000000000);
+}
+
+TEST_CASE("FrameMetadataT can store sequence number", "[camera][native]")
+{
+    core::FrameMetadataT metadata;
+
+    metadata.sequence_number = 42;
+
+    CHECK(metadata.sequence_number == 42);
+}
+
+TEST_CASE("FrameMetadataT can store full metadata", "[camera][native]")
+{
+    core::FrameMetadataT metadata;
+
+    // Set all fields.
+    metadata.timestamp = std::make_unique<core::Timestamp>(3000000000, 4000000000);
+    metadata.sequence_number = 100;
+
+    CHECK(metadata.timestamp != nullptr);
+    CHECK(metadata.timestamp->device_time() == 3000000000);
+    CHECK(metadata.timestamp->common_time() == 4000000000);
+    CHECK(metadata.sequence_number == 100);
+}
+
+// =============================================================================
+// FrameMetadata Serialization Tests
+// =============================================================================
+TEST_CASE("FrameMetadata serialization and deserialization", "[camera][serialize]")
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Create native object.
+    core::FrameMetadataT metadata;
+    metadata.timestamp = std::make_unique<core::Timestamp>(1234567890, 9876543210);
+    metadata.sequence_number = 999;
+
+    // Serialize.
+    auto offset = core::FrameMetadata::Pack(builder, &metadata);
+    builder.Finish(offset);
+
+    // Deserialize.
+    auto* deserialized = flatbuffers::GetRoot<core::FrameMetadata>(builder.GetBufferPointer());
+
+    // Verify timestamp.
+    REQUIRE(deserialized->timestamp() != nullptr);
+    CHECK(deserialized->timestamp()->device_time() == 1234567890);
+    CHECK(deserialized->timestamp()->common_time() == 9876543210);
+
+    // Verify sequence number.
+    CHECK(deserialized->sequence_number() == 999);
+}
+
+TEST_CASE("FrameMetadata can be unpacked from buffer", "[camera][serialize]")
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Create native object with minimal data.
+    core::FrameMetadataT metadata;
+    metadata.timestamp = std::make_unique<core::Timestamp>(100, 200);
+    metadata.sequence_number = 5;
+
+    // Serialize.
+    auto offset = core::FrameMetadata::Pack(builder, &metadata);
+    builder.Finish(offset);
+
+    // Deserialize to table.
+    auto* table = flatbuffers::GetRoot<core::FrameMetadata>(builder.GetBufferPointer());
+
+    // Unpack to native.
+    auto unpacked = std::make_unique<core::FrameMetadataT>();
+    table->UnPackTo(unpacked.get());
+
+    // Verify.
+    REQUIRE(unpacked->timestamp != nullptr);
+    CHECK(unpacked->timestamp->device_time() == 100);
+    CHECK(unpacked->timestamp->common_time() == 200);
+    CHECK(unpacked->sequence_number == 5);
+}
+
+TEST_CASE("FrameMetadata without timestamp", "[camera][serialize]")
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    core::FrameMetadataT metadata;
+    // timestamp is intentionally left null.
+    metadata.sequence_number = 123;
+
+    auto offset = core::FrameMetadata::Pack(builder, &metadata);
+    builder.Finish(offset);
+
+    auto* deserialized = flatbuffers::GetRoot<core::FrameMetadata>(builder.GetBufferPointer());
+
+    CHECK(deserialized->timestamp() == nullptr);
+    CHECK(deserialized->sequence_number() == 123);
+}
+
+// =============================================================================
+// Realistic Camera Frame Scenarios
+// =============================================================================
+TEST_CASE("FrameMetadata first frame", "[camera][scenario]")
+{
+    core::FrameMetadataT metadata;
+    metadata.timestamp = std::make_unique<core::Timestamp>(0, 1000000);
+    metadata.sequence_number = 0;
+
+    CHECK(metadata.sequence_number == 0);
+    CHECK(metadata.timestamp->device_time() == 0);
+}
+
+TEST_CASE("FrameMetadata streaming frames at 30 FPS", "[camera][scenario]")
+{
+    // Simulate 5 frames at 30 FPS (33.33ms interval = 33333333 ns).
+    constexpr int64_t base_time = 1000000000;
+    constexpr int64_t frame_interval = 33333333;
+
+    for (int i = 0; i < 5; ++i)
+    {
+        core::FrameMetadataT metadata;
+        metadata.timestamp = std::make_unique<core::Timestamp>(base_time + i * frame_interval,
+                                                               base_time + i * frame_interval + 100 // Small offset for
+                                                                                                    // common_time.
+        );
+        metadata.sequence_number = i;
+
+        CHECK(metadata.sequence_number == i);
+        CHECK(metadata.timestamp->device_time() == base_time + i * frame_interval);
+    }
+}
+
+TEST_CASE("FrameMetadata high frequency capture at 120 FPS", "[camera][scenario]")
+{
+    // 120 FPS = 8.33ms interval = 8333333 ns.
+    core::FrameMetadataT metadata;
+    metadata.timestamp = std::make_unique<core::Timestamp>(8333333, 8333400);
+    metadata.sequence_number = 1;
+
+    CHECK(metadata.sequence_number == 1);
+    CHECK(metadata.timestamp->device_time() == 8333333);
+}
+
+TEST_CASE("FrameMetadata sequence rollover scenario", "[camera][scenario]")
+{
+    // Test near max int32 boundary.
+    core::FrameMetadataT metadata;
+    metadata.timestamp = std::make_unique<core::Timestamp>(999999999999, 999999999999);
+    metadata.sequence_number = 2147483646; // Near max int32.
+
+    CHECK(metadata.sequence_number == 2147483646);
+
+    // Increment to max.
+    metadata.sequence_number = 2147483647;
+    CHECK(metadata.sequence_number == 2147483647);
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+TEST_CASE("FrameMetadata with negative sequence number", "[camera][edge]")
+{
+    // Although sequence numbers are typically positive, test negative values.
+    core::FrameMetadataT metadata;
+    metadata.sequence_number = -1;
+
+    CHECK(metadata.sequence_number == -1);
+}
+
+TEST_CASE("FrameMetadata with zero timestamp", "[camera][edge]")
+{
+    core::FrameMetadataT metadata;
+    metadata.timestamp = std::make_unique<core::Timestamp>(0, 0);
+    metadata.sequence_number = 0;
+
+    CHECK(metadata.timestamp->device_time() == 0);
+    CHECK(metadata.timestamp->common_time() == 0);
+}
+
+TEST_CASE("FrameMetadata with negative timestamp", "[camera][edge]")
+{
+    // Test with negative timestamp values (valid for relative times).
+    core::FrameMetadataT metadata;
+    metadata.timestamp = std::make_unique<core::Timestamp>(-1000, -2000);
+
+    CHECK(metadata.timestamp->device_time() == -1000);
+    CHECK(metadata.timestamp->common_time() == -2000);
+}
+
+TEST_CASE("FrameMetadata with large timestamp values", "[camera][edge]")
+{
+    core::FrameMetadataT metadata;
+    int64_t max_int64 = 9223372036854775807;
+    metadata.timestamp = std::make_unique<core::Timestamp>(max_int64, max_int64 - 1000);
+    metadata.sequence_number = 1;
+
+    CHECK(metadata.timestamp->device_time() == max_int64);
+    CHECK(metadata.timestamp->common_time() == max_int64 - 1000);
+}
+
+TEST_CASE("FrameMetadata with max int32 sequence number", "[camera][edge]")
+{
+    core::FrameMetadataT metadata;
+    metadata.sequence_number = 2147483647; // Max int32.
+
+    CHECK(metadata.sequence_number == 2147483647);
+}
+
+TEST_CASE("FrameMetadata with min int32 sequence number", "[camera][edge]")
+{
+    core::FrameMetadataT metadata;
+    metadata.sequence_number = -2147483648; // Min int32.
+
+    CHECK(metadata.sequence_number == -2147483648);
+}
+
+TEST_CASE("FrameMetadata buffer size is reasonable", "[camera][serialize]")
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    core::FrameMetadataT metadata;
+    metadata.timestamp = std::make_unique<core::Timestamp>(0, 0);
+    metadata.sequence_number = 0;
+
+    auto offset = core::FrameMetadata::Pack(builder, &metadata);
+    builder.Finish(offset);
+
+    // Buffer should be reasonably small (under 100 bytes for this simple message).
+    CHECK(builder.GetSize() < 100);
+}
+
+TEST_CASE("FrameMetadata can update sequence number", "[camera][native]")
+{
+    core::FrameMetadataT metadata;
+    metadata.sequence_number = 0;
+
+    // Simulate frame counter increment.
+    for (int i = 1; i <= 10; ++i)
+    {
+        metadata.sequence_number = i;
+        CHECK(metadata.sequence_number == i);
+    }
+}
+
+TEST_CASE("FrameMetadata can update timestamp", "[camera][native]")
+{
+    core::FrameMetadataT metadata;
+
+    // Set initial timestamp.
+    metadata.timestamp = std::make_unique<core::Timestamp>(100, 200);
+    CHECK(metadata.timestamp->device_time() == 100);
+
+    // Update timestamp.
+    metadata.timestamp = std::make_unique<core::Timestamp>(300, 400);
+    CHECK(metadata.timestamp->device_time() == 300);
+    CHECK(metadata.timestamp->common_time() == 400);
+}
+
+TEST_CASE("FrameMetadata roundtrip preserves all data", "[camera][scenario]")
+{
+    flatbuffers::FlatBufferBuilder builder;
+
+    // Create comprehensive metadata.
+    core::FrameMetadataT original;
+    original.timestamp = std::make_unique<core::Timestamp>(5555555555, 6666666666);
+    original.sequence_number = 12345;
+
+    // Serialize.
+    auto offset = core::FrameMetadata::Pack(builder, &original);
+    builder.Finish(offset);
+
+    // Unpack to new object.
+    auto* table = flatbuffers::GetRoot<core::FrameMetadata>(builder.GetBufferPointer());
+    core::FrameMetadataT roundtrip;
+    table->UnPackTo(&roundtrip);
+
+    // Verify all data preserved.
+    REQUIRE(roundtrip.timestamp != nullptr);
+    CHECK(roundtrip.timestamp->device_time() == 5555555555);
+    CHECK(roundtrip.timestamp->common_time() == 6666666666);
+    CHECK(roundtrip.sequence_number == 12345);
+}

--- a/src/core/schema_tests/python/test_camera.py
+++ b/src/core/schema_tests/python/test_camera.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for FrameMetadata type in teleopcore.schema.
+
+Tests the following FlatBuffers types:
+- FrameMetadata: Table with timestamp and sequence_number
+"""
+
+import pytest
+
+from teleopcore.schema import (
+    FrameMetadata,
+    Timestamp,
+)
+
+
+class TestFrameMetadataConstruction:
+    """Tests for FrameMetadata table construction."""
+
+    def test_default_construction(self):
+        """Test default construction creates FrameMetadata with None/zero fields."""
+        metadata = FrameMetadata()
+
+        assert metadata.timestamp is None
+        assert metadata.sequence_number == 0
+
+    def test_repr(self):
+        """Test __repr__ returns meaningful string."""
+        metadata = FrameMetadata()
+        repr_str = repr(metadata)
+
+        assert "FrameMetadata" in repr_str
+
+
+class TestFrameMetadataTimestamp:
+    """Tests for FrameMetadata timestamp property."""
+
+    def test_set_timestamp(self):
+        """Test setting timestamp."""
+        metadata = FrameMetadata()
+        timestamp = Timestamp(device_time=1000000000, common_time=2000000000)
+        metadata.timestamp = timestamp
+
+        assert metadata.timestamp is not None
+        assert metadata.timestamp.device_time == 1000000000
+        assert metadata.timestamp.common_time == 2000000000
+
+    def test_large_timestamp_values(self):
+        """Test with large int64 timestamp values."""
+        metadata = FrameMetadata()
+        max_int64 = 9223372036854775807
+        timestamp = Timestamp(device_time=max_int64, common_time=max_int64 - 1000)
+        metadata.timestamp = timestamp
+
+        assert metadata.timestamp.device_time == max_int64
+        assert metadata.timestamp.common_time == max_int64 - 1000
+
+
+class TestFrameMetadataSequenceNumber:
+    """Tests for FrameMetadata sequence_number property."""
+
+    def test_set_sequence_number(self):
+        """Test setting sequence number."""
+        metadata = FrameMetadata()
+        metadata.sequence_number = 42
+
+        assert metadata.sequence_number == 42
+
+    def test_set_large_sequence_number(self):
+        """Test setting large sequence number."""
+        metadata = FrameMetadata()
+        metadata.sequence_number = 2147483647  # Max int32
+
+        assert metadata.sequence_number == 2147483647
+
+    def test_set_negative_sequence_number(self):
+        """Test setting negative sequence number (edge case)."""
+        metadata = FrameMetadata()
+        metadata.sequence_number = -1
+
+        assert metadata.sequence_number == -1
+
+    def test_increment_sequence_number(self):
+        """Test incrementing sequence number."""
+        metadata = FrameMetadata()
+        metadata.sequence_number = 0
+        metadata.sequence_number = metadata.sequence_number + 1
+
+        assert metadata.sequence_number == 1
+
+
+class TestFrameMetadataCombined:
+    """Tests for FrameMetadata with multiple fields set."""
+
+    def test_full_metadata(self):
+        """Test with all fields set."""
+        metadata = FrameMetadata()
+        metadata.timestamp = Timestamp(device_time=1000, common_time=2000)
+        metadata.sequence_number = 100
+
+        assert metadata.timestamp is not None
+        assert metadata.timestamp.device_time == 1000
+        assert metadata.timestamp.common_time == 2000
+        assert metadata.sequence_number == 100
+
+
+class TestFrameMetadataScenarios:
+    """Tests for realistic OAK-D frame metadata scenarios."""
+
+    def test_first_frame(self):
+        """Test metadata for the first captured frame."""
+        metadata = FrameMetadata()
+        metadata.timestamp = Timestamp(device_time=0, common_time=1000000)
+        metadata.sequence_number = 0
+
+        assert metadata.sequence_number == 0
+        assert metadata.timestamp.device_time == 0
+
+    def test_streaming_frames(self):
+        """Test metadata for sequential streaming frames."""
+        frames = []
+        base_device_time = 1000000000  # 1 second in nanoseconds.
+        frame_interval = 33333333  # ~30 FPS in nanoseconds.
+
+        for i in range(5):
+            metadata = FrameMetadata()
+            metadata.timestamp = Timestamp(
+                device_time=base_device_time + i * frame_interval,
+                common_time=base_device_time + i * frame_interval + 100,  # Small offset.
+            )
+            metadata.sequence_number = i
+            frames.append(metadata)
+
+        # Verify sequential sequence numbers.
+        for i, frame in enumerate(frames):
+            assert frame.sequence_number == i
+
+        # Verify timestamps are increasing.
+        for i in range(1, len(frames)):
+            assert frames[i].timestamp.device_time > frames[i - 1].timestamp.device_time
+
+    def test_high_frequency_capture(self):
+        """Test metadata for high-frequency capture (e.g., 120 FPS)."""
+        metadata = FrameMetadata()
+        metadata.timestamp = Timestamp(
+            device_time=8333333,  # ~8.3ms (120 FPS interval)
+            common_time=8333400,
+        )
+        metadata.sequence_number = 1
+
+        assert metadata.sequence_number == 1
+
+    def test_sequence_rollover_scenario(self):
+        """Test metadata near sequence number boundaries."""
+        metadata = FrameMetadata()
+        metadata.timestamp = Timestamp(device_time=999999999999, common_time=999999999999)
+        metadata.sequence_number = 2147483646  # Near max int32
+
+        assert metadata.sequence_number == 2147483646
+
+        # Increment to max.
+        metadata.sequence_number = 2147483647
+        assert metadata.sequence_number == 2147483647
+
+
+class TestFrameMetadataEdgeCases:
+    """Edge case tests for FrameMetadata table."""
+
+    def test_zero_timestamp(self):
+        """Test with zero timestamp values."""
+        metadata = FrameMetadata()
+        metadata.timestamp = Timestamp(device_time=0, common_time=0)
+
+        assert metadata.timestamp.device_time == 0
+        assert metadata.timestamp.common_time == 0
+
+    def test_negative_timestamp(self):
+        """Test with negative timestamp values (valid for relative times)."""
+        metadata = FrameMetadata()
+        metadata.timestamp = Timestamp(device_time=-1000, common_time=-2000)
+
+        assert metadata.timestamp.device_time == -1000
+        assert metadata.timestamp.common_time == -2000
+
+    def test_overwrite_sequence_number(self):
+        """Test overwriting sequence number."""
+        metadata = FrameMetadata()
+        metadata.sequence_number = 10
+        metadata.sequence_number = 20
+
+        assert metadata.sequence_number == 20
+
+    def test_overwrite_timestamp(self):
+        """Test overwriting timestamp."""
+        metadata = FrameMetadata()
+        metadata.timestamp = Timestamp(device_time=100, common_time=200)
+        metadata.timestamp = Timestamp(device_time=300, common_time=400)
+
+        assert metadata.timestamp.device_time == 300
+        assert metadata.timestamp.common_time == 400
+
+    def test_repr_with_timestamp(self):
+        """Test __repr__ with timestamp set."""
+        metadata = FrameMetadata()
+        metadata.timestamp = Timestamp(device_time=123, common_time=456)
+        metadata.sequence_number = 789
+        repr_str = repr(metadata)
+
+        assert "FrameMetadata" in repr_str
+        assert "timestamp" in repr_str
+        assert "sequence_number" in repr_str
+
+    def test_repr_without_timestamp(self):
+        """Test __repr__ without timestamp set."""
+        metadata = FrameMetadata()
+        metadata.sequence_number = 42
+        repr_str = repr(metadata)
+
+        assert "FrameMetadata" in repr_str
+        assert "None" in repr_str or "timestamp" in repr_str


### PR DESCRIPTION
- The camera.fbs defines the needed per-frame metadata for a generic camera device.
- We will introduce the vendor specific data with a byte array.