### PR TITLE
CloudXR web app dockerfile npm install fix

### DIFF
--- a/deps/cloudxr/Dockerfile.web-app
+++ b/deps/cloudxr/Dockerfile.web-app
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # CloudXR Web App - Dev server on 8080 (HTTP), nginx on 8443 (HTTPS only, proxies to 8080).
@@ -69,7 +69,7 @@ RUN echo 'server { \
 }' > /etc/nginx/conf.d/default.conf
 
 # Entrypoint: require mount, then generate cert, install deps if needed, start dev server and nginx
-COPY <<EOF /entrypoint.sh
+COPY <<'EOF' /entrypoint.sh
 #!/bin/bash
 set -e
 if [ ! -f /app/webxr_client/package.json ]; then
@@ -78,9 +78,13 @@ if [ ! -f /app/webxr_client/package.json ]; then
 fi
 /usr/local/bin/generate-cert.sh
 cd /app/webxr_client
-if [ ! -d node_modules ]; then
-  echo "Installing dependencies..."
+CURRENT_HASH="$(sha256sum package.json ../sdk.tgz | sha256sum | cut -d' ' -f1)"
+PREVIOUS_HASH_FILE="node_modules/.deps-hash"
+if [ ! -d node_modules ] || [ ! -f "$PREVIOUS_HASH_FILE" ] || [ "$(cat "$PREVIOUS_HASH_FILE")" != "$CURRENT_HASH" ]; then
+  echo "Installing dependencies (SDK: $SDK_TARBALL_NAME)..."
+  rm -rf node_modules
   npm install --ignore-scripts ../sdk.tgz && npm install --ignore-scripts
+  echo "$CURRENT_HASH" > "$PREVIOUS_HASH_FILE"
 fi
 npm run dev-server &
 exec nginx -g "daemon off;"


### PR DESCRIPTION
Previously when starting the web app docker it would only run npm install when there was no existing node_modules folder, so updates to the sdk etc. were ignored after the first time the dockerfile was run on a machine. This checks for changes to the sdk and package.json, and reruns npm install if necessary.