### PR TITLE
Add teleop state transitions

### DIFF
--- a/docs/source/getting_started/teleop_control_state_machine.rst
+++ b/docs/source/getting_started/teleop_control_state_machine.rst
@@ -1,0 +1,141 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Teleop Control State Machine
+============================
+
+This page describes the default teleop control state machine used by
+``DefaultTeleopStateManager`` and how to connect button inputs.
+
+Overview
+--------
+
+``TeleopSession`` expects the optional ``teleop_control_pipeline`` to expose
+this output contract:
+
+- ``teleop_state``: one-hot execution state channels in this order:
+  ``stopped``, ``paused``, ``running``
+- ``reset_event``: bool pulse
+
+When provided, ``TeleopSession`` decodes these outputs into
+``ComputeContext.execution_events`` so downstream retargeters and high-level app
+logic can read:
+
+- ``context.execution_events.execution_state``
+- ``context.execution_events.reset``
+
+Isaac Teleop provides ``DefaultTeleopStateManager`` as a ready-to-use default
+state machine. It should work for most setups, but you can also implement your
+own control state machine as long as it preserves the same output contract.
+
+Default State Machine Behavior
+------------------------------
+
+Inputs (all optional bool signals):
+
+- ``kill_button``
+- ``run_toggle_button``
+- ``reset_button``
+
+Transitions:
+
+1. ``kill_button`` level-held:
+
+   - while asserted, state is forced to ``STOPPED``
+   - emits ``reset_event = True``
+
+2. ``run_toggle_button`` rising edge:
+
+   - ``STOPPED`` -> ``PAUSED``
+   - ``PAUSED`` -> ``RUNNING``
+   - ``RUNNING`` -> ``PAUSED``
+
+3. ``reset_button`` rising edge:
+
+   - state unchanged
+   - emits ``reset_event = True``
+
+Safety behavior:
+
+- If a required control input (kill/run-toggle) is absent for the frame, manager
+  fail-safes to ``STOPPED``.
+- Loss-driven ``reset_event`` is edge-triggered on availability loss (emitted once
+  on the first frame required inputs drop out, not unconditionally every frame).
+- This fail-safe is immediate (same frame). If teleop control inputs are lost
+  (for example controller disconnect, tracking loss, or selector output becomes
+  unavailable), execution state is forced to ``STOPPED`` right away.
+
+Connecting Inputs
+-----------------
+
+Use one debounced selector per signal (simple wiring, no multi-input lambdas):
+see :code-file:`teleop_controls_simple_example.py <examples/teleop_session_manager/python/teleop_controls_simple_example.py>`
+for the full runnable setup.
+
+.. code-block:: python
+
+   from isaacteleop.retargeting_engine.deviceio_source_nodes import ControllersSource
+   from isaacteleop.retargeting_engine.tensor_types import ControllerInputIndex
+   from isaacteleop.teleop_session_manager import (
+       DefaultTeleopStateManager,
+       create_bool_selector,
+   )
+
+   controllers = ControllersSource(name="controllers")
+   left = controllers.output(ControllersSource.LEFT)
+
+   kill_signal = create_bool_selector(
+       left,
+       name="kill_signal_selector",
+       selector_fn=lambda selected: selected[ControllerInputIndex.SECONDARY_CLICK],
+   )
+   run_toggle_signal = create_bool_selector(
+       left,
+       name="run_toggle_signal_selector",
+       selector_fn=lambda selected: selected[ControllerInputIndex.PRIMARY_CLICK],
+   )
+   reset_signal = create_bool_selector(
+       left,
+       name="reset_signal_selector",
+       selector_fn=lambda selected: selected[ControllerInputIndex.THUMBSTICK_CLICK],
+   )
+
+   manager = DefaultTeleopStateManager(name="teleop_manager")
+   control_pipeline = manager.connect(
+       {
+           manager.INPUT_KILL: kill_signal.output("value"),
+           manager.INPUT_RUN_TOGGLE: run_toggle_signal.output("value"),
+           manager.INPUT_RESET: reset_signal.output("value"),
+       }
+   )
+
+Debounce behavior is configurable in ``create_bool_selector``:
+
+- ``threshold`` / ``release_threshold`` for float hysteresis
+- ``activate_frames`` / ``deactivate_frames`` for rising/falling debounce length
+- automatic ``None`` propagation when upstream input is absent
+
+Important availability note:
+
+- ``create_bool_selector`` propagates unavailable upstream input as ``None``.
+- ``DefaultTeleopStateManager`` treats ``None`` on any required control input
+  as a safety fault and immediately transitions to ``STOPPED``; when required
+  inputs first become unavailable it emits a single loss-driven
+  ``reset_event = True`` pulse.
+
+Using Context in High-Level App Logic
+-------------------------------------
+
+After ``session.step()``, use ``session.last_context`` to gate robot enablement
+or other high-level behavior:
+
+.. code-block:: python
+
+   from isaacteleop.retargeting_engine.interface.execution_events import ExecutionState
+
+   outputs = session.step()
+   context = session.last_context
+   if context is not None:
+       robot_enabled = context.execution_events.execution_state != ExecutionState.STOPPED
+       if context.execution_events.reset:
+           handle_reset()

--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -133,10 +133,13 @@ TeleopSession
 Methods
 """""""
 
-- ``step(external_inputs=None) -> Dict[str, TensorGroup]`` -- Execute one step:
-  updates the DeviceIO session, polls tracker data, merges any caller-provided
-  ``external_inputs``, and executes the retargeting pipeline. Raises
-  ``ValueError`` if required external inputs are missing or collide with
+- ``step(*, external_inputs=None, graph_time=None, execution_events=None) -> Dict[str, TensorGroup]``
+  -- Execute one step: updates the DeviceIO session, polls tracker data, merges
+  any caller-provided ``external_inputs``, and executes the retargeting pipeline.
+  ``graph_time`` can be provided explicitly; when omitted, monotonic time is used
+  for both sim/real time. If ``execution_events`` is provided, it is injected into
+  ``ComputeContext`` and ``teleop_control_pipeline`` is skipped for that step.
+  Raises ``ValueError`` if required external inputs are missing or collide with
   DeviceIO source names.
 - ``get_external_input_specs() -> Dict[str, RetargeterIOType]`` -- Return the
   input specifications for all external (non-DeviceIO) leaf nodes that require
@@ -144,6 +147,27 @@ Methods
 - ``has_external_inputs() -> bool`` -- Whether this pipeline has external leaf
   nodes that require caller-provided inputs.
 - ``get_elapsed_time() -> float`` -- Get elapsed time since session started.
