### PR TITLE
Move NGC_TELEOP_CORE_GITHUB_SERVICE_KEY out of dev environment

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -20,7 +20,6 @@ jobs:
     # Pin to 22.04 so the wheel is built with GCC 11's libstdc++. The resulting wheel
     # then runs on both Ubuntu 22.04 and 24.04 (24.04's libstdc++ is backward compatible).
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
-    environment: dev
 
     strategy:
       matrix:
@@ -107,7 +106,6 @@ jobs:
 
   teleop-ros2-docker:
     runs-on: ubuntu-22.04
-    environment: dev
     strategy:
       fail-fast: false
       matrix:
@@ -146,7 +144,6 @@ jobs:
   test-cloudxr:
     runs-on: [self-hosted, linux, gpu, "${{ matrix.arch }}"]
     needs: build-ubuntu
-    environment: dev
 
     strategy:
       matrix:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -99,7 +99,6 @@ jobs:
     name: Build Teleop Web App
     runs-on: ubuntu-latest
     needs: [check-repo]
-    environment: dev
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified deployment environment configuration across build and documentation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->