### PR TITLE
Add concurrency setting for Windows workflow

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -12,8 +12,8 @@ on:
     branches: [ main ]
   pull_request:
 
-# For PRs, we want to cancel in-progress runs to save resources.
-# For pushes to main, we want to allow all runs to complete.
+# Per workflow+ref: max 1 running + 1 pending (new pending replaces old).
+# PRs cancel in-progress runs; pushes to main do not.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI to limit concurrent Windows build runs and to automatically cancel prior in-progress runs for new pull requests.
  * Clarified concurrency behavior so cancellation applies to PRs but not to other branches/refs.
* **Documentation**
  * Added top-level notes marking Windows builds as experimental and clarified PR vs. main behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->