### PR TITLE
Enable external inputs in TeleopSession

### DIFF
--- a/examples/retargeting/python/dual_source_teleop_example.py
+++ b/examples/retargeting/python/dual_source_teleop_example.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Dual ControllersSource Teleop Example
+
+Demonstrates using two ControllersSource nodes in a single TeleopSession pipeline.
+This is a realistic scenario for bimanual control: one ControllersSource feeds the
+left arm SE3 retargeter, another feeds the right arm SE3 retargeter.
+
+KNOWN BUG: This example currently triggers a bug in TeleopSession where only the
+first source's ControllerTracker is registered with DeviceIO (tracker deduplication
+in __enter__), but the second source still tries to poll its own unregistered
+tracker in _collect_tracker_data(). The second source will either crash or return
+stale/uninitialized data.
+
+Bug location:
+  - teleop_session.py __enter__(): tracker_by_type.setdefault(type(tracker), tracker)
+    keeps only the first tracker of each type
+  - teleop_session.py _collect_tracker_data(): iterates ALL sources, each polls
+    its OWN tracker -- the second source's tracker was never given to DeviceIO
+
+Pipeline structure:
+  ControllersSource("ctrl_left")  ──> Se3AbsRetargeter ──> "left_ee_pose"
+  ControllersSource("ctrl_right") ──> Se3AbsRetargeter ──> "right_ee_pose"
+                                                      └──> OutputCombiner
+"""
+
+import sys
+import time
+import numpy as np
+
+from isaacteleop.retargeting_engine.deviceio_source_nodes import (
+    ControllersSource,
+)
+from isaacteleop.retargeting_engine.retargeters import (
+    Se3AbsRetargeter,
+    Se3RetargeterConfig,
+)
+from isaacteleop.retargeting_engine.interface import OutputCombiner
+from isaacteleop.teleop_session_manager import (
+    TeleopSession,
+    TeleopSessionConfig,
+)
+
+
+def main() -> int:
+    print("=" * 80)
+    print("  Dual ControllersSource Teleop Example")
+    print("=" * 80)
+    print("Uses two ControllersSource nodes in a single pipeline.")
+    print("Each source feeds one SE3 retargeter for bimanual arm control.")
+    print("=" * 80 + "\n")
+
+    # ==================================================================
+    # Step 1: Create two separate ControllersSource nodes
+    # ==================================================================
+    # Each ControllersSource creates its own ControllerTracker internally.
+    # BUG: TeleopSession deduplicates trackers by type, so only the first
+    #       source's tracker will be registered with DeviceIO. The second
+    #       source's tracker is orphaned.
+
+    print("[Step 1] Creating two ControllersSource nodes...")
+    ctrl_left_source = ControllersSource(name="ctrl_left")
+    ctrl_right_source = ControllersSource(name="ctrl_right")
+    print(f"  ✓ ControllersSource('ctrl_left')  - tracker id: {id(ctrl_left_source.get_tracker())}")
+    print(f"  ✓ ControllersSource('ctrl_right') - tracker id: {id(ctrl_right_source.get_tracker())}")
+    print(f"  ⚠ Both trackers are type: {type(ctrl_left_source.get_tracker()).__name__}")
+    print(f"    Only one will survive deduplication in TeleopSession.__enter__()")
+
+    # ==================================================================
+    # Step 2: Build retargeting pipeline
+    # ==================================================================
+    # Left arm: controller_left from first source
+    # Right arm: controller_right from second source
+
+    print("\n[Step 2] Building retargeting pipeline...")
+
+    # Left arm SE3 retargeter (using left controller from first source)
+    left_se3_config = Se3RetargeterConfig(
+        input_device=ControllersSource.LEFT,
+        use_wrist_position=True,
+        use_wrist_rotation=True,
+        zero_out_xy_rotation=False,
+    )
+    left_se3 = Se3AbsRetargeter(left_se3_config, name="left_se3")
+    connected_left = left_se3.connect({
+        ControllersSource.LEFT: ctrl_left_source.output(ControllersSource.LEFT),
+    })
+    print("  ✓ Left SE3: ctrl_left_source.controller_left -> left_ee_pose")
+
+    # Right arm SE3 retargeter (using right controller from second source)
+    right_se3_config = Se3RetargeterConfig(
+        input_device=ControllersSource.RIGHT,
+        use_wrist_position=True,
+        use_wrist_rotation=True,
+        zero_out_xy_rotation=False,
+    )
+    right_se3 = Se3AbsRetargeter(right_se3_config, name="right_se3")
+    connected_right = right_se3.connect({
+        ControllersSource.RIGHT: ctrl_right_source.output(ControllersSource.RIGHT),
+    })
+    print("  ✓ Right SE3: ctrl_right_source.controller_right -> right_ee_pose")
+
+    # ==================================================================
+    # Step 3: Combine outputs
+    # ==================================================================
+    print("\n[Step 3] Combining outputs...")
+
+    pipeline = OutputCombiner({
+        "left_ee_pose": connected_left.output("ee_pose"),
+        "right_ee_pose": connected_right.output("ee_pose"),
+    })
+    print("  ✓ Pipeline: 2 ControllersSource -> 2 Se3AbsRetargeter -> OutputCombiner")
+
+    # ==================================================================
+    # Step 4: Create and run TeleopSession
+    # ==================================================================
+    print("\n[Step 4] Creating TeleopSession...")
+
+    session_config = TeleopSessionConfig(
+        app_name="DualControllerSourceExample",
+        trackers=[],  # Auto-discovered from pipeline sources
+        pipeline=pipeline,
+    )
+
+    with TeleopSession(session_config) as session:
+        print("  ✓ Session initialized")
+
+        # Diagnostic: show which tracker survived deduplication
+        print("\n  [Diagnostic] Discovered sources:")
+        for source in session._sources:
+            tracker = source.get_tracker()
+            print(f"    - {source.name}: tracker id={id(tracker)}, type={type(tracker).__name__}")
+
+        print("\n" + "=" * 80)
+        print("  Running Bimanual Controller Teleop (20 seconds)")
+        print("  Move left/right controllers to position arms")
+        print("=" * 80 + "\n")
+
+        start_time = time.time()
+        duration = 20.0
+
+        while time.time() - start_time < duration:
+            # BUG: This will fail or produce incorrect results for the second source.
+            # The second ControllersSource polls its own tracker, which was never
+            # registered with DeviceIO (discarded during deduplication).
+            result = session.step()
+
+            left_pose = result["left_ee_pose"][0]
+            right_pose = result["right_ee_pose"][0]
+
+            if session.frame_count % 30 == 0:
+                elapsed = session.get_elapsed_time()
+                left_pos = left_pose[:3]
+                right_pos = right_pose[:3]
+
+                print(f"[{elapsed:5.1f}s] Frame {session.frame_count}")
+                print(f"  Left  arm: ({left_pos[0]:+6.3f}, {left_pos[1]:+6.3f}, {left_pos[2]:+6.3f})")
+                print(f"  Right arm: ({right_pos[0]:+6.3f}, {right_pos[1]:+6.3f}, {right_pos[2]:+6.3f})")
+
+            time.sleep(0.016)
+
+        fps = session.frame_count / duration
+        print(f"\n  Done. Processed {session.frame_count} frames ({fps:.1f} FPS)")
+
+    print("\n✅ Example completed successfully!")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/teleop_session_manager/python/external_inputs_example.py
+++ b/examples/teleop_session_manager/python/external_inputs_example.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+External Inputs Example with TeleopSessionManager
+
+Demonstrates using TeleopSession with a pipeline that has both DeviceIO sources
+(auto-polled from hardware trackers) and external leaf nodes whose inputs are
+provided by the caller at each step().
+
+This example shows:
+1. Creating a pipeline with mixed DeviceIO and non-DeviceIO leaf nodes
+2. Using ValueInput for simple external values (robot EE state, transform matrix)
+3. Using get_external_input_specs() to discover required external inputs
+4. Passing external inputs to step()
+
+External input options -- any non-DeviceIO leaf node becomes an external input:
+
+    1. ValueInput (shortcut): Use for any external value you want to feed into
+       the graph without any computation. One typed input, one output, data
+       passed straight through. Good for sim state, transform matrices,
+       configuration parameters, etc.
+
+    2. Any existing BaseRetargeter: Any retargeter that is a leaf node (i.e. not
+       connected to a DeviceIO source) automatically becomes an external input.
+       You provide its inputs via step(external_inputs=...). This is useful when
+       you already have a node class and want the caller to drive it directly --
+       no need to wrap it in ValueInput.
+
+    3. Custom BaseRetargeter subclass: Write a new subclass when you need
+       computation on the external inputs before they enter the graph (e.g.,
+       fusing multiple sensor readings, applying filtering).
+
+Scenario:
+    A "delta position" retargeter takes two inputs:
+    - Controller grip position (from DeviceIO via ControllersSource, transformed)
+    - Current robot end-effector position (from the caller / simulator)
+
+    A coordinate-frame transform is applied to the controller data before
+    computing the delta, allowing the caller to align the VR tracking frame
+    with the robot's world frame.
+
+    Both the robot EE state and the transform matrix are simple external values,
+    so they both use ValueInput rather than custom subclasses.
+"""
+
+import sys
+import time
+import numpy as np
+from pathlib import Path
+
+from isaacteleop.retargeting_engine.deviceio_source_nodes import ControllersSource
+from isaacteleop.retargeting_engine.interface import (
+    BaseRetargeter,
+    OutputCombiner,
+    ValueInput,
+    TensorGroup,
+    TensorGroupType,
+)
+from isaacteleop.retargeting_engine.tensor_types import (
+    ControllerInput,
+    TransformMatrix,
+    NDArrayType,
+    DLDataType,
+)
+from isaacteleop.teleop_session_manager import (
+    TeleopSession,
+    TeleopSessionConfig,
+    PluginConfig,
+)
+
+
+PLUGIN_ROOT_DIR = Path(__file__).resolve().parent.parent.parent.parent / "plugins"
+
+
+# ==============================================================================
+# Custom Tensor Types
+# ==============================================================================
+
+
+def RobotEndEffectorState() -> TensorGroupType:
+    """End-effector state provided by the simulator each frame.
+
+    Contains:
+        position: (3,) float32 array [x, y, z]
+    """
+    return TensorGroupType("robot_ee_state", [
+        NDArrayType("position", shape=(3,), dtype=DLDataType.FLOAT, dtype_bits=32),
+    ])
+
+
+def DeltaCommand() -> TensorGroupType:
+    """Velocity / delta-position command for the robot.
+
+    Contains:
+        delta_position: (3,) float32 array [dx, dy, dz]
+    """
+    return TensorGroupType("delta_command", [
+        NDArrayType("delta_position", shape=(3,), dtype=DLDataType.FLOAT, dtype_bits=32),
+    ])
+
+
+# ==============================================================================
+# Delta Position Retargeter (custom node -- has real computation)
+# ==============================================================================
+
+
+class DeltaPositionRetargeter(BaseRetargeter):
+    """Computes delta between controller grip position and robot end-effector.
+
+    This is an example of a custom BaseRetargeter that performs actual
+    computation (subtraction) on its inputs. Unlike ValueInput, this node
+    transforms data rather than passing it through.
+
+    Inputs:
+        - "controller": ControllerInput (from ControllersSource)
+        - "ee_state":   RobotEndEffectorState (from ValueInput)
+
+    Outputs:
+        - "delta": DeltaCommand -- (controller_pos - ee_pos)
+    """
+
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+
+    def input_spec(self):
+        return {
+            "controller": ControllerInput(),
+            "ee_state": RobotEndEffectorState(),
+        }
+
+    def output_spec(self):
+        return {
+            "delta": DeltaCommand(),
+        }
+
+    def compute(self, inputs, outputs):
+        # ControllerInput tensor 0 is grip_position (3,)
+        grip_pos = np.asarray(inputs["controller"][0], dtype=np.float32)
+        ee_pos = np.asarray(inputs["ee_state"][0], dtype=np.float32)
+        outputs["delta"][0] = grip_pos - ee_pos
+
+
+# ==============================================================================
+# Main
+# ==============================================================================
+
+
+def main() -> int:
+    # ==================================================================
+    # 1. Build Pipeline
+    # ==================================================================
+    #
+    # Leaf nodes (auto-polled by DeviceIO):
+    #   - controllers    (ControllersSource)  -> hardware tracker
+    #
+    # Leaf nodes (external -- caller provides values via step()):
+    #   - ee_state        (ValueInput)  -> robot end-effector position from sim
+    #   - transform_input (ValueInput)  -> 4x4 coordinate-frame transform
+    #
+    # ValueInput is used for both external leaves because they just pass a
+    # value into the graph without any computation. No custom subclass needed.
+    #
+    # Graph:
+    #   controllers ──> .transformed() ──> delta_left  ──┐
+    #   transform_input ──────────────────> delta_left  ──┤
+    #   ee_state ─────────────────────────> delta_left  ──┤
+    #                                                     ├──> OutputCombiner
+    #   controllers ──> .transformed() ──> delta_right ──┤
+    #   transform_input ──────────────────> delta_right ──┤
+    #   ee_state ─────────────────────────> delta_right ──┘
+    #
+
+    controllers = ControllersSource(name="controllers")
+
+    # ValueInput for the robot's current end-effector position.
+    # The simulator provides this value each frame via step(external_inputs=...).
+    ee_state = ValueInput("ee_state", RobotEndEffectorState())
+
+    # ValueInput for the coordinate-frame transform matrix.
+    # The caller provides this 4x4 matrix to align VR frame with robot frame.
+    transform_input = ValueInput("transform_input", TransformMatrix())
+
+    # Apply the transform to controller data before retargeting.
+    # .transformed() wires up the internal transform node and returns a subgraph
+    # with the same outputs ("controller_left", "controller_right") but in the
+    # new coordinate frame.
+    transformed_controllers = controllers.transformed(
+        transform_input.output(ValueInput.VALUE)
+    )
+
+    delta_left = DeltaPositionRetargeter(name="delta_left")
+    pipeline_left = delta_left.connect({
+        "controller": transformed_controllers.output(ControllersSource.LEFT),
+        "ee_state": ee_state.output(ValueInput.VALUE),
+    })
+
+    delta_right = DeltaPositionRetargeter(name="delta_right")
+    pipeline_right = delta_right.connect({
+        "controller": transformed_controllers.output(ControllersSource.RIGHT),
+        "ee_state": ee_state.output(ValueInput.VALUE),
+    })
+
+    pipeline = OutputCombiner({
+        "delta_left": pipeline_left.output("delta"),
+        "delta_right": pipeline_right.output("delta"),
+    })
+
+    # ------------------------------------------------------------------
+    # Alternative: using an existing retargeter directly as an external leaf
+    # ------------------------------------------------------------------
+    # Any BaseRetargeter that ends up as a leaf (not connected to a DeviceIO
+    # source) automatically becomes an external input. You don't need to wrap
+    # it in ValueInput. For example, DeltaPositionRetargeter could itself be
+    # used as a standalone external leaf -- the caller would then provide
+    # *all* of its inputs (both "controller" and "ee_state") via step():
+    #
+    #     delta = DeltaPositionRetargeter(name="delta_manual")
+    #     pipeline = delta  # delta is the only (leaf) node -- no DeviceIO
+    #
+    #     with TeleopSession(config) as session:
+    #         specs = session.get_external_input_specs()
+    #         # specs == {"delta_manual": {"controller": ..., "ee_state": ...}}
+    #
+    #         ctrl_tg = TensorGroup(ControllerInput())
+    #         ctrl_tg[0] = my_controller_data
+    #         ee_tg = TensorGroup(RobotEndEffectorState())
+    #         ee_tg[0] = my_ee_position
+    #
+    #         result = session.step(external_inputs={
+    #             "delta_manual": {"controller": ctrl_tg, "ee_state": ee_tg}
+    #         })
+    #
+    # This works with any retargeter -- ValueInput is just a convenience
+    # shortcut for the common single-value passthrough case.
+    # ------------------------------------------------------------------
+
+    # ==================================================================
+    # 2. Create TeleopSession
+    # ==================================================================
+
+    config = TeleopSessionConfig(
+        app_name="ExternalInputsExample",
+        pipeline=pipeline,
+        plugins=[
+            PluginConfig(
+                plugin_name="controller_synthetic_hands",
+                plugin_root_id="synthetic_hands",
+                search_paths=[PLUGIN_ROOT_DIR],
+            )
+        ],
+    )
+
+    with TeleopSession(config) as session:
+        # ==============================================================
+        # 3. Discover what external inputs the pipeline expects
+        # ==============================================================
+        ext_specs = session.get_external_input_specs()
+        print("\n" + "=" * 70)
+        print("External Inputs Example (with transform)")
+        print("=" * 70)
+        print(f"\nPipeline has external inputs: {session.has_external_inputs()}")
+        print(f"External leaf nodes and their input specs:")
+        for leaf_name, input_spec in ext_specs.items():
+            print(f"  - {leaf_name}:")
+            for input_name, tensor_group_type in input_spec.items():
+                print(f"      {input_name}: {tensor_group_type}")
+        print("\nPress Ctrl+C to exit\n")
+
+        # ==============================================================
+        # 4. Simulated robot state and coordinate transform
+        # ==============================================================
+        sim_ee_position = np.array([0.3, 0.0, 0.5], dtype=np.float32)
+
+        # Example: 90-degree rotation about Y to align VR frame with robot frame,
+        # plus a 1m translation along Z.
+        vr_to_robot = np.array([
+            [ 0.0, 0.0, 1.0, 0.0],
+            [ 0.0, 1.0, 0.0, 0.0],
+            [-1.0, 0.0, 0.0, 1.0],
+            [ 0.0, 0.0, 0.0, 1.0],
+        ], dtype=np.float32)
+
+        # ==============================================================
+        # 5. Main loop -- pass external inputs to step()
+        # ==============================================================
+        while True:
+            # Build TensorGroup for the ee_state leaf's "value" input
+            ee_input = TensorGroup(RobotEndEffectorState())
+            ee_input[0] = sim_ee_position
+
+            # Build TensorGroup for the transform_input leaf's "value" input
+            xform_input = TensorGroup(TransformMatrix())
+            xform_input[0] = vr_to_robot
+
+            # Call step() with external inputs for the non-DeviceIO leaves.
+            # Keys match the ValueInput node names; inner keys are always "value"
+            # for ValueInput nodes.
+            result = session.step(external_inputs={
+                "ee_state": {ValueInput.VALUE: ee_input},
+                "transform_input": {ValueInput.VALUE: xform_input},
+            })
+
+            # Read outputs
+            delta_l = result["delta_left"][0]
+            delta_r = result["delta_right"][0]
+
+            if session.frame_count % 30 == 0:
+                elapsed = session.get_elapsed_time()
+                print(
+                    f"[{elapsed:5.1f}s] "
+                    f"delta_L=[{delta_l[0]:+.3f}, {delta_l[1]:+.3f}, {delta_l[2]:+.3f}]  "
+                    f"delta_R=[{delta_r[0]:+.3f}, {delta_r[1]:+.3f}, {delta_r[2]:+.3f}]"
+                )
+
+            # Slowly drift the simulated EE position (pretend robot is moving)
+            sim_ee_position += np.array([0.0001, 0.0, 0.0], dtype=np.float32)
+
+            time.sleep(0.016)  # ~60 FPS
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/core/python/MANIFEST.in
+++ b/src/core/python/MANIFEST.in
@@ -18,6 +18,8 @@ include isaacteleop/retargeting_engine/*.py
 include isaacteleop/retargeting_engine/interface/*.py
 include isaacteleop/retargeting_engine/tensor_types/*.py
 include isaacteleop/retargeting_engine/deviceio_source_nodes/*.py
+include isaacteleop/retargeting_engine/retargeters/*.py
+include isaacteleop/retargeting_engine/retargeters/G1/*.py
 include isaacteleop/retargeting_engine/utilities/*.py
 include isaacteleop/retargeting_engine_ui/*.py
 include isaacteleop/teleop_session_manager/*.py

--- a/src/core/retargeting_engine/python/deviceio_source_nodes/controllers_source.py
+++ b/src/core/retargeting_engine/python/deviceio_source_nodes/controllers_source.py
@@ -172,7 +172,7 @@ class ControllersSource(IDeviceIOSource):
 
         Args:
             transform_input: An OutputSelector providing a TransformMatrix
-                (e.g., passthrough_input.output("value")).
+                (e.g., value_input.output("value")).
 
         Returns:
             A RetargeterSubgraph with outputs "controller_left" and "controller_right"
@@ -180,7 +180,7 @@ class ControllersSource(IDeviceIOSource):
 
         Example:
             ctrl_source = ControllersSource("controllers")
-            xform_input = PassthroughInput("xform", TransformMatrix())
+            xform_input = ValueInput("xform", TransformMatrix())
             transformed = ctrl_source.transformed(xform_input.output("value"))
         """
         from ..utilities.controller_transform import ControllerTransform

--- a/src/core/retargeting_engine/python/deviceio_source_nodes/hands_source.py
+++ b/src/core/retargeting_engine/python/deviceio_source_nodes/hands_source.py
@@ -156,7 +156,7 @@ class HandsSource(IDeviceIOSource):
 
         Args:
             transform_input: An OutputSelector providing a TransformMatrix
-                (e.g., passthrough_input.output("value")).
+                (e.g., value_input.output("value")).
 
         Returns:
             A RetargeterSubgraph with outputs "hand_left" and "hand_right"
@@ -164,7 +164,7 @@ class HandsSource(IDeviceIOSource):
 
         Example:
             hand_source = HandsSource("hands")
-            xform_input = PassthroughInput("xform", TransformMatrix())
+            xform_input = ValueInput("xform", TransformMatrix())
             transformed = hand_source.transformed(xform_input.output("value"))
         """
         from ..utilities.hand_transform import HandTransform

--- a/src/core/retargeting_engine/python/deviceio_source_nodes/head_source.py
+++ b/src/core/retargeting_engine/python/deviceio_source_nodes/head_source.py
@@ -125,14 +125,14 @@ class HeadSource(IDeviceIOSource):
 
         Args:
             transform_input: An OutputSelector providing a TransformMatrix
-                (e.g., passthrough_input.output("value")).
+                (e.g., value_input.output("value")).
 
         Returns:
             A RetargeterSubgraph with output "head" containing the transformed HeadPose.
 
         Example:
             head_source = HeadSource("head")
-            xform_input = PassthroughInput("xform", TransformMatrix())
+            xform_input = ValueInput("xform", TransformMatrix())
             transformed = head_source.transformed(xform_input.output("value"))
         """
         from ..utilities.head_transform import HeadTransform

--- a/src/core/retargeting_engine/python/interface/__init__.py
+++ b/src/core/retargeting_engine/python/interface/__init__.py
@@ -5,6 +5,7 @@
 
 from .base_retargeter import BaseRetargeter
 from .output_combiner import OutputCombiner
+from .value_input import ValueInput
 from .parameter_state import ParameterState
 from .retargeter_core_types import (
     ExecutionContext,
@@ -33,6 +34,7 @@ __all__ = [
     "TensorGroup",
     "UNSET_VALUE",
     "BaseRetargeter",
+    "ValueInput",
     "RetargeterSubgraph",
     "OutputCombiner",
     "OutputSelector",

--- a/src/core/retargeting_engine/python/interface/value_input.py
+++ b/src/core/retargeting_engine/python/interface/value_input.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Value Input Node - Generic typed placeholder for external graph inputs.
+
+Provides a way to represent an externally-fed input as a proper graph node,
+so it can be wired into connect() calls alongside other graph outputs.
+
+Use ValueInput when you need to feed a simple value into the graph from
+external code (e.g., from the simulator or caller) without defining a
+custom BaseRetargeter subclass. It's a shortcut: one input, one output,
+data passed straight through.
+"""
+
+from .base_retargeter import BaseRetargeter
+from .retargeter_core_types import RetargeterIO, RetargeterIOType
+from .tensor_group_type import TensorGroupType
+from .tensor_group import TensorGroup
+
+
+class ValueInput(BaseRetargeter):
+    """
+    Generic value-input node representing a single external input in the graph.
+
+    Takes any TensorGroupType and creates a leaf node with one input and one
+    output of that type. Data is fed externally (e.g., by TeleopSession) and
+    passed straight through to the output.
+
+    This is useful when a downstream node has multiple inputs, and some come
+    from other graph nodes while others come from external code. Use
+    ValueInput for the externally-provided ones so they can participate
+    in connect() wiring.
+
+    Inputs:
+        - "value": TensorGroup of the specified type (fed externally)
+
+    Outputs:
+        - "value": TensorGroup of the same type (passthrough)
+
+    Example:
+        # HeadTransform has two inputs: "head" and "transform"
+        # "head" comes from the graph, "transform" comes from TeleopSession
+
+        from ..tensor_types import TransformMatrix
+
+        transform_input = ValueInput("xform_input", TransformMatrix())
+        head_xform = HeadTransform("head_xform")
+
+        graph = head_xform.connect({
+            "head": head_source.output("head"),
+            "transform": transform_input.output("value"),
+        })
+
+        # At runtime, TeleopSession feeds data to the value input node:
+        # leaf_inputs["xform_input"] = {"value": tensor_group_with_matrix}
+    """
+
+    VALUE = "value"
+
+    def __init__(self, name: str, tensor_type: TensorGroupType) -> None:
+        """
+        Initialize a value input node.
+
+        Args:
+            name: Unique name for this node (used as the leaf input key).
+            tensor_type: The TensorGroupType this node accepts and outputs.
+        """
+        self._tensor_type = tensor_type
+        super().__init__(name)
+
+    def input_spec(self) -> RetargeterIOType:
+        """Single input of the specified type."""
+        return {self.VALUE: self._tensor_type}
+
+    def output_spec(self) -> RetargeterIOType:
+        """Single output of the same type."""
+        return {self.VALUE: self._tensor_type}
+
+    def compute(self, inputs: RetargeterIO, outputs: RetargeterIO) -> None:
+        """
+        Copy all tensor values from input to output.
+
+        Args:
+            inputs: Dict with "value" TensorGroup (fed externally).
+            outputs: Dict with "value" TensorGroup to populate.
+        """
+        inp: TensorGroup = inputs[self.VALUE]
+        out: TensorGroup = outputs[self.VALUE]
+        for i in range(len(inp)):
+            out[i] = inp[i]

--- a/src/core/retargeting_engine/python/utilities/controller_transform.py
+++ b/src/core/retargeting_engine/python/utilities/controller_transform.py
@@ -51,7 +51,7 @@ class ControllerTransform(BaseRetargeter):
         - "controller_right": ControllerInput tensor with transformed poses
 
     Example:
-        transform_input = PassthroughInput("xform_input", TransformMatrix())
+        transform_input = ValueInput("xform_input", TransformMatrix())
         controller_transform = ControllerTransform("ctrl_xform")
 
         transformed = controller_transform.connect({

--- a/src/core/retargeting_engine/python/utilities/hand_transform.py
+++ b/src/core/retargeting_engine/python/utilities/hand_transform.py
@@ -56,7 +56,7 @@ class HandTransform(BaseRetargeter):
         - "hand_right": HandInput tensor with transformed joint poses
 
     Example:
-        transform_input = PassthroughInput("xform_input", TransformMatrix())
+        transform_input = ValueInput("xform_input", TransformMatrix())
         hand_transform = HandTransform("hand_xform")
 
         transformed = hand_transform.connect({

--- a/src/core/retargeting_engine/python/utilities/head_transform.py
+++ b/src/core/retargeting_engine/python/utilities/head_transform.py
@@ -47,7 +47,7 @@ class HeadTransform(BaseRetargeter):
         - "head": HeadPose tensor with transformed position and orientation
 
     Example:
-        transform_input = PassthroughInput("xform_input", TransformMatrix())
+        transform_input = ValueInput("xform_input", TransformMatrix())
         head_transform = HeadTransform("head_xform")
 
         transformed = head_transform.connect({

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -10,13 +10,13 @@ plugins, and retargeting engines, allowing users to focus on configuration
 rather than initialization code.
 """
 
-import sys
 import time
 from contextlib import ExitStack
 from typing import Optional, Dict, Any, List
 
 from isaacteleop.retargeting_engine.deviceio_source_nodes import IDeviceIOSource
-from isaacteleop.retargeting_engine.interface import TensorGroup
+from isaacteleop.retargeting_engine.interface import BaseRetargeter
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import RetargeterIO, RetargeterIOType
 
 import isaacteleop.deviceio as deviceio
 import isaacteleop.oxr as oxr
@@ -37,33 +37,51 @@ class TeleopSession:
     1. Creating OpenXR session with required extensions
     2. Creating DeviceIO session with trackers
     3. Initializing plugins
-    4. Running retargeting pipeline via run() method
+    4. Running retargeting pipeline via step() method
     5. Cleanup on exit
 
-    Usage with new retargeting engine:
-        # Create tracker and source modules
-        controller_tracker = deviceio.ControllerTracker()
-        controllers = ControllersSource(controller_tracker, name="controllers")
-
-        # Build retargeting pipeline
+    Pipelines may contain leaf nodes that are DeviceIO sources (auto-polled from
+    hardware trackers) and/or leaf nodes that are regular retargeters requiring
+    external inputs. External inputs are provided by the caller when calling step().
+    
+    Usage with DeviceIO-only pipeline:
+        controllers = ControllersSource(name="controllers")
         gripper = GripperRetargeter(name="gripper")
         pipeline = gripper.connect({
             "controller_left": controllers.output("controller_left"),
             "controller_right": controllers.output("controller_right")
         })
 
-        # Configure session
-        config = TeleopSessionConfig(
-            app_name="MyApp",
-            trackers=[controller_tracker],
-            pipeline=pipeline,
-        )
-
-        # Run session
+        config = TeleopSessionConfig(app_name="MyApp", pipeline=pipeline)
         with TeleopSession(config) as session:
             while True:
-                result = session.step()  # Returns Dict[str, TensorGroup]
+                result = session.step()
                 left = result["gripper_left"][0]
+    
+    Usage with external (non-DeviceIO) inputs via ValueInput:
+        controllers = ControllersSource(name="controllers")
+        ee_state = ValueInput("ee_state", RobotEEState())  # external leaf
+        pipeline = combiner.connect({
+            "controller_left": controllers.output("controller_left"),
+            "ee_pos": ee_state.output("value"),
+        })
+        
+        config = TeleopSessionConfig(app_name="MyApp", pipeline=pipeline)
+        with TeleopSession(config) as session:
+            ext_specs = session.get_external_input_specs()
+            # ext_specs == {"ee_state": {"value": TensorGroupType(...)}}
+            
+            while True:
+                ee_tg = TensorGroup(RobotEEState())
+                ee_tg[0] = get_ee_position()
+                
+                result = session.step(external_inputs={
+                    "ee_state": {"value": ee_tg}
+                })
+    
+    Any BaseRetargeter that is a leaf (not connected to a DeviceIO source)
+    automatically becomes an external input -- ValueInput is just a shortcut
+    for the common single-value passthrough case. See external_inputs_example.py.
     """
 
     def __init__(self, config: TeleopSessionConfig):
@@ -90,12 +108,15 @@ class TeleopSession:
         # Auto-discovered sources
         self._sources: List[IDeviceIOSource] = []
 
+        # External (non-DeviceIO) leaf nodes that require caller-provided inputs
+        self._external_leaves: List[BaseRetargeter] = []
+
         # Runtime state
         self.frame_count: int = 0
         self.start_time: float = 0.0
         self._setup_complete: bool = False
 
-        # Discover sources from pipeline
+        # Discover sources and external leaves from pipeline
         self._discover_sources()
 
     @property
@@ -105,24 +126,84 @@ class TeleopSession:
 
 
     def _discover_sources(self) -> None:
-        """Discover DeviceIO source modules from the pipeline.
+        """Discover DeviceIO source modules and external leaf nodes from the pipeline.
 
-        Traverses the pipeline to find all IDeviceIOSource instances.
+        Traverses the pipeline to find all leaf nodes, partitioning them into:
+        - IDeviceIOSource instances (auto-polled from hardware trackers)
+        - External leaves (non-DeviceIO leaves with non-empty input_spec() that
+          require caller-provided inputs in step()). Leaves with empty input_spec()
+          (e.g. fixed-command retargeters) are not treated as external and do not
+          require external_inputs.
         """
-        # Get leaf nodes from pipeline (now correctly returns all BaseRetargeter instances)
         leaf_nodes = self.pipeline.get_leaf_nodes()
 
-        # Filter for IDeviceIOSource instances
-        self._sources = [node for node in leaf_nodes if isinstance(node, IDeviceIOSource)]
+        self._sources = []
+        self._external_leaves = []
+        for node in leaf_nodes:
+            if isinstance(node, IDeviceIOSource):
+                self._sources.append(node)
+            elif node.input_spec():
+                self._external_leaves.append(node)
 
-    def step(self):
+        # Create tracker-to-source mapping for efficient lookup
+        self._tracker_to_source: Dict[Any, Any] = {}
+        for source in self._sources:
+            tracker = source.get_tracker()
+            self._tracker_to_source[id(tracker)] = source
+
+    def get_external_input_specs(self) -> Dict[str, RetargeterIOType]:
+        """Get the input specifications for all external leaf nodes that need inputs.
+
+        Only includes non-DeviceIO leaves with non-empty input_spec(). Leaves with
+        empty input_spec() (e.g. fixed-command retargeters) are not included.
+
+        Returns:
+            Dict mapping leaf node name to its input_spec (Dict[str, TensorGroupType]).
+            Empty dict if no leaves require caller-provided inputs.
+
+        Example:
+            specs = session.get_external_input_specs()
+            # specs == {"sim_state": {"joint_positions": TensorGroupType(...)}}
+        """
+        return {
+            leaf.name: leaf.input_spec()
+            for leaf in self._external_leaves
+        }
+
+    def has_external_inputs(self) -> bool:
+        """Check whether this pipeline requires caller-provided external inputs.
+
+        Returns True only if there are leaf nodes that are not DeviceIO sources
+        and have a non-empty input_spec() (i.e. they need inputs in step()).
+        """
+        return len(self._external_leaves) > 0
+
+    def step(self, external_inputs: Optional[Dict[str, RetargeterIO]] = None):
         """Execute a single step of the teleop session.
-
-        Updates DeviceIO session, polls tracker data, and executes the retargeting pipeline.
+        
+        Updates DeviceIO session, polls tracker data, merges any caller-provided
+        external inputs, and executes the retargeting pipeline.
+        
+        Args:
+            external_inputs: Optional dict mapping external leaf node names to their
+                input data (Dict[str, TensorGroup]). Required when the pipeline has
+                leaf nodes that require caller-provided inputs. Use get_external_input_specs()
+                to discover what external inputs are expected. Keys that do not correspond
+                to an external leaf node or a DeviceIO source name are silently ignored.
+                Keys that collide with a DeviceIO source name are invalid and cause
+                validation to raise.
 
         Returns:
             Dict[str, TensorGroup] - Output from the retargeting pipeline
+
+        Raises:
+            ValueError: If external leaves exist but external_inputs is missing or
+                incomplete, or if external_inputs contains keys that collide with
+                DeviceIO source names.
         """
+        # Validate external inputs
+        self._validate_external_inputs(external_inputs)
+        
         # Check plugin health periodically
         if self.frame_count % 60 == 0:
             self._check_plugin_health()
@@ -133,11 +214,73 @@ class TeleopSession:
         # Build input dictionary from tracker data
         pipeline_inputs = self._collect_tracker_data()
 
-        # Execute retargeting pipeline with tracker data
+        # Merge external inputs (for non-DeviceIO leaf nodes)
+        if external_inputs:
+            pipeline_inputs.update(external_inputs)
+
+        # Execute retargeting pipeline with all inputs
         result = self.pipeline(pipeline_inputs)
 
         self.frame_count += 1
         return result
+
+    def _validate_external_inputs(self, external_inputs: Optional[Dict[str, RetargeterIO]]) -> None:
+        """Validate that all required external inputs are provided.
+        
+        Checks that:
+        1. No external input name collides with a DeviceIO source name (always).
+        2. If external leaves exist: all required leaf names and keys are present.
+        
+        Args:
+            external_inputs: The external inputs provided by the caller.
+        
+        Raises:
+            ValueError: If external input names collide with source names, or if
+                external leaves exist but inputs are missing or incomplete.
+        """
+        if external_inputs:
+            source_names = {source.name for source in self._sources}
+            provided_names = set(external_inputs.keys())
+            collisions = provided_names & source_names
+            if collisions:
+                raise ValueError(
+                    f"External input names collide with DeviceIO source names: {collisions}. "
+                    f"Do not provide external inputs for source nodes; they are polled from hardware."
+                )
+
+        if not self._external_leaves:
+            return
+
+        expected_names = {leaf.name for leaf in self._external_leaves}
+
+        if external_inputs is None:
+            raise ValueError(
+                f"Pipeline has external (non-DeviceIO) leaf nodes that require inputs: "
+                f"{expected_names}. Pass external_inputs to step(). "
+                f"Use get_external_input_specs() to discover required inputs."
+            )
+
+        provided_names = set(external_inputs.keys())
+        missing = expected_names - provided_names
+        if missing:
+            raise ValueError(
+                f"Missing external inputs for leaf nodes: {missing}. "
+                f"Expected inputs for: {expected_names}. "
+                f"Use get_external_input_specs() to discover required inputs."
+            )
+
+        # Validate per-leaf input keys
+        for leaf in self._external_leaves:
+            leaf_data = external_inputs[leaf.name]
+            expected_keys = set(leaf.input_spec().keys())
+            provided_keys = set(leaf_data.keys())
+            missing_keys = expected_keys - provided_keys
+            if missing_keys:
+                raise ValueError(
+                    f"External input '{leaf.name}' is missing input keys: {missing_keys}. "
+                    f"Expected keys: {expected_keys}. "
+                    f"Use get_external_input_specs() to discover required inputs."
+                )
 
     def _collect_tracker_data(self) -> Dict[str, Any]:
         """Collect raw tracking data from all sources and map to module names.
@@ -162,6 +305,10 @@ class TeleopSession:
     def get_elapsed_time(self) -> float:
         """Get elapsed time since session started."""
         return time.time() - self.start_time
+
+    # ========================================================================
+    # Context manager protocol
+    # ========================================================================
 
     def __enter__(self):
         """Enter the context - create sessions and resources.

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1,0 +1,1328 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for TeleopSession - core logic unit tests.
+
+Tests the TeleopSession class without requiring OpenXR hardware by patching
+OpenXR, DeviceIO, and PluginManager (unittest.mock.patch). Covers source
+discovery, external input validation, step execution, session lifecycle,
+and plugin management.
+"""
+
+import time
+import pytest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+from contextlib import contextmanager
+
+from isaacteleop.retargeting_engine.interface import (
+    BaseRetargeter,
+    TensorGroupType,
+    TensorGroup,
+)
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
+    RetargeterIO,
+    RetargeterIOType,
+)
+from isaacteleop.retargeting_engine.deviceio_source_nodes import IDeviceIOSource
+from isaacteleop.retargeting_engine.tensor_types import FloatType
+
+from isaacteleop.teleop_session_manager.config import (
+    TeleopSessionConfig,
+    PluginConfig,
+)
+from isaacteleop.teleop_session_manager.teleop_session import TeleopSession
+
+
+# ============================================================================
+# Mock Tracker Classes
+# ============================================================================
+# These mock trackers replicate the polling APIs of real DeviceIO trackers.
+
+
+class HeadTracker:
+    """Mock head tracker for testing."""
+
+    def __init__(self):
+        self._head_data = 42.0
+
+    def get_head(self, session):
+        return self._head_data
+
+    def get_required_extensions(self):
+        return ["XR_EXT_head_tracking"]
+
+
+class HandTracker:
+    """Mock hand tracker for testing."""
+
+    def __init__(self):
+        self._left_hand = 1.0
+        self._right_hand = 2.0
+
+    def get_left_hand(self, session):
+        return self._left_hand
+
+    def get_right_hand(self, session):
+        return self._right_hand
+
+    def get_required_extensions(self):
+        return ["XR_EXT_hand_tracking"]
+
+
+class _MockControllerData:
+    """Mock controller data returned by ControllerTracker."""
+
+    def __init__(self):
+        self.left_controller = 3.0
+        self.right_controller = 4.0
+
+
+class ControllerTracker:
+    """Mock controller tracker for testing."""
+
+    def __init__(self):
+        self._data = _MockControllerData()
+
+    def get_controller_data(self, session):
+        return self._data
+
+    def get_required_extensions(self):
+        return ["XR_EXT_controller_interaction"]
+
+
+# ============================================================================
+# Mock DeviceIO Source Nodes
+# ============================================================================
+
+
+class MockDeviceIOSource(IDeviceIOSource):
+    """A mock DeviceIO source that acts as both a retargeter and a source."""
+
+    def __init__(self, source_name: str, tracker, input_names=None):
+        self._tracker = tracker
+        self._input_names = input_names or ["input_0"]
+        super().__init__(source_name)
+
+    def get_tracker(self):
+        return self._tracker
+
+    def poll_tracker(self, deviceio_session):
+        """Default poll_tracker: creates a TensorGroup per input with value 0.0."""
+        source_inputs = self.input_spec()
+        result = {}
+        for input_name, group_type in source_inputs.items():
+            tg = TensorGroup(group_type)
+            tg[0] = 0.0
+            result[input_name] = tg
+        return result
+
+    def input_spec(self) -> RetargeterIOType:
+        return {
+            name: TensorGroupType(f"type_{name}", [FloatType("value")])
+            for name in self._input_names
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        return {
+            "output_0": TensorGroupType("type_output", [FloatType("value")]),
+        }
+
+    def compute(self, inputs: RetargeterIO, outputs: RetargeterIO) -> None:
+        outputs["output_0"][0] = 0.0
+
+
+class MockHeadSource(MockDeviceIOSource):
+    """Mock head source for testing."""
+
+    def __init__(self, name: str = "head"):
+        super().__init__(name, HeadTracker(), input_names=["head_pose"])
+
+    def poll_tracker(self, deviceio_session):
+        source_inputs = self.input_spec()
+        head_data = self._tracker.get_head(deviceio_session)
+        result = {}
+        for input_name, group_type in source_inputs.items():
+            tg = TensorGroup(group_type)
+            tg[0] = head_data
+            result[input_name] = tg
+        return result
+
+
+class MockHandsSource(MockDeviceIOSource):
+    """Mock hands source for testing."""
+
+    def __init__(self, name: str = "hands"):
+        super().__init__(
+            name, HandTracker(), input_names=["hand_left", "hand_right"]
+        )
+
+    def poll_tracker(self, deviceio_session):
+        source_inputs = self.input_spec()
+        result = {}
+        for input_name, group_type in source_inputs.items():
+            tg = TensorGroup(group_type)
+            if "left" in input_name:
+                tg[0] = self._tracker.get_left_hand(deviceio_session)
+            elif "right" in input_name:
+                tg[0] = self._tracker.get_right_hand(deviceio_session)
+            result[input_name] = tg
+        return result
+
+
+class MockControllersSource(MockDeviceIOSource):
+    """Mock controllers source for testing."""
+
+    def __init__(self, name: str = "controllers"):
+        super().__init__(
+            name,
+            ControllerTracker(),
+            input_names=["controller_left", "controller_right"],
+        )
+
+    def poll_tracker(self, deviceio_session):
+        source_inputs = self.input_spec()
+        controller_data = self._tracker.get_controller_data(deviceio_session)
+        result = {}
+        for input_name, group_type in source_inputs.items():
+            tg = TensorGroup(group_type)
+            if "left" in input_name:
+                tg[0] = controller_data.left_controller
+            elif "right" in input_name:
+                tg[0] = controller_data.right_controller
+            result[input_name] = tg
+        return result
+
+
+# ============================================================================
+# Mock External Retargeter (non-DeviceIO leaf)
+# ============================================================================
+
+
+class MockExternalRetargeter(BaseRetargeter):
+    """A mock retargeter that is NOT a DeviceIO source (requires external inputs)."""
+
+    def __init__(self, name: str):
+        super().__init__(name)
+
+    def input_spec(self) -> RetargeterIOType:
+        return {
+            "external_data": TensorGroupType("type_ext", [FloatType("value")]),
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        return {
+            "result": TensorGroupType("type_result", [FloatType("value")]),
+        }
+
+    def compute(self, inputs: RetargeterIO, outputs: RetargeterIO) -> None:
+        outputs["result"][0] = inputs["external_data"][0]
+
+
+# ============================================================================
+# Mock empty input_spec retargeter (generator/constant source)
+# ============================================================================
+
+
+class MockEmptyInputRetargeter(BaseRetargeter):
+    """A mock retargeter that is NOT a DeviceIO source and has empty input_spec().
+
+    Models a generator or constant source that does not require caller-provided
+    inputs. Should not be treated as an external leaf.
+    """
+
+    def __init__(self, name: str):
+        super().__init__(name)
+
+    def input_spec(self) -> RetargeterIOType:
+        return {}
+
+    def output_spec(self) -> RetargeterIOType:
+        return {
+            "value": TensorGroupType("type_value", [FloatType("value")]),
+        }
+
+    def compute(self, inputs: RetargeterIO, outputs: RetargeterIO) -> None:
+        outputs["value"][0] = 1.0
+
+
+# ============================================================================
+# Mock Pipeline
+# ============================================================================
+
+
+class MockPipeline:
+    """Mock pipeline that returns configurable leaf nodes and accepts inputs."""
+
+    def __init__(self, leaf_nodes=None, call_result=None):
+        self._leaf_nodes = leaf_nodes or []
+        self._call_result = call_result or {}
+        self.last_inputs = None
+
+    def get_leaf_nodes(self):
+        return self._leaf_nodes
+
+    def __call__(self, inputs):
+        self.last_inputs = inputs
+        return self._call_result
+
+
+# ============================================================================
+# Mock OpenXR Session
+# ============================================================================
+
+
+class MockOpenXRHandles:
+    """Mock OpenXR session handles."""
+    pass
+
+
+class MockOpenXRSession:
+    """Mock OpenXR session that supports context manager protocol."""
+
+    def __init__(self, app_name="test", extensions=None):
+        self.app_name = app_name
+        self.extensions = extensions or []
+        self._handles = MockOpenXRHandles()
+
+    def get_handles(self):
+        return self._handles
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+# ============================================================================
+# Mock DeviceIO Session
+# ============================================================================
+
+
+class MockDeviceIOSession:
+    """Mock DeviceIO session that supports context manager and update."""
+
+    def __init__(self):
+        self.update_count = 0
+
+    def update(self):
+        self.update_count += 1
+        return True
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+
+# ============================================================================
+# Mock Plugin Infrastructure
+# ============================================================================
+
+
+class MockPluginContext:
+    """Mock plugin context that supports context manager and health checks."""
+
+    def __init__(self):
+        self.health_check_count = 0
+        self.entered = False
+        self.exited = False
+
+    def check_health(self):
+        self.health_check_count += 1
+
+    def __enter__(self):
+        self.entered = True
+        return self
+
+    def __exit__(self, *args):
+        self.exited = True
+
+
+class MockPluginManager:
+    """Mock plugin manager for testing."""
+
+    def __init__(self, plugin_names=None):
+        self._plugin_names = plugin_names or []
+        self._contexts = {}
+        for name in self._plugin_names:
+            self._contexts[name] = MockPluginContext()
+        self.start_calls: list = []
+
+    def get_plugin_names(self):
+        return self._plugin_names
+
+    def start(self, plugin_name, plugin_root_id, plugin_args=None):
+        self.start_calls.append({
+            "plugin_name": plugin_name,
+            "plugin_root_id": plugin_root_id,
+            "plugin_args": plugin_args,
+        })
+        return self._contexts[plugin_name]
+
+
+# ============================================================================
+# Patch-based session dependencies (no hardware)
+# ============================================================================
+
+
+@contextmanager
+def mock_session_dependencies(
+    mock_oxr=None,
+    mock_dio=None,
+    mock_pm=None,
+    get_required_extensions_return=None,
+    collected_trackers=None,
+):
+    """Patch OpenXR, DeviceIO, and PluginManager so TeleopSession.__enter__ runs without hardware.
+
+    Use this when a test needs to create a TeleopSession and call __enter__ (e.g. with session:).
+    Yields nothing; create TeleopSession(config) inside the block.
+
+    Args:
+        mock_oxr: Optional mock OpenXR session (default: MockOpenXRSession()).
+        mock_dio: Optional mock DeviceIO session (default: MockDeviceIOSession()).
+        mock_pm: Optional mock PluginManager (default: MockPluginManager()).
+        get_required_extensions_return: List returned by get_required_extensions (default: []).
+        collected_trackers: If provided, trackers passed to get_required_extensions are appended here.
+    """
+    mock_oxr = mock_oxr or MockOpenXRSession()
+    mock_dio = mock_dio or MockDeviceIOSession()
+    mock_pm = mock_pm or MockPluginManager()
+
+    if collected_trackers is not None:
+        def get_ext_side_effect(trackers):
+            collected_trackers.extend(trackers)
+            return []
+        patch_get_ext = patch(
+            "isaacteleop.deviceio.DeviceIOSession.get_required_extensions",
+            side_effect=get_ext_side_effect,
+        )
+    else:
+        get_ext_return = get_required_extensions_return if get_required_extensions_return is not None else []
+        patch_get_ext = patch(
+            "isaacteleop.deviceio.DeviceIOSession.get_required_extensions",
+            return_value=get_ext_return,
+        )
+
+    with (
+        patch("isaacteleop.oxr.OpenXRSession", return_value=mock_oxr),
+        patch("isaacteleop.deviceio.DeviceIOSession.run", return_value=mock_dio),
+        patch("isaacteleop.plugin_manager.PluginManager", return_value=mock_pm),
+        patch_get_ext,
+    ):
+        yield
+
+
+# ============================================================================
+# Helper to build a TeleopSessionConfig quickly
+# ============================================================================
+
+
+def make_config(pipeline, plugins=None, trackers=None, app_name="TestApp"):
+    """Create a TeleopSessionConfig with sensible test defaults."""
+    return TeleopSessionConfig(
+        app_name=app_name,
+        pipeline=pipeline,
+        trackers=trackers or [],
+        plugins=plugins or [],
+        verbose=False,
+    )
+
+
+# ============================================================================
+# Test Classes
+# ============================================================================
+
+
+class TestSourceDiscovery:
+    """Test that _discover_sources correctly partitions leaf nodes."""
+
+    def test_all_deviceio_sources(self):
+        """All leaf nodes are DeviceIO sources - no external leaves."""
+        head = MockHeadSource()
+        controllers = MockControllersSource()
+        pipeline = MockPipeline(leaf_nodes=[head, controllers])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert len(session._sources) == 2
+        assert head in session._sources
+        assert controllers in session._sources
+        assert len(session._external_leaves) == 0
+
+    def test_all_external_leaves(self):
+        """All leaf nodes are external retargeters - no DeviceIO sources."""
+        ext1 = MockExternalRetargeter("ext1")
+        ext2 = MockExternalRetargeter("ext2")
+        pipeline = MockPipeline(leaf_nodes=[ext1, ext2])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert len(session._sources) == 0
+        assert len(session._external_leaves) == 2
+        assert ext1 in session._external_leaves
+        assert ext2 in session._external_leaves
+
+    def test_mixed_sources_and_external(self):
+        """Pipeline has both DeviceIO sources and external leaves."""
+        head = MockHeadSource()
+        ext = MockExternalRetargeter("sim_state")
+        pipeline = MockPipeline(leaf_nodes=[head, ext])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert len(session._sources) == 1
+        assert head in session._sources
+        assert len(session._external_leaves) == 1
+        assert ext in session._external_leaves
+
+    def test_empty_pipeline(self):
+        """Pipeline with no leaf nodes."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert len(session._sources) == 0
+        assert len(session._external_leaves) == 0
+
+    def test_empty_input_spec_leaf_not_external(self):
+        """Non-DeviceIO leaf with empty input_spec() is not treated as external."""
+        constant_source = MockEmptyInputRetargeter("constant")
+        pipeline = MockPipeline(leaf_nodes=[constant_source])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert len(session._sources) == 0
+        assert len(session._external_leaves) == 0
+
+    def test_tracker_to_source_mapping(self):
+        """Tracker-to-source mapping is built correctly."""
+        head = MockHeadSource()
+        controllers = MockControllersSource()
+        pipeline = MockPipeline(leaf_nodes=[head, controllers])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        # Each source's tracker id should map back to that source
+        head_tracker = head.get_tracker()
+        ctrl_tracker = controllers.get_tracker()
+        assert id(head_tracker) in session._tracker_to_source
+        assert id(ctrl_tracker) in session._tracker_to_source
+        assert session._tracker_to_source[id(head_tracker)] is head
+        assert session._tracker_to_source[id(ctrl_tracker)] is controllers
+
+
+class TestExternalInputSpecs:
+    """Test external input specification discovery."""
+
+    def test_get_specs_with_external_leaves(self):
+        """External leaves should report their input specs."""
+        ext1 = MockExternalRetargeter("sim_state")
+        ext2 = MockExternalRetargeter("robot_state")
+        pipeline = MockPipeline(leaf_nodes=[ext1, ext2])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        specs = session.get_external_input_specs()
+
+        assert "sim_state" in specs
+        assert "robot_state" in specs
+        # Each spec should contain the input_spec of that retargeter
+        assert "external_data" in specs["sim_state"]
+
+    def test_get_specs_empty_when_all_deviceio(self):
+        """No external specs when all leaves are DeviceIO sources."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        specs = session.get_external_input_specs()
+        assert specs == {}
+
+    def test_has_external_inputs_true(self):
+        """has_external_inputs returns True when external leaves exist."""
+        ext = MockExternalRetargeter("ext")
+        pipeline = MockPipeline(leaf_nodes=[ext])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert session.has_external_inputs() is True
+
+    def test_has_external_inputs_false(self):
+        """has_external_inputs returns False when no external leaves."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert session.has_external_inputs() is False
+
+    def test_has_external_inputs_empty(self):
+        """has_external_inputs returns False when pipeline has no leaves."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert session.has_external_inputs() is False
+
+    def test_has_external_inputs_false_when_only_empty_input_spec_leaves(self):
+        """has_external_inputs returns False when only non-DeviceIO leaves have empty input_spec()."""
+        constant_source = MockEmptyInputRetargeter("constant")
+        pipeline = MockPipeline(leaf_nodes=[constant_source])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        assert session.has_external_inputs() is False
+        assert session.get_external_input_specs() == {}
+
+    def test_step_succeeds_without_external_inputs_for_empty_input_spec_leaf(self):
+        """step() succeeds without external_inputs when pipeline has only empty input_spec() leaves."""
+        constant_source = MockEmptyInputRetargeter("constant")
+        pipeline = MockPipeline(leaf_nodes=[constant_source], call_result={"constant": None})
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                result = session.step()
+                assert result == {"constant": None}
+
+
+class TestValidateExternalInputs:
+    """Test the _validate_external_inputs method."""
+
+    def test_no_external_leaves_no_inputs(self):
+        """No validation error when there are no external leaves."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        # Should not raise
+        session._validate_external_inputs(None)
+
+    def test_no_external_leaves_with_inputs(self):
+        """No validation error even if inputs provided when none needed."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        # Should not raise (extra inputs are silently ignored by validation)
+        session._validate_external_inputs({"extra": {}})
+
+    def test_external_leaves_missing_all_inputs(self):
+        """ValueError when external leaves exist but no inputs provided."""
+        ext = MockExternalRetargeter("sim_state")
+        pipeline = MockPipeline(leaf_nodes=[ext])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        with pytest.raises(ValueError, match="external.*non-DeviceIO"):
+            session._validate_external_inputs(None)
+
+    def test_external_leaves_missing_some_inputs(self):
+        """ValueError when some external inputs are missing."""
+        ext1 = MockExternalRetargeter("sim_state")
+        ext2 = MockExternalRetargeter("robot_state")
+        pipeline = MockPipeline(leaf_nodes=[ext1, ext2])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        # Only provide one of the two required inputs
+        with pytest.raises(ValueError, match="Missing external inputs"):
+            session._validate_external_inputs({"sim_state": {}})
+
+    def test_external_leaves_all_inputs_provided(self):
+        """No error when all required external inputs are provided."""
+        ext1 = MockExternalRetargeter("sim_state")
+        ext2 = MockExternalRetargeter("robot_state")
+        pipeline = MockPipeline(leaf_nodes=[ext1, ext2])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        # Should not raise
+        session._validate_external_inputs({
+            "sim_state": {"external_data": MagicMock()},
+            "robot_state": {"external_data": MagicMock()},
+        })
+
+    def test_external_leaves_extra_inputs_allowed(self):
+        """Extra inputs beyond what's required should not cause errors."""
+        ext = MockExternalRetargeter("sim_state")
+        pipeline = MockPipeline(leaf_nodes=[ext])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        # Provide required plus extra
+        session._validate_external_inputs({
+            "sim_state": {"external_data": MagicMock()},
+            "bonus_data": {"something": MagicMock()},
+        })
+
+
+class TestSessionLifecycle:
+    """Test __enter__ and __exit__ session lifecycle."""
+
+    def test_enter_creates_sessions(self):
+        """__enter__ should create OpenXR and DeviceIO sessions."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+        mock_oxr = MockOpenXRSession()
+        mock_dio = MockDeviceIOSession()
+
+        config = make_config(pipeline)
+        with mock_session_dependencies(mock_oxr=mock_oxr, mock_dio=mock_dio):
+            session = TeleopSession(config)
+            with session as s:
+                assert s is session
+                assert s.oxr_session is mock_oxr
+                assert s.deviceio_session is mock_dio
+                assert s._setup_complete is True
+                assert s.frame_count == 0
+
+    def test_enter_initializes_runtime_state(self):
+        """__enter__ should reset frame count and record start time."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            before = time.time()
+            with session as s:
+                after = time.time()
+                assert s.frame_count == 0
+                assert before <= s.start_time <= after
+
+    def test_exit_cleans_up(self):
+        """__exit__ should clean up via ExitStack."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session as s:
+                assert s._setup_complete is True
+
+        # After exit, setup_complete is still True (not reset)
+        # but the exit stack has been unwound
+        assert session._setup_complete is True
+
+    def test_context_manager_protocol(self):
+        """TeleopSession works correctly as a context manager."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+
+        config = make_config(pipeline)
+        entered = False
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session as s:
+                entered = True
+                assert s._setup_complete is True
+
+        assert entered is True
+
+    def test_enter_collects_trackers_from_sources(self):
+        """__enter__ should gather trackers from all discovered sources."""
+        head = MockHeadSource()
+        controllers = MockControllersSource()
+        pipeline = MockPipeline(leaf_nodes=[head, controllers])
+
+        collected_trackers = []
+        config = make_config(pipeline)
+        with mock_session_dependencies(collected_trackers=collected_trackers):
+            session = TeleopSession(config)
+            with session:
+                pass
+
+        # Should have collected trackers from both sources
+        assert len(collected_trackers) == 2
+
+    def test_enter_includes_manual_trackers(self):
+        """__enter__ should include manual trackers of new types, dedup same types."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+        # Manual tracker of a *different* type should be included
+        manual_tracker = ControllerTracker()
+
+        collected_trackers = []
+        config = make_config(pipeline, trackers=[manual_tracker])
+        with mock_session_dependencies(collected_trackers=collected_trackers):
+            session = TeleopSession(config)
+            with session:
+                pass
+
+        # 1 HeadTracker from source + 1 ControllerTracker manual = 2 unique types
+        assert len(collected_trackers) == 2
+        assert manual_tracker in collected_trackers
+
+    def test_enter_does_not_deduplicate_same_type_trackers(self):
+        """__enter__ should pass all trackers including duplicates of the same type."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+        duplicate_tracker = HeadTracker()
+
+        collected_trackers = []
+        config = make_config(pipeline, trackers=[duplicate_tracker])
+        with mock_session_dependencies(collected_trackers=collected_trackers):
+            session = TeleopSession(config)
+            with session:
+                pass
+
+        # Both trackers are passed through: source tracker + manual tracker
+        assert len(collected_trackers) == 2
+        assert collected_trackers[0] is head.get_tracker()
+        assert collected_trackers[1] is duplicate_tracker
+
+
+class TestPluginInitialization:
+    """Test plugin initialization in __enter__."""
+
+    def test_plugins_initialized(self, tmp_path):
+        """Enabled plugins with valid paths are started."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        mock_pm = MockPluginManager(plugin_names=["test_plugin"])
+
+        plugin_config = PluginConfig(
+            plugin_name="test_plugin",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            enabled=True,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            with session:
+                assert len(session.plugin_managers) == 1
+                assert len(session.plugin_contexts) == 1
+
+    def test_disabled_plugin_skipped(self, tmp_path):
+        """Disabled plugins are not started."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        mock_pm = MockPluginManager(plugin_names=["test_plugin"])
+
+        plugin_config = PluginConfig(
+            plugin_name="test_plugin",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            enabled=False,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            with session:
+                assert len(session.plugin_managers) == 0
+                assert len(session.plugin_contexts) == 0
+
+    def test_missing_plugin_skipped(self, tmp_path):
+        """Plugins not found in search paths are skipped."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        # Plugin manager doesn't know about "nonexistent_plugin"
+        mock_pm = MockPluginManager(plugin_names=["other_plugin"])
+
+        plugin_config = PluginConfig(
+            plugin_name="nonexistent_plugin",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            enabled=True,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            with session:
+                # Manager was created but plugin not found, so no context started
+                assert len(session.plugin_managers) == 1
+                assert len(session.plugin_contexts) == 0
+
+    def test_invalid_search_paths_skipped(self):
+        """Plugins with no valid search paths are skipped entirely."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        mock_pm = MockPluginManager(plugin_names=["test_plugin"])
+
+        plugin_config = PluginConfig(
+            plugin_name="test_plugin",
+            plugin_root_id="/root",
+            search_paths=[Path("/nonexistent/path/that/does/not/exist")],
+            enabled=True,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            with session:
+                # Skipped because no valid search paths
+                assert len(session.plugin_managers) == 0
+                assert len(session.plugin_contexts) == 0
+
+    def test_no_plugins_configured(self):
+        """Session works fine with no plugins configured."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline, plugins=[])
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                assert len(session.plugin_managers) == 0
+                assert len(session.plugin_contexts) == 0
+
+    def test_plugin_args_passed_through(self, tmp_path):
+        """Plugin args from config are forwarded to manager.start()."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        mock_pm = MockPluginManager(plugin_names=["test_plugin"])
+
+        plugin_config = PluginConfig(
+            plugin_name="test_plugin",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            enabled=True,
+            plugin_args=["--flag", "value"],
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            with session:
+                assert len(mock_pm.start_calls) == 1
+                call = mock_pm.start_calls[0]
+                assert call["plugin_name"] == "test_plugin"
+                assert call["plugin_root_id"] == "/root"
+                assert call["plugin_args"] == ["--flag", "value"]
+
+    def test_plugin_args_default_empty(self, tmp_path):
+        """Plugin args default to an empty list when not specified."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        mock_pm = MockPluginManager(plugin_names=["test_plugin"])
+
+        plugin_config = PluginConfig(
+            plugin_name="test_plugin",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            enabled=True,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            with session:
+                assert len(mock_pm.start_calls) == 1
+                assert mock_pm.start_calls[0]["plugin_args"] == []
+
+
+class TestStep:
+    """Test the step() method execution flow."""
+
+    def test_step_calls_deviceio_update(self):
+        """step() should call deviceio_session.update()."""
+        head = MockHeadSource()
+        mock_dio = MockDeviceIOSession()
+        pipeline = MockPipeline(leaf_nodes=[head])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies(mock_dio=mock_dio):
+            session = TeleopSession(config)
+            with session:
+                session.step()
+                assert mock_dio.update_count == 1
+
+                session.step()
+                assert mock_dio.update_count == 2
+
+    def test_step_calls_pipeline(self):
+        """step() should call the pipeline with collected inputs."""
+        head = MockHeadSource()
+        expected_result = {"output": "data"}
+        pipeline = MockPipeline(leaf_nodes=[head], call_result=expected_result)
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                result = session.step()
+                assert result == expected_result
+                assert pipeline.last_inputs is not None
+
+    def test_step_increments_frame_count(self):
+        """step() should increment frame_count each call."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                assert session.frame_count == 0
+                session.step()
+                assert session.frame_count == 1
+                session.step()
+                assert session.frame_count == 2
+                session.step()
+                assert session.frame_count == 3
+
+    def test_step_with_external_inputs(self):
+        """step() should merge external inputs into pipeline inputs."""
+        ext = MockExternalRetargeter("sim_state")
+        pipeline = MockPipeline(leaf_nodes=[ext])
+
+        config = make_config(pipeline)
+        external_data = {"sim_state": {"external_data": MagicMock()}}
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                session.step(external_inputs=external_data)
+                # The pipeline should receive the external inputs
+                assert "sim_state" in pipeline.last_inputs
+
+    def test_step_with_mixed_sources(self):
+        """step() with both DeviceIO sources and external inputs."""
+        head = MockHeadSource()
+        ext = MockExternalRetargeter("sim_state")
+        pipeline = MockPipeline(leaf_nodes=[head, ext])
+
+        config = make_config(pipeline)
+        external_data = {"sim_state": {"external_data": MagicMock()}}
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                session.step(external_inputs=external_data)
+                # Pipeline should have both DeviceIO and external inputs
+                assert "head" in pipeline.last_inputs
+                assert "sim_state" in pipeline.last_inputs
+
+    def test_step_raises_on_missing_external_inputs(self):
+        """step() should raise ValueError when external inputs are required but missing."""
+        ext = MockExternalRetargeter("sim_state")
+        pipeline = MockPipeline(leaf_nodes=[ext])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                with pytest.raises(ValueError, match="external.*non-DeviceIO"):
+                    session.step()
+
+    def test_step_checks_plugin_health_every_60_frames(self):
+        """step() should check plugin health every 60 frames."""
+        pipeline = MockPipeline(leaf_nodes=[])
+        mock_ctx = MockPluginContext()
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                # Manually add a mock plugin context
+                session.plugin_contexts.append(mock_ctx)
+
+                # Frame 0: should check (0 % 60 == 0)
+                session.step()
+                assert mock_ctx.health_check_count == 1
+
+                # Frames 1-59: should not check
+                for _ in range(59):
+                    session.step()
+                assert mock_ctx.health_check_count == 1
+
+                # Frame 60: should check again
+                session.step()
+                assert mock_ctx.health_check_count == 2
+
+    def test_step_no_external_inputs_when_none_needed(self):
+        """step() without external_inputs works when no external leaves exist."""
+        head = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                # Should not raise
+                session.step()
+                assert session.frame_count == 1
+
+
+class TestTrackerDataCollection:
+    """Test _collect_tracker_data for different tracker types."""
+
+    def test_collect_head_tracker_data(self):
+        """Head tracker data should be wrapped in TensorGroups."""
+        head_source = MockHeadSource()
+        pipeline = MockPipeline(leaf_nodes=[head_source])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                data = session._collect_tracker_data()
+
+                # Should have data keyed by source name
+                assert "head" in data
+                # The data should contain the input spec keys
+                assert "head_pose" in data["head"]
+                # The TensorGroup should contain the head data from the tracker
+                tg = data["head"]["head_pose"]
+                assert isinstance(tg, TensorGroup)
+                assert tg[0] == 42.0  # HeadTracker returns 42.0
+
+    def test_collect_controller_tracker_data(self):
+        """Controller tracker data should be split into left/right."""
+        ctrl_source = MockControllersSource()
+        pipeline = MockPipeline(leaf_nodes=[ctrl_source])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                data = session._collect_tracker_data()
+
+                assert "controllers" in data
+                assert "controller_left" in data["controllers"]
+                assert "controller_right" in data["controllers"]
+
+                # Left should get left_controller data
+                tg_left = data["controllers"]["controller_left"]
+                assert isinstance(tg_left, TensorGroup)
+                assert tg_left[0] == 3.0
+
+                # Right should get right_controller data
+                tg_right = data["controllers"]["controller_right"]
+                assert isinstance(tg_right, TensorGroup)
+                assert tg_right[0] == 4.0
+
+    def test_collect_hand_tracker_data(self):
+        """Hand tracker data should be split into left/right."""
+        hands_source = MockHandsSource()
+        pipeline = MockPipeline(leaf_nodes=[hands_source])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                data = session._collect_tracker_data()
+
+                assert "hands" in data
+                assert "hand_left" in data["hands"]
+                assert "hand_right" in data["hands"]
+
+                tg_left = data["hands"]["hand_left"]
+                assert isinstance(tg_left, TensorGroup)
+                assert tg_left[0] == 1.0
+
+                tg_right = data["hands"]["hand_right"]
+                assert isinstance(tg_right, TensorGroup)
+                assert tg_right[0] == 2.0
+
+    def test_collect_multiple_sources(self):
+        """Data collection works with multiple sources simultaneously."""
+        head = MockHeadSource()
+        controllers = MockControllersSource()
+        pipeline = MockPipeline(leaf_nodes=[head, controllers])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                data = session._collect_tracker_data()
+
+                assert "head" in data
+                assert "controllers" in data
+                assert len(data) == 2
+
+    def test_collect_no_sources(self):
+        """Data collection with no sources returns empty dict."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                data = session._collect_tracker_data()
+                assert data == {}
+
+
+class TestElapsedTime:
+    """Test get_elapsed_time."""
+
+    def test_elapsed_time_increases(self):
+        """Elapsed time should be >= 0 and increase over time."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                t1 = session.get_elapsed_time()
+                assert t1 >= 0.0
+
+                # Small sleep to ensure measurable difference
+                time.sleep(0.01)
+
+                t2 = session.get_elapsed_time()
+                assert t2 > t1
+
+
+class TestPluginHealthChecking:
+    """Test _check_plugin_health."""
+
+    def test_check_plugin_health_calls_all_contexts(self):
+        """_check_plugin_health should call check_health on all plugin contexts."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        ctx1 = MockPluginContext()
+        ctx2 = MockPluginContext()
+        session.plugin_contexts = [ctx1, ctx2]
+
+        session._check_plugin_health()
+
+        assert ctx1.health_check_count == 1
+        assert ctx2.health_check_count == 1
+
+    def test_check_plugin_health_no_contexts(self):
+        """_check_plugin_health with no contexts should not fail."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        session = TeleopSession(config)
+
+        # Should not raise
+        session._check_plugin_health()
+
+
+class TestConfiguration:
+    """Test TeleopSessionConfig and PluginConfig dataclasses."""
+
+    def test_teleop_session_config_defaults(self):
+        """TeleopSessionConfig should have sensible defaults."""
+        pipeline = MockPipeline()
+        config = TeleopSessionConfig(app_name="Test", pipeline=pipeline)
+
+        assert config.app_name == "Test"
+        assert config.pipeline is pipeline
+        assert config.trackers == []
+        assert config.plugins == []
+        assert config.verbose is True
+
+    def test_teleop_session_config_custom(self, tmp_path):
+        """TeleopSessionConfig should accept custom values."""
+        pipeline = MockPipeline()
+        tracker = HeadTracker()
+        plugin = PluginConfig(
+            plugin_name="p", plugin_root_id="/r", search_paths=[tmp_path]
+        )
+
+        config = TeleopSessionConfig(
+            app_name="CustomApp",
+            pipeline=pipeline,
+            trackers=[tracker],
+            plugins=[plugin],
+            verbose=False,
+        )
+
+        assert config.app_name == "CustomApp"
+        assert len(config.trackers) == 1
+        assert len(config.plugins) == 1
+        assert config.verbose is False
+
+    def test_plugin_config_defaults(self, tmp_path):
+        """PluginConfig should have enabled=True by default."""
+        config = PluginConfig(
+            plugin_name="test",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+        )
+
+        assert config.enabled is True
+
+    def test_plugin_config_disabled(self, tmp_path):
+        """PluginConfig can be created with enabled=False."""
+        config = PluginConfig(
+            plugin_name="test",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            enabled=False,
+        )
+
+        assert config.enabled is False
+
+
+class TestSessionReuse:
+    """Test that session state is properly reset between uses."""
+
+    def test_frame_count_resets_on_reenter(self):
+        """frame_count should reset when re-entering the session."""
+        pipeline = MockPipeline(leaf_nodes=[])
+
+        config = make_config(pipeline)
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                session.step()
+                session.step()
+                assert session.frame_count == 2
+
+            # Re-entering should reset state
+            # Need a new ExitStack since the old one was consumed
+            session._exit_stack = __import__("contextlib").ExitStack()
+
+            with session:
+                assert session.frame_count == 0
+
+    def test_plugin_lists_accumulate(self, tmp_path):
+        """Plugin lists should accumulate if session is re-entered without reset."""
+        pipeline = MockPipeline(leaf_nodes=[])
+        mock_pm = MockPluginManager(plugin_names=["test_plugin"])
+
+        plugin_config = PluginConfig(
+            plugin_name="test_plugin",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            enabled=True,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            with session:
+                first_count = len(session.plugin_managers)
+
+        # Note: plugin_managers list is not cleared on re-entry
+        # This is expected behavior - users should create new sessions
+        assert first_count == 1
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Add support for pipelines with non-DeviceIO leaf nodes whose inputs are provided by the caller at each step():

- PassthroughInput: generic typed placeholder for external graph inputs
- TeleopSession discovers external leaves and validates inputs each frame
- step() accepts optional external_inputs dict for non-DeviceIO leaves
- get_external_input_specs() / has_external_inputs() for introspection
- Factory methods on TeleopSession for testability (mock hardware)
- Comprehensive unit tests (mocked hardware, ~1200 lines)
- External inputs example with coordinate-frame transform