### PR TITLE
Refactor IDeviceIOSource: add poll_tracker(), fix class hierarchy

### DIFF
--- a/src/core/retargeting_engine/python/deviceio_source_nodes/interface.py
+++ b/src/core/retargeting_engine/python/deviceio_source_nodes/interface.py
@@ -8,44 +8,37 @@ DeviceIO source nodes are stateless converters that transform raw DeviceIO
 flatbuffer data into standard retargeting engine tensor formats.
 """
 
-from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING
+from abc import abstractmethod
+from typing import Any, TYPE_CHECKING
+
+from ..interface.base_retargeter import BaseRetargeter
+from ..interface.retargeter_core_types import RetargeterIO
 
 if TYPE_CHECKING:
     from isaacteleop.deviceio import ITracker
 
 
-class IDeviceIOSource(ABC):
+class IDeviceIOSource(BaseRetargeter):
     """
     Interface for DeviceIO source nodes.
     
-    DeviceIO source nodes are stateless retargeters that:
+    Extends BaseRetargeter to add DeviceIO tracker discovery and polling.
+    
+    DeviceIO source nodes are retargeters that:
     - Take DeviceIO flatbuffer objects as input (DeviceIOHeadPose, DeviceIOHandPose, etc.)
     - Convert them to standard retargeting engine tensor formats (HeadPose, HandInput, etc.)
     - Are pure converters with no internal state or session dependencies
     - Provide access to their associated tracker via get_tracker()
-    - Expose their name for input argument mapping
+    - Know how to poll their own tracker via poll_tracker()
     
     This allows TeleopSession to:
     1. Discover required trackers via get_tracker()
     2. Initialize DeviceIO session with all trackers
-    3. Manually poll DeviceIO trackers
-    4. Map tracker data to correct input arguments via name property
+    3. Poll each source for its own tracker data via poll_tracker()
+    4. Map tracker data to correct input arguments via name
     5. Pass raw data as inputs to the retargeting pipeline
     6. Keep all session management in one place
     """
-    
-    @property
-    @abstractmethod
-    def name(self) -> str:
-        """Get the name of this source node.
-        
-        Used by TeleopSession to map tracker data to pipeline input arguments.
-        
-        Returns:
-            The unique name of this source node
-        """
-        pass
     
     @abstractmethod
     def get_tracker(self) -> "ITracker":
@@ -55,6 +48,22 @@ class IDeviceIOSource(ABC):
         
         Returns:
             The ITracker instance (e.g., HeadTracker, HandTracker, ControllerTracker)
+        """
+        pass
+
+    @abstractmethod
+    def poll_tracker(self, deviceio_session: Any) -> RetargeterIO:
+        """Poll the tracker and return input data as a RetargeterIO dict.
+        
+        Each source knows its own tracker's API and its input_spec.
+        Called by TeleopSession each frame to collect tracker data.
+        
+        Args:
+            deviceio_session: The active DeviceIO session to poll from.
+        
+        Returns:
+            Dict mapping input names to TensorGroups containing raw tracker data,
+            matching this source's input_spec().
         """
         pass
 

--- a/src/core/retargeting_engine/python/interface/base_retargeter.py
+++ b/src/core/retargeting_engine/python/interface/base_retargeter.py
@@ -71,6 +71,11 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
         self._outputs: RetargeterIOType = self.output_spec()
         self._parameter_state: Optional[ParameterState] = parameter_state
 
+    @property
+    def name(self) -> str:
+        """Get the name of this retargeter."""
+        return self._name
+
     def _sync_parameters_from_state(self) -> None:
         """
         Sync parameter values from ParameterState (main thread only).
@@ -186,7 +191,7 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
                 msg.append(f"Missing inputs: {missing}")
             if extra:
                 msg.append(f"Extra inputs: {extra}")
-            raise ValueError(f"Input mismatch for {self._name}: {', '.join(msg)}")
+            raise ValueError(f"Input mismatch for {self.name}: {', '.join(msg)}")
 
         # Validate types
         for input_name, output_selector in input_connections.items():
@@ -233,9 +238,9 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
 
         # Get inputs from context (if any are needed)
         if len(self._inputs) > 0:  # Only look for inputs if this module has any
-            inputs = context.get_leaf_input(self._name)
+            inputs = context.get_leaf_input(self.name)
             if inputs is None:
-                raise ValueError(f"Input '{self._name}' not found in context")
+                raise ValueError(f"Input '{self.name}' not found in context")
         else:
             # Source modules with no inputs use empty dict
             inputs = {}

--- a/src/core/retargeting_engine/python/interface/retargeter_core_types.py
+++ b/src/core/retargeting_engine/python/interface/retargeter_core_types.py
@@ -30,6 +30,12 @@ class OutputSelector:
         self.output_name = output_name
 
 class BaseExecutable(ABC):
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        """Get the name of this executable."""
+        pass
+
     @abstractmethod
     def _compute_without_context(self, inputs: RetargeterIO) -> RetargeterIO:
         """


### PR DESCRIPTION
- IDeviceIOSource now extends BaseRetargeter (was a separate ABC), removing the need for source nodes to inherit from both.
- Move the `name` property up to BaseRetargeter / BaseExecutable so all graph nodes expose it uniformly.
- Each source node now implements poll_tracker() to encapsulate its own tracker polling logic, eliminating the tracker-type switch in TeleopSession._collect_tracker_data().
- Deduplicate trackers by type in __enter__ so that source-discovered and config-provided trackers don't clash.