### PR TITLE
Fix package version

### DIFF
--- a/deps/cloudxr/docker-compose.test.yaml
+++ b/deps/cloudxr/docker-compose.test.yaml
@@ -45,6 +45,7 @@ services:
       - XR_RUNTIME_JSON=/cloudxr-test/openxr_cloudxr.json
       - CXR_PYTHON_GPU_TESTS=${CXR_PYTHON_GPU_TESTS:-}
       - CXR_NATIVE_GPU_TESTS=${CXR_NATIVE_GPU_TESTS:-}
+      - EXPECTED_ISAACTELEOP_VERSION=${EXPECTED_ISAACTELEOP_VERSION:-}
     volumes:
       - openxr-volume:/cloudxr-test/:ro
     working_dir: /app/tests

--- a/examples/oxr/python/test_package_version.py
+++ b/examples/oxr/python/test_package_version.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate isaacteleop module version reporting against CI-provided expected version."""
+
+import os
+
+import isaacteleop
+
+
+if not hasattr(isaacteleop, "__version__"):
+    raise SystemExit("isaacteleop module does not define __version__")
+
+expected = os.environ.get("EXPECTED_ISAACTELEOP_VERSION", "").strip()
+if not expected:
+    raise SystemExit("EXPECTED_ISAACTELEOP_VERSION is not set")
+
+reported = isaacteleop.__version__
+
+print(f"isaacteleop.__version__: {reported}")
+print(f"Expected version from CI: {expected}")
+
+if reported != expected:
+    raise SystemExit(
+        f"Version mismatch: isaacteleop.__version__ ({reported}) != expected CI version ({expected})"
+    )
+
+print("Version check passed")

--- a/scripts/run_tests_with_cloudxr.sh
+++ b/scripts/run_tests_with_cloudxr.sh
@@ -25,6 +25,7 @@ set -euo pipefail
 # run on a runner without GPU support immediately after the build.
 #==============================================================================
 CXR_PYTHON_GPU_TESTS=(
+    "test_package_version.py"
     "test_extensions.py"
     "test_modular.py"
 )
@@ -228,6 +229,16 @@ elif [ "$WHEEL_COUNT" -gt 1 ]; then
 fi
 
 log_success "Found isaacteleop wheel in install/wheels/"
+
+WHEEL_PATH=$(find install/wheels -name "isaacteleop-*.whl")
+WHEEL_BASENAME=$(basename "$WHEEL_PATH")
+EXPECTED_ISAACTELEOP_VERSION=$(echo "$WHEEL_BASENAME" | sed -E 's/^isaacteleop-([^-]+)-.*/\1/' | tr '_' '-')
+if [ -z "$EXPECTED_ISAACTELEOP_VERSION" ]; then
+    log_error "Failed to derive expected version from wheel name: $WHEEL_BASENAME"
+    exit 1
+fi
+export EXPECTED_ISAACTELEOP_VERSION
+log_info "Expected isaacteleop version from wheel artifact: $EXPECTED_ISAACTELEOP_VERSION"
 
 # Build test container
 log_info "Building test container..."

--- a/src/core/python/isaacteleop_init.py
+++ b/src/core/python/isaacteleop_init.py
@@ -6,7 +6,13 @@
 This package provides Python bindings for teleoperation with Device I/O.
 """
 
-__version__ = "1.0.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("isaacteleop")
+except PackageNotFoundError:
+    # Fallback for local source-tree usage before wheel/package installation.
+    __version__ = "0+unknown"
 
 # Import submodules.
 from . import deviceio


### PR DESCRIPTION
Fixes #234 -- `isaacteleop.__version__` always report '1.0.0'


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added package version validation test to ensure correct Isaac Teleop version is deployed.

* **Chores**
  * Updated test infrastructure to extract and verify package version from built wheels.
  * Modified package initialization to dynamically resolve version from distribution metadata with fallback for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->