### PR TITLE
Move [tool.uv] config to CMake install step

### DIFF
--- a/cmake/InstallPythonExample.cmake
+++ b/cmake/InstallPythonExample.cmake
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ==============================================================================
+# InstallPythonExample.cmake
+# ==============================================================================
+# Macro to install a Python example directory with a generated pyproject.toml.
+#
+# Reads the source pyproject.toml (which stays tool-agnostic) and appends a
+# [tool.uv] block only to the installed copy so that `uv run` works out of the
+# box in the install tree.
+#
+# Usage:
+#   install_python_example(DESTINATION examples/oxr/python)
+# ==============================================================================
+
+macro(install_python_example)
+    cmake_parse_arguments(_IPE "" "DESTINATION" "" ${ARGN})
+    if(NOT _IPE_DESTINATION)
+        message(FATAL_ERROR "install_python_example: DESTINATION is required")
+    endif()
+
+    # Read the bare pyproject.toml and append uv configuration for the
+    # installed environment.
+    file(READ "${CMAKE_CURRENT_SOURCE_DIR}/python/pyproject.toml" _PYPROJECT_BASE)
+    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml"
+"${_PYPROJECT_BASE}
+[tool.uv]
+find-links = [\"../../../wheels\"]
+python-preference = \"only-managed\"
+environments = [\"python_version == '${ISAAC_TELEOP_PYTHON_VERSION}'\"]
+")
+
+    # Install generated pyproject.toml (with [tool.uv] appended)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml"
+        DESTINATION ${_IPE_DESTINATION}
+    )
+
+    # Install Python example sources
+    install(DIRECTORY python/
+        DESTINATION ${_IPE_DESTINATION}
+        FILES_MATCHING
+            PATTERN "*.py"
+            PATTERN "*.md"
+        PATTERN ".venv" EXCLUDE
+        PATTERN "__pycache__" EXCLUDE
+        PATTERN "*.pyc" EXCLUDE
+    )
+endmacro()

--- a/examples/oxr/CMakeLists.txt
+++ b/examples/oxr/CMakeLists.txt
@@ -6,16 +6,5 @@ cmake_minimum_required(VERSION 3.20)
 # Build C++ examples
 add_subdirectory(cpp)
 
-# Python examples don't need CMake - they use uv
-# Just install them to the appropriate location
-install(DIRECTORY python/
-    DESTINATION examples/oxr/python
-    FILES_MATCHING 
-        PATTERN "*.py" 
-        PATTERN "*.toml"
-        PATTERN "*.md"
-    PATTERN ".venv" EXCLUDE
-    PATTERN "__pycache__" EXCLUDE
-    PATTERN "*.pyc" EXCLUDE
-)
-
+include(${CMAKE_SOURCE_DIR}/cmake/InstallPythonExample.cmake)
+install_python_example(DESTINATION examples/oxr/python)

--- a/examples/oxr/python/pyproject.toml
+++ b/examples/oxr/python/pyproject.toml
@@ -10,10 +10,3 @@ dependencies = [
     "isaacteleop",
     "numpy>=1.22.0",
 ]
-
-[tool.uv]
-# When running with uv, it will find the wheel from the install directory
-find-links = ["../../../wheels"]
-# Only use managed Python installations (not system Python)
-python-preference = "only-managed"
-

--- a/examples/retargeting/CMakeLists.txt
+++ b/examples/retargeting/CMakeLists.txt
@@ -3,16 +3,5 @@
 
 cmake_minimum_required(VERSION 3.20)
 
-# Python examples don't need CMake - they use uv
-# Just install them to the appropriate location
-install(DIRECTORY python/
-    DESTINATION examples/retargeting/python
-    FILES_MATCHING 
-        PATTERN "*.py" 
-        PATTERN "*.toml"
-        PATTERN "*.md"
-    PATTERN ".venv" EXCLUDE
-    PATTERN "__pycache__" EXCLUDE
-    PATTERN "*.pyc" EXCLUDE
-)
-
+include(${CMAKE_SOURCE_DIR}/cmake/InstallPythonExample.cmake)
+install_python_example(DESTINATION examples/retargeting/python)

--- a/examples/retargeting/python/pyproject.toml
+++ b/examples/retargeting/python/pyproject.toml
@@ -10,10 +10,3 @@ dependencies = [
     "isaacteleop[ui]",
     "numpy>=1.22.0",
 ]
-
-[tool.uv]
-# When running with uv, it will find the wheel from the install directory
-find-links = ["../../../wheels"]
-# Only use managed Python installations (not system Python)
-python-preference = "only-managed"
-

--- a/examples/teleop/CMakeLists.txt
+++ b/examples/teleop/CMakeLists.txt
@@ -4,16 +4,5 @@
 cmake_minimum_required(VERSION 3.20)
 project(teleop_examples)
 
-# Python examples don't need CMake - they use uv
-# Just install them to the appropriate location
-install(DIRECTORY python/
-    DESTINATION examples/teleop/python
-    FILES_MATCHING 
-        PATTERN "*.py" 
-        PATTERN "*.toml"
-        PATTERN "*.md"
-    PATTERN ".venv" EXCLUDE
-    PATTERN "__pycache__" EXCLUDE
-    PATTERN "*.pyc" EXCLUDE
-)
-
+include(${CMAKE_SOURCE_DIR}/cmake/InstallPythonExample.cmake)
+install_python_example(DESTINATION examples/teleop/python)

--- a/examples/teleop/python/pyproject.toml
+++ b/examples/teleop/python/pyproject.toml
@@ -9,10 +9,3 @@ requires-python = ">=3.10,<3.13"
 dependencies = [
     "isaacteleop[retargeters]",
 ]
-
-[tool.uv]
-# When running with uv, it will find the wheel from the install directory
-find-links = ["../../../wheels"]
-# Only use managed Python installations (not system Python)
-python-preference = "only-managed"
-

--- a/examples/teleop_session_manager/CMakeLists.txt
+++ b/examples/teleop_session_manager/CMakeLists.txt
@@ -3,15 +3,5 @@
 
 cmake_minimum_required(VERSION 3.20)
 
-# Python examples don't need CMake - they use uv
-# Just install them to the appropriate location
-install(DIRECTORY python/
-    DESTINATION examples/teleop_session_manager/python
-    FILES_MATCHING 
-        PATTERN "*.py" 
-        PATTERN "*.toml"
-        PATTERN "*.md"
-    PATTERN ".venv" EXCLUDE
-    PATTERN "__pycache__" EXCLUDE
-    PATTERN "*.pyc" EXCLUDE
-)
+include(${CMAKE_SOURCE_DIR}/cmake/InstallPythonExample.cmake)
+install_python_example(DESTINATION examples/teleop_session_manager/python)

--- a/examples/teleop_session_manager/python/pyproject.toml
+++ b/examples/teleop_session_manager/python/pyproject.toml
@@ -10,10 +10,3 @@ dependencies = [
     "isaacteleop[ui]",
     "numpy>=1.22.0",
 ]
-
-[tool.uv]
-# When running with uv, it will find the wheel from the install directory
-find-links = ["../../../wheels"]
-# Only use managed Python installations (not system Python)
-python-preference = "only-managed"
-


### PR DESCRIPTION
The source pyproject.toml files now stay tool-agnostic. The [tool.uv] block (find-links, python-preference, environments) is appended only to the installed copy by CMake at configure time. This keeps the source files clean and avoids duplicating uv-specific settings across examples.