### PR TITLE
Remove OXR dependency from public hand-tracker, and define in schema

### DIFF
--- a/src/core/deviceio_trackers/cpp/CMakeLists.txt
+++ b/src/core/deviceio_trackers/cpp/CMakeLists.txt
@@ -27,8 +27,6 @@ target_include_directories(deviceio_trackers
 target_link_libraries(deviceio_trackers
     PUBLIC
         deviceio::deviceio_base
-    PRIVATE
-        Teleop::openxr_extensions
 )
 
 add_library(deviceio::deviceio_trackers ALIAS deviceio_trackers)

--- a/src/core/deviceio_trackers/cpp/hand_tracker.cpp
+++ b/src/core/deviceio_trackers/cpp/hand_tracker.cpp
@@ -3,8 +3,6 @@
 
 #include "inc/deviceio_trackers/hand_tracker.hpp"
 
-#include <array>
-
 namespace core
 {
 
@@ -20,43 +18,6 @@ const HandPoseTrackedT& HandTracker::get_left_hand(const ITrackerSession& sessio
 const HandPoseTrackedT& HandTracker::get_right_hand(const ITrackerSession& session) const
 {
     return static_cast<const IHandTrackerImpl&>(session.get_tracker_impl(*this)).get_right_hand();
-}
-
-std::string HandTracker::get_joint_name(uint32_t joint_index)
-{
-    static constexpr std::array<const char*, XR_HAND_JOINT_COUNT_EXT> joint_names = { { "Palm",
-                                                                                        "Wrist",
-                                                                                        "Thumb_Metacarpal",
-                                                                                        "Thumb_Proximal",
-                                                                                        "Thumb_Distal",
-                                                                                        "Thumb_Tip",
-                                                                                        "Index_Metacarpal",
-                                                                                        "Index_Proximal",
-                                                                                        "Index_Intermediate",
-                                                                                        "Index_Distal",
-                                                                                        "Index_Tip",
-                                                                                        "Middle_Metacarpal",
-                                                                                        "Middle_Proximal",
-                                                                                        "Middle_Intermediate",
-                                                                                        "Middle_Distal",
-                                                                                        "Middle_Tip",
-                                                                                        "Ring_Metacarpal",
-                                                                                        "Ring_Proximal",
-                                                                                        "Ring_Intermediate",
-                                                                                        "Ring_Distal",
-                                                                                        "Ring_Tip",
-                                                                                        "Little_Metacarpal",
-                                                                                        "Little_Proximal",
-                                                                                        "Little_Intermediate",
-                                                                                        "Little_Distal",
-                                                                                        "Little_Tip" } };
-    static_assert(joint_names.size() == XR_HAND_JOINT_COUNT_EXT, "joint names count must match XR_HAND_JOINT_COUNT_EXT");
-
-    if (joint_index < joint_names.size())
-    {
-        return joint_names[joint_index];
-    }
-    return "Unknown";
 }
 
 } // namespace core

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/hand_tracker.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/hand_tracker.hpp
@@ -6,8 +6,6 @@
 #include <deviceio_base/hand_tracker_base.hpp>
 #include <schema/hand_generated.h>
 
-#include <string>
-
 namespace core
 {
 
@@ -25,9 +23,6 @@ public:
     // - when tracked.data is non-null, nested fields in HandPoseT are safe to read.
     const HandPoseTrackedT& get_left_hand(const ITrackerSession& session) const;
     const HandPoseTrackedT& get_right_hand(const ITrackerSession& session) const;
-
-    /** @brief Get joint name for debugging. */
-    static std::string get_joint_name(uint32_t joint_index);
 
 private:
     static constexpr const char* TRACKER_NAME = "HandTracker";

--- a/src/core/deviceio_trackers/python/tracker_bindings.cpp
+++ b/src/core/deviceio_trackers/python/tracker_bindings.cpp
@@ -7,9 +7,9 @@
 #include <deviceio_trackers/generic_3axis_pedal_tracker.hpp>
 #include <deviceio_trackers/hand_tracker.hpp>
 #include <deviceio_trackers/head_tracker.hpp>
-#include <openxr/openxr.h>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
+#include <schema/hand_generated.h>
 
 namespace py = pybind11;
 
@@ -35,8 +35,7 @@ PYBIND11_MODULE(_deviceio_trackers, m)
             "get_right_hand",
             [](const core::HandTracker& self, const core::ITrackerSession& session) -> core::HandPoseTrackedT
             { return self.get_right_hand(session); },
-            py::arg("session"))
-        .def_static("get_joint_name", &core::HandTracker::get_joint_name);
+            py::arg("session"));
 
     py::class_<core::HeadTracker, core::ITracker, std::shared_ptr<core::HeadTracker>>(m, "HeadTracker")
         .def(py::init<>())
@@ -96,9 +95,9 @@ PYBIND11_MODULE(_deviceio_trackers, m)
             { return self.get_body_pose(session); },
             py::arg("session"), "Get full body pose tracked state (data is None if inactive)");
 
