### PR TITLE
Whitelist docs from nspect OSS scan

### DIFF
--- a/.nspect-allowlist.toml
+++ b/.nspect-allowlist.toml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+version = "1.0.0"
+
+[oss.excluded]
+[[oss.excluded.directories]]
+
+paths = ['docs']
+comment = 'NVIDIA specific documentation'

--- a/docs/source/references/license.rst
+++ b/docs/source/references/license.rst
@@ -15,6 +15,7 @@ Known exceptions
   `MIT license <https://opensource.org/licenses/MIT>`_ or `Boost Software License 1.0 <https://www.boost.org/LICENSE_1_0.txt>`_.
 
 - CloudXR SDK is NVIDIA's proprietary software, licensed under the `NVIDIA CloudXR License <https://github.com/NVIDIA/IsaacTeleop/blob/main/deps/cloudxr/CLOUDXR_LICENSE>`_.
+- The documentation is built using `NVIDIA Sphinx Theme <https://pypi.org/project/nvidia-sphinx-theme/>`_.
 
 License headers
 ---------------


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a new public allowlist configuration (v1.0.0) to explicitly exclude the documentation directory from OSS distribution.
* **Documentation**
  * Updated license/reference notes to document that the docs are built with the NVIDIA Sphinx Theme and are intentionally excluded from distribution, including a brief comment explaining the rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->