### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["Debug", "Release"]
-        python_version: ['3.10', '3.11', '3.12']
+        python_version: ['3.10', '3.11', '3.12', '3.13']
         arch: ['x64', 'arm64']
 
     steps:
@@ -148,7 +148,7 @@ jobs:
 
     strategy:
       matrix:
-        python_version: ['3.10', '3.11', '3.12']
+        python_version: ['3.10', '3.11', '3.12', '3.13']
         arch: ['x64', 'arm64']
 
     steps:

--- a/docs/source/getting_started/build_from_source.rst
+++ b/docs/source/getting_started/build_from_source.rst
@@ -17,7 +17,7 @@ Prerequisites
 
 - **CMake** 3.20 or higher
 - **C++20** compatible compiler
-- **Python** 3.10, 3.11, or 3.12 (default 3.11; see ``ISAAC_TELEOP_PYTHON_VERSION`` in root ``CMakeLists.txt``)
+- **Python** 3.10, 3.11, 3.12, or 3.13 (default 3.11; see ``ISAAC_TELEOP_PYTHON_VERSION`` in root ``CMakeLists.txt``)
 - **uv** for Python dependency management and managed Python
 - **Internet connection** for downloading dependencies via CMake FetchContent
 
@@ -159,7 +159,7 @@ The CMake options (defined in root :code-file:`CMakeLists.txt`, :code-file:`cmak
      - ``ON``
    * - **Python version**
      - ``ISAAC_TELEOP_PYTHON_VERSION``
-     - ``3.11`` (3.10, 3.11, or 3.12)
+     - ``3.11`` (3.10, 3.11, 3.12, or 3.13)
    * - **Testing**
      - ``BUILD_TESTING``
      - ``ON``; enables CTest and Catch2

--- a/docs/source/references/build.rst
+++ b/docs/source/references/build.rst
@@ -116,7 +116,7 @@ uv or Python version
 
 ``cmake/SetupPython.cmake`` requires **uv** and uses ``ISAAC_TELEOP_PYTHON_VERSION``. Install uv as
 in :ref:`One time setup <one-time-setup>` and pass ``-DISAAC_TELEOP_PYTHON_VERSION=3.10`` (or 3.11,
-3.12) if you need a specific version.
+3.12, 3.13) if you need a specific version.
 
 Reference
 ---------

--- a/docs/source/references/requirements.rst
+++ b/docs/source/references/requirements.rst
@@ -27,7 +27,7 @@ network.  The minimum requirements for the laptop/workstation are:
     * - OS
       - Ubuntu 22.04 or 24.04
     * - Python
-      - 3.10 / 3.11 / 3.12
+      - 3.10 / 3.11 / 3.12 / 3.13
     * - CUDA
       - 12.8 or newer
     * - NVIDIA Driver
@@ -93,7 +93,7 @@ to device peripherals. The minimum requirements for the laptop/workstation are:
     * - OS
       - Ubuntu 22.04 or 24.04
     * - Python
-      - 3.10 / 3.11 / 3.12
+      - 3.10 / 3.11 / 3.12 / 3.13
     * - CUDA
       - 12.8 or newer
     * - NVIDIA Driver

--- a/examples/camera_streamer/pyproject.toml
+++ b/examples/camera_streamer/pyproject.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
 name = "teleop-camera-streamer"
 version = "0.1.0"
 description = "Isaac Teleop multi-camera streaming (Holoscan-based)"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "pyyaml",
     "loguru",

--- a/examples/oxr/python/pyproject.toml
+++ b/examples/oxr/python/pyproject.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
 name = "oxr-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "OpenXR Tracking Python Examples"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "isaacteleop",
     "numpy>=1.22.2",

--- a/examples/retargeting/python/pyproject.toml
+++ b/examples/retargeting/python/pyproject.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
 name = "retargeting-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "Retargeting Engine Python Examples"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "isaacteleop[ui,retargeters-lite]",
     "numpy>=1.22.2",

--- a/examples/teleop/python/pyproject.toml
+++ b/examples/teleop/python/pyproject.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
 name = "teleop-examples"
 version = "0.1.0"
 description = "Isaac Teleop Retargeting Examples"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "isaacteleop[retargeters]",
 ]

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleop-ros2-example"
 version = "0.1.0"
 description = "Isaac Teleop ROS2 Example"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "isaacteleop[retargeters]",
     "msgpack",

--- a/examples/teleop_session_manager/python/pyproject.toml
+++ b/examples/teleop_session_manager/python/pyproject.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
 name = "teleop-utils-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "TeleopUtils Python Examples"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 dependencies = [
     "isaacteleop[ui]",
     "numpy>=1.22.2",

--- a/src/core/python/stubgen_pyproject.toml
+++ b/src/core/python/stubgen_pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # pyproject.toml for stub generation
@@ -8,7 +8,7 @@
 name = "isaacteleop-stubgen"
 version = "0.0.0"  # Internal tooling - not versioned
 description = "Stub generation dependencies for Isaac Teleop pybind11 modules"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 
 dependencies = [
     "pybind11-stubgen",

--- a/src/core/retargeting_engine_tests/python/pyproject.toml
+++ b/src/core/retargeting_engine_tests/python/pyproject.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
 name = "isaacteleop-retargeting-engine"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Retargeting engine type system for Isaac Teleop"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/schema_tests/python/pyproject.toml
+++ b/src/core/schema_tests/python/pyproject.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
 name = "isaacteleop-schema-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Tests for Isaac Teleop schema types"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/teleop_session_manager_tests/python/pyproject.toml
+++ b/src/core/teleop_session_manager_tests/python/pyproject.toml
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
 name = "teleopcore-teleop-session-manager-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Teleop session manager tests for TeleopCore"
-requires-python = ">=3.10,<3.13"
+requires-python = ">=3.10,<3.14"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
Fixes #357 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended Python 3.13 support across all build pipelines and CI/CD workflows.
  * Updated project metadata and dependencies to support Python 3.13 for all packages and examples.
  * Updated documentation to reflect compatibility with Python 3.10–3.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->