### PR TITLE
Use action context extension for the controller tracker.

### DIFF
--- a/deps/cloudxr/openxr_extensions/CMakeLists.txt
+++ b/deps/cloudxr/openxr_extensions/CMakeLists.txt
@@ -13,5 +13,6 @@ install(FILES
     XR_NVX1_device_interface.h
     XR_NVX1_tensor_data.h
     XR_NVX1_push_tensor.h
+    XR_NVX1_action_context.h
     DESTINATION include
 )

--- a/deps/cloudxr/openxr_extensions/XR_NVX1_action_context.h
+++ b/deps/cloudxr/openxr_extensions/XR_NVX1_action_context.h
@@ -1,0 +1,232 @@
+// Copyright 2026, NVIDIA CORPORATION.
+// SPDX-License-Identifier: Apache-2.0 or BSL-1.0
+/*!
+ * @file
+ * @brief Header for OpenXR XR_NVX1_action_context extension.
+ * @ingroup external_openxr
+ */
+
+#pragma once
+
+#include "openxr_extension_helpers.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*
+ * Default action contexts:
+ * OpenXR has a default instance action context and a default session action
+ * context. Action sets created without XrInstanceActionContextInfoNV belong to
+ * the default instance context; xrAttachSessionActionSets attaches them to the
+ * default session context. This extension adds named instance and session
+ * action contexts (XrInstanceActionContextNV, XrSessionActionContextNV) so
+ * that applications can create multiple action configurations and bind them
+ * to sessions in a single "attach all" step.
+ *
+ * XR_NVX1_action_context: xrCreateSessionActionContextNV creates an empty
+ * session action context from an instance action context and makes that
+ * instance context immutable. Action sets are attached to the session context
+ * via xrAttachSessionActionSets by chaining XrSessionActionContextInfoNV; all
+ * action sets in that call must belong to the same instance action context
+ * (the one the session context was created from).
+ *
+ * xrAttachSessionActionSets: when not chaining XrSessionActionContextInfoNV
+ * (or sessionActionContext is XR_NULL_HANDLE), only action sets from the
+ * default instance action context may be attached, to the default session
+ * context. The runtime must return
+ * XR_ERROR_ACTION_SETS_DIFFERENT_INSTANCE_ACTION_CONTEXT_NV if any action set
+ * belongs to an XrInstanceActionContextNV. When chaining
+ * XrSessionActionContextInfoNV with a valid sessionActionContext, the action
+ * sets are attached to that session context and must all belong to the same
+ * instance action context.
+ *
+ * xrSyncActions may only be used with action sets attached via
+ * xrAttachSessionActionSets (default context). Action sets that belong to an
+ * XrInstanceActionContextNV must be synced with xrSyncActions2NV. The runtime
+ * must return XR_ERROR_ACTION_SETS_DIFFERENT_INSTANCE_ACTION_CONTEXT_NV if
+ * xrSyncActions is called with action sets that belong to an instance action
+ * context.
+ *
+ * The core session-level action APIs (xrGetActionStateBoolean,
+ * xrGetActionStateFloat, xrGetActionStateVector2f, xrGetActionStatePose,
+ * xrEnumerateBoundSourcesForAction, xrGetInputSourceLocalizedName,
+ * xrApplyHapticFeedback, xrStopHapticFeedback, xrCreateActionSpace) apply to
+ * any action attached to the session, whether from the default context or
+ * from an XrSessionActionContextNV; they do not take a session action context
+ * parameter.
+ */
+
+// Extension number 848
+#define XR_NVX1_action_context 1
+#define XR_NVX1_action_context_SPEC_VERSION 1
+#define XR_NVX1_ACTION_CONTEXT_EXTENSION_NAME "XR_NVX1_action_context"
+
+/*
+ * Handle definitions.
+ */
+XR_DEFINE_HANDLE(XrInstanceActionContextNV)
+XR_DEFINE_HANDLE(XrSessionActionContextNV)
+
+/*
+ * Structure types.
+ */
+XR_STRUCT_ENUM(XR_TYPE_INSTANCE_ACTION_CONTEXT_CREATE_INFO_NV, 1000848001);
+XR_STRUCT_ENUM(XR_TYPE_SESSION_ACTION_CONTEXT_CREATE_INFO_NV, 1000848002);
+XR_STRUCT_ENUM(XR_TYPE_INSTANCE_ACTION_CONTEXT_INFO_NV, 1000848003);
+XR_STRUCT_ENUM(XR_TYPE_SESSION_ACTION_CONTEXT_INFO_NV, 1000848007);
+XR_STRUCT_ENUM(XR_TYPE_ACTIONS_SYNC_INFO_2_NV, 1000848004);
+XR_STRUCT_ENUM(XR_TYPE_ACTIONS_SYNC_STATE_2_NV, 1000848005);
+XR_STRUCT_ENUM(XR_TYPE_INTERACTION_PROFILE_GET_INFO_2_NV, 1000848006);
+
+typedef struct XrInstanceActionContextCreateInfoNV {
+    XrStructureType type;
+    const void *XR_MAY_ALIAS next;
+} XrInstanceActionContextCreateInfoNV;
+
+typedef struct XrSessionActionContextCreateInfoNV {
+    XrStructureType type;
+    const void *XR_MAY_ALIAS next;
+    XrInstanceActionContextNV instanceActionContext;
+} XrSessionActionContextCreateInfoNV;
+
+/*
+ * Returned when not all action sets belong to the expected instance action
+ * context. An action set belongs to an instance action context if and only if
+ * it was created with that context (XrInstanceActionContextInfoNV in
+ * xrCreateActionSet createInfo->next). Returned by xrSyncActions when any
+ * active action set belongs to an instance action context (use
+ * xrSyncActions2NV instead). Returned by xrAttachSessionActionSets when
+ * attaching to a session context and the action sets do not all belong to that
+ * session context's instance action context.
+ */
+XR_RESULT_ENUM(XR_ERROR_ACTION_SETS_DIFFERENT_INSTANCE_ACTION_CONTEXT_NV, -1000848000);
+
+/*
+ * Returned when an action set is already attached to another
+ * XrSessionActionContextNV for this session (e.g. when attaching via
+ * xrAttachSessionActionSets with XrSessionActionContextInfoNV). An action set
+ * from an instance action context may only be attached to one session action
+ * context at a time; destroying that session action context allows attaching
+ * it again.
+ */
+XR_RESULT_ENUM(XR_ERROR_ACTION_SET_ALREADY_ATTACHED_TO_SESSION_CONTEXT_NV, -1000848001);
+
+/*
+ * Chain struct for instance-level action APIs. Valid only when chained from
+ * XrActionSetCreateInfo::next or XrInteractionProfileSuggestedBinding::next.
+ * When present, the given instanceActionContext is used instead of the
+ * default. If chained from any other structure, the runtime must return
+ * XR_ERROR_VALIDATION_FAILURE.
+ */
+typedef struct XrInstanceActionContextInfoNV {
+    XrStructureType type;
+    const void *XR_MAY_ALIAS next;
+    XrInstanceActionContextNV instanceActionContext;
+} XrInstanceActionContextInfoNV;
+
+/*
+ * Chain struct for xrAttachSessionActionSets. Valid when chained from
+ * XrSessionActionSetsAttachInfo::next. When present and sessionActionContext
+ * is not XR_NULL_HANDLE, the action sets are attached to that session action
+ * context; they must all belong to the same instance action context (the one
+ * that session context was created from). When absent or sessionActionContext
+ * is XR_NULL_HANDLE, action sets are attached to the default session context
+ * and must belong to the default instance action context.
+ */
+typedef struct XrSessionActionContextInfoNV {
+    XrStructureType type;
+    const void *XR_MAY_ALIAS next;
+    XrSessionActionContextNV sessionActionContext;
+} XrSessionActionContextInfoNV;
+
+typedef struct XrActionsSyncInfo2NV {
+    XrStructureType type;
+    const void *XR_MAY_ALIAS next;
+    uint32_t countActiveActionSets;
+    const XrActiveActionSet *activeActionSets;
+    XrSessionActionContextNV sessionActionContext;
+} XrActionsSyncInfo2NV;
+
+typedef struct XrActionsSyncState2NV {
+    XrStructureType type;
+    void *XR_MAY_ALIAS next;
+    XrBool32 interactionProfileChanged;
+} XrActionsSyncState2NV;
+
+typedef struct XrInteractionProfileGetInfo2NV {
+    XrStructureType type;
+    const void *XR_MAY_ALIAS next;
+    XrPath topLevelUserPath;
+    XrSessionActionContextNV sessionActionContext;
+} XrInteractionProfileGetInfo2NV;
+
+/*
+ * Function pointer types.
+ */
+
+/*!
+ * Creates an instance action context. createInfo specifies no additional
+ * parameters; the context is populated by subsequent xrCreateActionSet and
+ * xrSuggestInteractionProfileBindings calls that chain XrInstanceActionContextInfoNV.
+ */
+typedef XrResult(XRAPI_PTR *PFN_xrCreateInstanceActionContextNV)(
+    XrInstance instance,
+    const XrInstanceActionContextCreateInfoNV *createInfo,
+    XrInstanceActionContextNV *instanceActionContext);
+
+typedef void(XRAPI_PTR *PFN_xrDestroyInstanceActionContextNV)(
+    XrInstanceActionContextNV instanceActionContext);
+
+/*!
+ * Creates an empty session action context from the given instance action
+ * context. The instance context becomes immutable. Attach action sets via
+ * xrAttachSessionActionSets with XrSessionActionContextInfoNV chained from
+ * XrSessionActionSetsAttachInfo::next; all action sets in that call must
+ * belong to the same instance action context.
+ */
+typedef XrResult(XRAPI_PTR *PFN_xrCreateSessionActionContextNV)(
+    XrSession session,
+    const XrSessionActionContextCreateInfoNV *createInfo,
+    XrSessionActionContextNV *sessionActionContext);
+
+typedef void(XRAPI_PTR *PFN_xrDestroySessionActionContextNV)(
+    XrSessionActionContextNV sessionActionContext);
+
+/*!
+ * Syncs action state for the given session action context. syncInfo is the
+ * same as XrActionsSyncInfo plus sessionActionContext. When sessionActionContext
+ * is a valid handle, activeActionSets must be action sets attached to that
+ * session action context. When sessionActionContext is XR_NULL_HANDLE, the
+ * default session action context (from xrAttachSessionActionSets) is used and
+ * activeActionSets must belong to the default instance action context.
+ *
+ * xrSyncActions2NV never queues XrEventDataInteractionProfileChanged; it only
+ * reports profile changes via syncState->interactionProfileChanged. This
+ * applies whether sessionActionContext is a valid handle or XR_NULL_HANDLE.
+ * syncState is required (non-NULL); the runtime must return
+ * XR_ERROR_VALIDATION_FAILURE if syncState is NULL. syncState->interactionProfileChanged
+ * is XR_TRUE if the current interaction profile for any active top-level user
+ * path has changed since the last sync for this session action context.
+ */
+typedef XrResult(XRAPI_PTR *PFN_xrSyncActions2NV)(XrSession session,
+                                                  const XrActionsSyncInfo2NV *syncInfo,
+                                                  XrActionsSyncState2NV *syncState);
+
+/*!
+ * Returns the current interaction profile for the given top-level user path
+ * in the specified session action context. getInfo->sessionActionContext may be
+ * XR_NULL_HANDLE to use the default session action context (from
+ * xrAttachSessionActionSets); the same errors apply (e.g.
+ * XR_ERROR_ACTIONSET_NOT_ATTACHED if no action sets have been attached).
+ */
+typedef XrResult(XRAPI_PTR *PFN_xrGetCurrentInteractionProfile2NV)(
+    XrSession session,
+    const XrInteractionProfileGetInfo2NV *getInfo,
+    XrInteractionProfileState *state);
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/oxr/python/test_controller_tracker.py
+++ b/examples/oxr/python/test_controller_tracker.py
@@ -2,10 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """
-Test script for ControllerTracker with simplified API.
+Test script for ControllerTracker with XR_NVX1_action_context support.
 
 Demonstrates:
 - Getting left and right controller data via get_left_controller() and get_right_controller()
+- Multiple ControllerTracker instances on the same session (action context isolation)
 """
 
 import sys
