### PR TITLE
Skip copyright year check in pre-commit doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ pre-commit install
 After that, pre-commit runs automatically on `git commit`. To run on all files manually:
 
 ```bash
-pre-commit run --all-files
+SKIP=check-copyright-year pre-commit run --all-files
 ```
 
 To run only Ruff (check + fix and format):


### PR DESCRIPTION
Skip check-copyright-year so that it doesn't write 2026 to those files, that are not modified this year.