### PR TITLE
Make the runtime SDK bundle optional

### DIFF
--- a/src/core/cloudxr/python/CMakeLists.txt
+++ b/src/core/cloudxr/python/CMakeLists.txt
@@ -4,34 +4,31 @@
 # Package output dir for cloudxr Python module (used on all platforms)
 set(CLOUDXR_PYTHON_DIR "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>/isaacteleop/cloudxr")
 
-# CloudXR native SDK bundle: Linux only (SDK tarball is Linux-specific)
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Look for CloudXR Runtime SDK tarball in deps/cloudxr/CloudXR-*-Linux-*-sdk.tar.gz
-    # (e.g. CloudXR-6.1.0-pid6-Linux-amd64-sdk.tar.gz)
-    if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64")
-        set(CLOUDXR_CPU_ARCH "amd64")
-    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
-        set(CLOUDXR_CPU_ARCH "arm64")
-    else()
-        message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
-    endif()
+# Look for CloudXR Runtime SDK tarball in deps/cloudxr/CloudXR-*-Linux-*-sdk.tar.gz
+# (e.g. CloudXR-6.1.0-pid6-Linux-amd64-sdk.tar.gz)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
+    set(CLOUDXR_CPU_ARCH "amd64")
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
+    set(CLOUDXR_CPU_ARCH "arm64")
+else()
+    message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
+endif()
 
-    file(GLOB CLOUDXR_SDK_CANDIDATES "${CMAKE_SOURCE_DIR}/deps/cloudxr/CloudXR-*-Linux-${CLOUDXR_CPU_ARCH}-sdk.tar.gz")
-    if(CLOUDXR_SDK_CANDIDATES)
-        list(GET CLOUDXR_SDK_CANDIDATES 0 CLOUDXR_SDK_PATH)
-    endif()
+file(GLOB CLOUDXR_SDK_CANDIDATES "${CMAKE_SOURCE_DIR}/deps/cloudxr/CloudXR-*-Linux-${CLOUDXR_CPU_ARCH}-sdk.tar.gz")
+if(CLOUDXR_SDK_CANDIDATES)
+    list(GET CLOUDXR_SDK_CANDIDATES 0 CLOUDXR_SDK_PATH)
+endif()
 
-    if(NOT CLOUDXR_SDK_PATH)
-        message(FATAL_ERROR
-            "CloudXR SDK tarball not found. Place CloudXR-<VERSION>-Linux-<ARCH>-sdk.tar.gz in "
-            "deps/cloudxr/ (e.g. run scripts/download_cloudxr_runtime_sdk.sh), or set "
-            "CLOUDXR_SDK_PATH to the tarball path."
-        )
-    endif()
-    if(NOT EXISTS "${CLOUDXR_SDK_PATH}")
-        message(FATAL_ERROR "CloudXR SDK tarball not found: ${CLOUDXR_SDK_PATH}")
-    endif()
-
+# TODO: Make download the CloudXR SDK tarball a FetchContent dependency once Runtime SDK is publicly available.
+set(CLOUDXR_NATIVE_AVAILABLE FALSE)
+if(NOT CLOUDXR_SDK_PATH)
+    message(WARNING
+        "CloudXR SDK tarball not found. Place CloudXR-<VERSION>-Linux-<ARCH>-sdk.tar.gz in "
+        "deps/cloudxr/ (e.g. run scripts/download_cloudxr_runtime_sdk.sh), or set "
+        "CLOUDXR_SDK_PATH to the tarball path. Skipping cloudxr_native_bundle."
+    )
+else()
+    set(CLOUDXR_NATIVE_AVAILABLE TRUE)
     set(CLOUDXR_NATIVE_DIR "${CLOUDXR_PYTHON_DIR}/native")
     add_custom_target(cloudxr_native_dir ALL
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CLOUDXR_NATIVE_DIR}"
@@ -56,7 +53,7 @@ add_custom_target(cloudxr_python ALL
     COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLOUDXR_PYTHON_DIR}/__pycache__"
     COMMENT "Copying cloudxr Python files to package structure"
 )
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CLOUDXR_NATIVE_AVAILABLE)
     add_dependencies(cloudxr_python cloudxr_native_bundle)
 endif()
 


### PR DESCRIPTION
1. This is a temporary fix before the runtime SDK is publicly available.
2. No need to gate on windows as we don't pull the runtime SDK for windows yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CloudXR detection is now platform-agnostic and more tolerant: missing native bundle no longer fails the build and emits a warning instead, allowing the Python package to be built when the native CloudXR bundle is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->