### PR TITLE
ROS2 Teleop Dockerfile nlopt build on arm64

### DIFF
--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -109,7 +109,9 @@ WORKDIR /opt/isaacteleop/install/examples/teleop_ros2/python
 # Copy requirements from the context, avoiding any files from the 'builder' stage.
 COPY src/core/python/requirements.txt src/core/python/requirements-retargeters.txt /tmp/
 RUN uv venv --python=${PYTHON_VERSION} && \
-    uv pip install -r /tmp/requirements.txt -r /tmp/requirements-retargeters.txt msgpack msgpack-numpy && \
+    uv pip install setuptools wheel && \
+    uv pip install --no-build-isolation-package nlopt \
+        -r /tmp/requirements.txt -r /tmp/requirements-retargeters.txt msgpack msgpack-numpy && \
     rm /tmp/requirements.txt /tmp/requirements-retargeters.txt
 
 COPY --from=builder /opt/isaacteleop/install /opt/isaacteleop/install


### PR DESCRIPTION
Address a build failure for nlopt observed when building the teleop ros2 reference application on arm64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build process for the teleop ROS2 example to improve package installation sequence and ensure required build tools are available during setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->