### PR TITLE
Adjust polling timeout for Kitmaker release with exponential backoff

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -466,8 +466,8 @@ jobs:
         fi
 
         status_url="${KITMAKER_API_ENDPOINT%/}/v0/status/${KITMAKER_RELEASE_UUID}"
-        # Limit total polling time to at most ~10 minutes (20 * 30s)
-        max_attempts=20
+        # Limit total polling time to under an hour with exponential backoff starting at 30s
+        max_attempts=15
         sleep_seconds=30
 
         for ((attempt=1; attempt<=max_attempts; attempt++)); do
@@ -495,6 +495,7 @@ jobs:
           fi
 
           sleep "${sleep_seconds}"
+          sleep_seconds=$(( sleep_seconds * 125 / 100 ))
         done
 
         echo "Timed out waiting for Kitmaker release ${KITMAKER_RELEASE_UUID} to complete"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build system efficiency by optimizing status polling behavior with exponential backoff strategy and reduced retry attempts. The updated approach minimizes unnecessary wait times during the build process, reduces overall build duration, and maintains reliability for continuous integration workflows while improving resource utilization across build iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->