-    m.attr("NUM_JOINTS") = static_cast<int>(XR_HAND_JOINT_COUNT_EXT);
-    m.attr("JOINT_PALM") = static_cast<int>(XR_HAND_JOINT_PALM_EXT);
-    m.attr("JOINT_WRIST") = static_cast<int>(XR_HAND_JOINT_WRIST_EXT);
-    m.attr("JOINT_THUMB_TIP") = static_cast<int>(XR_HAND_JOINT_THUMB_TIP_EXT);
-    m.attr("JOINT_INDEX_TIP") = static_cast<int>(XR_HAND_JOINT_INDEX_TIP_EXT);
+    m.attr("NUM_JOINTS") = static_cast<int>(core::HandJoint_NUM_JOINTS);
+    m.attr("JOINT_PALM") = static_cast<int>(core::HandJoint_PALM);
+    m.attr("JOINT_WRIST") = static_cast<int>(core::HandJoint_WRIST);
+    m.attr("JOINT_THUMB_TIP") = static_cast<int>(core::HandJoint_THUMB_TIP);
+    m.attr("JOINT_INDEX_TIP") = static_cast<int>(core::HandJoint_INDEX_TIP);
 }

--- a/src/core/schema/fbs/hand.fbs
+++ b/src/core/schema/fbs/hand.fbs
@@ -6,6 +6,44 @@ include "timestamp.fbs";
 
 namespace core;
 