+
+Example (explicit GraphTime + ExecutionEvents override):
+
+.. code-block:: python
+
+   import time
+
+   from isaacteleop.retargeting_engine.interface.execution_events import (
+       ExecutionEvents,
+       ExecutionState,
+   )
+   from isaacteleop.retargeting_engine.interface.retargeter_core_types import GraphTime
+
+   now_ns = time.monotonic_ns()
+   result = session.step(
+       graph_time=GraphTime(sim_time_ns=123_000_000, real_time_ns=now_ns),
+       execution_events=ExecutionEvents(
+           execution_state=ExecutionState.PAUSED,
+           reset=False,
+       ),
+   )
 
 Properties
 """"""""""

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -49,6 +49,7 @@ Table of Contents
    getting_started/quick_start
    getting_started/build_from_source
    getting_started/teleop_session
+   getting_started/teleop_control_state_machine
    getting_started/contributing
 
 .. toctree::

--- a/examples/teleop_session_manager/python/teleop_controls_simple_example.py
+++ b/examples/teleop_session_manager/python/teleop_controls_simple_example.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Simple Teleop controls example.
+
+Focuses on teleop-control wiring:
+- Converts left-controller button states to bool control signals.
+- Drives DefaultTeleopStateManager with bindings:
+  - kill (B): any state -> stopped
+  - run_toggle (A): stopped -> paused -> running -> paused -> ...
+  - reset (thumbstick click): emit reset without changing state
+
+Non-control demo plumbing (printing/observation retargeter) lives in
+``teleop_controls_simple_helper.py``.
+"""
+
+import sys
+import time
+from typing import Dict
+
+from isaacteleop.retargeting_engine.deviceio_source_nodes import (
+    HeadSource,
+    HandsSource,
+    ControllersSource,
+)
+from isaacteleop.retargeting_engine.interface.execution_events import ExecutionState
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
+    GraphExecutable,
+)
+from isaacteleop.retargeting_engine.tensor_types import ControllerInputIndex
+from isaacteleop.teleop_session_manager import (
+    TeleopSession,
+    TeleopSessionConfig,
+    create_bool_selector,
+    DefaultTeleopStateManager,
+)
+
+from teleop_controls_simple_helper import (
+    build_observation_pipeline,
+    print_frame,
+    print_header,
+)
+
+
+def _build_control_signals(
+    controllers: ControllersSource,
+) -> Dict[str, GraphExecutable]:
+    left_selector = controllers.output(ControllersSource.LEFT)
+    return {
+        "kill_signal": create_bool_selector(
+            left_selector,
+            name="kill_signal_selector",
+            selector_fn=lambda selected: selected[ControllerInputIndex.SECONDARY_CLICK],
+        ),
+        "run_toggle_signal": create_bool_selector(
+            left_selector,
+            name="run_toggle_signal_selector",
+            selector_fn=lambda selected: selected[ControllerInputIndex.PRIMARY_CLICK],
+        ),
+        "reset_signal": create_bool_selector(
+            left_selector,
+            name="reset_signal_selector",
+            selector_fn=lambda selected: selected[
+                ControllerInputIndex.THUMBSTICK_CLICK
+            ],
+        ),
+    }
+
+
+def main() -> int:
+    head = HeadSource(name="head")
+    hands = HandsSource(name="hands")
+    controllers = ControllersSource(name="controllers")
+
+    main_pipeline = build_observation_pipeline(head, hands, controllers)
+
+    control_signals = _build_control_signals(controllers)
+    teleop_manager = DefaultTeleopStateManager(name="teleop_manager")
+    teleop_control_pipeline = teleop_manager.connect(
+        {
+            teleop_manager.INPUT_KILL: control_signals["kill_signal"].output("value"),
+            teleop_manager.INPUT_RUN_TOGGLE: control_signals[
+                "run_toggle_signal"
+            ].output("value"),
+            teleop_manager.INPUT_RESET: control_signals["reset_signal"].output("value"),
+        }
+    )
+
+    config = TeleopSessionConfig(
+        app_name="TeleopControlsSimpleExample",
+        pipeline=main_pipeline,
+        teleop_control_pipeline=teleop_control_pipeline,
+    )
+
+    with TeleopSession(config) as session:
+        print_header()
+
+        # Example high-level hook: a caller can gate robot power/control using context.
+        robot_enabled: bool | None = None
+
+        while True:
+            outputs = session.step()
+            context = session.last_context
+            if context is not None:
+                enabled_now = (
+                    context.execution_events.execution_state != ExecutionState.STOPPED
+                )
+                if robot_enabled is None or enabled_now != robot_enabled:
+                    robot_enabled = enabled_now
+                    print(f"[high-level] robot_enabled={robot_enabled}")
+                if context.execution_events.reset:
+                    print("[high-level] reset pulse received")
+
+            if session.frame_count % 30 == 0:
+                print_frame(outputs, session.get_elapsed_time())
+            time.sleep(0.016)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/teleop_session_manager/python/teleop_controls_simple_helper.py
+++ b/examples/teleop_session_manager/python/teleop_controls_simple_helper.py
@@ -1,0 +1,137 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helper utilities for the simple teleop controls example."""
+
+from isaacteleop.retargeting_engine.deviceio_source_nodes import (
+    HeadSource,
+    HandsSource,
+    ControllersSource,
+)
+from isaacteleop.retargeting_engine.interface import (
+    BaseRetargeter,
+    OutputCombiner,
+    RetargeterIOType,
+)
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
+    ComputeContext,
+    RetargeterIO,
+)
+from isaacteleop.retargeting_engine.interface.tensor_group_type import (
+    OptionalType,
+    TensorGroupType,
+)
+from isaacteleop.retargeting_engine.tensor_types import (
+    BoolType,
+    ControllerInput,
+    HandInput,
+    HandInputIndex,
+    HeadPose,
+    HeadPoseIndex,
+)
+
+
+class TeleopStatePrinterRetargeter(BaseRetargeter):
+    """Dummy retargeter that prints execution events from ComputeContext."""
+
+    def __init__(self, name: str, print_every_n_frames: int = 30) -> None:
+        self._print_every_n_frames = print_every_n_frames
+        self._frame = 0
+        super().__init__(name=name)
+
+    def input_spec(self) -> RetargeterIOType:
+        return {
+            "head": OptionalType(HeadPose()),
+            "hand_left": OptionalType(HandInput()),
+            "hand_right": OptionalType(HandInput()),
+            "controller_left": OptionalType(ControllerInput()),
+            "controller_right": OptionalType(ControllerInput()),
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        return {"tick": TensorGroupType("tick", [BoolType("tick")])}
+
+    def _compute_fn(
+        self, inputs: RetargeterIO, outputs: RetargeterIO, context: ComputeContext
+    ) -> None:
+        if self._frame % self._print_every_n_frames == 0:
+            print(
+                "[retargeter] "
+                f"state={context.execution_events.execution_state.value} "
+                f"reset={context.execution_events.reset} "
+                f"head={not inputs['head'].is_none} "
+                f"hands(L/R)={not inputs['hand_left'].is_none}/{not inputs['hand_right'].is_none} "
+                f"controllers(L/R)={not inputs['controller_left'].is_none}/{not inputs['controller_right'].is_none}"
+            )
+        self._frame += 1
+        outputs["tick"][0] = True
+
+
+def build_observation_pipeline(
+    head: HeadSource, hands: HandsSource, controllers: ControllersSource
+) -> OutputCombiner:
+    """Build non-control pipeline pieces used only for demo printing."""
+    printer = TeleopStatePrinterRetargeter(name="teleop_state_printer")
+    printer_pipeline = printer.connect(
+        {
+            "head": head.output("head"),
+            "hand_left": hands.output(HandsSource.LEFT),
+            "hand_right": hands.output(HandsSource.RIGHT),
+            "controller_left": controllers.output(ControllersSource.LEFT),
+            "controller_right": controllers.output(ControllersSource.RIGHT),
+        }
+    )
+
+    return OutputCombiner(
+        {
+            "head": head.output("head"),
+            "hand_left": hands.output(HandsSource.LEFT),
+            "hand_right": hands.output(HandsSource.RIGHT),
+            "controller_left": controllers.output(ControllersSource.LEFT),
+            "controller_right": controllers.output(ControllersSource.RIGHT),
+            "printer_tick": printer_pipeline.output("tick"),
+        }
+    )
+
+
+def print_header() -> None:
+    print("\n" + "=" * 80)
+    print("Simple Teleop Controls Example")
+    print(
+        "Bindings (LEFT controller): kill=B (any->stopped), "
+        "run_toggle=A (stopped->paused->running->paused...), "
+        "reset=thumbstick_click (state unchanged)"
+    )
+    print("Press Ctrl+C to exit")
+    print("=" * 80 + "\n")
+
+
+def print_frame(outputs, elapsed: float) -> None:
+    head_present = not outputs["head"].is_none
+    left_hand_present = not outputs["hand_left"].is_none
+    right_hand_present = not outputs["hand_right"].is_none
+    left_ctrl_present = not outputs["controller_left"].is_none
+    right_ctrl_present = not outputs["controller_right"].is_none
+
+    head_pos_str = "absent"
+    if head_present:
+        p = outputs["head"][HeadPoseIndex.POSITION]
+        head_pos_str = f"[{p[0]:+.3f}, {p[1]:+.3f}, {p[2]:+.3f}]"
+
+    left_wrist_str = "absent"
+    if left_hand_present:
+        wp = outputs["hand_left"][HandInputIndex.JOINT_POSITIONS][0]
+        left_wrist_str = f"[{wp[0]:+.3f}, {wp[1]:+.3f}, {wp[2]:+.3f}]"
+
+    right_wrist_str = "absent"
+    if right_hand_present:
+        wp = outputs["hand_right"][HandInputIndex.JOINT_POSITIONS][0]
+        right_wrist_str = f"[{wp[0]:+.3f}, {wp[1]:+.3f}, {wp[2]:+.3f}]"
+
+    print(
+        f"[{elapsed:5.1f}s] "
+        f"head={head_present} pos={head_pos_str} | "
+        f"hands(L/R)={left_hand_present}/{right_hand_present} "
+        f"wristL={left_wrist_str} wristR={right_wrist_str} | "
+        f"ctrl(L/R)={left_ctrl_present}/{right_ctrl_present}"
+    )

--- a/src/core/retargeting_engine/python/interface/__init__.py
+++ b/src/core/retargeting_engine/python/interface/__init__.py
@@ -7,6 +7,7 @@ from .base_retargeter import BaseRetargeter
 from .output_combiner import OutputCombiner
 from .value_input import ValueInput
 from .parameter_state import ParameterState
+from .execution_events import ExecutionState, ExecutionEvents
 from .retargeter_core_types import (
     ComputeContext,
     GraphExecutable,
@@ -47,6 +48,8 @@ __all__ = [
     "GraphExecutable",
     "GraphTime",
     "ComputeContext",
+    "ExecutionEvents",
+    "ExecutionState",
     "ParameterSpec",
     "BoolParameter",
     "FloatParameter",

--- a/src/core/retargeting_engine/python/interface/base_retargeter.py
+++ b/src/core/retargeting_engine/python/interface/base_retargeter.py
@@ -25,7 +25,6 @@ from .retargeter_core_types import (
     BaseExecutable,
     RetargeterIOType,
     ComputeContext,
-    _default_compute_context,
 )
 from .retargeter_subgraph import RetargeterSubgraph
 from .parameter_state import ParameterState
@@ -177,7 +176,7 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
             Dict[str, TensorGroup] — freshly allocated, independently owned outputs.
         """
         if context is None:
