### PR TITLE
Add GitHub workflow to auto merge main to release/1.2.x

### DIFF
--- a/.github/workflows/sync-release-branches.yml
+++ b/.github/workflows/sync-release-branches.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Sync Release Branches
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  sync:
+    name: Sync ${{ matrix.branch }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: sync-branch-${{ matrix.branch }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+    strategy:
+      # Keep syncing other branches even if one fails
+      fail-fast: false
+      matrix:
+        branch:
+          # Add or remove release branches here to control which ones track main
+          - release/1.2.x
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_SYNC_TOKEN }}
+
+      - name: Fast-forward ${{ matrix.branch }} to main
+        run: |
+          git checkout ${{ matrix.branch }}
+          git merge --ff-only origin/main
+          git push origin ${{ matrix.branch }}


### PR DESCRIPTION
Fixes: https://github.com/NVIDIA/IsaacTeleop/issues/286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated synchronization to keep release branches aligned with main, ensuring release branches are regularly fast-forwarded and pushed.

---

*Note: This release contains internal infrastructure improvements with no direct impact on user-facing features or functionality.*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->