### PR TITLE
Remove ROS 2 topic parameters in favor of standard remapping

### DIFF
--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -72,9 +72,9 @@ docker run --rm --net=host --ipc=host \
   teleop_ros2_ref
 ```
 
-### Overriding parameters
+### Overriding parameters and remapping topics
 
-It's possible to set ROS 2 parameters from the command line when running the container. Append `--ros-args -p param_name:=value` after the image name:
+It's possible to set ROS 2 parameters and remap topics from the command line when running the container. Append `--ros-args -p param_name:=value` to set parameters, or `--ros-args -r old_topic:=new_topic` to remap topics after the image name:
 
 ```bash
 docker run --rm --net=host --ipc=host \
@@ -82,10 +82,13 @@ docker run --rm --net=host --ipc=host \
   -e ROS_LOCALHOST_ONLY=1 \
   -v $CXR_HOST_VOLUME_PATH:$CXR_HOST_VOLUME_PATH:ro \
   --name teleop_ros2_ref \
-  teleop_ros2_ref --ros-args -p world_frame:=odom -p rate_hz:=30.0
+  teleop_ros2_ref --ros-args -p world_frame:=odom -p rate_hz:=30.0 \
+  -r xr_teleop/hand:=my_robot/hand -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
 Available parameters: `rate_hz`, `mode`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`. Use `ros2 param list /teleop_ros2_publisher` and `ros2 param describe /teleop_ros2_publisher <param>` (with the node running) for the full set.
+
+Available topics for remapping: `xr_teleop/hand`, `xr_teleop/ee_poses`, `xr_teleop/root_twist`, `xr_teleop/root_pose`, `xr_teleop/controller_data`, `xr_teleop/full_body`, `xr_teleop/finger_joints`. Active remaps can be inspected with `ros2 node info /teleop_ros2_publisher`.
 
 ### Mode
 

--- a/examples/teleop_ros2/python/teleop_ros2_publisher.py
+++ b/examples/teleop_ros2/python/teleop_ros2_publisher.py
@@ -18,7 +18,7 @@ published:
   - controller_raw: controller_data only
   - full_body: full_body and controller_data
 
-Topic names (configurable via parameters):
+Topic names (remappable via ROS 2 remapping):
   - xr_teleop/hand (PoseArray): [finger_joint_poses...]
   - xr_teleop/ee_poses (PoseArray): [right_ee, left_ee]
   - xr_teleop/root_twist (TwistStamped): root velocity command
@@ -380,7 +380,7 @@ def _build_full_body_payload(full_body: OptionalTensorGroup) -> Dict:
 
 
 class TeleopRos2PublisherNode(Node):
-    """ROS 2 node that publishes teleop data to configurable topics."""
+    """ROS 2 node that publishes teleop data."""
 
     def __init__(self) -> None:
         super().__init__("teleop_ros2_publisher")


### PR DESCRIPTION
Remove redundant topic parameters from the ROS 2 publisher node and its documentation, relying on standard ROS 2 topic remapping

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed and expanded "Overriding parameters" to cover ROS 2 parameter overrides and topic remapping, updated command example, trimmed listed configurable parameters to non-topic settings, and added a list of remappable topics plus instructions to inspect active remaps.

* **Changes**
  * Teleop publisher no longer exposes topic-name parameters at runtime; it uses fixed default topic names that can be redirected via ROS 2 remapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->