### PR TITLE
Bump checkout, cache, setup-python to avoid node warnings

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0 # Full history for accurate git describe
 
@@ -54,7 +54,7 @@ jobs:
 
     # Hunter cache - caches depthai dependencies (OpenSSL, CURL, etc.)
     - name: Cache Hunter packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.hunter
         key: hunter-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cmake/SetupHunter.cmake') }}
@@ -62,7 +62,7 @@ jobs:
           hunter-${{ runner.os }}-${{ runner.arch }}-
 
     - name: Cache ccache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/ccache
         key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build_type }}-py${{ matrix.python_version }}-${{ hashFiles('**/CMakeLists.txt') }}
@@ -155,7 +155,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -190,7 +190,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -232,7 +232,7 @@ jobs:
 
     steps:
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -32,7 +32,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -45,7 +45,7 @@ jobs:
     # Hunter cache - caches depthai dependencies
     # Note: Hunter uses C:/.hunter on Windows (at drive root)
     - name: Cache Hunter packages
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: C:/.hunter
         key: hunter-${{ runner.os }}-${{ hashFiles('cmake/SetupHunter.cmake') }}
@@ -53,7 +53,7 @@ jobs:
           hunter-${{ runner.os }}-
 
     - name: Cache sccache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ${{ env.SCCACHE_DIR }}
         key: sccache-${{ runner.os }}-${{ matrix.build_type }}-${{ hashFiles('**/CMakeLists.txt') }}

--- a/.github/workflows/docs-cleanup-preview.yaml
+++ b/.github/workflows/docs-cleanup-preview.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -67,10 +67,10 @@ jobs:
     needs: [check-repo]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -101,7 +101,7 @@ jobs:
     needs: [check-repo]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set CloudXR Web SDK version
         id: sdk_version

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,8 +11,8 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v3
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
       with:
         python-version: "3.12"
     - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions across CI/CD pipelines, including checkout, caching, and Python setup actions, to latest major releases for enhanced stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->