### PR TITLE
Add transform utilities, TransformMatrix type, and .transformed() methods

### DIFF
--- a/src/core/python/MANIFEST.in
+++ b/src/core/python/MANIFEST.in
@@ -18,5 +18,6 @@ include isaacteleop/retargeting_engine/*.py
 include isaacteleop/retargeting_engine/interface/*.py
 include isaacteleop/retargeting_engine/tensor_types/*.py
 include isaacteleop/retargeting_engine/deviceio_source_nodes/*.py
+include isaacteleop/retargeting_engine/utilities/*.py
 include isaacteleop/retargeting_engine_ui/*.py
 include isaacteleop/teleop_session_manager/*.py

--- a/src/core/retargeting_engine/python/__init__.py
+++ b/src/core/retargeting_engine/python/__init__.py
@@ -11,6 +11,7 @@ __all__ = [
     "interface",
     "tensor_types",
     "deviceio_source_nodes",
+    "utilities",
 ]
 
 

--- a/src/core/retargeting_engine/python/deviceio_source_nodes/controllers_source.py
+++ b/src/core/retargeting_engine/python/deviceio_source_nodes/controllers_source.py
@@ -10,7 +10,8 @@ Converts raw ControllerSnapshot flatbuffer data to standard ControllerInput tens
 import numpy as np
 from typing import Any, TYPE_CHECKING
 from .interface import IDeviceIOSource
-from ..interface.retargeter_core_types import RetargeterIO, RetargeterIOType
+from ..interface.retargeter_core_types import OutputSelector, RetargeterIO, RetargeterIOType
+from ..interface.retargeter_subgraph import RetargeterSubgraph
 from ..interface.tensor_group import TensorGroup
 from ..tensor_types import ControllerInput
 from .deviceio_tensor_types import DeviceIOControllerSnapshot
@@ -161,3 +162,32 @@ class ControllersSource(IDeviceIOSource):
         group[9] = float(snapshot.inputs.squeeze_value)
         group[10] = float(snapshot.inputs.trigger_value)
         group[11] = snapshot.is_active  # BoolType, don't convert
+
+    def transformed(self, transform_input: OutputSelector) -> RetargeterSubgraph:
+        """
+        Create a subgraph that applies a 4x4 transform to controller poses.
+
+        This is a convenience method equivalent to manually creating a
+        ControllerTransform node and connecting it.
+
+        Args:
+            transform_input: An OutputSelector providing a TransformMatrix
+                (e.g., passthrough_input.output("value")).
+
+        Returns:
+            A RetargeterSubgraph with outputs "controller_left" and "controller_right"
+            containing the transformed ControllerInput data.
+
+        Example:
+            ctrl_source = ControllersSource("controllers")
+            xform_input = PassthroughInput("xform", TransformMatrix())
+            transformed = ctrl_source.transformed(xform_input.output("value"))
+        """
+        from ..utilities.controller_transform import ControllerTransform
+
+        xform_node = ControllerTransform(f"{self.name}_transform")
+        return xform_node.connect({
+            self.LEFT: self.output(self.LEFT),
+            self.RIGHT: self.output(self.RIGHT),
+            "transform": transform_input,
+        })

--- a/src/core/retargeting_engine/python/deviceio_source_nodes/hands_source.py
+++ b/src/core/retargeting_engine/python/deviceio_source_nodes/hands_source.py
@@ -10,7 +10,8 @@ Converts raw HandPoseT flatbuffer data to standard HandInput tensor format.
 import numpy as np
 from typing import Any, TYPE_CHECKING
 from .interface import IDeviceIOSource
-from ..interface.retargeter_core_types import RetargeterIO, RetargeterIOType
+from ..interface.retargeter_core_types import OutputSelector, RetargeterIO, RetargeterIOType
+from ..interface.retargeter_subgraph import RetargeterSubgraph
 from ..interface.tensor_group import TensorGroup
 from ..tensor_types import HandInput, NUM_HAND_JOINTS
 from .deviceio_tensor_types import DeviceIOHandPose
@@ -145,3 +146,32 @@ class HandsSource(IDeviceIOSource):
         group[3] = valid
         group[4] = hand_data.is_active
         group[5] = int(hand_data.timestamp.device_time)
+
+    def transformed(self, transform_input: OutputSelector) -> RetargeterSubgraph:
+        """
+        Create a subgraph that applies a 4x4 transform to all hand joint poses.
+
+        This is a convenience method equivalent to manually creating a HandTransform
+        node and connecting it.
+
+        Args:
+            transform_input: An OutputSelector providing a TransformMatrix
+                (e.g., passthrough_input.output("value")).
+
+        Returns:
+            A RetargeterSubgraph with outputs "hand_left" and "hand_right"
+            containing the transformed HandInput data.
+
+        Example:
+            hand_source = HandsSource("hands")
+            xform_input = PassthroughInput("xform", TransformMatrix())
+            transformed = hand_source.transformed(xform_input.output("value"))
+        """
+        from ..utilities.hand_transform import HandTransform
+
+        xform_node = HandTransform(f"{self.name}_transform")
+        return xform_node.connect({
+            self.LEFT: self.output(self.LEFT),
+            self.RIGHT: self.output(self.RIGHT),
+            "transform": transform_input,
+        })

--- a/src/core/retargeting_engine/python/tensor_types/__init__.py
+++ b/src/core/retargeting_engine/python/tensor_types/__init__.py
@@ -9,6 +9,7 @@ from .standard_types import (
     HandInput,
     HeadPose,
     ControllerInput,
+    TransformMatrix,
     NUM_HAND_JOINTS,
     RobotHandJoints,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "HandInput",
     "HeadPose",
     "ControllerInput",
+    "TransformMatrix",
     "NUM_HAND_JOINTS",
     "RobotHandJoints",
     # Indices

--- a/src/core/retargeting_engine/python/tensor_types/standard_types.py
+++ b/src/core/retargeting_engine/python/tensor_types/standard_types.py
@@ -195,6 +195,34 @@ def ControllerInput() -> TensorGroupType:
     ])
 
 
+# ============================================================================
+# Transform Types
+# ============================================================================
+
+def TransformMatrix() -> TensorGroupType:
+    """
+    Standard TensorGroupType for a 4x4 homogeneous transformation matrix.
+
+    Fields:
+        - matrix: (4, 4) float32 array - Homogeneous transformation matrix
+
+    Returns:
+        TensorGroupType for a 4x4 transform matrix
+    """
+    return TensorGroupType("transform", [
+        NDArrayType(
+            "transform_matrix",
+            shape=(4, 4),
+            dtype=DLDataType.FLOAT,
+            dtype_bits=32
+        ),
+    ])
+
+
+# ============================================================================
+# Robot Types
+# ============================================================================
+
 def RobotHandJoints(name: str, joint_names: list[str]) -> TensorGroupType:
     """
     Standard TensorGroupType for robot hand joint angles.

--- a/src/core/retargeting_engine/python/utilities/__init__.py
+++ b/src/core/retargeting_engine/python/utilities/__init__.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Utility nodes for the retargeting engine - transform, coordinate conversion, etc."""
+
+from .head_transform import HeadTransform
+from .controller_transform import ControllerTransform
+from .hand_transform import HandTransform
+from .transform_utils import (
+    validate_transform_matrix,
+    decompose_transform,
+    transform_position,
+    transform_positions_batch,
+    transform_orientation,
+    transform_orientations_batch,
+)
+
+__all__ = [
+    # Transform nodes
+    "HeadTransform",
+    "ControllerTransform",
+    "HandTransform",
+    # Utility functions
+    "validate_transform_matrix",
+    "decompose_transform",
+    "transform_position",
+    "transform_positions_batch",
+    "transform_orientation",
+    "transform_orientations_batch",
+]

--- a/src/core/retargeting_engine/python/utilities/controller_transform.py
+++ b/src/core/retargeting_engine/python/utilities/controller_transform.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Controller Transform Node - Applies a 4x4 transform to controller pose data.
+
+Transforms controller grip and aim positions/orientations using a homogeneous
+transformation matrix while preserving button/axis input fields.
+
+The transform matrix is received as a tensor input from the graph, typically
+provided by a TransformSource node.
+"""
+
+import copy
+
+import numpy as np
+
+from ..interface.base_retargeter import BaseRetargeter
+from ..interface.retargeter_core_types import RetargeterIO, RetargeterIOType
+from ..interface.tensor_group import TensorGroup
+from ..tensor_types import ControllerInput, ControllerInputIndex, TransformMatrix
+from .transform_utils import (
+    decompose_transform,
+    transform_position,
+    transform_orientation,
+)
+
+
+# Index of the matrix field within the TransformMatrix TensorGroupType
+_MATRIX_INDEX = 0
+
+
+class ControllerTransform(BaseRetargeter):
+    """
+    Applies a 4x4 homogeneous transform to controller pose data.
+
+    Transforms grip and aim positions (R @ p + t) and orientations (R_quat * q)
+    for both left and right controllers while passing through all button/axis
+    inputs unchanged.
+
+    The transform matrix is provided as a tensor input, allowing it to be
+    sourced from a TransformSource node in the graph.
+
+    Inputs:
+        - "controller_left": ControllerInput tensor
+        - "controller_right": ControllerInput tensor
+        - "transform": TransformMatrix tensor containing the (4, 4) matrix
+
+    Outputs:
+        - "controller_left": ControllerInput tensor with transformed poses
+        - "controller_right": ControllerInput tensor with transformed poses
+
+    Example:
+        transform_input = PassthroughInput("xform_input", TransformMatrix())
+        controller_transform = ControllerTransform("ctrl_xform")
+
+        transformed = controller_transform.connect({
+            "controller_left": ctrl_source.output("controller_left"),
+            "controller_right": ctrl_source.output("controller_right"),
+            "transform": transform_input.output("value"),
+        })
+    """
+
+    LEFT = "controller_left"
+    RIGHT = "controller_right"
+
+    def __init__(self, name: str) -> None:
+        """
+        Initialize controller transform node.
+
+        Args:
+            name: Unique name for this node.
+        """
+        super().__init__(name)
+
+    def input_spec(self) -> RetargeterIOType:
+        """Declare controller and transform matrix inputs."""
+        return {
+            self.LEFT: ControllerInput(),
+            self.RIGHT: ControllerInput(),
+            "transform": TransformMatrix(),
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        """Declare transformed controller output specs for left and right."""
+        return {
+            self.LEFT: ControllerInput(),
+            self.RIGHT: ControllerInput(),
+        }
+
+    def compute(self, inputs: RetargeterIO, outputs: RetargeterIO) -> None:
+        """
+        Apply the 4x4 transform to controller grip and aim poses.
+
+        Position is transformed as: p' = R @ p + t
+        Orientation is transformed as: q' = R_quat * q
+        All other fields (buttons, axes, is_active) are copied unchanged.
+
+        Args:
+            inputs: Dict with "controller_left", "controller_right", and "transform" TensorGroups.
+            outputs: Dict with "controller_left" and "controller_right" TensorGroups.
+        """
+        matrix = np.from_dlpack(inputs["transform"][_MATRIX_INDEX])
+        rotation, translation = decompose_transform(matrix)
+
+        self._transform_controller(inputs[self.LEFT], outputs[self.LEFT], rotation, translation)
+        self._transform_controller(inputs[self.RIGHT], outputs[self.RIGHT], rotation, translation)
+
+    @staticmethod
+    def _transform_controller(
+        inp: TensorGroup,
+        out: TensorGroup,
+        rotation: np.ndarray,
+        translation: np.ndarray,
+    ) -> None:
+        """Apply the transform to a single controller's data."""
+        # Deep-copy all fields from input to output (avoid aliasing)
+        for i in range(len(inp)):
+            out[i] = copy.deepcopy(inp[i])
+
+        # Transform pose fields in-place on the output buffers
+        transform_position(np.from_dlpack(out[ControllerInputIndex.GRIP_POSITION]), rotation, translation)
+        transform_orientation(np.from_dlpack(out[ControllerInputIndex.GRIP_ORIENTATION]), rotation)
+        transform_position(np.from_dlpack(out[ControllerInputIndex.AIM_POSITION]), rotation, translation)
+        transform_orientation(np.from_dlpack(out[ControllerInputIndex.AIM_ORIENTATION]), rotation)

--- a/src/core/retargeting_engine/python/utilities/hand_transform.py
+++ b/src/core/retargeting_engine/python/utilities/hand_transform.py
@@ -1,0 +1,128 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Hand Transform Node - Applies a 4x4 transform to hand tracking data.
+
+Transforms all hand joint positions and orientations using a homogeneous
+transformation matrix while preserving joint radii, validity, active state,
+and timestamp fields.
+
+The transform matrix is received as a tensor input from the graph, typically
+provided by a TransformSource node.
+
+Note: All 26 joint positions and orientations are transformed (not just the
+wrist) since all joints share the same coordinate frame. Transforming only
+the wrist while leaving other joints untransformed would break the hand skeleton.
+"""
+
+import copy
+
+import numpy as np
+
+from ..interface.base_retargeter import BaseRetargeter
+from ..interface.retargeter_core_types import RetargeterIO, RetargeterIOType
+from ..interface.tensor_group import TensorGroup
+from ..tensor_types import HandInput, HandInputIndex, TransformMatrix
+from .transform_utils import (
+    decompose_transform,
+    transform_positions_batch,
+    transform_orientations_batch,
+)
+
+
+# Index of the matrix field within the TransformMatrix TensorGroupType
+_MATRIX_INDEX = 0
+
+
+class HandTransform(BaseRetargeter):
+    """
+    Applies a 4x4 homogeneous transform to hand tracking data.
+
+    Transforms all 26 joint positions (R @ p + t) and orientations (R_quat * q)
+    for both left and right hands while passing through joint radii, validity
+    flags, active state, and timestamp unchanged.
+
+    The transform matrix is provided as a tensor input, allowing it to be
+    sourced from a TransformSource node in the graph.
+
+    Inputs:
+        - "hand_left": HandInput tensor (26 joints)
+        - "hand_right": HandInput tensor (26 joints)
+        - "transform": TransformMatrix tensor containing the (4, 4) matrix
+
+    Outputs:
+        - "hand_left": HandInput tensor with transformed joint poses
+        - "hand_right": HandInput tensor with transformed joint poses
+
+    Example:
+        transform_input = PassthroughInput("xform_input", TransformMatrix())
+        hand_transform = HandTransform("hand_xform")
+
+        transformed = hand_transform.connect({
+            "hand_left": hand_source.output("hand_left"),
+            "hand_right": hand_source.output("hand_right"),
+            "transform": transform_input.output("value"),
+        })
+    """
+
+    LEFT = "hand_left"
+    RIGHT = "hand_right"
+
+    def __init__(self, name: str) -> None:
+        """
+        Initialize hand transform node.
+
+        Args:
+            name: Unique name for this node.
+        """
+        super().__init__(name)
+
+    def input_spec(self) -> RetargeterIOType:
+        """Declare hand and transform matrix inputs."""
+        return {
+            self.LEFT: HandInput(),
+            self.RIGHT: HandInput(),
+            "transform": TransformMatrix(),
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        """Declare transformed hand output specs for left and right."""
+        return {
+            self.LEFT: HandInput(),
+            self.RIGHT: HandInput(),
+        }
+
+    def compute(self, inputs: RetargeterIO, outputs: RetargeterIO) -> None:
+        """
+        Apply the 4x4 transform to all hand joint positions and orientations.
+
+        Position is transformed as: p' = R @ p + t (batch over 26 joints)
+        Orientation is transformed as: q' = R_quat * q (batch over 26 joints)
+        All other fields (radii, validity, active, timestamp) are copied unchanged.
+
+        Args:
+            inputs: Dict with "hand_left", "hand_right", and "transform" TensorGroups.
+            outputs: Dict with "hand_left" and "hand_right" TensorGroups.
+        """
+        matrix = np.from_dlpack(inputs["transform"][_MATRIX_INDEX])
+        rotation, translation = decompose_transform(matrix)
+
+        self._transform_hand(inputs[self.LEFT], outputs[self.LEFT], rotation, translation)
+        self._transform_hand(inputs[self.RIGHT], outputs[self.RIGHT], rotation, translation)
+
+    @staticmethod
+    def _transform_hand(
+        inp: TensorGroup,
+        out: TensorGroup,
+        rotation: np.ndarray,
+        translation: np.ndarray,
+    ) -> None:
+        """Apply the transform to a single hand's joint data."""
+        # Deep-copy all fields from input to output (avoid aliasing)
+        for i in range(len(inp)):
+            out[i] = copy.deepcopy(inp[i])
+
+        # Transform pose fields in-place on the output buffers
+        transform_positions_batch(np.from_dlpack(out[HandInputIndex.JOINT_POSITIONS]), rotation, translation)
+        transform_orientations_batch(np.from_dlpack(out[HandInputIndex.JOINT_ORIENTATIONS]), rotation)

--- a/src/core/retargeting_engine/python/utilities/head_transform.py
+++ b/src/core/retargeting_engine/python/utilities/head_transform.py
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Head Transform Node - Applies a 4x4 transform to head pose data.
+
+Transforms head position and orientation using a homogeneous transformation
+matrix while preserving validity and timestamp fields.
+
+The transform matrix is received as a tensor input from the graph, typically
+provided by a TransformSource node.
+"""
+
+import copy
+
+import numpy as np
+
+from ..interface.base_retargeter import BaseRetargeter
+from ..interface.retargeter_core_types import RetargeterIO, RetargeterIOType
+from ..tensor_types import HeadPose, TransformMatrix
+from .transform_utils import (
+    decompose_transform,
+    transform_position,
+    transform_orientation,
+)
+
+
+# Index of the matrix field within the TransformMatrix TensorGroupType
+_MATRIX_INDEX = 0
+
+
+class HeadTransform(BaseRetargeter):
+    """
+    Applies a 4x4 homogeneous transform to head pose data.
+
+    Transforms the head position (R @ p + t) and orientation (R_quat * q)
+    while passing through is_valid and timestamp unchanged.
+
+    The transform matrix is provided as a tensor input, allowing it to be
+    sourced from a TransformSource node in the graph.
+
+    Inputs:
+        - "head": HeadPose tensor (position, orientation, is_valid, timestamp)
+        - "transform": TransformMatrix tensor containing the (4, 4) matrix
+
+    Outputs:
+        - "head": HeadPose tensor with transformed position and orientation
+
+    Example:
+        transform_input = PassthroughInput("xform_input", TransformMatrix())
+        head_transform = HeadTransform("head_xform")
+
+        transformed = head_transform.connect({
+            "head": head_source.output("head"),
+            "transform": transform_input.output("value"),
+        })
+    """
+
+    # Input/output tensor indices for HeadPose
+    _POSITION = 0
+    _ORIENTATION = 1
+    _IS_VALID = 2
+    _TIMESTAMP = 3
+
+    def __init__(self, name: str) -> None:
+        """
+        Initialize head transform node.
+
+        Args:
+            name: Unique name for this node.
+        """
+        super().__init__(name)
+
+    def input_spec(self) -> RetargeterIOType:
+        """Declare head pose and transform matrix inputs."""
+        return {
+            "head": HeadPose(),
+            "transform": TransformMatrix(),
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        """Declare transformed head pose output."""
+        return {
+            "head": HeadPose()
+        }
+
+    def compute(self, inputs: RetargeterIO, outputs: RetargeterIO) -> None:
+        """
+        Apply the 4x4 transform to head position and orientation.
+
+        Position is transformed as: p' = R @ p + t
+        Orientation is transformed as: q' = R_quat * q
+        All other fields (is_valid, timestamp) are copied unchanged.
+
+        Args:
+            inputs: Dict with "head" and "transform" TensorGroups.
+            outputs: Dict with "head" TensorGroup to populate.
+        """
+        matrix = np.from_dlpack(inputs["transform"][_MATRIX_INDEX])
+        rotation, translation = decompose_transform(matrix)
+
+        inp = inputs["head"]
+        out = outputs["head"]
+
+        # Deep-copy all fields from input to output (avoid aliasing)
+        for i in range(len(inp)):
+            out[i] = copy.deepcopy(inp[i])
+
+        # Transform pose fields in-place on the output buffers
+        transform_position(np.from_dlpack(out[self._POSITION]), rotation, translation)
+        transform_orientation(np.from_dlpack(out[self._ORIENTATION]), rotation)

--- a/src/core/retargeting_engine/python/utilities/transform_utils.py
+++ b/src/core/retargeting_engine/python/utilities/transform_utils.py
@@ -1,0 +1,227 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Transform Utilities - Shared math for applying 4x4 transforms to poses.
+
+Provides functions to apply a 4x4 homogeneous transformation matrix to
+position vectors and orientation quaternions. Uses only numpy (no scipy).
+
+Quaternion Convention:
+    Throughout this module, quaternions are stored as [x, y, z, w] arrays,
+    matching the order written by the DeviceIO source nodes (head_source.py,
+    hands_source.py, controllers_source.py).
+"""
+
+import numpy as np
+from typing import Tuple
+
+
+def validate_transform_matrix(matrix: np.ndarray) -> np.ndarray:
+    """
+    Validate and normalize a 4x4 homogeneous transformation matrix.
+
+    Args:
+        matrix: A (4, 4) numpy array representing the transform.
+
+    Returns:
+        The validated matrix as float64.
+
+    Raises:
+        ValueError: If matrix shape is not (4, 4) or bottom row is invalid.
+    """
+    matrix = np.asarray(matrix, dtype=np.float64)
+    if matrix.shape != (4, 4):
+        raise ValueError(f"Transform matrix must be (4, 4), got {matrix.shape}")
+
+    # Validate bottom row is [0, 0, 0, 1]
+    expected_bottom = np.array([0.0, 0.0, 0.0, 1.0])
+    if not np.allclose(matrix[3, :], expected_bottom, atol=1e-6):
+        raise ValueError(
+            f"Bottom row of transform matrix must be [0, 0, 0, 1], "
+            f"got {matrix[3, :]}"
+        )
+
+    return matrix
+
+
+def decompose_transform(matrix: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    """
+    Decompose a 4x4 homogeneous transform into rotation and translation.
+
+    Args:
+        matrix: A (4, 4) homogeneous transformation matrix.
+
+    Returns:
+        Tuple of:
+            - rotation: (3, 3) rotation matrix
+            - translation: (3,) translation vector
+    """
+    rotation = matrix[:3, :3]
+    translation = matrix[:3, 3]
+    return rotation, translation
+
+
+def transform_position(
+    position: np.ndarray,
+    rotation_3x3: np.ndarray,
+    translation: np.ndarray
+) -> None:
+    """
+    Apply a rigid transform to a position vector in-place: p[:] = R @ p + t.
+
+    Args:
+        position: (3,) position vector, modified in-place.
+        rotation_3x3: (3, 3) rotation matrix.
+        translation: (3,) translation vector.
+    """
+    position[:] = (rotation_3x3 @ position + translation).astype(position.dtype)
+
+
+def transform_positions_batch(
+    positions: np.ndarray,
+    rotation_3x3: np.ndarray,
+    translation: np.ndarray
+) -> None:
+    """
+    Apply a rigid transform to a batch of position vectors in-place: p[:] = R @ p + t.
+
+    Args:
+        positions: (N, 3) position vectors, modified in-place.
+        rotation_3x3: (3, 3) rotation matrix.
+        translation: (3,) translation vector.
+    """
+    # (N, 3) @ (3, 3)^T + (3,) = (N, 3)
+    positions[:] = (positions @ rotation_3x3.T + translation).astype(positions.dtype)
+
+
+# ============================================================================
+# Quaternion helpers (pure numpy, no scipy)
+# ============================================================================
+
+def _rotation_matrix_to_quat_xyzw(R: np.ndarray) -> np.ndarray:
+    """
+    Convert a 3x3 rotation matrix to a quaternion in [x, y, z, w] format.
+
+    Uses Shepperd's method for numerical stability.
+
+    Args:
+        R: (3, 3) rotation matrix.
+
+    Returns:
+        (4,) quaternion [x, y, z, w].
+    """
+    trace = R[0, 0] + R[1, 1] + R[2, 2]
+
+    if trace > 0:
+        s = 0.5 / np.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (R[2, 1] - R[1, 2]) * s
+        y = (R[0, 2] - R[2, 0]) * s
+        z = (R[1, 0] - R[0, 1]) * s
+    elif R[0, 0] > R[1, 1] and R[0, 0] > R[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + R[0, 0] - R[1, 1] - R[2, 2])
+        w = (R[2, 1] - R[1, 2]) / s
+        x = 0.25 * s
+        y = (R[0, 1] + R[1, 0]) / s
+        z = (R[0, 2] + R[2, 0]) / s
+    elif R[1, 1] > R[2, 2]:
+        s = 2.0 * np.sqrt(1.0 + R[1, 1] - R[0, 0] - R[2, 2])
+        w = (R[0, 2] - R[2, 0]) / s
+        x = (R[0, 1] + R[1, 0]) / s
+        y = 0.25 * s
+        z = (R[1, 2] + R[2, 1]) / s
+    else:
+        s = 2.0 * np.sqrt(1.0 + R[2, 2] - R[0, 0] - R[1, 1])
+        w = (R[1, 0] - R[0, 1]) / s
+        x = (R[0, 2] + R[2, 0]) / s
+        y = (R[1, 2] + R[2, 1]) / s
+        z = 0.25 * s
+
+    return np.array([x, y, z, w])
+
+
+def _quat_multiply_xyzw(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    """
+    Multiply two quaternions in [x, y, z, w] format: result = q1 * q2.
+
+    Args:
+        q1: (4,) quaternion [x, y, z, w].
+        q2: (4,) quaternion [x, y, z, w].
+
+    Returns:
+        (4,) product quaternion [x, y, z, w].
+    """
+    x1, y1, z1, w1 = q1
+    x2, y2, z2, w2 = q2
+    return np.array([
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+    ])
+
+
+def _quat_multiply_batch_xyzw(q1: np.ndarray, q2: np.ndarray) -> np.ndarray:
+    """
+    Multiply quaternion q1 with a batch of quaternions q2, all in [x, y, z, w].
+
+    Args:
+        q1: (4,) single quaternion [x, y, z, w].
+        q2: (N, 4) batch of quaternions [x, y, z, w].
+
+    Returns:
+        (N, 4) product quaternions [x, y, z, w].
+    """
+    x1, y1, z1, w1 = q1
+    x2 = q2[:, 0]
+    y2 = q2[:, 1]
+    z2 = q2[:, 2]
+    w2 = q2[:, 3]
+    return np.column_stack([
+        w1 * x2 + x1 * w2 + y1 * z2 - z1 * y2,
+        w1 * y2 - x1 * z2 + y1 * w2 + z1 * x2,
+        w1 * z2 + x1 * y2 - y1 * x2 + z1 * w2,
+        w1 * w2 - x1 * x2 - y1 * y2 - z1 * z2,
+    ])
+
+
+# ============================================================================
+# Public orientation transform functions
+# ============================================================================
+
+def transform_orientation(
+    orientation_xyzw: np.ndarray,
+    rotation_3x3: np.ndarray
+) -> None:
+    """
+    Apply a rotation to an orientation quaternion in-place: q[:] = R_quat * q.
+
+    The rotation from the 3x3 matrix is composed with the existing orientation
+    via quaternion multiplication.
+
+    Args:
+        orientation_xyzw: (4,) quaternion in [x, y, z, w] format, modified in-place.
+        rotation_3x3: (3, 3) rotation matrix to apply.
+    """
+    rot_quat = _rotation_matrix_to_quat_xyzw(rotation_3x3)
+    orientation_xyzw[:] = _quat_multiply_xyzw(rot_quat, orientation_xyzw).astype(
+        orientation_xyzw.dtype
+    )
+
+
+def transform_orientations_batch(
+    orientations_xyzw: np.ndarray,
+    rotation_3x3: np.ndarray
+) -> None:
+    """
+    Apply a rotation to a batch of orientation quaternions in-place: q[:] = R_quat * q.
+
+    Args:
+        orientations_xyzw: (N, 4) quaternions in [x, y, z, w] format, modified in-place.
+        rotation_3x3: (3, 3) rotation matrix to apply.
+    """
+    rot_quat = _rotation_matrix_to_quat_xyzw(rotation_3x3)
+    orientations_xyzw[:] = _quat_multiply_batch_xyzw(rot_quat, orientations_xyzw).astype(
+        orientations_xyzw.dtype
+    )

--- a/src/core/retargeting_engine_tests/python/test_transforms.py
+++ b/src/core/retargeting_engine_tests/python/test_transforms.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for transform utilities and transform retargeter nodes.
+
+Covers:
+- transform_utils: validate, decompose, position/orientation transforms
+- HeadTransform, HandTransform, ControllerTransform retargeter nodes
+"""
+
+import pytest
+import numpy as np
+import numpy.testing as npt
+
+from isaacteleop.retargeting_engine.interface import TensorGroup
+from isaacteleop.retargeting_engine.tensor_types import (
+    HeadPose,
+    HandInput,
+    ControllerInput,
+    TransformMatrix,
+    ControllerInputIndex,
+    HandInputIndex,
+    NUM_HAND_JOINTS,
+)
+from isaacteleop.retargeting_engine.utilities.transform_utils import (
+    validate_transform_matrix,
+    decompose_transform,
+    transform_position,
+    transform_positions_batch,
+    transform_orientation,
+    transform_orientations_batch,
+    _rotation_matrix_to_quat_xyzw,
+    _quat_multiply_xyzw,
+)
+from isaacteleop.retargeting_engine.utilities import (
+    HeadTransform,
+    HandTransform,
+    ControllerTransform,
+)
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+def _identity_4x4() -> np.ndarray:
+    return np.eye(4, dtype=np.float32)
+
+
+def _translation_4x4(tx: float, ty: float, tz: float) -> np.ndarray:
+    m = np.eye(4, dtype=np.float32)
+    m[:3, 3] = [tx, ty, tz]
+    return m
+
+
+def _rotation_z_90() -> np.ndarray:
+    """90-degree rotation about Z axis."""
+    m = np.eye(4, dtype=np.float32)
+    m[0, 0] = 0.0;  m[0, 1] = -1.0
+    m[1, 0] = 1.0;  m[1, 1] = 0.0
+    return m
+
+
+def _rotation_z_90_with_translation() -> np.ndarray:
+    """90-degree rotation about Z + translation (1, 2, 3)."""
+    m = _rotation_z_90()
+    m[:3, 3] = [1.0, 2.0, 3.0]
+    return m
+
+
+def _identity_quat_xyzw() -> np.ndarray:
+    return np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+
+
+def _make_transform_input(matrix: np.ndarray) -> TensorGroup:
+    """Build a TensorGroup for TransformMatrix from a numpy 4x4 array."""
+    tg = TensorGroup(TransformMatrix())
+    tg[0] = matrix
+    return tg
+
+
+def _run_retargeter(retargeter, inputs):
+    """Execute a retargeter using its callable interface."""
+    return retargeter(inputs)
+
+
+# ============================================================================
+# Tests: validate_transform_matrix
+# ============================================================================
+
+class TestValidateTransformMatrix:
+    def test_valid_identity(self):
+        result = validate_transform_matrix(np.eye(4))
+        assert result.shape == (4, 4)
+        npt.assert_array_almost_equal(result, np.eye(4))
+
+    def test_valid_transform(self):
+        m = _rotation_z_90_with_translation()
+        result = validate_transform_matrix(m)
+        assert result.dtype == np.float64
+        assert result.shape == (4, 4)
+
+    def test_wrong_shape(self):
+        with pytest.raises(ValueError, match="must be \\(4, 4\\)"):
+            validate_transform_matrix(np.eye(3))
+
+    def test_bad_bottom_row(self):
+        m = np.eye(4)
+        m[3, 3] = 2.0
+        with pytest.raises(ValueError, match="Bottom row"):
+            validate_transform_matrix(m)
+
+
+# ============================================================================
+# Tests: decompose_transform
+# ============================================================================
+
+class TestDecomposeTransform:
+    def test_identity(self):
+        R, t = decompose_transform(np.eye(4))
+        npt.assert_array_almost_equal(R, np.eye(3))
+        npt.assert_array_almost_equal(t, [0, 0, 0])
+
+    def test_translation_only(self):
+        R, t = decompose_transform(_translation_4x4(5, 6, 7))
+        npt.assert_array_almost_equal(R, np.eye(3))
+        npt.assert_array_almost_equal(t, [5, 6, 7])
+
+    def test_rotation_and_translation(self):
+        m = _rotation_z_90_with_translation()
+        R, t = decompose_transform(m)
+        npt.assert_array_almost_equal(t, [1, 2, 3])
+        # R should be a 90-degree Z rotation
+        npt.assert_array_almost_equal(R @ np.array([1, 0, 0]), [0, 1, 0], decimal=5)
+
+
+# ============================================================================
+# Tests: transform_position
+# ============================================================================
+
+class TestTransformPosition:
+    def test_identity(self):
+        pos = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        expected = pos.copy()
+        transform_position(pos, np.eye(3), np.zeros(3))
+        npt.assert_array_almost_equal(pos, expected)
+
+    def test_translation(self):
+        pos = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        transform_position(pos, np.eye(3), np.array([10, 20, 30]))
+        npt.assert_array_almost_equal(pos, [11, 20, 30])
+
+    def test_rotation_z_90(self):
+        R, t = decompose_transform(_rotation_z_90())
+        pos = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        transform_position(pos, R, t)
+        npt.assert_array_almost_equal(pos, [0, 1, 0], decimal=5)
+
+    def test_preserves_dtype(self):
+        pos = np.array([1, 2, 3], dtype=np.float32)
+        transform_position(pos, np.eye(3), np.zeros(3))
+        assert pos.dtype == np.float32
+
+
+# ============================================================================
+# Tests: transform_positions_batch
+# ============================================================================
+
+class TestTransformPositionsBatch:
+    def test_batch_identity(self):
+        pos = np.array([[1, 2, 3], [4, 5, 6]], dtype=np.float32)
+        expected = pos.copy()
+        transform_positions_batch(pos, np.eye(3), np.zeros(3))
+        npt.assert_array_almost_equal(pos, expected)
+
+    def test_batch_translation(self):
+        pos = np.zeros((3, 3), dtype=np.float32)
+        transform_positions_batch(pos, np.eye(3), np.array([1, 2, 3]))
+        expected = np.tile([1, 2, 3], (3, 1))
+        npt.assert_array_almost_equal(pos, expected)
+
+    def test_batch_rotation(self):
+        R, t = decompose_transform(_rotation_z_90())
+        pos = np.array([[1, 0, 0], [0, 1, 0]], dtype=np.float32)
+        transform_positions_batch(pos, R, t)
+        npt.assert_array_almost_equal(pos[0], [0, 1, 0], decimal=5)
+        npt.assert_array_almost_equal(pos[1], [-1, 0, 0], decimal=5)
+
+    def test_preserves_dtype(self):
+        pos = np.zeros((2, 3), dtype=np.float32)
+        transform_positions_batch(pos, np.eye(3), np.zeros(3))
+        assert pos.dtype == np.float32
+
+
+# ============================================================================
+# Tests: quaternion helpers
+# ============================================================================
+
+class TestQuaternionHelpers:
+    def test_identity_matrix_to_quat(self):
+        q = _rotation_matrix_to_quat_xyzw(np.eye(3))
+        npt.assert_array_almost_equal(q, [0, 0, 0, 1], decimal=5)
+
+    def test_z_90_matrix_to_quat(self):
+        R, _ = decompose_transform(_rotation_z_90())
+        q = _rotation_matrix_to_quat_xyzw(R)
+        # 90 deg about Z: quat = [0, 0, sin(45), cos(45)]
+        expected = np.array([0, 0, np.sin(np.pi / 4), np.cos(np.pi / 4)])
+        npt.assert_array_almost_equal(q, expected, decimal=5)
+
+    def test_quat_multiply_identity(self):
+        q = np.array([0.1, 0.2, 0.3, 0.9])
+        q = q / np.linalg.norm(q)
+        result = _quat_multiply_xyzw(np.array([0, 0, 0, 1.0]), q)
+        npt.assert_array_almost_equal(result, q, decimal=5)
+
+    def test_quat_multiply_inverse(self):
+        # q * q_conjugate = identity
+        q = np.array([0.1, 0.2, 0.3, 0.9])
+        q = q / np.linalg.norm(q)
+        q_conj = np.array([-q[0], -q[1], -q[2], q[3]])
+        result = _quat_multiply_xyzw(q, q_conj)
+        npt.assert_array_almost_equal(result, [0, 0, 0, 1], decimal=5)
+
+
+# ============================================================================
+# Tests: transform_orientation / transform_orientations_batch
+# ============================================================================
+
+class TestTransformOrientation:
+    def test_identity_rotation(self):
+        q = np.array([0.1, 0.2, 0.3, 0.9], dtype=np.float32)
+        q = q / np.linalg.norm(q)
+        expected = q.copy()
+        transform_orientation(q, np.eye(3))
+        npt.assert_array_almost_equal(q, expected, decimal=5)
+
+    def test_z_90_rotation(self):
+        R, _ = decompose_transform(_rotation_z_90())
+        q = _identity_quat_xyzw()
+        transform_orientation(q, R)
+        # Should match the Z-90 quaternion
+        expected = _rotation_matrix_to_quat_xyzw(R).astype(np.float32)
+        npt.assert_array_almost_equal(q, expected, decimal=5)
+
+    def test_preserves_dtype(self):
+        q = _identity_quat_xyzw()
+        transform_orientation(q, np.eye(3))
+        assert q.dtype == np.float32
+
+
+class TestTransformOrientationsBatch:
+    def test_batch_identity(self):
+        quats = np.tile(_identity_quat_xyzw(), (4, 1))
+        transform_orientations_batch(quats, np.eye(3))
+        for i in range(4):
+            npt.assert_array_almost_equal(quats[i], [0, 0, 0, 1], decimal=5)
+
+    def test_batch_z_90(self):
+        R, _ = decompose_transform(_rotation_z_90())
+        quats = np.tile(_identity_quat_xyzw(), (3, 1))
+        transform_orientations_batch(quats, R)
+        expected = _rotation_matrix_to_quat_xyzw(R).astype(np.float32)
+        for i in range(3):
+            npt.assert_array_almost_equal(quats[i], expected, decimal=5)
+
+    def test_preserves_shape_and_dtype(self):
+        quats = np.zeros((5, 4), dtype=np.float32)
+        quats[:, 3] = 1.0
+        transform_orientations_batch(quats, np.eye(3))
+        assert quats.shape == (5, 4)
+        assert quats.dtype == np.float32
+
+
+# ============================================================================
+# Tests: HeadTransform node
+# ============================================================================
+
+class TestHeadTransform:
+    def _make_head_input(self, position, orientation, is_valid=True, timestamp=100):
+        tg = TensorGroup(HeadPose())
+        tg[0] = np.array(position, dtype=np.float32)
+        tg[1] = np.array(orientation, dtype=np.float32)
+        tg[2] = is_valid
+        tg[3] = timestamp
+        return tg
+
+    def test_identity_transform(self):
+        node = HeadTransform("head_xform")
+        head_in = self._make_head_input([1, 2, 3], [0, 0, 0, 1])
+        xform_in = _make_transform_input(_identity_4x4())
+        result = _run_retargeter(node, {"head": head_in, "transform": xform_in})
+        out = result["head"]
+        npt.assert_array_almost_equal(np.from_dlpack(out[0]), [1, 2, 3], decimal=5)
+        npt.assert_array_almost_equal(np.from_dlpack(out[1]), [0, 0, 0, 1], decimal=5)
+        assert out[2] == True
+        assert out[3] == 100
+
+    def test_translation_transform(self):
+        node = HeadTransform("head_xform")
+        head_in = self._make_head_input([1, 0, 0], [0, 0, 0, 1])
+        xform_in = _make_transform_input(_translation_4x4(10, 20, 30))
+        result = _run_retargeter(node, {"head": head_in, "transform": xform_in})
+        out = result["head"]
+        npt.assert_array_almost_equal(np.from_dlpack(out[0]), [11, 20, 30], decimal=5)
+        # Orientation unchanged by pure translation
+        npt.assert_array_almost_equal(np.from_dlpack(out[1]), [0, 0, 0, 1], decimal=5)
+
+    def test_rotation_transform(self):
+        node = HeadTransform("head_xform")
+        head_in = self._make_head_input([1, 0, 0], [0, 0, 0, 1])
+        xform_in = _make_transform_input(_rotation_z_90())
+        result = _run_retargeter(node, {"head": head_in, "transform": xform_in})
+        out = result["head"]
+        npt.assert_array_almost_equal(np.from_dlpack(out[0]), [0, 1, 0], decimal=5)
+
+    def test_passthrough_fields_preserved(self):
+        node = HeadTransform("head_xform")
+        head_in = self._make_head_input([0, 0, 0], [0, 0, 0, 1], is_valid=False, timestamp=42)
+        xform_in = _make_transform_input(_rotation_z_90_with_translation())
+        result = _run_retargeter(node, {"head": head_in, "transform": xform_in})
+        out = result["head"]
+        assert out[2] == False
+        assert out[3] == 42
+
+
+# ============================================================================
+# Tests: ControllerTransform node
+# ============================================================================
+
+class TestControllerTransform:
+    def _make_controller_input(self, grip_pos, grip_ori, aim_pos, aim_ori,
+                                primary_click=0.0, is_active=True):
+        tg = TensorGroup(ControllerInput())
+        tg[ControllerInputIndex.GRIP_POSITION] = np.array(grip_pos, dtype=np.float32)
+        tg[ControllerInputIndex.GRIP_ORIENTATION] = np.array(grip_ori, dtype=np.float32)
+        tg[ControllerInputIndex.AIM_POSITION] = np.array(aim_pos, dtype=np.float32)
+        tg[ControllerInputIndex.AIM_ORIENTATION] = np.array(aim_ori, dtype=np.float32)
+        tg[ControllerInputIndex.PRIMARY_CLICK] = primary_click
+        tg[ControllerInputIndex.SECONDARY_CLICK] = 0.0
+        tg[ControllerInputIndex.THUMBSTICK_CLICK] = 0.0
+        tg[ControllerInputIndex.THUMBSTICK_X] = 0.0
+        tg[ControllerInputIndex.THUMBSTICK_Y] = 0.0
+        tg[ControllerInputIndex.SQUEEZE_VALUE] = 0.0
+        tg[ControllerInputIndex.TRIGGER_VALUE] = 0.0
+        tg[ControllerInputIndex.IS_ACTIVE] = is_active
+        return tg
+
+    def test_identity_transform(self):
+        node = ControllerTransform("ctrl_xform")
+        id_quat = [0, 0, 0, 1]
+        left = self._make_controller_input([1, 0, 0], id_quat, [2, 0, 0], id_quat)
+        right = self._make_controller_input([3, 0, 0], id_quat, [4, 0, 0], id_quat)
+        xform = _make_transform_input(_identity_4x4())
+
+        result = _run_retargeter(node, {
+            "controller_left": left,
+            "controller_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["controller_left"]
+        npt.assert_array_almost_equal(
+            np.from_dlpack(out_l[ControllerInputIndex.GRIP_POSITION]), [1, 0, 0], decimal=5)
+        out_r = result["controller_right"]
+        npt.assert_array_almost_equal(
+            np.from_dlpack(out_r[ControllerInputIndex.GRIP_POSITION]), [3, 0, 0], decimal=5)
+
+    def test_translation_transforms_both_poses(self):
+        node = ControllerTransform("ctrl_xform")
+        id_quat = [0, 0, 0, 1]
+        left = self._make_controller_input([1, 0, 0], id_quat, [2, 0, 0], id_quat)
+        right = self._make_controller_input([0, 0, 0], id_quat, [0, 0, 0], id_quat)
+        xform = _make_transform_input(_translation_4x4(10, 20, 30))
+
+        result = _run_retargeter(node, {
+            "controller_left": left,
+            "controller_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["controller_left"]
+        npt.assert_array_almost_equal(
+            np.from_dlpack(out_l[ControllerInputIndex.GRIP_POSITION]), [11, 20, 30], decimal=5)
+        npt.assert_array_almost_equal(
+            np.from_dlpack(out_l[ControllerInputIndex.AIM_POSITION]), [12, 20, 30], decimal=5)
+
+    def test_button_fields_preserved(self):
+        node = ControllerTransform("ctrl_xform")
+        id_quat = [0, 0, 0, 1]
+        left = self._make_controller_input(
+            [0, 0, 0], id_quat, [0, 0, 0], id_quat,
+            primary_click=1.0, is_active=False,
+        )
+        right = self._make_controller_input([0, 0, 0], id_quat, [0, 0, 0], id_quat)
+        xform = _make_transform_input(_rotation_z_90_with_translation())
+
+        result = _run_retargeter(node, {
+            "controller_left": left,
+            "controller_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["controller_left"]
+        assert float(out_l[ControllerInputIndex.PRIMARY_CLICK]) == 1.0
+        assert out_l[ControllerInputIndex.IS_ACTIVE] == False
+
+    def test_rotation_transforms_grip_and_aim(self):
+        node = ControllerTransform("ctrl_xform")
+        id_quat = [0, 0, 0, 1]
+        left = self._make_controller_input([1, 0, 0], id_quat, [0, 1, 0], id_quat)
+        right = self._make_controller_input([0, 0, 0], id_quat, [0, 0, 0], id_quat)
+        xform = _make_transform_input(_rotation_z_90())
+
+        result = _run_retargeter(node, {
+            "controller_left": left,
+            "controller_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["controller_left"]
+        npt.assert_array_almost_equal(
+            np.from_dlpack(out_l[ControllerInputIndex.GRIP_POSITION]), [0, 1, 0], decimal=5)
+        npt.assert_array_almost_equal(
+            np.from_dlpack(out_l[ControllerInputIndex.AIM_POSITION]), [-1, 0, 0], decimal=5)
+
+
+# ============================================================================
+# Tests: HandTransform node
+# ============================================================================
+
+class TestHandTransform:
+    def _make_hand_input(self, joint_offset=0.0, is_active=True, timestamp=200):
+        tg = TensorGroup(HandInput())
+        positions = np.zeros((NUM_HAND_JOINTS, 3), dtype=np.float32)
+        positions[:, 0] = np.arange(NUM_HAND_JOINTS, dtype=np.float32) + joint_offset
+        orientations = np.zeros((NUM_HAND_JOINTS, 4), dtype=np.float32)
+        orientations[:, 3] = 1.0  # identity quaternions
+        radii = np.ones(NUM_HAND_JOINTS, dtype=np.float32) * 0.01
+        valid = np.ones(NUM_HAND_JOINTS, dtype=np.uint8)
+
+        tg[HandInputIndex.JOINT_POSITIONS] = positions
+        tg[HandInputIndex.JOINT_ORIENTATIONS] = orientations
+        tg[HandInputIndex.JOINT_RADII] = radii
+        tg[HandInputIndex.JOINT_VALID] = valid
+        tg[HandInputIndex.IS_ACTIVE] = is_active
+        tg[HandInputIndex.TIMESTAMP] = timestamp
+        return tg
+
+    def test_identity_transform(self):
+        node = HandTransform("hand_xform")
+        left = self._make_hand_input(joint_offset=0.0)
+        right = self._make_hand_input(joint_offset=100.0)
+        xform = _make_transform_input(_identity_4x4())
+
+        result = _run_retargeter(node, {
+            "hand_left": left,
+            "hand_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["hand_left"]
+        out_pos = np.from_dlpack(out_l[HandInputIndex.JOINT_POSITIONS])
+        in_pos = np.from_dlpack(left[HandInputIndex.JOINT_POSITIONS])
+        npt.assert_array_almost_equal(out_pos, in_pos, decimal=5)
+
+    def test_translation_transforms_all_joints(self):
+        node = HandTransform("hand_xform")
+        left = self._make_hand_input()
+        right = self._make_hand_input()
+        xform = _make_transform_input(_translation_4x4(1, 2, 3))
+
+        result = _run_retargeter(node, {
+            "hand_left": left,
+            "hand_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["hand_left"]
+        out_pos = np.from_dlpack(out_l[HandInputIndex.JOINT_POSITIONS])
+        in_pos = np.from_dlpack(left[HandInputIndex.JOINT_POSITIONS])
+        # Every joint should have translation added
+        expected = in_pos + np.array([1, 2, 3], dtype=np.float32)
+        npt.assert_array_almost_equal(out_pos, expected, decimal=5)
+
+    def test_passthrough_fields_preserved(self):
+        node = HandTransform("hand_xform")
+        left = self._make_hand_input(is_active=False, timestamp=42)
+        right = self._make_hand_input(is_active=True, timestamp=99)
+        xform = _make_transform_input(_rotation_z_90_with_translation())
+
+        result = _run_retargeter(node, {
+            "hand_left": left,
+            "hand_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["hand_left"]
+        out_r = result["hand_right"]
+        assert out_l[HandInputIndex.IS_ACTIVE] == False
+        assert out_l[HandInputIndex.TIMESTAMP] == 42
+        assert out_r[HandInputIndex.IS_ACTIVE] == True
+        assert out_r[HandInputIndex.TIMESTAMP] == 99
+
+        # Radii and validity should be unchanged
+        npt.assert_array_almost_equal(
+            np.from_dlpack(out_l[HandInputIndex.JOINT_RADII]),
+            np.ones(NUM_HAND_JOINTS, dtype=np.float32) * 0.01,
+            decimal=5,
+        )
+
+    def test_rotation_transforms_positions_and_orientations(self):
+        node = HandTransform("hand_xform")
+        left = self._make_hand_input()
+        right = self._make_hand_input()
+        xform = _make_transform_input(_rotation_z_90())
+
+        result = _run_retargeter(node, {
+            "hand_left": left,
+            "hand_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["hand_left"]
+        out_pos = np.from_dlpack(out_l[HandInputIndex.JOINT_POSITIONS])
+        in_pos = np.from_dlpack(left[HandInputIndex.JOINT_POSITIONS])
+
+        # Z-90 rotation: (x, y, z) -> (-y, x, z)
+        npt.assert_array_almost_equal(out_pos[:, 0], -in_pos[:, 1], decimal=5)
+        npt.assert_array_almost_equal(out_pos[:, 1], in_pos[:, 0], decimal=5)
+        npt.assert_array_almost_equal(out_pos[:, 2], in_pos[:, 2], decimal=5)
+
+        # Orientations should all be the Z-90 quaternion (since inputs were identity)
+        out_ori = np.from_dlpack(out_l[HandInputIndex.JOINT_ORIENTATIONS])
+        R, _ = decompose_transform(_rotation_z_90())
+        expected_q = _rotation_matrix_to_quat_xyzw(R).astype(np.float32)
+        for i in range(NUM_HAND_JOINTS):
+            npt.assert_array_almost_equal(out_ori[i], expected_q, decimal=5)
+
+
+# ============================================================================
+# Tests: Output-to-input aliasing (regression)
+# ============================================================================
+
+class TestHeadTransformNoAliasing:
+    """Verify HeadTransform outputs do not alias inputs."""
+
+    def test_mutating_output_position_does_not_affect_input(self):
+        node = HeadTransform("head_xform")
+        head_in = TensorGroup(HeadPose())
+        head_in[0] = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        head_in[1] = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+        head_in[2] = True
+        head_in[3] = 100
+        xform_in = _make_transform_input(_identity_4x4())
+
+        # Save a copy of the original input values
+        orig_pos = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        orig_ori = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+
+        result = _run_retargeter(node, {"head": head_in, "transform": xform_in})
+        out = result["head"]
+
+        # Mutate the output position in-place
+        out_pos = np.from_dlpack(out[0])
+        out_pos[:] = [99.0, 99.0, 99.0]
+
+        # Mutate the output orientation in-place
+        out_ori = np.from_dlpack(out[1])
+        out_ori[:] = [1.0, 1.0, 1.0, 0.0]
+
+        # Original input must be unchanged
+        npt.assert_array_equal(np.from_dlpack(head_in[0]), orig_pos)
+        npt.assert_array_equal(np.from_dlpack(head_in[1]), orig_ori)
+
+
+class TestControllerTransformNoAliasing:
+    """Verify ControllerTransform outputs do not alias inputs."""
+
+    def _make_controller(self, grip_pos):
+        tg = TensorGroup(ControllerInput())
+        id_quat = np.array([0, 0, 0, 1], dtype=np.float32)
+        tg[ControllerInputIndex.GRIP_POSITION] = np.array(grip_pos, dtype=np.float32)
+        tg[ControllerInputIndex.GRIP_ORIENTATION] = id_quat.copy()
+        tg[ControllerInputIndex.AIM_POSITION] = np.zeros(3, dtype=np.float32)
+        tg[ControllerInputIndex.AIM_ORIENTATION] = id_quat.copy()
+        tg[ControllerInputIndex.PRIMARY_CLICK] = 0.5
+        tg[ControllerInputIndex.SECONDARY_CLICK] = 0.0
+        tg[ControllerInputIndex.THUMBSTICK_CLICK] = 0.0
+        tg[ControllerInputIndex.THUMBSTICK_X] = 0.0
+        tg[ControllerInputIndex.THUMBSTICK_Y] = 0.0
+        tg[ControllerInputIndex.SQUEEZE_VALUE] = 0.0
+        tg[ControllerInputIndex.TRIGGER_VALUE] = 0.0
+        tg[ControllerInputIndex.IS_ACTIVE] = True
+        return tg
+
+    def test_mutating_output_does_not_affect_input(self):
+        node = ControllerTransform("ctrl_xform")
+        left = self._make_controller([1, 2, 3])
+        right = self._make_controller([4, 5, 6])
+        xform = _make_transform_input(_identity_4x4())
+
+        orig_grip = np.array([1, 2, 3], dtype=np.float32)
+
+        result = _run_retargeter(node, {
+            "controller_left": left,
+            "controller_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["controller_left"]
+
+        # Mutate output grip position in-place
+        out_grip = np.from_dlpack(out_l[ControllerInputIndex.GRIP_POSITION])
+        out_grip[:] = [99, 99, 99]
+
+        # Original input must be unchanged
+        npt.assert_array_equal(
+            np.from_dlpack(left[ControllerInputIndex.GRIP_POSITION]), orig_grip)
+
+
+class TestHandTransformNoAliasing:
+    """Verify HandTransform outputs do not alias inputs."""
+
+    def test_mutating_output_does_not_affect_input(self):
+        node = HandTransform("hand_xform")
+
+        left = TensorGroup(HandInput())
+        positions = np.ones((NUM_HAND_JOINTS, 3), dtype=np.float32)
+        orientations = np.zeros((NUM_HAND_JOINTS, 4), dtype=np.float32)
+        orientations[:, 3] = 1.0
+        radii = np.ones(NUM_HAND_JOINTS, dtype=np.float32) * 0.01
+        valid = np.ones(NUM_HAND_JOINTS, dtype=np.uint8)
+        left[HandInputIndex.JOINT_POSITIONS] = positions
+        left[HandInputIndex.JOINT_ORIENTATIONS] = orientations
+        left[HandInputIndex.JOINT_RADII] = radii
+        left[HandInputIndex.JOINT_VALID] = valid
+        left[HandInputIndex.IS_ACTIVE] = True
+        left[HandInputIndex.TIMESTAMP] = 200
+
+        right = TensorGroup(HandInput())
+        right[HandInputIndex.JOINT_POSITIONS] = positions.copy()
+        right[HandInputIndex.JOINT_ORIENTATIONS] = orientations.copy()
+        right[HandInputIndex.JOINT_RADII] = radii.copy()
+        right[HandInputIndex.JOINT_VALID] = valid.copy()
+        right[HandInputIndex.IS_ACTIVE] = True
+        right[HandInputIndex.TIMESTAMP] = 200
+
+        xform = _make_transform_input(_identity_4x4())
+
+        orig_radii = radii.copy()
+        orig_positions = positions.copy()
+
+        result = _run_retargeter(node, {
+            "hand_left": left,
+            "hand_right": right,
+            "transform": xform,
+        })
+
+        out_l = result["hand_left"]
+
+        # Mutate output radii (a passthrough field) in-place
+        out_radii = np.from_dlpack(out_l[HandInputIndex.JOINT_RADII])
+        out_radii[:] = 999.0
+
+        # Mutate output positions (a transformed field) in-place
+        out_pos = np.from_dlpack(out_l[HandInputIndex.JOINT_POSITIONS])
+        out_pos[:] = 999.0
+
+        # Original input must be unchanged
+        npt.assert_array_equal(np.from_dlpack(left[HandInputIndex.JOINT_RADII]), orig_radii)
+        npt.assert_array_equal(np.from_dlpack(left[HandInputIndex.JOINT_POSITIONS]), orig_positions)


### PR DESCRIPTION
Add a utilities module with reusable transform nodes and math:
- TransformMatrix tensor type for 4x4 homogeneous transforms
- ControllerTransform, HandTransform, HeadTransform retargeter nodes
- Shared transform_utils with position/orientation math (pure numpy)

Each DeviceIO source node gains a .transformed() convenience method that wires up the appropriate transform node, allowing callers to apply a coordinate-frame transform to tracked data inline.