@@ -19,31 +20,34 @@ print("Controller Tracker Test")
 print("=" * 80)
 print()
 
-# Test 1: Create controller tracker (handles both controllers)
-print("[Test 1] Creating controller tracker...")
-controller_tracker = deviceio.ControllerTracker()
-print(f"✓ {controller_tracker.get_name()} created")
+# Test 1: Create two controller trackers to verify action context isolation
+print("[Test 1] Creating two controller trackers...")
+controller_tracker_a = deviceio.ControllerTracker()
+controller_tracker_b = deviceio.ControllerTracker()
+print(f"✓ {controller_tracker_a.get_name()} A created")
+print(f"✓ {controller_tracker_b.get_name()} B created")
 print()
 
-# Test 2: Query required extensions
+# Test 2: Query required extensions (should include XR_NVX1_action_context)
 print("[Test 2] Querying required extensions...")
-trackers = [controller_tracker]
+trackers = [controller_tracker_a, controller_tracker_b]
 required_extensions = deviceio.DeviceIOSession.get_required_extensions(trackers)
-print(
-    f"Required extensions: {required_extensions if required_extensions else 'None (uses core OpenXR)'}"
+print(f"Required extensions: {required_extensions}")
+assert "XR_NVX1_action_context" in required_extensions, (
+    "Expected XR_NVX1_action_context in required extensions"
 )
 print()
 
-# Test 3: Initialize
-print("[Test 3] Creating OpenXR session and initializing...")
+# Test 3: Initialize — both trackers on the same XrSession
+print("[Test 3] Creating OpenXR session with two ControllerTrackers...")
 
-# Use context managers for proper RAII cleanup
 with oxr.OpenXRSession("ControllerTrackerTest", required_extensions) as oxr_session:
     handles = oxr_session.get_handles()
 
-    # Run deviceio session with trackers (throws exception on failure)
     with deviceio.DeviceIOSession.run(trackers, handles) as session:
-        print("✅ OpenXR session initialized")
+        print(
+            "✅ OpenXR session initialized with two ControllerTrackers (action context isolation)"
+        )
         print()
 
         # Test 4: Initial update
@@ -55,22 +59,33 @@ with oxr.OpenXRSession("ControllerTrackerTest", required_extensions) as oxr_sess
         print("✓ Update successful")
         print()
 
-        # Test 5: Check initial controller state
-        print("[Test 5] Checking controller state...")
-        left_tracked = controller_tracker.get_left_controller(session)
-        right_tracked = controller_tracker.get_right_controller(session)
+        # Test 5: Both trackers should see the same controller state
+        print("[Test 5] Verifying both trackers report consistent data...")
+        left_a = controller_tracker_a.get_left_controller(session)
+        left_b = controller_tracker_b.get_left_controller(session)
+        right_a = controller_tracker_a.get_right_controller(session)
+        right_b = controller_tracker_b.get_right_controller(session)
 
-        if left_tracked.data is not None and left_tracked.data.grip_pose.is_valid:
-            pos = left_tracked.data.grip_pose.pose.position
-            print(f"  Left grip:  [{pos.x:.3f}, {pos.y:.3f}, {pos.z:.3f}]")
-        else:
-            print("  Left:  inactive")
+        def assert_trackers_consistent(label, ta, tb):
+            a_active = ta.data is not None and ta.data.grip_pose.is_valid
+            b_active = tb.data is not None and tb.data.grip_pose.is_valid
+            assert a_active == b_active, (
+                f"{label}: A active={a_active} but B active={b_active}"
+            )
+            if a_active:
+                pa = ta.data.grip_pose.pose.position
+                pb = tb.data.grip_pose.pose.position
+                tol = 0.01
+                assert abs(pa.x - pb.x) < tol, f"{label} x: {pa.x} vs {pb.x}"
+                assert abs(pa.y - pb.y) < tol, f"{label} y: {pa.y} vs {pb.y}"
+                assert abs(pa.z - pb.z) < tol, f"{label} z: {pa.z} vs {pb.z}"
+                print(f"  {label}: A and B match [{pa.x:.3f}, {pa.y:.3f}, {pa.z:.3f}]")
+            else:
+                print(f"  {label}: both inactive (consistent)")
 
-        if right_tracked.data is not None and right_tracked.data.grip_pose.is_valid:
-            pos = right_tracked.data.grip_pose.pose.position
-            print(f"  Right grip: [{pos.x:.3f}, {pos.y:.3f}, {pos.z:.3f}]")
-        else:
-            print("  Right: inactive")
+        assert_trackers_consistent("Left", left_a, left_b)
+        assert_trackers_consistent("Right", right_a, right_b)
+        print("✓ Tracker A and B report consistent data")
         print()
 
         # Test 6: Available inputs
@@ -94,12 +109,11 @@ with oxr.OpenXRSession("ControllerTrackerTest", required_extensions) as oxr_sess
                     print("Update failed")
                     break
 
-                # Get current controller data
                 current_time = time.time()
-                if current_time - last_status_print >= 0.5:  # Print every 0.5 seconds
+                if current_time - last_status_print >= 0.5:
                     elapsed = current_time - start_time
-                    left_tracked = controller_tracker.get_left_controller(session)
-                    right_tracked = controller_tracker.get_right_controller(session)
+                    left_tracked = controller_tracker_a.get_left_controller(session)
+                    right_tracked = controller_tracker_a.get_right_controller(session)
 
                     print(f"  [{elapsed:5.2f}s] Frame {frame_count:4d}")
 
@@ -161,8 +175,8 @@ with oxr.OpenXRSession("ControllerTrackerTest", required_extensions) as oxr_sess
             else:
                 print("    inactive")
 
-        left_tracked = controller_tracker.get_left_controller(session)
-        right_tracked = controller_tracker.get_right_controller(session)
+        left_tracked = controller_tracker_a.get_left_controller(session)
+        right_tracked = controller_tracker_a.get_right_controller(session)
         print_controller_summary("Left", left_tracked)
         print()
         print_controller_summary("Right", right_tracked)

--- a/src/core/deviceio/cpp/controller_tracker.cpp
+++ b/src/core/deviceio/cpp/controller_tracker.cpp
@@ -5,12 +5,15 @@
 
 #include "inc/deviceio/deviceio_session.hpp"
 
+#include <oxr_utils/oxr_funcs.hpp>
+#include <oxr_utils/oxr_time.hpp>
+#include <schema/controller_bfbs_generated.h>
+
 #include <cassert>
 #include <cmath>
 #include <cstring>
 #include <iostream>
 #include <stdexcept>
-#include <unordered_map>
 
 namespace core
 {
@@ -18,7 +21,21 @@ namespace core
 namespace
 {
 
-// Helper functions for getting OpenXR action states
+XrActionSetPtr createActionSetInContext(const OpenXRCoreFunctions& funcs, XrInstance instance, XrInstanceActionContextNV ctx)
+{
+    XrInstanceActionContextInfoNV ctx_info{ XR_TYPE_INSTANCE_ACTION_CONTEXT_INFO_NV };
+    ctx_info.instanceActionContext = ctx;
+
+    XrActionSetCreateInfo set_info{ XR_TYPE_ACTION_SET_CREATE_INFO };
+    set_info.next = &ctx_info;
+    strcpy(set_info.actionSetName, "controller_tracking");
+    strcpy(set_info.localizedActionSetName, "Controller Tracking");
+    set_info.priority = 0;
+
+    return createActionSet(funcs, instance, set_info);
+}
+
+// ---- OpenXR action helpers ----
 
 XrPath xr_path_from_string(const OpenXRCoreFunctions& funcs, XrInstance instance, const char* s)
 {
@@ -96,7 +113,7 @@ XrSpacePtr create_space(const OpenXRCoreFunctions& funcs, XrSession session, XrA
     space_info.poseInActionSpace.position = { 0.0f, 0.0f, 0.0f };
 
     return createActionSpace(funcs, session, &space_info);
-};
+}
 
 XrAction create_action(const OpenXRCoreFunctions& funcs,
                        XrActionSet action_set,
@@ -114,7 +131,7 @@ XrAction create_action(const OpenXRCoreFunctions& funcs,
     action_info.actionType = type;
     strcpy(action_info.actionName, name);
     strcpy(action_info.localizedActionName, localized_name);
-    action_info.countSubactionPaths = 2; // BOTH hands
+    action_info.countSubactionPaths = 2;
     action_info.subactionPaths = hand_paths;
 
     XrResult res = funcs.xrCreateAction(action_set, &action_info, &out_action);
@@ -124,29 +141,75 @@ XrAction create_action(const OpenXRCoreFunctions& funcs,
     }
 
     return out_action;
-};
+}
 
 } // anonymous namespace
 
 // ============================================================================
-// ControllerTracker::Impl Implementation
+// ControllerTracker::Impl
 // ============================================================================
 
-// Constructor - throws std::runtime_error on failure
+class ControllerTracker::Impl : public ITrackerImpl
+{
+public:
+    explicit Impl(const OpenXRSessionHandles& handles);
+    ~Impl() = default;
+
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
+
+    bool update(XrTime time) override;
+    void serialize_all(size_t channel_index, const RecordCallback& callback) const override;
+
+    const ControllerSnapshotTrackedT& get_left_controller() const;
+    const ControllerSnapshotTrackedT& get_right_controller() const;
+
+private:
+    const OpenXRCoreFunctions core_funcs_;
+    XrTimeConverter time_converter_;
+
+    XrSession session_;
+    XrSpace base_space_;
+
+    XrPath left_hand_path_;
+    XrPath right_hand_path_;
+
+    // Action context — declared before action_set_ so it outlives it.
+    ActionContextFunctions action_ctx_funcs_;
+    XrInstanceActionContextPtr instance_action_context_;
+    XrSessionActionContextPtr session_action_context_;
+
+    XrActionSetPtr action_set_;
+    XrAction grip_pose_action_;
+    XrAction aim_pose_action_;
+    XrAction primary_click_action_;
+    XrAction secondary_click_action_;
+    XrAction thumbstick_action_;
+    XrAction thumbstick_click_action_;
+    XrAction squeeze_value_action_;
+    XrAction trigger_value_action_;
+
+    XrSpacePtr left_grip_space_;
+    XrSpacePtr right_grip_space_;
+    XrSpacePtr left_aim_space_;
+    XrSpacePtr right_aim_space_;
+
+    ControllerSnapshotTrackedT left_tracked_;
+    ControllerSnapshotTrackedT right_tracked_;
+    XrTime last_update_time_ = 0;
+};
+
 ControllerTracker::Impl::Impl(const OpenXRSessionHandles& handles)
     : core_funcs_(OpenXRCoreFunctions::load(handles.instance, handles.xrGetInstanceProcAddr)),
       time_converter_(handles),
       session_(handles.session),
       base_space_(handles.space),
-
       left_hand_path_(xr_path_from_string(core_funcs_, handles.instance, "/user/hand/left")),
       right_hand_path_(xr_path_from_string(core_funcs_, handles.instance, "/user/hand/right")),
-
-      action_set_(createActionSet(core_funcs_,
-                                  handles.instance,
-                                  { .type = XR_TYPE_ACTION_SET_CREATE_INFO,
-                                    .actionSetName = "controller_tracking",
-                                    .localizedActionSetName = "Controller Tracking" })),
+      action_ctx_funcs_(ActionContextFunctions::load(handles.instance, handles.xrGetInstanceProcAddr)),
+      instance_action_context_(createInstanceActionContext(action_ctx_funcs_, handles.instance)),
+      session_action_context_(nullptr, nullptr),
+      action_set_(createActionSetInContext(core_funcs_, handles.instance, instance_action_context_.get())),
       grip_pose_action_(create_action(core_funcs_,
                                       action_set_.get(),
                                       left_hand_path_,
@@ -198,12 +261,12 @@ ControllerTracker::Impl::Impl(const OpenXRSessionHandles& handles)
                                           "trigger_value",
                                           "Trigger Value",
                                           XR_ACTION_TYPE_FLOAT_INPUT)),
-
       left_grip_space_(create_space(core_funcs_, session_, grip_pose_action_, left_hand_path_)),
       right_grip_space_(create_space(core_funcs_, session_, grip_pose_action_, right_hand_path_)),
       left_aim_space_(create_space(core_funcs_, session_, aim_pose_action_, left_hand_path_)),
       right_aim_space_(create_space(core_funcs_, session_, aim_pose_action_, right_hand_path_))
 {
+    // Suggest interaction profile bindings (chained to this action context)
     std::vector<XrActionSuggestedBinding> bindings;
     auto add_binding = [&](XrAction action, const char* path)
     {
@@ -214,7 +277,6 @@ ControllerTracker::Impl::Impl(const OpenXRSessionHandles& handles)
         }
     };
 
-    // Common bindings for both hands
     add_binding(grip_pose_action_, "/user/hand/left/input/grip/pose");
     add_binding(grip_pose_action_, "/user/hand/right/input/grip/pose");
     add_binding(aim_pose_action_, "/user/hand/left/input/aim/pose");
@@ -227,15 +289,16 @@ ControllerTracker::Impl::Impl(const OpenXRSessionHandles& handles)
     add_binding(squeeze_value_action_, "/user/hand/right/input/squeeze/value");
     add_binding(trigger_value_action_, "/user/hand/left/input/trigger/value");
     add_binding(trigger_value_action_, "/user/hand/right/input/trigger/value");
+    add_binding(primary_click_action_, "/user/hand/left/input/x/click");
+    add_binding(secondary_click_action_, "/user/hand/left/input/y/click");
+    add_binding(primary_click_action_, "/user/hand/right/input/a/click");
+    add_binding(secondary_click_action_, "/user/hand/right/input/b/click");
 
-    // Hand-specific button bindings
-    add_binding(primary_click_action_, "/user/hand/left/input/x/click"); // Left: X
-    add_binding(secondary_click_action_, "/user/hand/left/input/y/click"); // Left: Y
-    add_binding(primary_click_action_, "/user/hand/right/input/a/click"); // Right: A
-    add_binding(secondary_click_action_, "/user/hand/right/input/b/click"); // Right: B
+    XrInstanceActionContextInfoNV binding_ctx_info{ XR_TYPE_INSTANCE_ACTION_CONTEXT_INFO_NV };
+    binding_ctx_info.instanceActionContext = instance_action_context_.get();
 
-    // Suggest bindings for Oculus Touch controller profile
     XrInteractionProfileSuggestedBinding suggested_bindings{ XR_TYPE_INTERACTION_PROFILE_SUGGESTED_BINDING };
+    suggested_bindings.next = &binding_ctx_info;
     suggested_bindings.interactionProfile =
         xr_path_from_string(core_funcs_, handles.instance, "/interaction_profiles/oculus/touch_controller");
     suggested_bindings.countSuggestedBindings = static_cast<uint32_t>(bindings.size());
@@ -247,11 +310,17 @@ ControllerTracker::Impl::Impl(const OpenXRSessionHandles& handles)
         throw std::runtime_error("Failed to suggest interaction profile bindings: " + std::to_string(result));
     }
 
-    std::cout << "ControllerTracker: Using Oculus Touch Controller profile" << std::endl;
+    // Create session action context (makes the instance context immutable)
+    session_action_context_ =
+        createSessionActionContext(action_ctx_funcs_, handles.session, instance_action_context_.get());
 
-    // Attach action set to session
+    // Attach action sets to the session action context
+    XrSessionActionContextInfoNV sess_ctx_info{ XR_TYPE_SESSION_ACTION_CONTEXT_INFO_NV };
+    sess_ctx_info.sessionActionContext = session_action_context_.get();
+
     XrActionSet action_set_handle = action_set_.get();
     XrSessionActionSetsAttachInfo attach_info{ XR_TYPE_SESSION_ACTION_SETS_ATTACH_INFO };
+    attach_info.next = &sess_ctx_info;
     attach_info.countActionSets = 1;
     attach_info.actionSets = &action_set_handle;
 
@@ -261,28 +330,33 @@ ControllerTracker::Impl::Impl(const OpenXRSessionHandles& handles)
         throw std::runtime_error("Failed to attach action sets: " + std::to_string(result));
     }
 