-            context = _default_compute_context()
+            context = ComputeContext()
         outputs = self._allocate_outputs()
         self.compute(inputs, outputs, context)
         return outputs
@@ -262,7 +261,7 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
             Dict[str, TensorGroup] — freshly allocated populated output groups.
         """
         if context is None:
-            context = _default_compute_context()
+            context = ComputeContext()
         node_inputs = inputs.get(self.name, {})
         outputs = self._allocate_outputs()
         self.compute(node_inputs, outputs, context)
@@ -341,7 +340,7 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
                      Auto-generated from the monotonic clock when not provided.
         """
         if context is None:
-            context = _default_compute_context()
+            context = ComputeContext()
         inputs = self._fill_optional_inputs(inputs)
         self._validate_inputs(inputs)
         self._execute_compute(inputs, outputs, context)

--- a/src/core/retargeting_engine/python/interface/execution_events.py
+++ b/src/core/retargeting_engine/python/interface/execution_events.py
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Execution event state carried in ``ComputeContext``."""
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ExecutionState(str, Enum):
+    """Execution lifecycle state."""
+
+    UNKNOWN = "unknown"
+    STOPPED = "stopped"
+    PAUSED = "paused"
+    RUNNING = "running"
+
+
+@dataclass
+class ExecutionEvents:
+    """Per-step execution signals available to retargeters."""
+
+    # One-step signal retargeters can use to clear internal state.
+    reset: bool = False
+    # Current execution lifecycle state.
+    execution_state: ExecutionState = ExecutionState.UNKNOWN

--- a/src/core/retargeting_engine/python/interface/output_combiner.py
+++ b/src/core/retargeting_engine/python/interface/output_combiner.py
@@ -16,7 +16,6 @@ from .retargeter_core_types import (
     RetargeterIOType,
     BaseExecutable,
     ComputeContext,
-    _default_compute_context,
 )
 
 
@@ -139,7 +138,7 @@ class OutputCombiner(GraphExecutable):
             Dict[str, TensorGroup] - Combined outputs with custom names
         """
         if context is None:
