### PR TITLE
Create a parameter collection_id to the plugin

### DIFF
--- a/examples/oxr/python/test_oak_camera.py
+++ b/examples/oxr/python/test_oak_camera.py
@@ -81,14 +81,16 @@ def run_test(duration: float = 10.0, metadata_track: bool = True):
     required_extensions = []
     mcap_filename = None
 
+    collection_id = "oak_camera" if metadata_track else ""
+
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     if metadata_track:
         print("[Step 3] Creating FrameMetadataTrackerOak...")
-        # The collection_id must match the plugin_root_id used by the camera plugin
-        frame_tracker = deviceio.FrameMetadataTrackerOak(plugin_root_id)
+        # The collection_id must match the --collection-id used by the camera plugin
+        frame_tracker = deviceio.FrameMetadataTrackerOak(collection_id)
         trackers = [frame_tracker]
         required_extensions = deviceio.DeviceIOSession.get_required_extensions(trackers)
-        print(f"  ✓ Created {frame_tracker.get_name()} (collection_id: {plugin_root_id})")
+        print(f"  ✓ Created {frame_tracker.get_name()} (collection_id: {collection_id})")
         print()
         print("[Step 4] Getting required OpenXR extensions...")
         print(f"  ✓ Required extensions: {required_extensions}")  
@@ -100,6 +102,8 @@ def run_test(duration: float = 10.0, metadata_track: bool = True):
     # 5. Start Plugin and OpenXR session (if metadata tracking)
     print("[Step 5] Starting camera plugin...")
     print(f"  Plugin root ID: {plugin_root_id}")
+    if metadata_track:
+        print(f"  Collection ID:  {collection_id}")
     print(f"  Recording duration: {duration} seconds")
     if metadata_track:
         print(f"  MCAP output: {mcap_filename}")
@@ -110,7 +114,10 @@ def run_test(duration: float = 10.0, metadata_track: bool = True):
     print()
 
     output_path = f"./recordings/camera_{timestamp}.h264"
-    with manager.start(plugin_name, plugin_root_id, ["--output=" + output_path]) as plugin:
+    extra_args = ["--output=" + output_path]
+    if metadata_track:
+        extra_args.append("--collection-id=" + collection_id)
+    with manager.start(plugin_name, plugin_root_id, extra_args) as plugin:
         print("  ✓ Camera plugin started")
 
         if metadata_track:

--- a/src/plugins/oak/README.md
+++ b/src/plugins/oak/README.md
@@ -52,7 +52,7 @@ Press `Ctrl+C` to stop recording.
 | `--bitrate` | 8000000 | H.264 bitrate (bps) |
 | `--quality` | 80 | H.264 quality (1-100) |
 | `--output` | (required) | Full path for recording file |
-| `--plugin-root-id` | oak_camera | Plugin ID for Isaac Teleop integration |
+| `--collection-id` | oak_camera | Tensor collection ID for metadata (must match `FrameMetadataTrackerOak`) |
 
 ## Architecture
 

--- a/src/plugins/oak/main.cpp
+++ b/src/plugins/oak/main.cpp
@@ -42,7 +42,7 @@ void print_usage(const char* program_name)
               << "\nRecording Settings:\n"
               << "  --output=PATH       Full path for recording file (required)\n"
               << "\nOpenXR Settings:\n"
-              << "  --plugin-root-id=ID Tensor collection ID for metadata (default: oak_camera)\n"
+              << "  --collection-id=ID  Tensor collection ID for metadata (default: oak_camera)\n"
               << "\nGeneral Settings:\n"
               << "  --help              Show this help message\n"
               << "\nOutput:\n"
@@ -60,6 +60,7 @@ try
     OakConfig camera_config;
     std::string output_path;
     std::string plugin_root_id = "oak_camera";
+    std::string collection_id;
 
     // Parse command line arguments
     for (int i = 1; i < argc; ++i)
@@ -95,9 +96,12 @@ try
         {
             output_path = arg.substr(9);
         }
+        else if (arg.find("--collection-id=") == 0)
+        {
+            collection_id = arg.substr(16);
+        }
         else if (arg.find("--plugin-root-id=") == 0)
         {
-            plugin_root_id = arg.substr(17);
         }
         else
         {
@@ -124,7 +128,7 @@ try
 
     // Create camera and frame sink (H.264 writer + metadata pusher)
     OakCamera camera(camera_config);
-    FrameSink sink(output_path, plugin_root_id);
+    FrameSink sink(output_path, collection_id);
 
     uint64_t frame_count = 0;
     auto start_time = std::chrono::steady_clock::now();


### PR DESCRIPTION
the cxr becomes optional only if we provide the collection_id.

[Here](https://github.com/NVIDIA/IsaacTeleop/blob/main/src/plugins/oak/core/frame_sink.cpp#L53-L56) is where we make the cxr dependency optional control by the passed collection_id. 

In the main, it was previously set as plugin_root_id, which is always presented. With introducing the new parameter, we can control from the plugin_manager.