### PR TITLE
Use bridge network for test container

### DIFF
--- a/deps/cloudxr/docker-compose.runtime.yaml
+++ b/deps/cloudxr/docker-compose.runtime.yaml
@@ -16,7 +16,7 @@ services:
         ISAACTELEOP_PIP_DEBUG:
     container_name: cloudxr-runtime-${CXR_RUNTIME_SDK_VERSION:-unset}-${PYTHON_VERSION:-unset}
     user: "${CXR_UID:-1000}:${CXR_GID:-1000}"
-    network_mode: host
+    network_mode: "${CXR_RUNTIME_NETWORK_MODE:-host}"
     healthcheck:
       test: ["CMD", "test", "-f", "/openxr/.cloudxr/run/runtime_started"]
       interval: 1s

--- a/scripts/run_tests_with_cloudxr.sh
+++ b/scripts/run_tests_with_cloudxr.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # Test Runner Script with CloudXR
@@ -196,6 +196,9 @@ export CXR_PYTHON_GPU_TESTS="$CXR_PYTHON_GPU_TESTS_ENV"
 
 CXR_NATIVE_GPU_TESTS_ENV=$(IFS=','; echo "${CXR_NATIVE_GPU_TESTS[*]}")
 export CXR_NATIVE_GPU_TESTS="$CXR_NATIVE_GPU_TESTS_ENV"
+
+# Set CloudXR runtime network mode
+export CXR_RUNTIME_NETWORK_MODE="bridge"
 
 # Create/update .env file with test configuration
 log_info "Writing test configuration to $ENV_TEST..."


### PR DESCRIPTION
This should fix #299 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Made CloudXR runtime network configuration customizable via environment variable while preserving default host network behavior.
  * Updated test scripts to configure CloudXR runtime networking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->