### PR TITLE
Add quotations to pip install cmds

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -33,7 +33,7 @@ In a new terminal, install the package from PyPI (or from a local wheel if you b
 .. code-block:: bash
 
    # From PyPI
-   pip install isaacteleop[cloudxr,retargeters]~=1.0.0 --extra-index-url https://pypi.nvidia.com
+   pip install 'isaacteleop[cloudxr,retargeters]~=1.0.0' --extra-index-url https://pypi.nvidia.com
 
 Instead of installing the package from PyPI, you can build from source and install the local wheel.
 See :doc:`build_from_source` for more details.

--- a/scripts/run_cloudxr.sh
+++ b/scripts/run_cloudxr.sh
@@ -10,7 +10,7 @@ source "./setup_cloudxr_env.sh"
 
 echo "Starting WSS proxy..."
 if ! python -c "import isaacteleop.cloudxr" >/dev/null 2>&1; then
-    echo "Error: isaacteleop[cloudxr] is not installed. Install it before running this script (e.g. pip install isaacteleop[cloudxr])."
+    echo "Error: isaacteleop[cloudxr] is not installed. Install it before running this script (e.g. pip install 'isaacteleop[cloudxr]')."
     echo "Follow the Quick Start guide to install the package via pypi: https://nvidia.github.io/IsaacTeleop/main/getting_started/quick_start.html"
     echo "Or build and install the package from source: https://nvidia.github.io/IsaacTeleop/main/getting_started/build_from_source.html"
     exit 1

--- a/src/core/retargeting_engine_ui/python/__init__.py
+++ b/src/core/retargeting_engine_ui/python/__init__.py
@@ -4,7 +4,7 @@
 """ImGui-based UI for retargeting engine parameter tuning.
 
 This module requires imgui and glfw to be installed:
-    pip install isaacteleop[ui]
+    pip install 'isaacteleop[ui]'
 
 Or manually:
     pip install imgui[glfw]
@@ -26,7 +26,7 @@ except ImportError as e:
     error_msg = (
         "\n"
         "ImGui UI dependencies are not installed.\n"
-        "Install with: pip install isaacteleop[ui]\n"
+        "Install with: pip install 'isaacteleop[ui]'\n"
         f"Original error: {e}\n"
     )
     print(error_msg, file=sys.stderr)

--- a/src/retargeters/__init__.py
+++ b/src/retargeters/__init__.py
@@ -117,7 +117,7 @@ def __getattr__(name: str):
             raise
         raise ModuleNotFoundError(
             f"{name} requires additional dependencies that are not installed.\n"
-            f"Install them with:  pip install isaacteleop[{extra}]"
+            f"Install them with:  pip install 'isaacteleop[{extra}]'"
         ) from exc
 
     value = getattr(mod, attr)


### PR DESCRIPTION
Because zsh interprets square brackets as glob patterns, pip arguments that contain [ and ] must be quoted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions throughout documentation, setup scripts, and error messages to consistently quote package extras in pip install commands for proper shell parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->