### PR TITLE
Add Teleop ROS optional CycloneDDS dependency

### DIFF
--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -45,6 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxfixes-dev \
     libxxf86vm-dev \
     swig \
+    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv via standalone script (avoids PEP 668 "externally managed" pip on Ubuntu 24.04 / Jazzy)


### PR DESCRIPTION
Add cyclonedds dependency to Teleop ROS2 example.

e.g.
```bash
docker run ... -e RMW_IMPLEMENTATION=rmw_cyclonedds_cpp ... teleop_ros2_ref
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added CycloneDDS middleware support to the Docker image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->