### PR TITLE
hotfix: runtime sdk build

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -75,7 +75,14 @@ jobs:
         ccache --show-config
 
     - name: Configure CMake
-      run: cmake -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DISAAC_TELEOP_PYTHON_VERSION=${{ matrix.python_version }} -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DBUILD_PLUGIN_OAK_CAMERA=ON
+      run: |
+        cmake -B build \
+          -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+          -DISAAC_TELEOP_PYTHON_VERSION=${{ matrix.python_version }} \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DBUILD_PLUGIN_OAK_CAMERA=ON \
+          -DENABLE_CLOUDXR_BUNDLE_CHECK=ON
 
     - name: Build
       run: cmake --build build --parallel 4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20...3.25)
@@ -62,6 +62,11 @@ option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_EXAMPLE_TELEOP_ROS2 "Build only the teleop_ros2 example (e.g. for Docker)" OFF)
 option(BUILD_TESTING "Build unit tests" ON)
 option(ENABLE_EXPERIMENTAL_WINDOWS_BUILD "Enable experimental Windows build support (source code only)" OFF)
+
+# Note: This is used to check if the CloudXR bundle is available to be bundled with Isaac Teleop.
+# When enabled, build will fail if the CloudXR runtime SDK is not available.
+# TODO: Make this default to ON for Linux builds when the CloudXR runtime SDK is publicly available.
+option(ENABLE_CLOUDXR_BUNDLE_CHECK "Enable CloudXR bundle check" OFF)
 
 ## Enforce clang-format on Linux builds by default
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/src/core/cloudxr/python/CMakeLists.txt
+++ b/src/core/cloudxr/python/CMakeLists.txt
@@ -52,16 +52,19 @@ if(NOT EXISTS "${CLOUDXR_SDK_PATH}")
         message(STATUS "CloudXR SDK tarball download failed with exit code: ${DOWNLOAD_EXIT_CODE}")
         message(STATUS "stdout:\n${DOWNLOAD_OUT}")
         message(STATUS "stderr:\n${DOWNLOAD_ERR}")
+        set(CLOUDXR_SDK_PATH "")
     endif()
 endif()
 
 set(CLOUDXR_NATIVE_AVAILABLE FALSE)
-if(NOT EXISTS CLOUDXR_SDK_PATH)
-    message(WARNING
-        "CloudXR SDK tarball not found. Version is read from deps/cloudxr/.env.default (CXR_RUNTIME_SDK_VERSION). "
-        "Place ${CLOUDXR_SDK_FILE} in deps/cloudxr/ (e.g. run scripts/download_cloudxr_runtime_sdk.sh). "
-        "Skipping cloudxr_native_bundle."
-    )
+if(NOT EXISTS "${CLOUDXR_SDK_PATH}")
+    set(error_message "CloudXR SDK tarball is required. Place ${CLOUDXR_SDK_FILE} in "
+                      "deps/cloudxr/ or run scripts/download_cloudxr_runtime_sdk.sh.")
+    if(ENABLE_CLOUDXR_BUNDLE_CHECK)
+        message(FATAL_ERROR "${error_message}")
+    else()
+        message(WARNING "${error_message} Skipping cloudxr_native_bundle.")
+    endif()
 else()
     set(CLOUDXR_NATIVE_AVAILABLE TRUE)
     set(CLOUDXR_NATIVE_DIR "${CLOUDXR_PYTHON_DIR}/native")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional build flag to control whether missing CloudXR SDK bundles cause a fatal error or a warning/skip; CI now sets this flag for builds.

* **Bug Fixes**
  * Improved CloudXR SDK detection and recovery when download fails, clearing stale paths and preserving prior non-fatal behavior when configured.

* **Chores**
  * Adjusted code style check defaults by OS and updated copyright year.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->