### PR TITLE
upgrade depthai to 2.31 to resolve a soft-brick state issue

### DIFF
--- a/src/plugins/oak/CMakeLists.txt
+++ b/src/plugins/oak/CMakeLists.txt
@@ -21,7 +21,7 @@ set(DEPTHAI_BUILD_DOCS OFF CACHE BOOL "" FORCE)
 
 FetchContent_Declare(
     depthai
-    URL https://github.com/luxonis/depthai-core/releases/download/v2.29.0/depthai-core-v2.29.0.tar.gz
+    URL https://github.com/luxonis/depthai-core/releases/download/v2.31.0/depthai-core-v2.31.0.tar.gz
 )
 
 FetchContent_MakeAvailable(depthai)


### PR DESCRIPTION
There is an issue that the oak camera stays in a bad state where the sensors cannot be probed. Upgrading to depthai 2.31.0 solve the issue. 

Confirmed with @chaoyehc 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated DepthAI library to a newer version for improved compatibility and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->