### PR TITLE
Switch Kitmaker to use Artifactory

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -304,6 +304,13 @@ jobs:
             --data-urlencode "repos=${ARTIFACTORY_REPO}" \
             "${ARTIFACTORY_URL%/}/api/search/artifact")"
 
+          result_count="$(jq '.results | length' <<< "${search_json}")"
+          if [[ "${result_count}" -ne 1 ]]; then
+            echo "Expected exactly 1 Artifactory search result for ${wheel_name}, but got ${result_count}"
+            echo "${search_json}"
+            exit 1
+          fi
+
           storage_uri="$(jq -r '.results[0].uri // empty' <<< "${search_json}")"
           if [[ -z "${storage_uri}" ]]; then
             echo "Unable to resolve storage URI for ${wheel_name}"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Migrated wheel distribution from GitHub Releases to Artifactory; GitHub release/tag asset steps removed.
  * Publish job now exposes artifact path outputs, clears local wheel artifacts before downloading, and records uploaded wheel paths.
  * Downstream kitmaker integration updated to consume Artifactory paths, run only for non-PR events, and validate Artifactory config (HTTPS required).
  * Enhanced masking/redaction of Artifactory and kitmaker secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->