+// Hand joint indices for fixed-size hand pose arrays (e.g. HandJoints.poses).
+//
+// Ordinal values match Khronos OpenXR XrHandJointEXT (XR_EXT_hand_tracking):
+// https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XrHandJointEXT
+// There are 26 joints (OpenXR XR_HAND_JOINT_COUNT_EXT). Enum member names follow
+// the same ordering and naming as the OpenXR identifiers, omitting the
+// XR_HAND_JOINT_ prefix and _EXT suffix (e.g. XR_HAND_JOINT_THUMB_TIP_EXT -> THUMB_TIP).
+enum HandJoint : uint8 {
+    PALM = 0,
+    WRIST = 1,
+    THUMB_METACARPAL = 2,
+    THUMB_PROXIMAL = 3,
+    THUMB_DISTAL = 4,
+    THUMB_TIP = 5,
+    INDEX_METACARPAL = 6,
+    INDEX_PROXIMAL = 7,
+    INDEX_INTERMEDIATE = 8,
+    INDEX_DISTAL = 9,
+    INDEX_TIP = 10,
+    MIDDLE_METACARPAL = 11,
+    MIDDLE_PROXIMAL = 12,
+    MIDDLE_INTERMEDIATE = 13,
+    MIDDLE_DISTAL = 14,
+    MIDDLE_TIP = 15,
+    RING_METACARPAL = 16,
+    RING_PROXIMAL = 17,
+    RING_INTERMEDIATE = 18,
+    RING_DISTAL = 19,
+    RING_TIP = 20,
+    LITTLE_METACARPAL = 21,
+    LITTLE_PROXIMAL = 22,
+    LITTLE_INTERMEDIATE = 23,
+    LITTLE_DISTAL = 24,
+    LITTLE_TIP = 25,
+
+    NUM_JOINTS = 26,
+}
+
 // Describe a HandJoint pose.
 struct HandJointPose {
     // The concrete pose data
@@ -20,14 +58,15 @@ struct HandJointPose {
 }
 
 struct HandJoints {
+    // Fixed-size array; length must stay in sync with HandJoint::NUM_JOINTS (and the OpenXR joint count).
     poses: [HandJointPose:26];
 }
 
 // Hand pose data.
 // All fields are always present when the parent Tracked/Record wrapper's data is non-null.
 table HandPose {
-    // Vector of HandJointPose.
-    // For OpenXR, this should be 26 according to XR_HAND_JOINT_COUNT_EXT
+    // Fixed-size hand joint poses in HandJoint / OpenXR order (struct HandJoints, not a variable-length vector).
+    // The HandJoints.poses array length must stay in sync with HandJoint::NUM_JOINTS.
     joints: HandJoints (id: 0);
 }
 

--- a/src/core/schema/python/hand_bindings.h
+++ b/src/core/schema/python/hand_bindings.h
@@ -14,6 +14,7 @@
 #include <array>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace py = pybind11;
@@ -23,6 +24,36 @@ namespace core
 
 inline void bind_hand(py::module& m)
 {
+    // Bind HandJoint enum (indices align with OpenXR XrHandJointEXT; see hand.fbs).
+    py::enum_<HandJoint>(m, "HandJoint")
+        .value("PALM", HandJoint_PALM)
+        .value("WRIST", HandJoint_WRIST)
+        .value("THUMB_METACARPAL", HandJoint_THUMB_METACARPAL)
+        .value("THUMB_PROXIMAL", HandJoint_THUMB_PROXIMAL)
+        .value("THUMB_DISTAL", HandJoint_THUMB_DISTAL)
+        .value("THUMB_TIP", HandJoint_THUMB_TIP)
+        .value("INDEX_METACARPAL", HandJoint_INDEX_METACARPAL)
+        .value("INDEX_PROXIMAL", HandJoint_INDEX_PROXIMAL)
+        .value("INDEX_INTERMEDIATE", HandJoint_INDEX_INTERMEDIATE)
+        .value("INDEX_DISTAL", HandJoint_INDEX_DISTAL)
+        .value("INDEX_TIP", HandJoint_INDEX_TIP)
+        .value("MIDDLE_METACARPAL", HandJoint_MIDDLE_METACARPAL)
+        .value("MIDDLE_PROXIMAL", HandJoint_MIDDLE_PROXIMAL)
+        .value("MIDDLE_INTERMEDIATE", HandJoint_MIDDLE_INTERMEDIATE)
+        .value("MIDDLE_DISTAL", HandJoint_MIDDLE_DISTAL)
+        .value("MIDDLE_TIP", HandJoint_MIDDLE_TIP)
+        .value("RING_METACARPAL", HandJoint_RING_METACARPAL)
+        .value("RING_PROXIMAL", HandJoint_RING_PROXIMAL)
+        .value("RING_INTERMEDIATE", HandJoint_RING_INTERMEDIATE)
+        .value("RING_DISTAL", HandJoint_RING_DISTAL)
+        .value("RING_TIP", HandJoint_RING_TIP)
+        .value("LITTLE_METACARPAL", HandJoint_LITTLE_METACARPAL)
+        .value("LITTLE_PROXIMAL", HandJoint_LITTLE_PROXIMAL)
+        .value("LITTLE_INTERMEDIATE", HandJoint_LITTLE_INTERMEDIATE)
+        .value("LITTLE_DISTAL", HandJoint_LITTLE_DISTAL)
+        .value("LITTLE_TIP", HandJoint_LITTLE_TIP)
+        .value("NUM_JOINTS", HandJoint_NUM_JOINTS);
+
     // Bind HandJointPose struct (pose, is_valid, radius).
     py::class_<HandJointPose>(m, "HandJointPose")
         .def(py::init<>())
@@ -44,22 +75,25 @@ inline void bind_hand(py::module& m)
                         ", radius=" + std::to_string(self.radius()) + ")";
              });
 