-            context = _default_compute_context()
+            context = ComputeContext()
         return self._compute_with_cache(ExecutionCache(inputs, context))
 
     def __call__(

--- a/src/core/retargeting_engine/python/interface/retargeter_core_types.py
+++ b/src/core/retargeting_engine/python/interface/retargeter_core_types.py
@@ -2,12 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Dict, List, Optional
+from dataclasses import dataclass, field
 import time
+from typing import Dict, List, Optional
 
 from .tensor_group_type import TensorGroupType
 from .tensor_group import OptionalTensorGroup
+from .execution_events import ExecutionEvents
 
 
 RetargeterIOType = Dict[str, TensorGroupType]
@@ -22,17 +23,22 @@ class GraphTime:
     real_time_ns: int
 
 
+def _default_graph_time() -> GraphTime:
+    now_ns = time.monotonic_ns()
+    return GraphTime(sim_time_ns=now_ns, real_time_ns=now_ns)
+
+
 @dataclass
 class ComputeContext:
-    """Context passed to _compute_fn. Extensible for future per-step metadata."""
+    """Context passed to _compute_fn.
 
-    graph_time: GraphTime
+    ``graph_time`` carries timing information for the current step.
+    ``execution_events`` carries app-level control signals, such as reset and
+    run/pause/stop state.
+    """
 
-
-def _default_compute_context() -> "ComputeContext":
-    """Return a ComputeContext stamped with the current monotonic clock."""
-    now = time.monotonic_ns()
-    return ComputeContext(graph_time=GraphTime(sim_time_ns=now, real_time_ns=now))
+    graph_time: GraphTime = field(default_factory=_default_graph_time)
+    execution_events: ExecutionEvents = field(default_factory=ExecutionEvents)
 
 
 class ExecutionCache:

--- a/src/core/retargeting_engine/python/interface/retargeter_subgraph.py
+++ b/src/core/retargeting_engine/python/interface/retargeter_subgraph.py
@@ -17,7 +17,6 @@ from .retargeter_core_types import (
     OutputSelector,
     RetargeterIO,
     ComputeContext,
-    _default_compute_context,
 )
 
 
@@ -122,7 +121,7 @@ class RetargeterSubgraph(GraphExecutable):
             Dict[str, TensorGroup] - The computed output tensor groups
         """
         if context is None:
-            context = _default_compute_context()
+            context = ComputeContext()
         return self._compute_with_cache(ExecutionCache(inputs, context))
 
     def __call__(

--- a/src/core/teleop_session_manager/CMakeLists.txt
+++ b/src/core/teleop_session_manager/CMakeLists.txt
@@ -12,6 +12,9 @@ set(TELEOP_SESSION_MANAGER_PYTHON_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/python/config.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/python/teleop_session.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/python/helpers.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/python/teleop_state_manager_types.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/python/teleop_state_manager_retargeter.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/python/input_selector.py"
 )
 
 # Copy Python files to output directory during build

--- a/src/core/teleop_session_manager/python/__init__.py
+++ b/src/core/teleop_session_manager/python/__init__.py
@@ -10,6 +10,18 @@ from .helpers import (
     create_standard_inputs,
     get_required_oxr_extensions_from_pipeline,
 )
+from .teleop_state_manager_retargeter import (
+    TeleopStateManager,
+    DefaultTeleopStateManager,
+    TwoButtonTeleopStateManager,
+)
+from .teleop_state_manager_types import (
+    bool_signal,
+    teleop_state_channel,
+    reset_event_channel,
+    teleop_state_manager_output_spec,
+)
+from .input_selector import create_bool_selector
 
 __all__ = [
     "TeleopSession",
@@ -17,4 +29,12 @@ __all__ = [
     "PluginConfig",
     "create_standard_inputs",
     "get_required_oxr_extensions_from_pipeline",
+    "TeleopStateManager",
+    "DefaultTeleopStateManager",
+    "TwoButtonTeleopStateManager",
+    "bool_signal",
+    "teleop_state_channel",
+    "reset_event_channel",
+    "teleop_state_manager_output_spec",
+    "create_bool_selector",
 ]

--- a/src/core/teleop_session_manager/python/config.py
+++ b/src/core/teleop_session_manager/python/config.py
@@ -16,6 +16,9 @@ from typing import TYPE_CHECKING, Any, List, Optional
 from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
     GraphExecutable,
 )
+from isaacteleop.retargeting_engine.tensor_types import BoolType
+
+from .teleop_state_manager_types import teleop_control_states
 
 if TYPE_CHECKING:
     from teleopcore.oxr import OpenXRSessionHandles
@@ -46,6 +49,7 @@ class TeleopSessionConfig:
 
     Encapsulates all components needed to run a teleop session:
     - Retargeting pipeline (trackers auto-discovered from sources!)
+    - Optional teleop control pipeline (state/reset events for ComputeContext)
     - OpenXR application settings
     - Plugin configuration (optional)
     - Manual trackers (optional, for advanced use)
@@ -55,7 +59,12 @@ class TeleopSessionConfig:
 
     Attributes:
         app_name: Name of the OpenXR application
-        pipeline: Connected retargeting module (from new engine)
+        pipeline: Main retargeting pipeline.
+        teleop_control_pipeline: Optional control pipeline whose outputs are
+            decoded into ComputeContext.execution_events before running ``pipeline``.
+            Expected outputs:
+              - "teleop_state": one-hot bool group [stopped, paused, running]
+              - "reset_event": single bool pulse
         trackers: Optional list of manual trackers (usually not needed - auto-discovered!)
         plugins: List of plugin configurations
         verbose: Whether to print detailed progress information during setup
@@ -103,7 +112,66 @@ class TeleopSessionConfig:
 
     app_name: str
     pipeline: GraphExecutable
+    teleop_control_pipeline: Optional[GraphExecutable] = None
     trackers: List[Any] = field(default_factory=list)
     plugins: List[PluginConfig] = field(default_factory=list)
     verbose: bool = True
     oxr_handles: Optional[OpenXRSessionHandles] = None
+
+    def __post_init__(self) -> None:
+        """Validate optional teleop control pipeline output contract."""
+        if self.teleop_control_pipeline is None:
+            return
+
+        output_types = self.teleop_control_pipeline.output_types()
+        if "teleop_state" not in output_types:
+            raise ValueError(
+                "teleop_control_pipeline must output 'teleop_state' "
+                "(one-hot stopped/paused/running)"
+            )
+        if "reset_event" not in output_types:
+            raise ValueError(
+                "teleop_control_pipeline must output 'reset_event' (single bool pulse)"
+            )
+
+        teleop_state_type = output_types["teleop_state"]
+        if teleop_state_type.is_optional:
+            raise ValueError(
+                "teleop_control_pipeline output 'teleop_state' channels must be "
+                "plain BoolType (OptionalType is not allowed)"
+            )
+        expected_channels = [state.value for state in teleop_control_states()]
+        actual_channels = [tensor_type.name for tensor_type in teleop_state_type.types]
+        if set(actual_channels) != set(expected_channels):
+            raise ValueError(
+                "teleop_control_pipeline output 'teleop_state' must expose one bool "
+                f"channel per execution state {expected_channels} "
+                f"(got channels: {actual_channels})"
+            )
+        if len(actual_channels) != len(set(actual_channels)):
+            raise ValueError(
+                "teleop_control_pipeline output 'teleop_state' contains duplicate "
+                f"channels: {actual_channels}"
+            )
+        for tensor_type in teleop_state_type.types:
+            if not isinstance(tensor_type, BoolType):
+                raise ValueError(
+                    "teleop_control_pipeline output 'teleop_state' channels must be "
+                    f"BoolType, got {type(tensor_type).__name__}"
+                )
+
+        reset_event_type = output_types["reset_event"]
+        if reset_event_type.is_optional:
+            raise ValueError(
+                "teleop_control_pipeline output 'reset_event' must be a plain "
+                "BoolType scalar (OptionalType is not allowed)"
+            )
+        if len(reset_event_type.types) != 1:
+            raise ValueError(
+                "teleop_control_pipeline output 'reset_event' must have exactly 1 channel"
+            )
+        if not isinstance(reset_event_type.types[0], BoolType):
+            raise ValueError(
+                "teleop_control_pipeline output 'reset_event' must be a bool scalar "
+                f"(got {type(reset_event_type.types[0]).__name__})"
+            )

--- a/src/core/teleop_session_manager/python/input_selector.py
+++ b/src/core/teleop_session_manager/python/input_selector.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Debounced one-input selector utility for teleop-control graphs."""
+
+import math
+from numbers import Real
+from typing import Callable, Optional, Union
+
+from isaacteleop.retargeting_engine.interface import (
+    BaseRetargeter,
+    RetargeterIOType,
+    GraphExecutable,
+    OutputSelector,
+)
+from isaacteleop.retargeting_engine.interface.tensor_group import OptionalTensorGroup
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import RetargeterIO
+from isaacteleop.retargeting_engine.interface.tensor_group_type import TensorGroupType
+from isaacteleop.retargeting_engine.interface.tensor_group_type import OptionalType
+
+from .teleop_state_manager_types import bool_signal
+
+
+class _BoolSelectorRetargeter(BaseRetargeter):
+    """Compute one debounced bool output from one selected input tensor group."""
+
+    INPUT_VALUE = "selected_input"
+
+    def __init__(
+        self,
+        name: str,
+        selected_type: TensorGroupType,
+        selector_fn: Callable[[OptionalTensorGroup], Optional[Union[bool, float]]],
+        output_name: str,
+        threshold: float,
+        release_threshold: float,
+        activate_frames: int,
+        deactivate_frames: int,
+        initial_state: bool,
+    ) -> None:
+        self._selected_type = selected_type
+        self._selector_fn = selector_fn
+        self._output_name = output_name
+        self._threshold = threshold
+        self._release_threshold = release_threshold
+        self._activate_frames = activate_frames
+        self._deactivate_frames = deactivate_frames
+        self._initial_state = bool(initial_state)
+        self._debounced_state = self._initial_state
+        self._activate_count = 0
+        self._deactivate_count = 0
+        super().__init__(name=name)
+
+    def input_spec(self) -> RetargeterIOType:
+        return {self.INPUT_VALUE: OptionalType(self._selected_type)}
+
+    def output_spec(self) -> RetargeterIOType:
+        return {self._output_name: OptionalType(bool_signal(self._output_name))}
+
+    def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
+        del context
+        selected_input = inputs[self.INPUT_VALUE]
+        if selected_input.is_none:
+            self._debounced_state = self._initial_state
+            self._activate_count = 0
+            self._deactivate_count = 0
+            outputs[self._output_name].set_none()
+            return
+
+        value = self._selector_fn(selected_input)
+        if value is None:
+            self._debounced_state = self._initial_state
+            self._activate_count = 0
+            self._deactivate_count = 0
+            outputs[self._output_name].set_none()
+            return
+
+        raw_state = self._normalize_raw_value(value)
+        debounced = self._update_debounced_state(raw_state)
+        outputs[self._output_name][0] = debounced
+
+    def _normalize_raw_value(self, value: Union[bool, float]) -> bool:
+        if isinstance(value, bool):
+            return value
+        if not isinstance(value, Real):
+            raise TypeError(
+                f"selector_fn must return bool/float/None, got {type(value).__name__}"
+            )
+        scalar = float(value)
+        if self._debounced_state:
+            return scalar >= self._release_threshold
+        return scalar >= self._threshold
+
+    def _update_debounced_state(self, raw_state: bool) -> bool:
+        if raw_state == self._debounced_state:
+            self._activate_count = 0
+            self._deactivate_count = 0
+            return self._debounced_state
+
+        if raw_state:
+            self._activate_count += 1
+            self._deactivate_count = 0
+            if self._activate_count >= self._activate_frames:
+                self._debounced_state = True
+                self._activate_count = 0
+        else:
+            self._deactivate_count += 1
+            self._activate_count = 0
+            if self._deactivate_count >= self._deactivate_frames:
+                self._debounced_state = False
+                self._deactivate_count = 0
+
+        return self._debounced_state
+
+
+def create_bool_selector(
+    source_output_selector: OutputSelector,
+    *,
+    name: str,
+    selector_fn: Callable[[OptionalTensorGroup], Optional[Union[bool, float]]],
+    output_name: str = "value",
+    threshold: float = 0.5,
+    release_threshold: Optional[float] = None,
+    activate_frames: int = 2,
+    deactivate_frames: int = 2,
+    initial_state: bool = False,
+) -> GraphExecutable:
+    """Build one debounced bool signal from one selected input tensor group.
+
+    The utility handles ``None`` automatically:
+    - if upstream input is absent, output is set to ``None``
+    - if ``selector_fn`` returns ``None``, output is set to ``None``
+
+    ``selector_fn`` receives the selected input tensor group directly and should
+    return either:
+    - ``bool`` for directly interpreted digital signals, or
+    - ``float`` for analog signals thresholded into bool.
+
+    For float signals, hysteresis is applied:
+    - transition to True when value >= ``threshold``
+    - transition to False when value < ``release_threshold``
+    If ``release_threshold`` is omitted, it is set to ``threshold``.
+    """
+    if not callable(selector_fn):
+        raise TypeError(
+            "create_bool_selector requires selector_fn to be callable, "
+            f"got {type(selector_fn).__name__}"
+        )
+    if isinstance(threshold, bool) or not isinstance(threshold, (int, float)):
+        raise TypeError(
+            "create_bool_selector requires threshold to be numeric (int or float), "
+            f"got {type(threshold).__name__}"
+        )
+    threshold = float(threshold)
+    if not math.isfinite(threshold):
+        raise ValueError(
+            f"create_bool_selector requires threshold to be finite, got {threshold}"
+        )
+    if threshold < 0.0:
+        raise ValueError(
+            "create_bool_selector requires threshold to be non-negative, "
+            f"got {threshold}"
+        )
+    if release_threshold is None:
+        release_threshold = threshold
+    else:
+        if isinstance(release_threshold, bool) or not isinstance(
+            release_threshold, (int, float)
+        ):
+            raise TypeError(
+                "create_bool_selector requires release_threshold to be numeric "
+                "(int or float) when provided, "
+                f"got {type(release_threshold).__name__}"
+            )
+        release_threshold = float(release_threshold)
+    if not math.isfinite(release_threshold):
+        raise ValueError(
+            "create_bool_selector requires release_threshold to be finite, "
+            f"got {release_threshold}"
+        )
+    if release_threshold < 0.0:
+        raise ValueError(
+            "create_bool_selector requires release_threshold to be non-negative, "
+            f"got {release_threshold}"
+        )
+
+    if not isinstance(source_output_selector, OutputSelector):
+        raise TypeError(
+            "source_output_selector must be OutputSelector, "
+            f"got {type(source_output_selector).__name__}"
+        )
+    if activate_frames < 1:
+        raise ValueError("activate_frames must be >= 1")
+    if deactivate_frames < 1:
+        raise ValueError("deactivate_frames must be >= 1")
+    if release_threshold > threshold:
+        raise ValueError("release_threshold must be <= threshold")
+
+    module_outputs = source_output_selector.module.output_types()
+    if source_output_selector.output_name not in module_outputs:
+        available_outputs = sorted(module_outputs.keys())
+        raise ValueError(
+            "Invalid output selector for create_bool_selector: "
+            f"module '{source_output_selector.module.name}' has no output "
+            f"'{source_output_selector.output_name}'. "
+            f"Available outputs: {available_outputs}"
+        )
+    selected_type = module_outputs[source_output_selector.output_name]
+    selector = _BoolSelectorRetargeter(
+        name=name,
+        selected_type=selected_type,
+        selector_fn=selector_fn,
+        output_name=output_name,
+        threshold=threshold,
+        release_threshold=release_threshold,
+        activate_frames=activate_frames,
+        deactivate_frames=deactivate_frames,
+        initial_state=initial_state,
+    )
+    return selector.connect(
+        {_BoolSelectorRetargeter.INPUT_VALUE: source_output_selector}
+    )

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -11,15 +11,20 @@ rather than initialization code.
 
 import time
 from contextlib import ExitStack
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, Set
 
 from isaacteleop.retargeting_engine.deviceio_source_nodes import IDeviceIOSource
 from isaacteleop.retargeting_engine.interface import BaseRetargeter
 from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
     ComputeContext,
     GraphExecutable,
+    GraphTime,
     RetargeterIO,
     RetargeterIOType,
+)
+from isaacteleop.retargeting_engine.interface.execution_events import (
+    ExecutionEvents,
+    ExecutionState,
 )
 
 import isaacteleop.deviceio as deviceio
