### PR TITLE
enable build oak for github ci

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 name: Build Ubuntu
@@ -71,7 +71,7 @@ jobs:
         ccache --show-config
 
     - name: Configure CMake
-      run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DISAAC_TELEOP_PYTHON_VERSION=${{ matrix.python_version }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+      run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DISAAC_TELEOP_PYTHON_VERSION=${{ matrix.python_version }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_PLUGIN_OAK_CAMERA=ON
 
     - name: Build
       run: cmake --build build --parallel 4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 name: Build Windows (Experimental)
@@ -76,6 +76,7 @@ jobs:
         -DCMAKE_C_COMPILER="cl.exe"
         -DCMAKE_CXX_COMPILER="cl.exe"
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
+        -DBUILD_PLUGIN_OAK_CAMERA=ON
 
     - name: Build
       run: cmake --build build --parallel


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build workflows for Ubuntu and Windows to enable building the Oak camera plugin.
  * Updated copyright year to 2025–2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->