### PR TITLE
Make update consistent, remove bool return and throw only on critical error

### DIFF
--- a/examples/lerobot/record.py
+++ b/examples/lerobot/record.py
@@ -110,9 +110,7 @@ def main():
             try:
                 while time.time() - start_time < 10.0:
                     # Update session and all trackers
-                    if not session.update():
-                        print("Update failed")
-                        break
+                    session.update()
 
                     # Get hand data
                     left_tracked: schema.HandPoseTrackedT = hand_tracker.get_left_hand(

--- a/examples/native_openxr/xdev_list/main.cpp
+++ b/examples/native_openxr/xdev_list/main.cpp
@@ -180,20 +180,18 @@ public:
 };
 
 int main(int argc, char* argv[])
+try
 {
-    try
-    {
-        XDevListApp app;
-        return doHeadless(app);
-    }
-    catch (const std::exception& e)
-    {
-        std::cerr << "Error: " << e.what() << std::endl;
-        return 1;
-    }
-    catch (...)
-    {
-        std::cerr << "Unknown error occurred" << std::endl;
-        return 1;
-    }
+    XDevListApp app;
+    return doHeadless(app);
+}
+catch (const std::exception& e)
+{
+    std::cerr << argv[0] << ": " << e.what() << std::endl;
+    return 1;
+}
+catch (...)
+{
+    std::cerr << argv[0] << ": Unknown error occurred" << std::endl;
+    return 1;
 }