@@ -29,6 +34,7 @@ import isaacteleop.plugin_manager as pm
 from .config import (
     TeleopSessionConfig,
 )
+from .teleop_state_manager_types import teleop_control_states
 
 
 class TeleopSession:
@@ -99,6 +105,9 @@ class TeleopSession:
         """
         self.config = config
         self.pipeline: GraphExecutable = config.pipeline
+        self.teleop_control_pipeline: Optional[GraphExecutable] = (
+            config.teleop_control_pipeline
+        )
 
         # Core components (will be created in __enter__)
         self._oxr_session: Optional[oxr.OpenXRSession] = None
@@ -115,9 +124,14 @@ class TeleopSession:
         # External (non-DeviceIO) leaf nodes that require caller-provided inputs
         self._external_leaves: List[BaseRetargeter] = []
 
+        # Cached leaf name sets for filtering pipeline inputs
+        self._main_leaf_names: Set[str] = set()
+        self._control_leaf_names: Set[str] = set()
+
         # Runtime state
         self.frame_count: int = 0
         self.start_time: float = 0.0
+        self._last_context: Optional[ComputeContext] = None
         self._setup_complete: bool = False
         # Discover sources and external leaves from pipeline
         self._discover_sources()
@@ -126,6 +140,11 @@ class TeleopSession:
     def oxr_session(self) -> Optional[oxr.OpenXRSession]:
         """The internal OpenXR session, or ``None`` when using external handles (read-only)."""
         return self._oxr_session
+
+    @property
+    def last_context(self) -> Optional[ComputeContext]:
+        """Most recent ComputeContext produced by ``step()``, or ``None`` before first step."""
+        return self._last_context
 
     def _discover_sources(self) -> None:
         """Discover DeviceIO source modules and external leaf nodes from the pipeline.
