### PR TITLE
Ignore uv.lock files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ venv/
 **/.venv/
 **/venv/
 
+# uv lock files.
+uv.lock
+
 # Compiled files
 *.o
 *.so


### PR DESCRIPTION
We uv as convenience for managing dependencies when running tests and examples.  But we don't require dependencies with specific versions that need to be locked.