-    std::cout << "ControllerTracker initialized (left + right)" << std::endl;
+    std::cout << "ControllerTracker initialized (left + right) with action context" << std::endl;
 }
 
-// Override from ITrackerImpl
 bool ControllerTracker::Impl::update(XrTime time)
 {
     last_update_time_ = time;
 
-    // Sync actions
-    XrActionsSyncInfo sync_info{ XR_TYPE_ACTIONS_SYNC_INFO };
+    // Sync actions via xrSyncActions2NV with our session action context
     XrActiveActionSet active_action_set{ action_set_.get(), XR_NULL_PATH };
+
+    XrActionsSyncInfo2NV sync_info{ XR_TYPE_ACTIONS_SYNC_INFO_2_NV };
     sync_info.countActiveActionSets = 1;
     sync_info.activeActionSets = &active_action_set;
+    sync_info.sessionActionContext = session_action_context_.get();
 
-    XrResult result = core_funcs_.xrSyncActions(session_, &sync_info);
+    XrActionsSyncState2NV sync_state{ XR_TYPE_ACTIONS_SYNC_STATE_2_NV };
+
+    XrResult result = action_ctx_funcs_.sync_actions_2(session_, &sync_info, &sync_state);
     if (XR_FAILED(result))
     {
-        std::cerr << "[ControllerTracker] xrSyncActions failed: " << result << std::endl;
+        std::cerr << "[ControllerTracker] xrSyncActions2NV failed: " << result << std::endl;
         left_tracked_.data.reset();
         right_tracked_.data.reset();
         return false;
     }
+    // sync_state.interactionProfileChanged is intentionally ignored: this
+    // tracker uses a fixed Oculus Touch binding and has no rebinding logic.
 
     auto update_controller = [&](XrPath hand_path, const XrSpacePtr& grip_space, const XrSpacePtr& aim_space,
                                  ControllerSnapshotTrackedT& tracked)
@@ -291,7 +365,6 @@ bool ControllerTracker::Impl::update(XrTime time)
         ControllerPose aim_pose{};
         ControllerInputState inputs{};
 
-        // Update grip pose
         XrSpaceLocation grip_location{ XR_TYPE_SPACE_LOCATION };
         result = core_funcs_.xrLocateSpace(grip_space.get(), base_space_, time, &grip_location);
         if (XR_SUCCEEDED(result))
@@ -306,7 +379,6 @@ bool ControllerTracker::Impl::update(XrTime time)
             grip_pose = ControllerPose(pose, is_valid);
         }
 
