### PR TITLE
Fix camera_streamer Docker build on ARM64

### DIFF
--- a/examples/camera_streamer/Dockerfile
+++ b/examples/camera_streamer/Dockerfile
@@ -114,7 +114,7 @@ RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
     && ln -s /root/.local/bin/uv /usr/local/bin/uv
 
 COPY pyproject.toml /camera_streamer/pyproject.toml
-RUN uv pip install --system --no-cache-dir -e /camera_streamer
+RUN uv pip install --system --break-system-packages --no-cache-dir -e /camera_streamer
 
 # udev rules for OAK-D cameras.
 RUN echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"' \


### PR DESCRIPTION
ARM64 uses a newer base image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker installation compatibility for the camera streamer example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->