### PR TITLE
Relax Python dependencies for retargeters

### DIFF
--- a/src/core/python/requirements-retargeters.txt
+++ b/src/core/python/requirements-retargeters.txt
@@ -1,4 +1,4 @@
-dex-retargeting>=0.5.0,<0.6.0
-scipy>=1.17.0
+dex-retargeting>=0.4.6,<0.6.0
+scipy>=1.15.0
 pyyaml>=6.0.3
 torch==2.7.0


### PR DESCRIPTION
1/ Relax dex-retargeting to 0.4.6 or higher, to allow ARM 2/ Relax scipy version to 1.15.0 or higher, to allow Python 3.10