-        // Update aim pose
         XrSpaceLocation aim_location{ XR_TYPE_SPACE_LOCATION };
         result = core_funcs_.xrLocateSpace(aim_space.get(), base_space_, time, &aim_location);
         if (XR_SUCCEEDED(result))
@@ -323,7 +395,6 @@ bool ControllerTracker::Impl::update(XrTime time)
 
         bool is_active = grip_pose.is_valid() || aim_pose.is_valid();
 
-        // Update input values
         bool primary_click = get_boolean_action_state(session_, core_funcs_, primary_click_action_, hand_path);
         bool secondary_click = get_boolean_action_state(session_, core_funcs_, secondary_click_action_, hand_path);
 
@@ -395,13 +466,18 @@ void ControllerTracker::Impl::serialize_all(size_t channel_index, const RecordCa
 }
 
 // ============================================================================
-// ControllerTracker Public Interface Implementation
+// ControllerTracker Public Interface
 // ============================================================================
 
 std::vector<std::string> ControllerTracker::get_required_extensions() const
 {
-    // Controllers don't require any extensions (they're part of core OpenXR)
-    return {};
+    return { XR_NVX1_ACTION_CONTEXT_EXTENSION_NAME };
+}
+
+std::string_view ControllerTracker::get_schema_text() const
+{
+    return std::string_view(reinterpret_cast<const char*>(ControllerSnapshotRecordBinarySchema::data()),
+                            ControllerSnapshotRecordBinarySchema::size());
 }
 
 const ControllerSnapshotTrackedT& ControllerTracker::get_left_controller(const DeviceIOSession& session) const