-    // Bind HandJoints struct (fixed-size array of 26 HandJointPose).
+    // Bind HandJoints struct (fixed-size array; length matches HandJoint::NUM_JOINTS).
     py::class_<HandJoints>(m, "HandJoints")
         .def(py::init<>())
         .def(
             "poses",
             [](const HandJoints& self, size_t index) -> const HandJointPose*
             {
-                if (index >= 26)
+                if (index >= static_cast<size_t>(HandJoint_NUM_JOINTS))
                 {
-                    throw py::index_error("HandJoints index out of range (must be 0-25)");
+                    throw py::index_error("HandJoints index out of range (must be 0-" +
+                                          std::to_string(static_cast<int>(HandJoint_NUM_JOINTS) - 1) + ")");
                 }
                 return (*self.poses())[index];
             },
             py::arg("index"), py::return_value_policy::reference_internal,
-            "Get the HandJointPose at the specified index (0-25).")
-        .def("__repr__", [](const HandJoints&) { return "HandJoints(poses=[...26 HandJointPose entries...])"; });
+            "Get the HandJointPose at the specified index. Valid indices: 0 <= index < HandJoint.NUM_JOINTS "
+            "(OpenXR hand joint order).")
+        .def("__repr__",
+             [](const HandJoints&) { return "HandJoints(poses=[...HandJoint.NUM_JOINTS HandJointPose entries...])"; });
 
     // Bind HandPoseT class (FlatBuffers object API for tables).
     py::class_<HandPoseT, std::shared_ptr<HandPoseT>>(m, "HandPoseT")

