### PR TITLE
 Fix CloudXR runtime crash from OpenSSL symbol conflict

### DIFF
--- a/src/core/cloudxr/python/CMakeLists.txt
+++ b/src/core/cloudxr/python/CMakeLists.txt
@@ -78,6 +78,24 @@ else()
         COMMENT "Extracting CloudXR SDK tarball into python_package/.../cloudxr/native/"
     )
     add_dependencies(cloudxr_native_bundle cloudxr_native_dir)
+
+    # libcloudxr.so in the SDK tarball carries a NEEDED entry for libssl.so.3 even
+    # though it never calls any OpenSSL functions. When Python (which bundles its own
+    # OpenSSL) loads libcloudxr.so, the loader pulls in a second, incompatible
+    # libssl.so.3 and NVST crashes. Strip the spurious dependency at build time.
+    # A future SDK built with -Wl,--as-needed will make this step unnecessary.
+    find_program(PATCHELF_EXECUTABLE patchelf)
+    if(PATCHELF_EXECUTABLE)
+        add_custom_target(cloudxr_patchelf ALL
+            COMMAND ${PATCHELF_EXECUTABLE} --remove-needed libssl.so.3
+                    "${CLOUDXR_NATIVE_DIR}/libcloudxr.so"
+            COMMENT "Stripping spurious libssl.so.3 dependency from libcloudxr.so"
+        )
+        add_dependencies(cloudxr_patchelf cloudxr_native_bundle)
+    else()
+        message(WARNING "patchelf not found; libcloudxr.so will retain its libssl.so.3 "
+                        "dependency. Install patchelf to avoid OpenSSL symbol conflicts.")
+    endif()
 endif()
 
 # Copy CloudXR Python module to package structure (always; pure Python is cross-platform)
@@ -94,7 +112,11 @@ add_custom_target(cloudxr_python ALL
     COMMENT "Copying cloudxr Python files to package structure"
 )
 if(CLOUDXR_NATIVE_AVAILABLE)
-    add_dependencies(cloudxr_python cloudxr_native_bundle)
+    if(PATCHELF_EXECUTABLE)
+        add_dependencies(cloudxr_python cloudxr_patchelf)
+    else()
+        add_dependencies(cloudxr_python cloudxr_native_bundle)
+    endif()
 endif()
 
 install(

--- a/src/core/cloudxr/python/runtime.py
+++ b/src/core/cloudxr/python/runtime.py
@@ -190,7 +190,8 @@ def run() -> None:
         os.close(devnull_fd)
 
     lib_path = os.path.join(sdk_path, "libcloudxr.so")
-    lib = ctypes.CDLL(lib_path)
+    deepbind = getattr(os, "RTLD_DEEPBIND", 0)
+    lib = ctypes.CDLL(lib_path, mode=deepbind)
     svc = ctypes.c_void_p()
     # Signal handler must only call stop() after create() has run; avoid calling with null svc.
     state = {"service_created": False, "interrupted": False}


### PR DESCRIPTION
Load libcloudxr.so with RTLD_DEEPBIND so NVST resolves OpenSSL symbols from its own scope instead of picking up Python's incompatible libssl.so.3 from the global scope.
Add a patchelf build step to strip the spurious libssl.so.3 NEEDED entry from libcloudxr.so after extracting the SDK tarball, since the library never calls any OpenSSL functions directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved library loading behavior and runtime initialization stability.

* **Chores**
  * Optimized build process to remove unnecessary system dependencies from the CloudXR library, reducing installation footprint and improving initialization performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->