### PR TITLE
docs: use 1.0.0 as version for pip install

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -33,7 +33,7 @@ In a new terminal, install the package from PyPI (or from a local wheel if you b
 .. code-block:: bash
 
    # From PyPI
-   uv pip install isaacteleop[cloudxr,retargeters]~=1.0 --extra-index-url https://pypi.nvidia.com
+   pip install isaacteleop[cloudxr,retargeters]~=1.0.0 --extra-index-url https://pypi.nvidia.com
 
 Instead of installing the package from PyPI, you can build from source and install the local wheel.
 See :doc:`build_from_source` for more details.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed installation instructions for the package, including the correct package manager command and updated version specification format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->