@@ -416,30 +492,7 @@ const ControllerSnapshotTrackedT& ControllerTracker::get_right_controller(const 
 
 std::shared_ptr<ITrackerImpl> ControllerTracker::create_tracker(const OpenXRSessionHandles& handles) const
 {
-    // Multiple ControllerTracker instances sharing the same XrSession must reuse
-    // a single Impl because OpenXR forbids duplicate action-set names /
-    // interaction-profile bindings per session.
-    static std::unordered_map<XrSession, std::weak_ptr<ITrackerImpl>> shared_impls;
-
-    // Prune expired entries while we're here
-    for (auto it = shared_impls.begin(); it != shared_impls.end();)
-    {
-        if (it->second.expired())
-            it = shared_impls.erase(it);
-        else
-            ++it;
-    }
-
-    auto& weak = shared_impls[handles.session];
-    if (auto existing = weak.lock())
-    {
-        std::cout << "ControllerTracker: Reusing existing impl for this XrSession" << std::endl;
-        return existing;
-    }
-
-    auto impl = std::make_shared<Impl>(handles);
-    weak = impl;
-    return impl;
+    return std::make_shared<Impl>(handles);
 }
 
 } // namespace core

--- a/src/core/deviceio/cpp/deviceio_session.cpp
+++ b/src/core/deviceio/cpp/deviceio_session.cpp
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <set>
 #include <stdexcept>
