### PR TITLE
Add wheel repair step for Release builds

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -107,6 +107,7 @@ jobs:
         mkdir -p install/wheels-repaired
         for wheel in "${wheels[@]}"; do
           echo "Repairing ${wheel}"
+          # Exclude GPU driver/runtime libs so wheels stay portable across systems without bundling host-specific binaries.
           uv run --python ${{ matrix.python_version }} --with "auditwheel==6.6.0" \
             auditwheel repair --exclude libcuda.so.1 --exclude libvulkan.so.1 --wheel-dir install/wheels-repaired "${wheel}"
         done


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release pipeline now performs additional packaging and repair steps for Linux wheels to improve distribution reliability and compatibility.
  * Repaired artifacts are correctly placed and the pipeline explicitly fails fast if no build artifacts are found, reducing release errors and ensuring intact packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->