### PR TITLE
Introduce ROS teleop mode

### DIFF
--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -101,6 +101,7 @@ Example: `--ros-args -p mode:=controller_raw`
 docker exec -it teleop_ros2_ref /bin/bash
 
 ros2 topic echo /xr_teleop/hand geometry_msgs/msg/PoseArray
+ros2 topic echo /xr_teleop/ee_poses geometry_msgs/msg/PoseArray
 ros2 topic echo /xr_teleop/root_twist geometry_msgs/msg/TwistStamped
 ros2 topic echo /xr_teleop/root_pose geometry_msgs/msg/PoseStamped
 ros2 topic echo /xr_teleop/controller_data std_msgs/msg/ByteMultiArray

--- a/examples/teleop_ros2/python/teleop_ros2_publisher.py
+++ b/examples/teleop_ros2/python/teleop_ros2_publisher.py
@@ -406,23 +406,24 @@ class TeleopRos2PublisherNode(Node):
                                 self._pub_ee_pose.publish(ee_msg)
 
                         if self._mode in ("hand_teleop", "controller_teleop"):
-                            root_command = result["root_command"]
-                            cmd = np.asarray(root_command[0])
-                            twist_msg = TwistStamped()
-                            twist_msg.header.stamp = now
-                            twist_msg.header.frame_id = self._frame_id
-                            twist_msg.twist.linear.x = float(cmd[0])
-                            twist_msg.twist.linear.y = float(cmd[1])
-                            twist_msg.twist.linear.z = 0.0
-                            twist_msg.twist.angular.z = float(cmd[2])
-                            self._pub_root_twist.publish(twist_msg)
+                            root_command = result.get("root_command")
+                            if not root_command.is_none:
+                                cmd = np.asarray(root_command[0])
+                                twist_msg = TwistStamped()
+                                twist_msg.header.stamp = now
+                                twist_msg.header.frame_id = self._frame_id
+                                twist_msg.twist.linear.x = float(cmd[0])
+                                twist_msg.twist.linear.y = float(cmd[1])
+                                twist_msg.twist.linear.z = 0.0
+                                twist_msg.twist.angular.z = float(cmd[2])
+                                self._pub_root_twist.publish(twist_msg)
 
-                            pose_msg = PoseStamped()
-                            pose_msg.header.stamp = now
-                            pose_msg.header.frame_id = self._frame_id
-                            pose_msg.pose.position.z = float(cmd[3])
-                            pose_msg.pose.orientation.w = 1.0
-                            self._pub_root_pose.publish(pose_msg)
+                                pose_msg = PoseStamped()
+                                pose_msg.header.stamp = now
+                                pose_msg.header.frame_id = self._frame_id
+                                pose_msg.pose.position.z = float(cmd[3])
+                                pose_msg.pose.orientation.w = 1.0
+                                self._pub_root_pose.publish(pose_msg)
 
                         if self._mode == "controller_raw":
                             if not left_ctrl.is_none or not right_ctrl.is_none:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a mode parameter to select four teleoperation scenarios (controller_teleop, hand_teleop, controller_raw, full_body). Publishing now switches per mode and emits only relevant topics, including explicit root twist/root pose and an optional full-body command stream. Introduced a unified ee_poses topic and a dedicated end-effector topic for controller EE poses.

* **Documentation**
  * README updated with new mode descriptions, renamed topic/parameter names (ee_pose_topic, root_twist_topic, root_pose_topic, mode), a published-topics table, and an example invocation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->