--- a/src/core/schema/python/schema_init.py
+++ b/src/core/schema/python/schema_init.py
@@ -19,6 +19,7 @@ from ._schema import (
     HeadPoseTrackedT,
     HeadPoseRecord,
     # Hand-related types.
+    HandJoint,
     HandJointPose,
     HandJoints,
     HandPoseT,
@@ -61,6 +62,7 @@ __all__ = [
     "HeadPoseTrackedT",
     "HeadPoseRecord",
     # Hand types.
+    "HandJoint",
     "HandJointPose",
     "HandJoints",
     "HandPoseT",

--- a/src/core/schema_tests/cpp/CMakeLists.txt
+++ b/src/core/schema_tests/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@ add_executable(schema_tests
 target_link_libraries(schema_tests PRIVATE
   isaacteleop_schema
   Catch2::Catch2WithMain
+  OpenXR::headers
 )
 
 message(STATUS "schema_tests target enabled with Catch2")

--- a/src/core/schema_tests/cpp/test_hand.cpp
+++ b/src/core/schema_tests/cpp/test_hand.cpp
@@ -6,6 +6,7 @@
 #include <catch2/catch_approx.hpp>
 #include <catch2/catch_test_macros.hpp>
 #include <flatbuffers/flatbuffers.h>
+#include <openxr/openxr.h>
 
 // Include generated FlatBuffer headers.
 #include <schema/hand_generated.h>
@@ -39,9 +40,47 @@ static_assert(std::is_trivially_copyable_v<core::HandJointPose>, "HandJointPose 
 // =============================================================================
 static_assert(std::is_trivially_copyable_v<core::HandJoints>, "HandJoints should be a trivially copyable struct");
 
-// HandJoints should contain exactly 26 HandJointPose entries.
-static_assert(sizeof(core::HandJoints) == 26 * sizeof(core::HandJointPose),
-              "HandJoints should contain exactly 26 HandJointPose entries");
+// HandJoints should contain exactly HandJoint::NUM_JOINTS HandJointPose entries.
+static_assert(sizeof(core::HandJoints) == core::HandJoint_NUM_JOINTS * sizeof(core::HandJointPose),
+              "HandJoints size must match HandJoint::NUM_JOINTS");
+
+// =============================================================================
+// OpenXR parity: core::HandJoint ordinals must match XrHandJointEXT (XR_EXT_hand_tracking).
+// =============================================================================
+static_assert(static_cast<int>(core::HandJoint_NUM_JOINTS) == XR_HAND_JOINT_COUNT_EXT,
+              "HandJoint::NUM_JOINTS must match OpenXR XR_HAND_JOINT_COUNT_EXT");
+static_assert(static_cast<int>(core::HandJoint_PALM) == static_cast<int>(XR_HAND_JOINT_PALM_EXT));
+static_assert(static_cast<int>(core::HandJoint_WRIST) == static_cast<int>(XR_HAND_JOINT_WRIST_EXT));
+static_assert(static_cast<int>(core::HandJoint_THUMB_METACARPAL) == static_cast<int>(XR_HAND_JOINT_THUMB_METACARPAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_THUMB_PROXIMAL) == static_cast<int>(XR_HAND_JOINT_THUMB_PROXIMAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_THUMB_DISTAL) == static_cast<int>(XR_HAND_JOINT_THUMB_DISTAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_THUMB_TIP) == static_cast<int>(XR_HAND_JOINT_THUMB_TIP_EXT));
+static_assert(static_cast<int>(core::HandJoint_INDEX_METACARPAL) == static_cast<int>(XR_HAND_JOINT_INDEX_METACARPAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_INDEX_PROXIMAL) == static_cast<int>(XR_HAND_JOINT_INDEX_PROXIMAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_INDEX_INTERMEDIATE) ==
+              static_cast<int>(XR_HAND_JOINT_INDEX_INTERMEDIATE_EXT));
+static_assert(static_cast<int>(core::HandJoint_INDEX_DISTAL) == static_cast<int>(XR_HAND_JOINT_INDEX_DISTAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_INDEX_TIP) == static_cast<int>(XR_HAND_JOINT_INDEX_TIP_EXT));
+static_assert(static_cast<int>(core::HandJoint_MIDDLE_METACARPAL) ==
+              static_cast<int>(XR_HAND_JOINT_MIDDLE_METACARPAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_MIDDLE_PROXIMAL) == static_cast<int>(XR_HAND_JOINT_MIDDLE_PROXIMAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_MIDDLE_INTERMEDIATE) ==
+              static_cast<int>(XR_HAND_JOINT_MIDDLE_INTERMEDIATE_EXT));
+static_assert(static_cast<int>(core::HandJoint_MIDDLE_DISTAL) == static_cast<int>(XR_HAND_JOINT_MIDDLE_DISTAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_MIDDLE_TIP) == static_cast<int>(XR_HAND_JOINT_MIDDLE_TIP_EXT));
+static_assert(static_cast<int>(core::HandJoint_RING_METACARPAL) == static_cast<int>(XR_HAND_JOINT_RING_METACARPAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_RING_PROXIMAL) == static_cast<int>(XR_HAND_JOINT_RING_PROXIMAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_RING_INTERMEDIATE) ==
+              static_cast<int>(XR_HAND_JOINT_RING_INTERMEDIATE_EXT));
+static_assert(static_cast<int>(core::HandJoint_RING_DISTAL) == static_cast<int>(XR_HAND_JOINT_RING_DISTAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_RING_TIP) == static_cast<int>(XR_HAND_JOINT_RING_TIP_EXT));
+static_assert(static_cast<int>(core::HandJoint_LITTLE_METACARPAL) ==
+              static_cast<int>(XR_HAND_JOINT_LITTLE_METACARPAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_LITTLE_PROXIMAL) == static_cast<int>(XR_HAND_JOINT_LITTLE_PROXIMAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_LITTLE_INTERMEDIATE) ==
+              static_cast<int>(XR_HAND_JOINT_LITTLE_INTERMEDIATE_EXT));
+static_assert(static_cast<int>(core::HandJoint_LITTLE_DISTAL) == static_cast<int>(XR_HAND_JOINT_LITTLE_DISTAL_EXT));
+static_assert(static_cast<int>(core::HandJoint_LITTLE_TIP) == static_cast<int>(XR_HAND_JOINT_LITTLE_TIP_EXT));
 
 // =============================================================================
 // HandJointPose Tests
@@ -88,9 +127,9 @@ TEST_CASE("HandJointPose default construction", "[hand][struct]")
 // =============================================================================
 TEST_CASE("HandJoints struct has correct size", "[hand][struct]")
 {
-    // HandJoints should have exactly 26 entries (XR_HAND_JOINT_COUNT_EXT).
+    // HandJoints should have exactly HandJoint::NUM_JOINTS entries.
     core::HandJoints joints;
-    CHECK(joints.poses()->size() == 26);
+    CHECK(joints.poses()->size() == static_cast<size_t>(core::HandJoint_NUM_JOINTS));
 }
 
 TEST_CASE("HandJoints can be accessed by index", "[hand][struct]")
@@ -99,7 +138,7 @@ TEST_CASE("HandJoints can be accessed by index", "[hand][struct]")
 
     // Access first and last entries (returns pointers).
     const auto* first = (*joints.poses())[0];
-    const auto* last = (*joints.poses())[25];
+    const auto* last = (*joints.poses())[static_cast<size_t>(core::HandJoint_NUM_JOINTS) - 1];
 
     // Default values should be zero.
     CHECK(first->pose().position().x() == 0.0f);
@@ -124,7 +163,7 @@ TEST_CASE("HandPoseT can store joints data", "[hand][native]")
     // Create and set joints.
     hand_pose->joints = std::make_unique<core::HandJoints>();
 
-    CHECK(hand_pose->joints->poses()->size() == 26);
+    CHECK(hand_pose->joints->poses()->size() == static_cast<size_t>(core::HandJoint_NUM_JOINTS));
 }
 
 TEST_CASE("HandPoseT joints can be mutated via flatbuffers Array", "[hand][native]")
@@ -175,7 +214,7 @@ TEST_CASE("HandPoseT serialization and deserialization", "[hand][flatbuffers]")
     auto deserialized = flatbuffers::GetRoot<core::HandPose>(buffer);
 
     // Verify.
-    CHECK(deserialized->joints()->poses()->size() == 26);
+    CHECK(deserialized->joints()->poses()->size() == static_cast<size_t>(core::HandJoint_NUM_JOINTS));
 
     const auto* first_joint = (*deserialized->joints()->poses())[0];
     CHECK(first_joint->pose().position().x() == Catch::Approx(1.5f));
@@ -194,7 +233,7 @@ TEST_CASE("HandPoseT can be unpacked from buffer", "[hand][flatbuffers]")
     original->joints = std::make_unique<core::HandJoints>();
 
     // Set multiple joint poses
-    for (size_t i = 0; i < 26; ++i)
+    for (size_t i = 0; i < static_cast<size_t>(core::HandJoint_NUM_JOINTS); ++i)
     {
         core::Point position(static_cast<float>(i), static_cast<float>(i * 2), static_cast<float>(i * 3));
         core::Quaternion orientation(0.0f, 0.0f, 0.0f, 1.0f);
@@ -218,19 +257,20 @@ TEST_CASE("HandPoseT can be unpacked from buffer", "[hand][flatbuffers]")
     CHECK(joint_5->pose().position().y() == Catch::Approx(10.0f));
     CHECK(joint_5->pose().position().z() == Catch::Approx(15.0f));
 
-    const auto* joint_25 = (*unpacked->joints->poses())[25];
-    CHECK(joint_25->pose().position().x() == Catch::Approx(25.0f));
-    CHECK(joint_25->pose().position().y() == Catch::Approx(50.0f));
-    CHECK(joint_25->pose().position().z() == Catch::Approx(75.0f));
+    const size_t last_joint_index = static_cast<size_t>(core::HandJoint_NUM_JOINTS) - 1;
+    const auto* joint_last = (*unpacked->joints->poses())[last_joint_index];
+    CHECK(joint_last->pose().position().x() == Catch::Approx(static_cast<float>(last_joint_index)));
+    CHECK(joint_last->pose().position().y() == Catch::Approx(static_cast<float>(last_joint_index * 2)));
+    CHECK(joint_last->pose().position().z() == Catch::Approx(static_cast<float>(last_joint_index * 3)));
 }
 
-TEST_CASE("HandPoseT all 26 joints can be set and verified", "[hand][native]")
+TEST_CASE("HandPoseT all joints can be set and verified", "[hand][native]")
 {
     auto hand_pose = std::make_unique<core::HandPoseT>();
     hand_pose->joints = std::make_unique<core::HandJoints>();
 
-    // Set all 26 joints with unique positions.
-    for (size_t i = 0; i < 26; ++i)
+    // Set every joint slot with a unique position.
+    for (size_t i = 0; i < static_cast<size_t>(core::HandJoint_NUM_JOINTS); ++i)
     {
         core::Point position(static_cast<float>(i), 0.0f, 0.0f);
         core::Quaternion orientation(0.0f, 0.0f, 0.0f, 1.0f);
@@ -240,7 +280,7 @@ TEST_CASE("HandPoseT all 26 joints can be set and verified", "[hand][native]")
     }
 
     // Verify all joints.
-    for (size_t i = 0; i < 26; ++i)
+    for (size_t i = 0; i < static_cast<size_t>(core::HandJoint_NUM_JOINTS); ++i)
     {
         const auto* joint = (*hand_pose->joints->poses())[i];
         CHECK(joint->pose().position().x() == Catch::Approx(static_cast<float>(i)));
@@ -268,7 +308,7 @@ TEST_CASE("HandPoseRecord serialization with DeviceDataTimestamp", "[hand][flatb
     CHECK(deserialized->timestamp()->available_time_local_common_clock() == 1000000000LL);
     CHECK(deserialized->timestamp()->sample_time_local_common_clock() == 2000000000LL);
     CHECK(deserialized->timestamp()->sample_time_raw_device_clock() == 3000000000LL);
-    CHECK(deserialized->data()->joints()->poses()->size() == 26);
+    CHECK(deserialized->data()->joints()->poses()->size() == static_cast<size_t>(core::HandJoint_NUM_JOINTS));
 }
 
 TEST_CASE("HandPoseRecord can be unpacked with DeviceDataTimestamp", "[hand][flatbuffers]")
@@ -290,5 +330,5 @@ TEST_CASE("HandPoseRecord can be unpacked with DeviceDataTimestamp", "[hand][fla
     CHECK(unpacked->timestamp->available_time_local_common_clock() == 111LL);
     CHECK(unpacked->timestamp->sample_time_local_common_clock() == 222LL);
     CHECK(unpacked->timestamp->sample_time_raw_device_clock() == 333LL);
-    CHECK(unpacked->data->joints->poses()->size() == 26);
+    CHECK(unpacked->data->joints->poses()->size() == static_cast<size_t>(core::HandJoint_NUM_JOINTS));
 }

--- a/src/core/schema_tests/python/test_hand.py
+++ b/src/core/schema_tests/python/test_hand.py
@@ -4,9 +4,9 @@
 """Unit tests for HandPoseT and related types in isaacteleop.schema.
 
 HandPoseT is a FlatBuffers table that represents hand pose data:
-- joints: HandJoints struct containing 26 HandJointPose entries (XR_HAND_JOINT_COUNT_EXT)
+- joints: HandJoints struct with a fixed-size poses array (length HandJoint.NUM_JOINTS; OpenXR order)
 
-HandJoints is a struct with a fixed-size array of 26 HandJointPose entries.
+HandJoints is a struct with a fixed-size array of HandJointPose (length HandJoint.NUM_JOINTS).
 
 HandJointPose is a struct containing:
 - pose: The Pose (position and orientation)
@@ -19,15 +19,25 @@ Timestamps are carried by HandPoseRecord, not HandPoseT.
 import pytest
 
 from isaacteleop.schema import (
-    HandPoseT,
-    HandPoseRecord,
-    HandJoints,
-    HandJointPose,
-    Pose,
-    Point,
-    Quaternion,
     DeviceDataTimestamp,
+    HandJoint,
+    HandJointPose,
+    HandJoints,
+    HandPoseRecord,
+    HandPoseT,
+    Point,
+    Pose,
+    Quaternion,
 )
+
+
+def test_hand_joint_enum_sentinels():
+    """HandJoint ordinals match expected OpenXR-style layout."""
+    assert HandJoint.PALM == 0
+    assert HandJoint.WRIST == 1
+    assert HandJoint.THUMB_TIP == 5
+    assert HandJoint.LITTLE_TIP == 25
+    assert HandJoint.NUM_JOINTS == 26
 
 
 class TestHandJointPoseConstruction:
@@ -105,10 +115,10 @@ class TestHandJointsStruct:
     """Tests for HandJoints struct."""
 
     def test_poses_access(self):
-        """Test accessing all 26 joints via poses() method."""
+        """Test accessing every joint slot via poses() method."""
         hand_joints = HandJoints()
 
-        for i in range(26):
+        for i in range(HandJoint.NUM_JOINTS):
             joint = hand_joints.poses(i)
             assert joint is not None
 
@@ -117,7 +127,7 @@ class TestHandJointsStruct:
         hand_joints = HandJoints()
 
         with pytest.raises(IndexError):
-            _ = hand_joints.poses(26)
+            _ = hand_joints.poses(HandJoint.NUM_JOINTS)
 
 
 class TestHandJointsRepr:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a standardized HandJoint enum with named joint indices and NUM_JOINTS; exposed to Python.

* **Removals**
  * Removed the public get_joint_name() debugging API.
  * Python hand-joint constants now source values from the new HandJoint enum.

* **Tests**
  * Updated tests and docs to use HandJoint.NUM_JOINTS and to assert enum/ordering parity.

* **Chores**
  * Adjusted build/test configuration to ensure OpenXR parity checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->