### PR TITLE
Make head pose optional in the retargeter source

### DIFF
--- a/examples/retargeting/python/sources_example.py
+++ b/examples/retargeting/python/sources_example.py
@@ -215,17 +215,20 @@ def main():
                             f"      Wrist: [{wrist_pos[0]:6.3f}, {wrist_pos[1]:6.3f}, {wrist_pos[2]:6.3f}]"
                         )
 
-                    # Extract head data
+                    # Extract head data (Optional — absent when no tracker)
                     head = all_data["head"]
-                    head_valid = head[HeadPoseIndex.IS_VALID]
 
                     print("  Head:")
-                    print(f"    Status: {'VALID' if head_valid else 'INVALID'}")
-                    if head_valid:
-                        head_position = head[HeadPoseIndex.POSITION]
-                        print(
-                            f"    Position: [{head_position[0]:6.3f}, {head_position[1]:6.3f}, {head_position[2]:6.3f}]"
-                        )
+                    if head.is_none:
+                        print("    Status: ABSENT (no tracker)")
+                    else:
+                        head_valid = head[HeadPoseIndex.IS_VALID]
+                        print(f"    Status: {'VALID' if head_valid else 'INVALID'}")
+                        if head_valid:
+                            head_position = head[HeadPoseIndex.POSITION]
+                            print(
+                                f"    Position: [{head_position[0]:6.3f}, {head_position[1]:6.3f}, {head_position[2]:6.3f}]"
+                            )
 
                     # Extract controller data
                     left_controller = all_data[ControllersSource.LEFT]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Head pose is now optional: if absent it’s reported as ABSENT; if present it’s shown as VALID/INVALID and position is displayed only when VALID. Absence is propagated safely through processing.

* **Documentation**
  * Examples and docs updated to describe optional head semantics and advise checking presence before access.

* **Tests**
  * Tests renamed and updated to validate optional inputs/outputs, propagation behavior, and absent-head handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->