### PR TITLE
ROS publisher: add controller data for full body in documentation

### DIFF
--- a/examples/teleop_ros2/python/teleop_ros2_publisher.py
+++ b/examples/teleop_ros2/python/teleop_ros2_publisher.py
@@ -16,7 +16,7 @@ published:
   - hand_teleop: ee_poses (from hand tracking wrist), hand (raw finger poses),
                  root_twist, root_pose, and TF transforms for left/right wrists
   - controller_raw: controller_data only
-  - full_body: full_body only
+  - full_body: full_body and controller_data
 
 Topic names (configurable via parameters):
   - xr_teleop/hand (PoseArray): [finger_joint_poses...]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified full_body mode functionality in documentation to indicate that controller data is considered alongside full_body data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->