@@ -137,14 +156,48 @@ class TeleopSession:
           (e.g. fixed-command retargeters) are not treated as external and do not
           require external_inputs.
         """
-        leaf_nodes = self.pipeline.get_leaf_nodes()
+        main_leaf_nodes = self.pipeline.get_leaf_nodes()
+        control_leaf_nodes: List[BaseRetargeter] = []
+        if self.teleop_control_pipeline is not None:
+            control_leaf_nodes = self.teleop_control_pipeline.get_leaf_nodes()
+
+        leaf_nodes = main_leaf_nodes + control_leaf_nodes
+        main_leaf_ids = {id(node) for node in main_leaf_nodes}
+        control_leaf_ids = {id(node) for node in control_leaf_nodes}
+
+        # Cache leaf name sets for filtering pipeline inputs
+        self._main_leaf_names = {node.name for node in main_leaf_nodes}
+        self._control_leaf_names = {node.name for node in control_leaf_nodes}
+
+        # Leaf names must be unique across main and control pipelines because
+        # they are used as top-level keys in collected pipeline inputs.
+        seen_name_to_id: Dict[str, int] = {}
+        for node in leaf_nodes:
+            existing_id = seen_name_to_id.get(node.name)
+            if existing_id is not None and existing_id != id(node):
+                raise ValueError(
+                    "Duplicate leaf node name detected across pipeline and "
+                    "teleop_control_pipeline: "
+                    f"'{node.name}' (node ids: {existing_id}, {id(node)})"
+                )
+            seen_name_to_id[node.name] = id(node)
 
         self._sources = []
         self._external_leaves = []
+        visited_nodes = set()
         for node in leaf_nodes:
+            if id(node) in visited_nodes:
+                continue
+            visited_nodes.add(id(node))
             if isinstance(node, IDeviceIOSource):
                 self._sources.append(node)
             elif node.input_spec():
+                if id(node) in control_leaf_ids and id(node) not in main_leaf_ids:
+                    raise ValueError(
+                        "teleop_control_pipeline contains an external-input leaf "
+                        f"'{node.name}', which is not supported. Control pipeline "
+                        "inputs must come from DeviceIO sources (or be no-input nodes)."
+                    )
                 self._external_leaves.append(node)
 
         # Create tracker-to-source mapping for efficient lookup
@@ -179,8 +232,10 @@ class TeleopSession:
 
     def step(
         self,
+        *,
         external_inputs: Optional[Dict[str, RetargeterIO]] = None,
-        context: Optional[ComputeContext] = None,
+        graph_time: Optional[GraphTime] = None,
+        execution_events: Optional[ExecutionEvents] = None,
     ):
         """Execute a single step of the teleop session.
 
