### PR TITLE
Replace manual sccache installation with github action

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -53,7 +53,7 @@ jobs:
 
     - name: Verify sccache
       run: |
-        & "${env:SCCACHE_PATH}" --version
+        sccache --version
 
     # Put cl.exe and other build tools in PATH
     - name: Setup MSVC (Developer Command Prompt)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Windows build workflow by switching to a dedicated sccache action, removing manual installation, legacy cache steps and related environment variables, and simplifying verification and post-build reporting. The change keeps a lightweight pre-build verification step and reduces redundant post-build reporting for more reliable, maintainable builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->