### PR TITLE
Adds to accept EULA via flag --accept-eula

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -50,13 +50,11 @@ and asks you to review and accept the EULA:
 
    python -m isaacteleop.cloudxr
 
-To bypass the interactive EULA prompt (e.g. for CI or headless runs), set the environment variable:
+To bypass the interactive EULA prompt (e.g. for CI or headless runs), pass the flag:
 
 .. code-block:: bash
 
-   ACCEPT_EULA=true python -m isaacteleop.cloudxr
-
-Accepted values for ``ACCEPT_EULA`` are ``true``, ``yes``, ``y``, or ``1`` (case-insensitive).
+   python -m isaacteleop.cloudxr --accept-eula
 
 You should see output similar to:
 

--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -37,13 +37,18 @@ def _parse_args() -> argparse.Namespace:
         metavar="PATH",
         help="Optional env file (KEY=value per line) to override default CloudXR env vars",
     )
+    parser.add_argument(
+        "--accept-eula",
+        action="store_true",
+        help="Accept the NVIDIA CloudXR EULA non-interactively (e.g. for CI or containers).",
+    )
     return parser.parse_args()
 
 
 async def _main_async() -> None:
     args = _parse_args()
     env_cfg = EnvConfig.from_args(args.cloudxr_install_dir, args.cloudxr_env_config)
-    check_eula()
+    check_eula(accept_eula=args.accept_eula or None)
     logs_dir_path = env_cfg.ensure_logs_dir()
     wss_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
     wss_log_path = logs_dir_path / f"wss.{wss_ts}.log"

--- a/src/core/cloudxr/python/runtime.py
+++ b/src/core/cloudxr/python/runtime.py
@@ -19,38 +19,26 @@ _RUNTIME_JOIN_TIMEOUT = 10
 _RUNTIME_STARTUP_TIMEOUT_SEC = 10
 
 
-def _eula_accepted_via_env() -> bool | None:
-    """Return True if ACCEPT_EULA env indicates acceptance, False if rejection, None if unset/unknown."""
-    raw = os.environ.get("ACCEPT_EULA", "").strip()
-    if not raw:
-        return None
-    lower = raw.lower()
-    if lower in ("true", "yes", "y", "1"):
-        return True
-    if lower in ("false", "no", "n", "0"):
-        return False
-    return None
+def _write_eula_marker(marker: str) -> None:
+    run_dir = os.path.dirname(marker)
+    os.makedirs(run_dir, mode=0o700, exist_ok=True)
+    with open(marker, "w") as f:
+        f.write("accepted\n")
 
 
-def check_eula() -> None:
-    """Require CloudXR EULA to be accepted; exits the process if not. Call from main process before spawning runtime."""
+def check_eula(*, accept_eula: bool | None = None) -> None:
+    """Require CloudXR EULA to be accepted; exits the process if not. Call from main process before spawning runtime.
+
+    Args:
+        accept_eula: If True, accept and write marker. If None, check marker then prompt interactively.
+    """
     marker = os.path.join(get_env_config().openxr_run_dir(), "eula_accepted")
     if os.path.isfile(marker):
         return
 
-    accepted = _eula_accepted_via_env()
-    if accepted is True:
-        run_dir = os.path.dirname(marker)
-        os.makedirs(run_dir, mode=0o700, exist_ok=True)
-        with open(marker, "w") as f:
-            f.write("accepted\n")
+    if accept_eula is True:
+        _write_eula_marker(marker)
         return
-    if accepted is False:
-        print(
-            "EULA not accepted (ACCEPT_EULA is set to a negative value). Exiting.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
 
     print(
         "\nNVIDIA CloudXR EULA must be accepted to run. View: " + _EULA_URL,
@@ -64,10 +52,7 @@ def check_eula() -> None:
         print("EULA not accepted. Exiting.", file=sys.stderr)
         sys.exit(1)
 
-    run_dir = os.path.dirname(marker)
-    os.makedirs(run_dir, mode=0o700, exist_ok=True)
-    with open(marker, "w") as f:
-        f.write("accepted\n")
+    _write_eula_marker(marker)
 
 
 def _get_sdk_path() -> str | None:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a CLI flag (--accept-eula) to non-interactively accept the CloudXR EULA, enabling CI/headless setups.

* **Documentation**
  * Quick Start updated with exact command and inline example showing how to use --accept-eula to bypass the interactive EULA prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->