### PR TITLE
Restore NGC workflow for run_cloudxr_via_docker.sh

### DIFF
--- a/deps/cloudxr/Dockerfile.runtime-ngc
+++ b/deps/cloudxr/Dockerfile.runtime-ngc
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Minimal CloudXR runtime image.
+# The SDK must be downloaded first (see scripts/download_cloudxr_runtime_sdk.sh).
+#
+# Build context: deps/cloudxr/ (contains CloudXR-<VERSION>-Linux-<ARCH>-sdk.tar.gz)
+#
+# Environment overrides:
+#   NV_DEVICE_PROFILE   Device profile (default: auto-webrtc).
+#                        Values: auto-native, auto-webrtc,
+#                        apple-vision-pro, ipad-pro, quest3
+
+# -------------------------------------------------------------------
+# Stage 0: Extract the SDK tarball.
+# -------------------------------------------------------------------
+FROM scratch AS sdk
+ARG TARGETARCH
+ARG CXR_RUNTIME_SDK_VERSION
+ADD CloudXR-${CXR_RUNTIME_SDK_VERSION}-Linux-${TARGETARCH}-sdk.tar.gz /sdk/
+
+# -------------------------------------------------------------------
+# Stage 1: Runtime image.
+# -------------------------------------------------------------------
+FROM ubuntu:24.04
+
+ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=all
+ENV LD_LIBRARY_PATH=/opt/cloudxr
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        libatomic1 \
+        libbsd0 \
+        libegl1 \
+        libgl1 \
+        libglx0 \
+        libvulkan1 \
+        libx11-6 \
+        libxext6 \
+        python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Vulkan ICD + EGL vendor so the loader can find the NVIDIA driver.
+RUN mkdir -p /etc/vulkan/icd.d /usr/share/glvnd/egl_vendor.d
+COPY runtime/data/10_nvidia.json /usr/share/glvnd/egl_vendor.d/
+COPY runtime/data/nvidia_icd.json /etc/vulkan/icd.d/
+ENV VK_DRIVER_FILES=/etc/vulkan/icd.d/nvidia_icd.json
+
+RUN mkdir -p /openxr/run && chmod 777 /openxr /openxr/run && \
+    touch /var/run/utmp
+
+WORKDIR /opt/cloudxr
+
+COPY runtime/main.py .
+COPY --from=sdk /sdk/*.so /sdk/*.so.* ./
+COPY --from=sdk /sdk/openxr_cloudxr.json .
+
+# CloudXR / OpenXR runtime configuration.
+ENV XR_RUNTIME_JSON=/openxr/openxr_cloudxr.json
+ENV NV_CXR_RUNTIME_DIR=/openxr/run
+ENV XRT_NO_STDIN=true
+ENV NV_CXR_FILE_LOGGING=false
+ENV NV_DEVICE_PROFILE=auto-webrtc
+
+COPY --chmod=0755 runtime/eula.sh /eula.sh
+COPY --chmod=0755 runtime/entrypoint-ngc.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh", "python3", "/opt/cloudxr/main.py"]

--- a/deps/cloudxr/docker-compose.yaml
+++ b/deps/cloudxr/docker-compose.yaml
@@ -1,10 +1,33 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# CloudXR compose override for web/proxy services and runtime mode.
-# Used together with docker-compose.runtime.yaml.
-
 services:
+  # CloudXR Runtime
+  cloudxr-runtime:
+    build:
+      context: .
+      dockerfile: Dockerfile.runtime-ngc
+      args:
+        CXR_RUNTIME_SDK_VERSION: ${CXR_RUNTIME_SDK_VERSION}
+    container_name: cloudxr-runtime-${CXR_RUNTIME_SDK_VERSION}
+    user: "${CXR_UID:-1000}:${CXR_GID:-1000}"
+    network_mode: host
+    healthcheck:
+      test: ["CMD", "test", "-f", "/openxr/run/runtime_started"]
+      interval: 1s
+      timeout: 1s
+      retries: 10
+      start_period: 5s
+    environment:
+      - ACCEPT_EULA=${ACCEPT_CLOUDXR_EULA:-Y}
+      - NV_CXR_ENABLE_PUSH_DEVICES=${NV_CXR_ENABLE_PUSH_DEVICES}
+      - NV_CXR_ENABLE_TENSOR_DATA=${NV_CXR_ENABLE_TENSOR_DATA}
+      - NV_DEVICE_PROFILE=${NV_DEVICE_PROFILE:-auto-webrtc}
+      - NV_GPU_INDEX=${NV_GPU_INDEX:-0}
+    volumes:
+      - openxr-volume:/openxr/
+    runtime: nvidia
+
   # WebSocket SSL Proxy Service
   wss-proxy:
     build:
@@ -40,3 +63,11 @@ services:
     volumes:
       - ./webxr_client:/app/webxr_client
     restart: unless-stopped
+
+volumes:
+  openxr-volume:
+    driver: local
+    driver_opts:
+      type: none
+      o: bind
+      device: ${CXR_HOST_VOLUME_PATH:-/tmp/cloudxr}

--- a/deps/cloudxr/runtime/entrypoint-ngc.sh
+++ b/deps/cloudxr/runtime/entrypoint-ngc.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+set -e
+
+mkdir -p /openxr/run
+cp -f /opt/cloudxr/libopenxr_cloudxr.so /openxr/
+cp -f /opt/cloudxr/openxr_cloudxr.json /openxr/
+rm -f /openxr/run/ipc_cloudxr /openxr/run/runtime_started
+exec /eula.sh "$@"

--- a/deps/cloudxr/runtime/main.py
+++ b/deps/cloudxr/runtime/main.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import ctypes
+import signal
+
+lib = ctypes.CDLL("libcloudxr.so")
+svc = ctypes.c_void_p()
+
+
+def stop(sig, frame):
+    lib.nv_cxr_service_stop(svc)
+
+
+lib.nv_cxr_service_create(ctypes.byref(svc))
+signal.signal(signal.SIGINT, stop)
+signal.signal(signal.SIGTERM, stop)
+lib.nv_cxr_service_start(svc)
+lib.nv_cxr_service_join(svc)
+lib.nv_cxr_service_destroy(svc)

--- a/scripts/run_cloudxr_via_docker.sh
+++ b/scripts/run_cloudxr_via_docker.sh
@@ -15,6 +15,9 @@ source scripts/setup_cloudxr_env.sh
 # Check CloudXR EULA acceptance
 ./scripts/check_cloudxr_eula.sh || exit 1
 
+# Download CloudXR Runtime SDK if not already present
+./scripts/download_cloudxr_runtime_sdk.sh || exit 1
+
 # Download CloudXR Web SDK if not already present
 ./scripts/download_cloudxr_sdk.sh || exit 1
 
@@ -31,6 +34,5 @@ fi
 $COMPOSE_CMD \
     --env-file "$ENV_DEFAULT" \
     --env-file "$ENV_LOCAL" \
-    -f deps/cloudxr/docker-compose.runtime.yaml \
     -f deps/cloudxr/docker-compose.yaml \
     up --build


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced CloudXR runtime as a containerized service deployable via Docker Compose.
  * Added automatic SDK download to the setup process.
  * Runtime service includes health monitoring and proper environment configuration with graphics, Vulkan, and Python dependencies.
  * OpenXR runtime environment is now pre-configured and ready for deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->