-#include <unordered_set>
 
 namespace core
 {
@@ -71,18 +70,8 @@ bool DeviceIOSession::update()
 {
     XrTime current_time = time_converter_.os_monotonic_now();
 
-    // Multiple ITracker instances may share the same ITrackerImpl (e.g. two
-    // ControllerTrackers on the same XrSession).  Deduplicate so that each
-    // unique impl is updated exactly once per frame.
-    std::unordered_set<ITrackerImpl*> updated;
-
     for (auto& [tracker, impl] : tracker_impls_)
     {
-        if (!updated.insert(impl.get()).second)
-        {
-            continue; // already updated this impl
-        }
-
         if (!impl->update(current_time))
         {
             auto& count = tracker_update_failure_counts_[tracker];

--- a/src/core/deviceio/cpp/inc/deviceio/controller_tracker.hpp
+++ b/src/core/deviceio/cpp/inc/deviceio/controller_tracker.hpp
@@ -5,9 +5,6 @@
 
 #include "tracker.hpp"
 
-#include <oxr_utils/oxr_funcs.hpp>
-#include <oxr_utils/oxr_time.hpp>
-#include <schema/controller_bfbs_generated.h>
 #include <schema/controller_generated.h>
 
 #include <memory>
@@ -15,36 +12,27 @@
 namespace core
 {
 
-// Controller tracker - tracks both left and right controllers
-// Updates all controller state (poses + inputs) each frame
+// Each instance creates its own XR_NVX1_action_context so that multiple
+// ControllerTracker instances can coexist on the same XrSession without
+// conflicting action-set names or interaction-profile bindings.
 class ControllerTracker : public ITracker
 {
 public:
-    // Public API - what external users see
     std::vector<std::string> get_required_extensions() const override;
-
     std::string_view get_name() const override
     {
         return TRACKER_NAME;
     }
-
     std::string_view get_schema_name() const override
     {
         return SCHEMA_NAME;
     }
-
-    std::string_view get_schema_text() const override
-    {
-        return std::string_view(reinterpret_cast<const char*>(ControllerSnapshotRecordBinarySchema::data()),
-                                ControllerSnapshotRecordBinarySchema::size());
-    }
-
+    std::string_view get_schema_text() const override;
     std::vector<std::string> get_record_channels() const override
     {
         return { "left_controller", "right_controller" };
     }
 
-    // Query methods - public API for getting controller data (tracked.data is null when inactive)
     const ControllerSnapshotTrackedT& get_left_controller(const DeviceIOSession& session) const;
     const ControllerSnapshotTrackedT& get_right_controller(const DeviceIOSession& session) const;
 
@@ -54,52 +42,7 @@ private:
 
     std::shared_ptr<ITrackerImpl> create_tracker(const OpenXRSessionHandles& handles) const override;
 
-    class Impl : public ITrackerImpl
-    {
-    public:
-        explicit Impl(const OpenXRSessionHandles& handles);
-
-        // Override from ITrackerImpl
-        bool update(XrTime time) override;
-
-        void serialize_all(size_t channel_index, const RecordCallback& callback) const override;
-
-        const ControllerSnapshotTrackedT& get_left_controller() const;
-        const ControllerSnapshotTrackedT& get_right_controller() const;
-
-    private:
-        const OpenXRCoreFunctions core_funcs_;
-        XrTimeConverter time_converter_;
-
-        XrSession session_;
-        XrSpace base_space_;
-
-        // Paths for both hands
-        XrPath left_hand_path_;
-        XrPath right_hand_path_;
-
-        // Actions - simplified to only the inputs we care about
-        XrActionSetPtr action_set_;
-        XrAction grip_pose_action_;
-        XrAction aim_pose_action_;
-        XrAction primary_click_action_;
-        XrAction secondary_click_action_;
-        XrAction thumbstick_action_;
-        XrAction thumbstick_click_action_;
-        XrAction squeeze_value_action_;
-        XrAction trigger_value_action_;
-
-        // Action spaces for both hands
-        XrSpacePtr left_grip_space_;
-        XrSpacePtr right_grip_space_;
-        XrSpacePtr left_aim_space_;
-        XrSpacePtr right_aim_space_;
-
-        // Controller data (tracked.data is null when inactive)
-        ControllerSnapshotTrackedT left_tracked_;
-        ControllerSnapshotTrackedT right_tracked_;
-        XrTime last_update_time_ = 0;
-    };
+    class Impl;
 };
 
 } // namespace core

--- a/src/core/oxr_utils/cpp/inc/oxr_utils/oxr_funcs.hpp
+++ b/src/core/oxr_utils/cpp/inc/oxr_utils/oxr_funcs.hpp
@@ -9,6 +9,7 @@
 
 #include <openxr/openxr.h>
 
+#include <XR_NVX1_action_context.h>
 #include <cassert>
 #include <functional>
 #include <memory>
@@ -117,6 +118,42 @@ inline void loadExtensionFunction(XrInstance instance,
 // Smart pointer type aliases for OpenXR resources
 using XrActionSetPtr = std::unique_ptr<std::remove_pointer_t<XrActionSet>, PFN_xrDestroyActionSet>;
 using XrSpacePtr = std::unique_ptr<std::remove_pointer_t<XrSpace>, PFN_xrDestroySpace>;
+using XrInstanceActionContextPtr =
+    std::unique_ptr<std::remove_pointer_t<XrInstanceActionContextNV>, PFN_xrDestroyInstanceActionContextNV>;
+using XrSessionActionContextPtr =
+    std::unique_ptr<std::remove_pointer_t<XrSessionActionContextNV>, PFN_xrDestroySessionActionContextNV>;
+
+// Dynamically loaded XR_NVX1_action_context extension function pointers.
+struct ActionContextFunctions
+{
+    PFN_xrCreateInstanceActionContextNV create_instance_ctx;
+    PFN_xrDestroyInstanceActionContextNV destroy_instance_ctx;
+    PFN_xrCreateSessionActionContextNV create_session_ctx;
+    PFN_xrDestroySessionActionContextNV destroy_session_ctx;
+    PFN_xrSyncActions2NV sync_actions_2;
+
+    static ActionContextFunctions load(XrInstance instance, PFN_xrGetInstanceProcAddr getProcAddr)
+    {
+        ActionContextFunctions f{};
+        loadExtensionFunction(instance, getProcAddr, "xrCreateInstanceActionContextNV",
+                              reinterpret_cast<PFN_xrVoidFunction*>(&f.create_instance_ctx));
+        loadExtensionFunction(instance, getProcAddr, "xrDestroyInstanceActionContextNV",
+                              reinterpret_cast<PFN_xrVoidFunction*>(&f.destroy_instance_ctx));
+        loadExtensionFunction(instance, getProcAddr, "xrCreateSessionActionContextNV",
+                              reinterpret_cast<PFN_xrVoidFunction*>(&f.create_session_ctx));
+        loadExtensionFunction(instance, getProcAddr, "xrDestroySessionActionContextNV",
+                              reinterpret_cast<PFN_xrVoidFunction*>(&f.destroy_session_ctx));
+        loadExtensionFunction(
+            instance, getProcAddr, "xrSyncActions2NV", reinterpret_cast<PFN_xrVoidFunction*>(&f.sync_actions_2));
+
+        if (!f.create_instance_ctx || !f.destroy_instance_ctx || !f.create_session_ctx || !f.destroy_session_ctx ||
+            !f.sync_actions_2)
+        {
+            throw std::runtime_error("Required XR_NVX1_action_context extension functions are missing");
+        }
+        return f;
+    }
+};
 
 // Create an action set with automatic cleanup - throws on failure
 inline XrActionSetPtr createActionSet(const OpenXRCoreFunctions& funcs,
@@ -170,6 +207,35 @@ inline XrSpacePtr createActionSpace(const OpenXRCoreFunctions& funcs,
     }
 
     return XrSpacePtr(space, funcs.xrDestroySpace);
+}
+
+// Create an instance action context with automatic cleanup - throws on failure
+inline XrInstanceActionContextPtr createInstanceActionContext(const ActionContextFunctions& funcs, XrInstance instance)
+{
+    XrInstanceActionContextCreateInfoNV create_info{ XR_TYPE_INSTANCE_ACTION_CONTEXT_CREATE_INFO_NV };
+    XrInstanceActionContextNV ctx = XR_NULL_HANDLE;
+    XrResult result = funcs.create_instance_ctx(instance, &create_info, &ctx);
+    if (XR_FAILED(result))
+    {
+        throw std::runtime_error("Failed to create instance action context: " + std::to_string(result));
+    }
+    return XrInstanceActionContextPtr(ctx, funcs.destroy_instance_ctx);
+}
+
+// Create a session action context with automatic cleanup - throws on failure
+inline XrSessionActionContextPtr createSessionActionContext(const ActionContextFunctions& funcs,
+                                                            XrSession session,
+                                                            XrInstanceActionContextNV instance_ctx)
+{
+    XrSessionActionContextCreateInfoNV create_info{ XR_TYPE_SESSION_ACTION_CONTEXT_CREATE_INFO_NV };
+    create_info.instanceActionContext = instance_ctx;
+    XrSessionActionContextNV ctx = XR_NULL_HANDLE;
+    XrResult result = funcs.create_session_ctx(session, &create_info, &ctx);
+    if (XR_FAILED(result))
+    {
+        throw std::runtime_error("Failed to create session action context: " + std::to_string(result));
+    }
+    return XrSessionActionContextPtr(ctx, funcs.destroy_session_ctx);
 }
 
 } // namespace core


### PR DESCRIPTION
This removes the temporary work-around that deduplicates controller tracker implementations and uses the action context extension supported by the rutnime to support multiple controller trackers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the OpenXR NVX1 action-context extension and installed its public header.

* **Behavioral Changes**
  * Tracker lifecycle now uses per-instance action contexts with context-aware action sync.
  * Update loop deduplication removed — tracker implementations may be updated multiple times per frame if shared.

* **Tests**
  * Controller test expanded to verify cross-tracker isolation within a single session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->