@@ -195,14 +250,18 @@ class TeleopSession:
                 to an external leaf node or a DeviceIO source name are silently ignored.
                 Keys that collide with a DeviceIO source name are invalid and cause
                 validation to raise.
-            context: Optional ComputeContext carrying GraphTime and any future per-step
-                metadata. When omitted, a context is auto-generated from the monotonic clock.
+            graph_time: Optional ``GraphTime`` for this step. When omitted,
+                both sim/real time are initialized from the current monotonic clock.
+            execution_events: Optional externally-specified execution control events.
+                When provided, these values are injected into ``ComputeContext`` and
+                the session will skip running ``teleop_control_pipeline`` for this step.
 
         Returns:
             Dict[str, TensorGroup] - Output from the retargeting pipeline. The
             returned reference points into the session's internal output buffers and
             will be overwritten on the next call to step(). Consumers that need to
             retain the result across steps must copy it themselves.
+            The per-step context is available via ``session.last_context``.
 
         Raises:
             ValueError: If external leaves exist but external_inputs is missing or
@@ -212,7 +271,7 @@ class TeleopSession:
                 while updating the session. This is a fatal condition; the
                 application is expected to terminate rather than continue.
         """
-        # Validate external inputs
+        # Validate external inputs required by main pipeline leaves.
         self._validate_external_inputs(external_inputs)
 
         # Check plugin health periodically
@@ -229,13 +288,104 @@ class TeleopSession:
         if external_inputs:
             pipeline_inputs.update(external_inputs)
 
-        result = self.pipeline.execute_pipeline(pipeline_inputs, context)
+        now_ns = time.monotonic_ns()
+        if graph_time is None:
+            graph_time = GraphTime(sim_time_ns=now_ns, real_time_ns=now_ns)
+
+        if execution_events is None and self.teleop_control_pipeline is not None:
+            # Filter pipeline_inputs to only control leaf inputs
+            control_inputs = {
+                k: v
+                for k, v in pipeline_inputs.items()
+                if k in self._control_leaf_names
+            }
+            control_outputs = self.teleop_control_pipeline.execute_pipeline(
+                control_inputs
+            )
+            execution_events = self._decode_teleop_control_events(control_outputs)
+        elif execution_events is None:
+            # Auto-fire START on the first step when no control pipeline is configured
+            execution_events = ExecutionEvents(
+                reset=False, execution_state=ExecutionState.RUNNING
+            )
+
+        context = ComputeContext(
+            graph_time=graph_time,
+            execution_events=execution_events,
+        )
+        self._last_context = context
+
+        # Filter pipeline_inputs to only main leaf inputs
+        main_inputs = {
+            k: v for k, v in pipeline_inputs.items() if k in self._main_leaf_names
+        }
+        result = self.pipeline.execute_pipeline(main_inputs, context)
 
         self.frame_count += 1
         return result
 
+    def _decode_teleop_control_events(
+        self, control_outputs: RetargeterIO
+    ) -> ExecutionEvents:
+        """Decode teleop control pipeline outputs into ``ExecutionEvents``."""
+        if "teleop_state" not in control_outputs:
+            raise ValueError(
+                "teleop_control_pipeline must output 'teleop_state' "
+                "(one-hot stopped/paused/running)"
+            )
+        if "reset_event" not in control_outputs:
+            raise ValueError(
+                "teleop_control_pipeline must output 'reset_event' (single bool pulse)"
+            )
+
+        state_group = control_outputs["teleop_state"]
+        reset_group = control_outputs["reset_event"]
+
+        expected_states: Set[ExecutionState] = set(teleop_control_states())
+        if len(reset_group) != 1:
+            raise ValueError(
+                "teleop_control_pipeline output 'reset_event' must have 1 bool slot"
+            )
+
+        state_flags: Dict[ExecutionState, bool] = {}
+        for idx, tensor_type in enumerate(state_group.group_type.types):
+            try:
+                channel_state = ExecutionState(tensor_type.name)
+            except ValueError as exc:
+                raise ValueError(
+                    "teleop_control_pipeline output 'teleop_state' contains unknown "
+                    f"channel '{tensor_type.name}'. Channels must match ExecutionState."
+                ) from exc
+            if channel_state in state_flags:
+                raise ValueError(
+                    "teleop_control_pipeline output 'teleop_state' contains duplicate "
+                    f"channel '{channel_state.value}'"
+                )
+            state_flags[channel_state] = bool(state_group[idx])
+
+        if set(state_flags.keys()) != expected_states:
+            missing = sorted(
+                state.value for state in (expected_states - set(state_flags))
+            )
+            raise ValueError(
+                "teleop_control_pipeline output 'teleop_state' missing required "
+                f"ExecutionState channels: {missing}"
+            )
+
+        active_states = [state for state, is_active in state_flags.items() if is_active]
+        if len(active_states) != 1:
+            raise ValueError(
+                "teleop_control_pipeline output 'teleop_state' must be one-hot "
+                f"(got {state_flags})"
+            )
+        return ExecutionEvents(
+            execution_state=active_states[0],
+            reset=bool(reset_group[0]),
+        )
+
     def _validate_external_inputs(
-        self, external_inputs: Optional[Dict[str, RetargeterIO]]
+        self,
+        external_inputs: Optional[Dict[str, RetargeterIO]],
     ) -> None:
         """Validate that all required external inputs are provided.
 