--- a/examples/oxr/cpp/oxr_session_sharing.cpp
+++ b/examples/oxr/cpp/oxr_session_sharing.cpp
@@ -76,17 +76,8 @@ try
     for (int i = 0; i < 10; ++i)
     {
         // Both sessions update using the same underlying OpenXR session
-        if (!session1->update())
-        {
-            std::cerr << "Session 1 update failed" << std::endl;
-            break;
-        }
-
-        if (!session2->update())
-        {
-            std::cerr << "Session 2 update failed" << std::endl;
-            break;
-        }
+        session1->update();
+        session2->update();
 
         // Get data from both trackers
         const auto& left_tracked = hand_tracker->get_left_hand(*session1);

--- a/examples/oxr/cpp/oxr_simple_api_demo.cpp
+++ b/examples/oxr/cpp/oxr_simple_api_demo.cpp
@@ -76,11 +76,7 @@ try
     for (int i = 0; i < 5; ++i)
     {
         // Session handles internal update() calls to trackers
-        if (!session->update())
-        {
-            std::cerr << "Update failed" << std::endl;
-            break;
-        }
+        session->update();
 
         // External user only uses public query methods
         const auto& left_tracked = hand_tracker->get_left_hand(*session);
@@ -93,7 +89,7 @@ try
         std::cout << "  Head pose:  " << ((head_tracked.data && head_tracked.data->is_valid) ? "VALID" : "INVALID")
                   << std::endl;
 
-        if (head_tracked.data && head_tracked.data->is_valid && head_tracked.data->pose)
+        if (head_tracked.data && head_tracked.data->is_valid)
         {
             const auto& pos = head_tracked.data->pose->position();
             std::cout << "    Position: [" << pos.x() << ", " << pos.y() << ", " << pos.z() << "]" << std::endl;

--- a/examples/oxr/python/modular_example.py
+++ b/examples/oxr/python/modular_example.py
@@ -60,9 +60,7 @@ def main():
 
             while time.time() - start_time < 10.0:
                 # Update session and all trackers
-                if not session.update():
-                    print("Update failed")
-                    break
+                session.update()
 
                 # Print every 60 frames (~1 second)
                 if frame_count % 60 == 0:

--- a/examples/oxr/python/test_controller_tracker.py
+++ b/examples/oxr/python/test_controller_tracker.py
@@ -9,7 +9,6 @@ Demonstrates:
 - Multiple ControllerTracker instances on the same session (action context isolation)
 """
 
-import sys
 import time
 
 import isaacteleop.deviceio as deviceio
@@ -52,9 +51,7 @@ with oxr.OpenXRSession("ControllerTrackerTest", required_extensions) as oxr_sess
 
         # Test 4: Initial update
         print("[Test 4] Testing initial data retrieval...")
-        if not session.update():
-            print("❌ Update failed")
-            sys.exit(1)
+        session.update()
 
         print("✓ Update successful")
         print()
@@ -104,9 +101,7 @@ with oxr.OpenXRSession("ControllerTrackerTest", required_extensions) as oxr_sess
         last_status_print = start_time
 
         while time.time() - start_time < 10.0:
-            if not session.update():
-                print("Update failed")
-                break
+            session.update()
 
             current_time = time.time()
             if current_time - last_status_print >= 0.5:

--- a/examples/oxr/python/test_extensions.py
+++ b/examples/oxr/python/test_extensions.py
@@ -87,20 +87,20 @@ with oxr.OpenXRSession("ExtensionTest", required_exts) as oxr_session:
         print("  ✅ Initialized successfully")
 
         # Quick update test
-        if session.update():
-            left_tracked = hand.get_left_hand(session)
-            head_tracked = head.get_head(session)
-            print("  ✅ Update successful")
-            if left_tracked.data is not None:
-                pos = left_tracked.data.joints.poses(deviceio.JOINT_WRIST).pose.position
-                print(f"    Left wrist: [{pos.x:.3f}, {pos.y:.3f}, {pos.z:.3f}]")
-            else:
-                print("    Left hand:  inactive")
-            if head_tracked.data is not None:
-                pos = head_tracked.data.pose.position
-                print(f"    Head pos:   [{pos.x:.3f}, {pos.y:.3f}, {pos.z:.3f}]")
-            else:
-                print("    Head:       inactive")
+        session.update()
+        left_tracked = hand.get_left_hand(session)
+        head_tracked = head.get_head(session)
+        print("  ✅ Update successful")
+        if left_tracked.data is not None:
+            pos = left_tracked.data.joints.poses(deviceio.JOINT_WRIST).pose.position
+            print(f"    Left wrist: [{pos.x:.3f}, {pos.y:.3f}, {pos.z:.3f}]")
+        else:
+            print("    Left hand:  inactive")
+        if head_tracked.data is not None:
+            pos = head_tracked.data.pose.position
+            print(f"    Head pos:   [{pos.x:.3f}, {pos.y:.3f}, {pos.z:.3f}]")
+        else:
+            print("    Head:       inactive")
 
         # Session will be cleaned up when exiting 'with' block (RAII)
 

--- a/examples/oxr/python/test_full_body_tracker.py
+++ b/examples/oxr/python/test_full_body_tracker.py
@@ -9,7 +9,6 @@ Demonstrates:
 - Requires PICO device with body tracking support
 """
 
-import sys
 import time
 
 import isaacteleop.deviceio as deviceio
@@ -56,9 +55,7 @@ with oxr.OpenXRSession("FullBodyTrackerTest", required_extensions) as oxr_sessio
 
         # Test 5: Initial update
         print("[Test 5] Testing initial data retrieval...")
-        if not session.update():
-            print("❌ Update failed")
-            sys.exit(1)
+        session.update()
 
         print("✓ Update successful")
         print()
@@ -89,9 +86,7 @@ with oxr.OpenXRSession("FullBodyTrackerTest", required_extensions) as oxr_sessio
         last_status_print = start_time
 
         while time.time() - start_time < 10.0:
-            if not session.update():
-                print("Update failed")
-                break
+            session.update()
 
             # Get current body pose
             current_time = time.time()

--- a/examples/oxr/python/test_hand_inactive_on_plugin_stop.py
+++ b/examples/oxr/python/test_hand_inactive_on_plugin_stop.py
@@ -27,18 +27,9 @@ INACTIVE_WAIT_S = 5.0  # max time to wait for hands to become inactive after sto
 FRAME_SLEEP_S = 0.016
 
 
-class UpdateFailedError(RuntimeError):
-    """Raised when deviceio_session.update() fails."""
-
-
 def poll_hands(hand_tracker, deviceio_session):
-    """Return (left_active, right_active) for the current frame.
-
-    Raises UpdateFailedError if the underlying DeviceIOSession update fails so
-    callers can distinguish a session error from genuine hand inactivity.
-    """
-    if not deviceio_session.update():
-        raise UpdateFailedError("deviceio_session.update() returned False")
+    """Return (left_active, right_active) for the current frame."""
+    deviceio_session.update()
     left = hand_tracker.get_left_hand(deviceio_session)
     right = hand_tracker.get_right_hand(deviceio_session)
     return left.data is not None, right.data is not None
@@ -94,19 +85,10 @@ def run_test():
                 left_active = right_active = False
 
                 while time.monotonic() < deadline:
-                    try:
-                        plugin.check_health()
-                    except pm.PluginCrashException as e:
-                        print(f"✗ Plugin crashed before hands became active: {e}")
-                        return False
-
-                    try:
-                        left_active, right_active = poll_hands(
-                            hand_tracker, deviceio_session
-                        )
-                    except UpdateFailedError as e:
-                        print(f"✗ Session update failed during Phase 1: {e}")
-                        return False
+                    plugin.check_health()
+                    left_active, right_active = poll_hands(
+                        hand_tracker, deviceio_session
+                    )
 
                     if left_active and right_active:
                         break
@@ -136,13 +118,9 @@ def run_test():
                 left_inactive = right_inactive = False
 
                 while time.monotonic() < deadline:
-                    try:
-                        left_active, right_active = poll_hands(
-                            hand_tracker, deviceio_session
-                        )
-                    except UpdateFailedError as e:
-                        print(f"✗ Session update failed during Phase 2: {e}")
-                        return False
+                    left_active, right_active = poll_hands(
+                        hand_tracker, deviceio_session
+                    )
 
                     left_inactive = not left_active
                     right_inactive = not right_active

--- a/examples/oxr/python/test_modular.py
+++ b/examples/oxr/python/test_modular.py
@@ -6,7 +6,6 @@
 Test script for modular OpenXR tracking API
 """
 
-import sys
 import time
 
 import isaacteleop.deviceio as deviceio
@@ -47,9 +46,7 @@ with oxr.OpenXRSession("ModularTest", required_extensions) as oxr_session:
 
         # Test 4: Update and get data
         print("[Test 4] Testing data retrieval...")
-        if not session.update():
-            print("❌ Update failed")
-            sys.exit(1)
+        session.update()
 
         print("✓ Update successful")
         print()
@@ -92,9 +89,7 @@ with oxr.OpenXRSession("ModularTest", required_extensions) as oxr_session:
         start_time = time.time()
 
         while time.time() - start_time < 5.0:
-            if not session.update():
-                print("Update failed")
-                break
+            session.update()
 
             if frame_count % 60 == 0:
                 elapsed = time.time() - start_time

--- a/examples/oxr/python/test_session_sharing.py
+++ b/examples/oxr/python/test_session_sharing.py
@@ -83,13 +83,8 @@ with oxr.OpenXRSession("SessionSharingExample", extensions) as oxr_session:
         frame_count = 0
         while time.time() - start_time < 5.0:
             # Both sessions update using the same underlying OpenXR session
-            if not session1.update():
-                print("Session 1 update failed")
-                break
-
-            if not session2.update():
-                print("Session 2 update failed")
-                break
+            session1.update()
+            session2.update()
 
             # Print status every 60 frames
             if frame_count % 60 == 0:

--- a/examples/oxr/python/test_synthetic_hands.py
+++ b/examples/oxr/python/test_synthetic_hands.py
@@ -94,15 +94,9 @@ def run_test():
             while time.time() - start_time < 10.0:
                 # Poll plugin health every ~1 second
                 if frame_count % 60 == 0:
-                    try:
-                        plugin.check_health()  # Throws PluginCrashException if plugin crashed
-                    except pm.PluginCrashException as e:
-                        print(f"Plugin crashed: {e}")
-                        break
+                    plugin.check_health()  # Throws PluginCrashException if plugin crashed
 
-                if not deviceio_session.update():
-                    print("  ✗ Reader session update failed")
-                    break
+                deviceio_session.update()
 
                 if frame_count % 60 == 0:
                     left_tracked = hand_tracker.get_left_hand(deviceio_session)

--- a/examples/retargeting/python/sources_example.py
+++ b/examples/retargeting/python/sources_example.py
@@ -121,9 +121,7 @@ def main():
 
             while time.time() - start_time < 10.0:
                 # Update session and all trackers
-                if not session.update():
-                    print("Update failed")
-                    break
+                session.update()
 
                 # Print every 60 frames (~1 second)
                 if frame_count % 60 == 0:

--- a/examples/schemaio/frame_metadata_printer.cpp
+++ b/examples/schemaio/frame_metadata_printer.cpp
@@ -107,11 +107,7 @@ try
 
     while (true)
     {
-        if (!session->update())
-        {
-            std::cerr << "Update failed" << std::endl;
-            break;
-        }
+        session->update();
 
         // Refresh stream count and extend per-stream tracking if streams were added.
         stream_count = tracker->get_stream_count();

--- a/examples/schemaio/pedal_printer.cpp
+++ b/examples/schemaio/pedal_printer.cpp
@@ -69,11 +69,7 @@ try
     while (received_count < MAX_SAMPLES)
     {
         // Update session (this calls update on all trackers)
-        if (!session->update())
-        {
-            std::cerr << "Update failed" << std::endl;
-            break;
-        }
+        session->update();
 
         // Print current data if available
         const auto& tracked = tracker->get_data(*session);

--- a/src/core/deviceio_base/cpp/inc/deviceio_base/tracker.hpp
+++ b/src/core/deviceio_base/cpp/inc/deviceio_base/tracker.hpp
@@ -22,7 +22,14 @@ class ITrackerImpl
 public:
     virtual ~ITrackerImpl() = default;
 
-    virtual bool update(XrTime time) = 0;
+    /**
+     * @brief Updates tracker state for the specified OpenXR time.
+     *
+     * @throws std::runtime_error On critical tracker/runtime failures.
+     * @note A thrown exception indicates a fatal condition; the application is
+     *       expected to terminate rather than continue running.
+     */
+    virtual void update(XrTime time) = 0;
 };
 
 /**

--- a/src/core/deviceio_session/cpp/deviceio_session.cpp
+++ b/src/core/deviceio_session/cpp/deviceio_session.cpp
@@ -101,29 +101,14 @@ std::unique_ptr<DeviceIOSession> DeviceIOSession::run(const std::vector<std::sha
     return std::unique_ptr<DeviceIOSession>(new DeviceIOSession(trackers, handles, std::move(recording_config)));
 }
 
-bool DeviceIOSession::update()
+void DeviceIOSession::update()
 {
     XrTime current_time = time_converter_.os_monotonic_now();
 
-    for (auto& [tracker, impl] : tracker_impls_)
+    for (auto& kv : tracker_impls_)
     {
-        if (!impl->update(current_time))
-        {
-            auto& count = tracker_update_failure_counts_[tracker];
-            count++;
-            if (count == 1 || count % 1000 == 0)
-            {
-                std::cerr << "Warning: tracker '" << tracker->get_name() << "' update failed (count: " << count << ")"
-                          << std::endl;
-            }
-        }
-        else
-        {
-            tracker_update_failure_counts_[tracker] = 0;
-        }
+        kv.second->update(current_time);
     }
-
-    return true;
 }
 
 } // namespace core

--- a/src/core/deviceio_session/cpp/inc/deviceio_session/deviceio_session.hpp
+++ b/src/core/deviceio_session/cpp/inc/deviceio_session/deviceio_session.hpp
@@ -59,9 +59,17 @@ public:
     // Destructor defined in .cpp where mcap::McapWriter is fully defined
     ~DeviceIOSession();
 
-    // Update session and all trackers. If recording is active, tracker impls
-    // write their data to the MCAP file directly during this call.
-    bool update();
+    /**
+     * @brief Updates the session and all registered trackers.
+     *
+     * If recording is active, tracker implementations write MCAP samples
+     * directly during this call.
+     *
+     * @throws std::runtime_error On critical tracker/runtime failures.
+     * @note A thrown exception indicates a fatal condition; the application is
+     *       expected to terminate rather than continue running.
+     */
+    void update();
 
     const ITrackerImpl& get_tracker_impl(const ITracker& tracker) const override
     {
@@ -80,7 +88,6 @@ private:
 
     const OpenXRSessionHandles handles_;
     std::unordered_map<const ITracker*, std::unique_ptr<ITrackerImpl>> tracker_impls_;
-    std::unordered_map<const ITracker*, uint64_t> tracker_update_failure_counts_;
     XrTimeConverter time_converter_;
 
     // Owned MCAP writer; null when recording is not configured.

--- a/src/core/deviceio_session/py_utils/inc/deviceio_py_utils/session.hpp
+++ b/src/core/deviceio_session/py_utils/inc/deviceio_py_utils/session.hpp
@@ -29,13 +29,13 @@ public:
     {
     }
 
-    bool update()
+    void update()
     {
         if (!impl_)
         {
             throw std::runtime_error("Session has been closed/destroyed");
         }
-        return impl_->update();
+        impl_->update();
     }
 
     void close()

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/controller_tracker.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/controller_tracker.hpp
@@ -20,7 +20,9 @@ public:
         return TRACKER_NAME;
     }
 
-    // Query methods - tracked.data is null when the controller is inactive
+    // Query methods:
+    // - tracked.data is null when the controller is inactive.
+    // - when tracked.data is non-null, nested fields in ControllerSnapshotT are safe to read.
     const ControllerSnapshotTrackedT& get_left_controller(const ITrackerSession& session) const;
     const ControllerSnapshotTrackedT& get_right_controller(const ITrackerSession& session) const;
 

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/frame_metadata_tracker_oak.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/frame_metadata_tracker_oak.hpp
@@ -58,6 +58,8 @@ public:
      * @param stream_index Index into the streams vector passed at construction.
      * @return Reference to the FrameMetadataOakTrackedT for that stream.
      *         The inner @c data pointer is null until the first frame arrives.
+     *         When @c data is non-null, nested fields in FrameMetadataOakT are
+     *         safe to read.
      */
     const FrameMetadataOakTrackedT& get_stream_data(const ITrackerSession& session, size_t stream_index) const;
 

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/full_body_tracker_pico.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/full_body_tracker_pico.hpp
@@ -23,7 +23,9 @@ public:
         return TRACKER_NAME;
     }
 
-    // Query method - tracked.data is null when the body tracker is inactive
+    // Query method:
+    // - tracked.data is null when the body tracker is inactive.
+    // - when tracked.data is non-null, nested fields in FullBodyPosePicoT are safe to read.
     const FullBodyPosePicoTrackedT& get_body_pose(const ITrackerSession& session) const;
 
 private:

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/generic_3axis_pedal_tracker.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/generic_3axis_pedal_tracker.hpp
@@ -62,7 +62,8 @@ public:
      * ``tracked.data`` is null when there is no valid last-known sample (source never provided data or
      * implementation cleared state when the collection is gone). When non-null, values may still be **unchanged**
      * from the previous ``update()`` if that tick produced no new samples (see ``LiveGeneric3AxisPedalTrackerImpl``
-     * and ``m_pending_records``).
+     * and ``m_pending_records``). When ``tracked.data`` is non-null, nested fields in
+     * ``Generic3AxisPedalOutputT`` are safe to read.
      */
     const Generic3AxisPedalOutputTrackedT& get_data(const ITrackerSession& session) const;
 

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/hand_tracker.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/hand_tracker.hpp
@@ -20,7 +20,9 @@ public:
         return TRACKER_NAME;
     }
 
-    // Query methods - tracked.data is null when the hand is inactive
+    // Query methods:
+    // - tracked.data is null when the hand is inactive.
+    // - when tracked.data is non-null, nested fields in HandPoseT are safe to read.
     const HandPoseTrackedT& get_left_hand(const ITrackerSession& session) const;
     const HandPoseTrackedT& get_right_hand(const ITrackerSession& session) const;
 

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/head_tracker.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/head_tracker.hpp
@@ -18,7 +18,9 @@ public:
         return TRACKER_NAME;
     }
 
-    // Query method - tracked.data is always set when the HMD is present
+    // Query method:
+    // - tracked.data is null when no head sample is available for the frame.
+    // - when tracked.data is non-null, nested fields in HeadPoseT are safe to read.
     const HeadPoseTrackedT& get_head(const ITrackerSession& session) const;
 
 private:

--- a/src/core/live_trackers/cpp/inc/live_trackers/schema_tracker.hpp
+++ b/src/core/live_trackers/cpp/inc/live_trackers/schema_tracker.hpp
@@ -53,10 +53,14 @@ public:
      * returned via out_latest (if non-null and samples were read).
      *
      * @param out_latest If non-null and samples were read, receives the unpacked
-     *                   data from the last sample.
-     * @return true if the tensor collection is present.
+     *                   data from the last sample. Cleared when the tensor collection
+     *                   is absent.
+     * @throws std::runtime_error On critical OpenXR/tensor API failures propagated
+     *         from SchemaTrackerBase.
+     * @note Missing collection, temporary collection loss, and "no new sample"
+     *       are treated as common non-fatal conditions and do not throw.
      */
-    bool update(std::shared_ptr<NativeDataT>& out_latest)
+    void update(std::shared_ptr<NativeDataT>& out_latest)
     {
         samples_.clear();
         bool present = read_all_samples(samples_);
@@ -67,7 +71,7 @@ public:
             {
                 out_latest.reset();
             }
-            return present;
+            return;
         }
 
         for (const auto& sample : samples_)
@@ -91,8 +95,6 @@ public:
                 mcap_channels_->write(mcap_channel_index_, sample.timestamp, out_latest);
             }
         }
-
-        return present;
     }
 
 private:

--- a/src/core/live_trackers/cpp/live_controller_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_controller_tracker_impl.cpp
@@ -55,7 +55,11 @@ bool get_boolean_action_state(XrSession session, const OpenXRCoreFunctions& core
 
     XrActionStateBoolean state{ XR_TYPE_ACTION_STATE_BOOLEAN };
     XrResult result = core_funcs.xrGetActionStateBoolean(session, &get_info, &state);
-    if (XR_SUCCEEDED(result) && state.isActive)
+    if (XR_FAILED(result))
+    {
+        throw std::runtime_error("xrGetActionStateBoolean failed: " + std::to_string(result));
+    }
+    if (state.isActive)
     {
         return state.currentState;
     }
@@ -70,7 +74,11 @@ float get_float_action_state(XrSession session, const OpenXRCoreFunctions& core_
 
     XrActionStateFloat state{ XR_TYPE_ACTION_STATE_FLOAT };
     XrResult result = core_funcs.xrGetActionStateFloat(session, &get_info, &state);
-    if (XR_SUCCEEDED(result) && state.isActive)
+    if (XR_FAILED(result))
+    {
+        throw std::runtime_error("xrGetActionStateFloat failed: " + std::to_string(result));
+    }
+    if (state.isActive)
     {
         return state.currentState;
     }
@@ -90,7 +98,11 @@ bool get_vector2_action_state(XrSession session,
 
     XrActionStateVector2f state{ XR_TYPE_ACTION_STATE_VECTOR2F };
     XrResult result = core_funcs.xrGetActionStateVector2f(session, &get_info, &state);
-    if (XR_SUCCEEDED(result) && state.isActive)
+    if (XR_FAILED(result))
+    {
+        throw std::runtime_error("xrGetActionStateVector2f failed: " + std::to_string(result));
+    }
+    if (state.isActive)
     {
         out_x = state.currentState.x;
         out_y = state.currentState.y;
@@ -108,7 +120,11 @@ bool get_pose_action_active(XrSession session, const OpenXRCoreFunctions& core_f
 
     XrActionStatePose state{ XR_TYPE_ACTION_STATE_POSE };
     XrResult result = core_funcs.xrGetActionStatePose(session, &get_info, &state);
-    return XR_SUCCEEDED(result) && state.isActive;
+    if (XR_FAILED(result))
+    {
+        throw std::runtime_error("xrGetActionStatePose failed: " + std::to_string(result));
+    }
+    return state.isActive;
 }
 
 XrSpacePtr create_space(const OpenXRCoreFunctions& funcs, XrSession session, XrAction action, XrPath subaction_path)
@@ -298,7 +314,7 @@ LiveControllerTrackerImpl::LiveControllerTrackerImpl(const OpenXRSessionHandles&
     std::cout << "ControllerTracker initialized (left + right) with action context" << std::endl;
 }
 
-bool LiveControllerTrackerImpl::update(XrTime time)
+void LiveControllerTrackerImpl::update(XrTime time)
 {
     last_update_time_ = time;
 
@@ -315,10 +331,11 @@ bool LiveControllerTrackerImpl::update(XrTime time)
     XrResult result = action_ctx_funcs_.sync_actions_2(session_, &sync_info, &sync_state);
     if (XR_FAILED(result))
     {
-        std::cerr << "[ControllerTracker] xrSyncActions2NV failed: " << result << std::endl;
+        // Policy: action sync failure is a critical tracker/runtime error.
+        // Ensure callers do not observe stale controller data after sync failure.
         left_tracked_.data.reset();
         right_tracked_.data.reset();
-        return false;
+        throw std::runtime_error("[ControllerTracker] xrSyncActions2NV failed: " + std::to_string(result));
     }
 
     auto update_controller = [&](XrPath hand_path, const XrSpacePtr& grip_space, const XrSpacePtr& aim_space,
@@ -326,6 +343,7 @@ bool LiveControllerTrackerImpl::update(XrTime time)
     {
         if (!get_pose_action_active(session_, core_funcs_, grip_pose_action_, hand_path))
         {
+            // Policy: controller not active is a common runtime condition.
             tracked.data.reset();
             return;
         }
@@ -335,6 +353,11 @@ bool LiveControllerTrackerImpl::update(XrTime time)
 
         XrSpaceLocation grip_location{ XR_TYPE_SPACE_LOCATION };
         result = core_funcs_.xrLocateSpace(grip_space.get(), base_space_, time, &grip_location);
+        if (XR_FAILED(result))
+        {
+            tracked.data.reset();
+            throw std::runtime_error("[ControllerTracker] xrLocateSpace(grip) failed: " + std::to_string(result));
+        }
         if (XR_SUCCEEDED(result))
         {
             bool is_valid = (grip_location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) &&
@@ -351,6 +374,11 @@ bool LiveControllerTrackerImpl::update(XrTime time)
 
         XrSpaceLocation aim_location{ XR_TYPE_SPACE_LOCATION };
         result = core_funcs_.xrLocateSpace(aim_space.get(), base_space_, time, &aim_location);
+        if (XR_FAILED(result))
+        {
+            tracked.data.reset();
+            throw std::runtime_error("[ControllerTracker] xrLocateSpace(aim) failed: " + std::to_string(result));
+        }
         if (XR_SUCCEEDED(result))
         {
             bool is_valid = (aim_location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) &&
@@ -396,8 +424,6 @@ bool LiveControllerTrackerImpl::update(XrTime time)
         mcap_channels_->write(0, timestamp, left_tracked_.data);
         mcap_channels_->write(1, timestamp, right_tracked_.data);
     }
-
-    return true;
 }
 
 const ControllerSnapshotTrackedT& LiveControllerTrackerImpl::get_left_controller() const

--- a/src/core/live_trackers/cpp/live_controller_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_controller_tracker_impl.hpp
@@ -40,7 +40,7 @@ public:
     LiveControllerTrackerImpl(LiveControllerTrackerImpl&&) = delete;
     LiveControllerTrackerImpl& operator=(LiveControllerTrackerImpl&&) = delete;
 
-    bool update(XrTime time) override;
+    void update(XrTime time) override;
     const ControllerSnapshotTrackedT& get_left_controller() const override;
     const ControllerSnapshotTrackedT& get_right_controller() const override;
 

--- a/src/core/live_trackers/cpp/live_frame_metadata_tracker_oak_impl.cpp
+++ b/src/core/live_trackers/cpp/live_frame_metadata_tracker_oak_impl.cpp
@@ -59,14 +59,14 @@ LiveFrameMetadataTrackerOakImpl::LiveFrameMetadataTrackerOakImpl(const OpenXRSes
     }
 }
 
-bool LiveFrameMetadataTrackerOakImpl::update(XrTime /*time*/)
+void LiveFrameMetadataTrackerOakImpl::update(XrTime /*time*/)
 {
-    bool any_present = false;
+    // Policy: per-stream SchemaTracker throws on critical OpenXR/tensor API failures.
+    // Missing stream collection/no fresh sample are treated as common non-fatal cases.
     for (auto& stream : m_streams)
     {
-        any_present |= stream.reader->update(stream.tracked.data);
+        stream.reader->update(stream.tracked.data);
     }
-    return any_present;
 }
 
 const FrameMetadataOakTrackedT& LiveFrameMetadataTrackerOakImpl::get_stream_data(size_t stream_index) const

--- a/src/core/live_trackers/cpp/live_frame_metadata_tracker_oak_impl.hpp
+++ b/src/core/live_trackers/cpp/live_frame_metadata_tracker_oak_impl.hpp
@@ -40,7 +40,7 @@ public:
     LiveFrameMetadataTrackerOakImpl(LiveFrameMetadataTrackerOakImpl&&) = delete;
     LiveFrameMetadataTrackerOakImpl& operator=(LiveFrameMetadataTrackerOakImpl&&) = delete;
 
-    bool update(XrTime time) override;
+    void update(XrTime time) override;
     const FrameMetadataOakTrackedT& get_stream_data(size_t stream_index) const override;
 
 private:

--- a/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.cpp
+++ b/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.cpp
@@ -97,14 +97,15 @@ LiveFullBodyTrackerPicoImpl::~LiveFullBodyTrackerPicoImpl()
     }
 }
 
-bool LiveFullBodyTrackerPicoImpl::update(XrTime time)
+void LiveFullBodyTrackerPicoImpl::update(XrTime time)
 {
     last_update_time_ = time;
 
     if (body_tracker_ == XR_NULL_HANDLE)
     {
+        // Policy: limp mode (feature unsupported/unavailable) is non-fatal.
         tracked_.data.reset();
-        return true;
+        return;
     }
 
     XrBodyJointsLocateInfoBD locate_info{ XR_TYPE_BODY_JOINTS_LOCATE_INFO_BD };
@@ -123,7 +124,7 @@ bool LiveFullBodyTrackerPicoImpl::update(XrTime time)
     if (XR_FAILED(result))
     {
         tracked_.data.reset();
-        return false;
+        throw std::runtime_error("[FullBodyTrackerPico] xrLocateBodyJointsBD failed: " + std::to_string(result));
     }
 
     if (!tracked_.data)
@@ -160,8 +161,6 @@ bool LiveFullBodyTrackerPicoImpl::update(XrTime time)
         DeviceDataTimestamp timestamp(monotonic_ns, monotonic_ns, last_update_time_);
         mcap_channels_->write(0, timestamp, tracked_.data);
     }
-
-    return true;
 }
 
 const FullBodyPosePicoTrackedT& LiveFullBodyTrackerPicoImpl::get_body_pose() const

--- a/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.hpp
+++ b/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.hpp
@@ -40,7 +40,7 @@ public:
     LiveFullBodyTrackerPicoImpl(LiveFullBodyTrackerPicoImpl&&) = delete;
     LiveFullBodyTrackerPicoImpl& operator=(LiveFullBodyTrackerPicoImpl&&) = delete;
 
-    bool update(XrTime time) override;
+    void update(XrTime time) override;
     const FullBodyPosePicoTrackedT& get_body_pose() const override;
 
 private:

--- a/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
@@ -44,9 +44,11 @@ LiveGeneric3AxisPedalTrackerImpl::LiveGeneric3AxisPedalTrackerImpl(const OpenXRS
 {
 }
 
-bool LiveGeneric3AxisPedalTrackerImpl::update(XrTime /*time*/)
+void LiveGeneric3AxisPedalTrackerImpl::update(XrTime /*time*/)
 {
-    return m_schema_reader.update(m_tracked.data);
+    // Policy: SchemaTracker throws on critical OpenXR/tensor API failures.
+    // Missing collection/no new data are treated as common non-fatal cases.
+    m_schema_reader.update(m_tracked.data);
 }
 
 const Generic3AxisPedalOutputTrackedT& LiveGeneric3AxisPedalTrackerImpl::get_data() const

--- a/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.hpp
@@ -38,7 +38,7 @@ public:
     LiveGeneric3AxisPedalTrackerImpl(LiveGeneric3AxisPedalTrackerImpl&&) = delete;
     LiveGeneric3AxisPedalTrackerImpl& operator=(LiveGeneric3AxisPedalTrackerImpl&&) = delete;
 
-    bool update(XrTime time) override;
+    void update(XrTime time) override;
     const Generic3AxisPedalOutputTrackedT& get_data() const override;
 
 private:

--- a/src/core/live_trackers/cpp/live_hand_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_hand_tracker_impl.cpp
@@ -117,11 +117,11 @@ LiveHandTrackerImpl::~LiveHandTrackerImpl()
     }
 }
 
-bool LiveHandTrackerImpl::update(XrTime time)
+void LiveHandTrackerImpl::update(XrTime time)
 {
     last_update_time_ = time;
-    bool left_ok = update_hand(left_hand_tracker_, time, left_tracked_);
-    bool right_ok = update_hand(right_hand_tracker_, time, right_tracked_);
+    update_hand(left_hand_tracker_, time, left_tracked_);
+    update_hand(right_hand_tracker_, time, right_tracked_);
 
     if (mcap_channels_)
     {
@@ -130,8 +130,6 @@ bool LiveHandTrackerImpl::update(XrTime time)
         mcap_channels_->write(0, timestamp, left_tracked_.data);
         mcap_channels_->write(1, timestamp, right_tracked_.data);
     }
-
-    return left_ok || right_ok;
 }
 
 const HandPoseTrackedT& LiveHandTrackerImpl::get_left_hand() const
@@ -144,7 +142,7 @@ const HandPoseTrackedT& LiveHandTrackerImpl::get_right_hand() const
     return right_tracked_;
 }
 
-bool LiveHandTrackerImpl::update_hand(XrHandTrackerEXT tracker, XrTime time, HandPoseTrackedT& tracked)
+void LiveHandTrackerImpl::update_hand(XrHandTrackerEXT tracker, XrTime time, HandPoseTrackedT& tracked)
 {
     XrHandJointsLocateInfoEXT locate_info{ XR_TYPE_HAND_JOINTS_LOCATE_INFO_EXT };
     locate_info.baseSpace = base_space_;
@@ -161,13 +159,14 @@ bool LiveHandTrackerImpl::update_hand(XrHandTrackerEXT tracker, XrTime time, Han
     if (XR_FAILED(result))
     {
         tracked.data.reset();
-        return false;
+        throw std::runtime_error("[HandTracker] xrLocateHandJointsEXT failed: " + std::to_string(result));
     }
 
     if (!locations.isActive)
     {
+        // Policy: inactive hand is a common runtime condition; non-fatal.
         tracked.data.reset();
-        return true;
+        return;
     }
 
     if (!tracked.data)
@@ -195,8 +194,6 @@ bool LiveHandTrackerImpl::update_hand(XrHandTrackerEXT tracker, XrTime time, Han
         HandJointPose joint_pose(pose, is_valid, joint_loc.radius);
         tracked.data->joints->mutable_poses()->Mutate(i, joint_pose);
     }
-
-    return true;
 }
 
 } // namespace core

--- a/src/core/live_trackers/cpp/live_hand_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_hand_tracker_impl.hpp
@@ -38,12 +38,12 @@ public:
     LiveHandTrackerImpl(LiveHandTrackerImpl&&) = delete;
     LiveHandTrackerImpl& operator=(LiveHandTrackerImpl&&) = delete;
 
-    bool update(XrTime time) override;
+    void update(XrTime time) override;
     const HandPoseTrackedT& get_left_hand() const override;
     const HandPoseTrackedT& get_right_hand() const override;
 
 private:
-    bool update_hand(XrHandTrackerEXT tracker, XrTime time, HandPoseTrackedT& tracked);
+    void update_hand(XrHandTrackerEXT tracker, XrTime time, HandPoseTrackedT& tracked);
 
     XrTimeConverter time_converter_;
     XrSpace base_space_;

--- a/src/core/live_trackers/cpp/live_head_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_head_tracker_impl.cpp
@@ -8,6 +8,7 @@
 
 #include <cstring>
 #include <iostream>
+#include <stdexcept>
 
 namespace core
 {
@@ -39,7 +40,7 @@ LiveHeadTrackerImpl::LiveHeadTrackerImpl(const OpenXRSessionHandles& handles,
 {
 }
 
-bool LiveHeadTrackerImpl::update(XrTime time)
+void LiveHeadTrackerImpl::update(XrTime time)
 {
     last_update_time_ = time;
 
@@ -49,7 +50,7 @@ bool LiveHeadTrackerImpl::update(XrTime time)
     if (XR_FAILED(result))
     {
         tracked_.data.reset();
-        return false;
+        throw std::runtime_error("[HeadTracker] xrLocateSpace failed: " + std::to_string(result));
     }
 
     bool position_valid = (location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0;
@@ -71,7 +72,8 @@ bool LiveHeadTrackerImpl::update(XrTime time)
     }
     else
     {
-        tracked_.data->pose.reset();
+        // Keep pose populated whenever data is present; validity is indicated by is_valid.
+        tracked_.data->pose = std::make_shared<Pose>();
     }
 
     if (mcap_channels_)
@@ -80,8 +82,6 @@ bool LiveHeadTrackerImpl::update(XrTime time)
         DeviceDataTimestamp timestamp(monotonic_ns, monotonic_ns, last_update_time_);
         mcap_channels_->write(0, timestamp, tracked_.data);
     }
-
-    return true;
 }
 
 const HeadPoseTrackedT& LiveHeadTrackerImpl::get_head() const

--- a/src/core/live_trackers/cpp/live_head_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_head_tracker_impl.hpp
@@ -36,7 +36,7 @@ public:
     LiveHeadTrackerImpl(LiveHeadTrackerImpl&&) = delete;
     LiveHeadTrackerImpl& operator=(LiveHeadTrackerImpl&&) = delete;
 
-    bool update(XrTime time) override;
+    void update(XrTime time) override;
     const HeadPoseTrackedT& get_head() const override;
 
 private:

--- a/src/core/live_trackers/cpp/schema_tracker_base.cpp
+++ b/src/core/live_trackers/cpp/schema_tracker_base.cpp
@@ -15,6 +15,16 @@
 namespace core
 {
 
+namespace
+{
+
+bool is_known_non_fatal_tensor_unavailable(XrResult result)
+{
+    return result == XR_ERROR_TENSOR_LOST_NV;
+}
+
+} // namespace
+
 // =============================================================================
 // SchemaTracker Implementation
 // =============================================================================
@@ -64,6 +74,11 @@ bool SchemaTrackerBase::ensure_collection()
     XrResult result = m_get_latest_gen_fn(m_handles.session, &latest_generation);
     if (result != XR_SUCCESS)
     {
+        if (is_known_non_fatal_tensor_unavailable(result))
+        {
+            m_target_collection_index.reset();
+            return false;
+        }
         throw std::runtime_error("Failed to get latest generation, result=" + std::to_string(result));
     }
 
@@ -77,6 +92,11 @@ bool SchemaTrackerBase::ensure_collection()
         result = m_update_list_fn(m_tensor_list);
         if (result != XR_SUCCESS)
         {
+            if (is_known_non_fatal_tensor_unavailable(result))
+            {
+                m_target_collection_index.reset();
+                return false;
+            }
             throw std::runtime_error("Failed to update tensor list, result=" + std::to_string(result));
         }
         m_cached_generation = latest_generation;
@@ -86,6 +106,11 @@ bool SchemaTrackerBase::ensure_collection()
     result = m_get_list_props_fn(m_tensor_list, &list_props);
     if (result != XR_SUCCESS)
     {
+        if (is_known_non_fatal_tensor_unavailable(result))
+        {
+            m_target_collection_index.reset();
+            return false;
+        }
         throw std::runtime_error("Failed to get list properties, result=" + std::to_string(result));
     }
 
@@ -95,6 +120,11 @@ bool SchemaTrackerBase::ensure_collection()
         result = m_get_coll_props_fn(m_tensor_list, i, &coll_props);
         if (result != XR_SUCCESS)
         {
+            if (is_known_non_fatal_tensor_unavailable(result))
+            {
+                m_target_collection_index.reset();
+                return false;
+            }
             throw std::runtime_error("Failed to get collection properties, result=" + std::to_string(result));
         }
 
@@ -216,6 +246,7 @@ bool SchemaTrackerBase::read_next_sample(SampleResult& out)
     {
         if (result == XR_ERROR_TENSOR_LOST_NV)
         {
+            // Policy: temporary collection loss is treated as non-fatal.
             std::cerr << "[SchemaTracker] m_get_data_fn(m_tensor_list, &retrievalInfo, &tensorData): "
                       << "XR_ERROR_TENSOR_LOST_NV — tensor/collection data lost; clearing m_target_collection_index."
                       << std::endl;

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -208,6 +208,9 @@ class TeleopSession:
             ValueError: If external leaves exist but external_inputs is missing or
                 incomplete, or if external_inputs contains keys that collide with
                 DeviceIO source names.
+            RuntimeError: If a critical DeviceIO/tracker/runtime failure occurs
+                while updating the session. This is a fatal condition; the
+                application is expected to terminate rather than continue.
         """
         # Validate external inputs
         self._validate_external_inputs(external_inputs)

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -299,7 +299,6 @@ class MockDeviceIOSession:
 
     def update(self):
         self.update_count += 1
-        return True
 
     def __enter__(self):
         return self

--- a/src/plugins/controller_synthetic_hands/synthetic_hands_plugin.cpp
+++ b/src/plugins/controller_synthetic_hands/synthetic_hands_plugin.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdlib>
+#include <exception>
 #include <iostream>
 
 namespace plugins
@@ -66,17 +68,31 @@ void SyntheticHandsPlugin::worker_thread()
 
     while (m_running)
     {
-        // Update DeviceIOSession (handles time and tracker updates)
-        if (!m_deviceio_session->update())
+        core::ControllerSnapshotTrackedT left_tracked;
+        core::ControllerSnapshotTrackedT right_tracked;
+        try
         {
-            std::cerr << "DeviceIOSession update failed" << std::endl;
-            std::this_thread::sleep_for(std::chrono::milliseconds(16));
-            continue;
-        }
+            // Update DeviceIOSession (handles time and tracker updates)
+            m_deviceio_session->update();
 
-        // Get controller data from tracker
-        const auto& left_tracked = m_controller_tracker->get_left_controller(*m_deviceio_session);
-        const auto& right_tracked = m_controller_tracker->get_right_controller(*m_deviceio_session);
+            // Read tracker data in the same exception boundary as update.
+            left_tracked = m_controller_tracker->get_left_controller(*m_deviceio_session);
+            right_tracked = m_controller_tracker->get_right_controller(*m_deviceio_session);
+        }
+        catch (const std::exception& e)
+        {
+            std::cerr << "SyntheticHandsPlugin update error: " << e.what() << std::endl;
+            m_left_injector.reset();
+            m_right_injector.reset();
+            std::exit(1);
+        }
+        catch (...)
+        {
+            std::cerr << "SyntheticHandsPlugin update error: unknown exception" << std::endl;
+            m_left_injector.reset();
+            m_right_injector.reset();
+            std::exit(1);
+        }
 
         // Use the OpenXR runtime clock for injection time so it aligns with the
         // runtime's own time domain (XrTime), rather than a raw steady_clock cast.

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -36,10 +36,7 @@ ManusTracker& ManusTracker::instance(const std::string& app_name) noexcept(false
 void ManusTracker::update()
 {
     // Update DeviceIOSession which handles time conversion and tracker updates internally
-    if (!m_deviceio_session->update())
-    {
-        return;
-    }
+    m_deviceio_session->update();
 
     inject_hand_data();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Update operations no longer return success/failure booleans; critical failures are surfaced as exceptions.

* **Refactor**
  * Example apps and demos no longer early-exit on update failures; loops continue until normal completion or an exception.
  * Session/update flows consolidated to exception-driven error handling with adjusted termination behavior.

* **Documentation**
  * Clarified that update-time critical failures are treated as fatal and may terminate the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->