### PR TITLE
Proxy shows a friendlier page when certificate is accepted

### DIFF
--- a/deps/cloudxr/Dockerfile.wss-proxy
+++ b/deps/cloudxr/Dockerfile.wss-proxy
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 FROM haproxy:3.2
@@ -76,6 +76,10 @@ frontend websocket_frontend
 
         # Handle OPTIONS requests for CORS preflight
         http-request return status 200 content-type "text/plain" string "OK" if METH_OPTIONS
+
+        # Return a friendly page for non-WebSocket requests (e.g. cert acceptance)
+        acl is_websocket hdr(Upgrade) -i websocket
+        http-request return status 200 content-type "text/html; charset=utf-8" string "<!doctype html><html><head><meta charset=utf-8><style>body{font-family:system-ui,sans-serif;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;background:#f5f5f5;color:#222}div{text-align:center}h1{font-weight:600;font-size:1.5rem;margin-bottom:.5rem}p{color:#555;font-size:1rem}</style></head><body><div><h1>Certificate Accepted</h1><p>You can close this tab and return to the web client.</p></div></body></html>" unless is_websocket
 
         default_backend websocket_backend
 

--- a/src/core/cloudxr/python/wss.py
+++ b/src/core/cloudxr/python/wss.py
@@ -5,7 +5,6 @@
 
 import asyncio
 import errno
-import http.client
 import logging
 import shutil
 import ssl
@@ -112,56 +111,6 @@ CORS_HEADERS = {
 }
 
 
-def _forward_http(backend_host, backend_port, request):
-    """Forward plain HTTP requests to the backend and return its response."""
-    conn = http.client.HTTPConnection(backend_host, backend_port, timeout=5)
-    try:
-        method = getattr(request, "method", "GET")
-        body = getattr(request, "body", None)
-
-        hop_by_hop_headers = {
-            "host",
-            "connection",
-            "upgrade",
-            "proxy-connection",
-            "transfer-encoding",
-            "content-length",
-            "keep-alive",
-            "te",
-            "trailer",
-        }
-        request_headers = {}
-        for k, v in request.headers.raw_items():
-            if k.lower() not in hop_by_hop_headers:
-                request_headers[k] = v
-
-        conn.request(method, request.path or "/", body=body, headers=request_headers)
-        resp = conn.getresponse()
-        body = resp.read()
-        headers = Headers(
-            (k, v) for k, v in resp.getheaders() if k.lower() != "transfer-encoding"
-        )
-        headers.update(CORS_HEADERS)
-        return Response(resp.status, resp.reason, headers, body)
-    except TimeoutError:
-        return Response(
-            504,
-            "Gateway Timeout",
-            Headers({"Content-Type": "text/plain", **CORS_HEADERS}),
-            b"Backend did not respond in time.\n",
-        )
-    except (http.client.HTTPException, OSError) as exc:
-        log.warning("Backend HTTP request failed: %s", exc)
-        return Response(
-            502,
-            "Bad Gateway",
-            Headers({"Content-Type": "text/plain", **CORS_HEADERS}),
-            f"Backend connection failed: {exc}\n".encode(),
-        )
-    finally:
-        conn.close()
-
-
 def _make_http_handler(backend_host, backend_port):
     async def handle_http_request(connection, request):
         if request.headers.get("Upgrade", "").lower() == "websocket":
@@ -173,8 +122,19 @@ def _make_http_handler(backend_host, backend_port):
                 Headers({"Content-Type": "text/plain", **CORS_HEADERS}),
                 b"OK",
             )
-        return await asyncio.to_thread(
-            _forward_http, backend_host, backend_port, request
+        return Response(
+            200,
+            "OK",
+            Headers({"Content-Type": "text/html; charset=utf-8", **CORS_HEADERS}),
+            b"<!doctype html><html><head><meta charset=utf-8>"
+            b"<style>body{font-family:system-ui,sans-serif;display:flex;"
+            b"align-items:center;justify-content:center;height:100vh;margin:0;"
+            b"background:#f5f5f5;color:#222}div{text-align:center}"
+            b"h1{font-weight:600;font-size:1.5rem;margin-bottom:.5rem}"
+            b"p{color:#555;font-size:1rem}</style></head>"
+            b"<body><div><h1>Certificate Accepted</h1>"
+            b"<p>You can close this tab and return to the web client.</p>"
+            b"</div></body></html>",
         )
 
     return handle_http_request


### PR DESCRIPTION
For both the docker and python wss proxies, instead of a 501 error page this will show a friendlier page when a self-signed certificate is accepted:
<img width="551" height="264" alt="image" src="https://github.com/user-attachments/assets/1a64130a-de4d-4d73-b42f-5f7347551090" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Non-WebSocket HTTP requests now receive a direct certificate-accepted confirmation response, eliminating unnecessary backend forwarding operations.
  * Updated request handling infrastructure for improved system efficiency and cleaner resource utilization.
  * WebSocket proxy functionality remains fully operational and stable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->