### PR TITLE
Relax nlopt version

### DIFF
--- a/src/core/python/requirements-retargeters.txt
+++ b/src/core/python/requirements-retargeters.txt
@@ -2,5 +2,7 @@ dex-retargeting>=0.4.6,<0.6.0
 scipy>=1.15.0
 pyyaml>=6.0.3
 torch>=2.7.0
-# nlopt: no aarch64 wheel/sdist on PyPI for >=2.7; pin to last version with sdist
-nlopt==2.6.2
+
+# nlopt: architecture-specific so x86_64 can use pre-built wheels; arm builds from sdist
+nlopt==2.6.2; platform_machine == "aarch64" or platform_machine == "arm64"
+nlopt>=2.6.2; platform_machine != "aarch64" and platform_machine != "arm64"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted NLopt version constraints to be architecture-aware: allow newer pre-built wheel versions on x86_64 while preserving compatible behavior for aarch64/arm64 (which will build from source as needed), improving compatibility across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->