@@ -335,6 +485,10 @@ class TeleopSession:
         Returns:
             self for context manager protocol
         """
+        # Reset run-scoped plugin containers on each context entry.
+        self.plugin_managers = []
+        self.plugin_contexts = []
+
         # Collect trackers from source nodes and config
         trackers = [source.get_tracker() for source in self._sources]
         if self.config.trackers:
@@ -392,6 +546,7 @@ class TeleopSession:
         # Initialize runtime state
         self.frame_count = 0
         self.start_time = time.time()
+        self._last_context = None
 
         self._setup_complete = True
         return self

--- a/src/core/teleop_session_manager/python/teleop_state_manager_retargeter.py
+++ b/src/core/teleop_session_manager/python/teleop_state_manager_retargeter.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Teleop state-manager retargeters.
+
+Defines:
+    - TeleopStateManager: abstract API retargeter with fixed outputs.
+    - DefaultTeleopStateManager: concrete default execution state manager.
+"""
+
+from abc import abstractmethod
+
+from isaacteleop.retargeting_engine.interface import BaseRetargeter, RetargeterIOType
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
+    ComputeContext,
+    RetargeterIO,
+)
+from isaacteleop.retargeting_engine.interface.tensor_group_type import OptionalType
+from isaacteleop.retargeting_engine.interface.execution_events import (
+    ExecutionState,
+    ExecutionEvents,
+)
+
+from .teleop_state_manager_types import bool_signal, teleop_state_manager_output_spec
+
+
+class TeleopStateManager(BaseRetargeter):
+    """Abstract teleop state-manager API with fixed teleop-state/reset outputs."""
+
+    OUTPUT_TELEOP_STATE = "teleop_state"
+    OUTPUT_RESET_EVENT = "reset_event"
+
+    def output_spec(self) -> RetargeterIOType:
+        """Fixed output contract for all teleop state managers."""
+        return teleop_state_manager_output_spec()
+
+    @abstractmethod
+    def _compute_execution_events(
+        self, inputs: RetargeterIO, context: ComputeContext
+    ) -> ExecutionEvents:
+        """Compute teleop app state and reset pulse for this frame."""
+        ...
+
+    def _compute_fn(
+        self, inputs: RetargeterIO, outputs: RetargeterIO, context: ComputeContext
+    ) -> None:
+        events = self._compute_execution_events(inputs, context)
+        teleop_state = outputs[self.OUTPUT_TELEOP_STATE]
+
+        for idx, tensor_type in enumerate(teleop_state.group_type.types):
+            try:
+                channel_state = ExecutionState(tensor_type.name)
+            except ValueError as exc:
+                raise ValueError(
+                    "teleop_state output channels must be named with ExecutionState "
+                    f"values; got unknown channel '{tensor_type.name}'"
+                ) from exc
+            teleop_state[idx] = channel_state == events.execution_state
+
+        outputs[self.OUTPUT_RESET_EVENT][0] = events.reset
+
+
+class DefaultTeleopStateManager(TeleopStateManager):
+    """Default execution state manager.
+
+    Inputs:
+        - kill_button: dedicated safety button. When pressed, force STOPPED and
+          emit reset_event=True.
+        - run_toggle_button: rising edge drives the sequence:
+          * STOPPED -> PAUSED
+          * PAUSED -> RUNNING
+          * RUNNING -> PAUSED
+        - reset_button: rising edge emits reset_event=True without changing state.
+
+    Safety:
+        If kill/run-toggle input is absent (OptionalTensorGroup is None),
+        fail-safe immediately to STOPPED. Reset input is optional.
+    """
+
+    INPUT_KILL = "kill_button"
+    INPUT_RUN_TOGGLE = "run_toggle_button"
+    INPUT_RESET = "reset_button"
+
+    def __init__(self, name: str) -> None:
+        self._state = ExecutionState.STOPPED
+        self._prev_kill = False
+        self._prev_run_toggle = False
+        self._prev_reset = False
+        self._required_inputs_lost_prev = False
+        super().__init__(name=name)
+
+    def input_spec(self) -> RetargeterIOType:
+        return {
+            self.INPUT_KILL: OptionalType(bool_signal(self.INPUT_KILL)),
+            self.INPUT_RUN_TOGGLE: OptionalType(bool_signal(self.INPUT_RUN_TOGGLE)),
+            self.INPUT_RESET: OptionalType(bool_signal(self.INPUT_RESET)),
+        }
+
+    def _compute_execution_events(
+        self, inputs: RetargeterIO, context: ComputeContext
+    ) -> ExecutionEvents:
+        del context
+
+        reset_present = not inputs[self.INPUT_RESET].is_none
+
+        if inputs[self.INPUT_KILL].is_none or inputs[self.INPUT_RUN_TOGGLE].is_none:
+            self._state = ExecutionState.STOPPED
+            reset_on_loss = reset_present and not self._required_inputs_lost_prev
+            self._required_inputs_lost_prev = True
+            # Conservative fail-safe: require button release after input recovery
+            # so a still-held button cannot appear as a synthetic rising edge.
+            self._prev_kill = True
+            self._prev_run_toggle = True
+            self._prev_reset = True
+            return ExecutionEvents(
+                reset=reset_on_loss,
+                execution_state=self._state,
+            )
+
+        self._required_inputs_lost_prev = False
+        kill_pressed = bool(inputs[self.INPUT_KILL][0])
+        run_toggle_pressed = bool(inputs[self.INPUT_RUN_TOGGLE][0])
+        if reset_present:
+            reset_pressed = bool(inputs[self.INPUT_RESET][0])
+            reset_edge = reset_pressed and not self._prev_reset
+            self._prev_reset = reset_pressed
+        else:
+            reset_edge = False
+
+        run_toggle_edge = run_toggle_pressed and not self._prev_run_toggle
+        self._prev_kill = kill_pressed
+        self._prev_run_toggle = run_toggle_pressed
+
+        reset = reset_edge
+        if kill_pressed:
+            self._state = ExecutionState.STOPPED
+            reset = True
+        elif run_toggle_edge:
+            if self._state == ExecutionState.STOPPED:
+                self._state = ExecutionState.PAUSED
+            elif self._state == ExecutionState.PAUSED:
+                self._state = ExecutionState.RUNNING
+            elif self._state == ExecutionState.RUNNING:
+                self._state = ExecutionState.PAUSED
+
+        return ExecutionEvents(reset=reset, execution_state=self._state)
+
+
+# Backward-compatible alias kept for downstream code migration.
+TwoButtonTeleopStateManager = DefaultTeleopStateManager

--- a/src/core/teleop_session_manager/python/teleop_state_manager_types.py
+++ b/src/core/teleop_session_manager/python/teleop_state_manager_types.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tensor channel helpers for TeleopStateManager retargeters."""
+
+from typing import Dict, List
+
+from isaacteleop.retargeting_engine.interface.execution_events import ExecutionState
+from isaacteleop.retargeting_engine.interface.tensor_group_type import TensorGroupType
+from isaacteleop.retargeting_engine.tensor_types import BoolType
+
+
+def teleop_control_states() -> List[ExecutionState]:
+    """Execution states represented in teleop control one-hot channels."""
+    return [
+        ExecutionState.STOPPED,
+        ExecutionState.PAUSED,
+        ExecutionState.RUNNING,
+    ]
+
+
+def bool_signal(name: str) -> TensorGroupType:
+    """Single-boolean signal channel."""
+    return TensorGroupType(name, [BoolType(name)])
+
+
+def teleop_state_channel() -> TensorGroupType:
+    """One-hot teleop app state channel: stopped, paused, running."""
+    return TensorGroupType(
+        "teleop_state",
+        [BoolType(state.value) for state in teleop_control_states()],
+    )
+
+
+def reset_event_channel() -> TensorGroupType:
+    """Single reset pulse channel."""
+    return bool_signal("reset_event")
+
+
+def teleop_state_manager_output_spec() -> Dict[str, TensorGroupType]:
+    """Standard output spec for TeleopStateManager nodes."""
+    return {
+        "teleop_state": teleop_state_channel(),
+        "reset_event": reset_event_channel(),
+    }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teleoperation control state machine with one‑hot execution states (STOPPED, PAUSED, RUNNING), reset pulses, and exposed per-step execution events; session config accepts an optional teleop control pipeline and session exposes the last execution context.
  * Debounced boolean input selectors and a runnable example wiring controller buttons to teleop controls; new state‑manager implementations and a two‑button alias for convenience.

* **Documentation**
  * Added user guide describing the state machine, wiring examples, debounce settings, and updated TeleopSession.step API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->