### PR TITLE
Make serverIP default use the page URL for localhost

### DIFF
--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -279,7 +279,7 @@ export class CloudXR2DUI {
     // Default port: HTTP → 49100, HTTPS without proxy → 48322, HTTPS with proxy → 443
     const defaultPort = useSecure ? 48322 : 49100;
     return {
-      serverIP: typeof window !== 'undefined' ? window.location.hostname : '127.0.0.1',
+      serverIP: (typeof window !== 'undefined' && window.location.hostname) || '127.0.0.1',
       port: defaultPort,
       useSecureConnection: useSecure,
       perEyeWidth: 2048,


### PR DESCRIPTION
This makes the default serverIp be the page URL instead of hardcoding 127.0.0.1, which caused a mismatch with the self-signed certificate acceptance link when the page was at "localhost".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default server address now uses the current browser's hostname when available, falling back to localhost in non-browser environments—improves out-of-the-box connectivity for web deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->