### PR TITLE
ci: move docs deploy into a separate workflow

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -341,8 +341,15 @@ jobs:
     outputs:
       wheel_paths: ${{ steps.upload-artifactory.outputs.wheel_paths }}
     environment: dev
-    # Publish only after build and CloudXR tests succeed.
-    if: ${{ needs.build-ubuntu.result == 'success' && needs.test-cloudxr.result == 'success' && needs.test-teleop-ros2.result == 'success' }}
+
+    # Publish only for PRs wihtin the canonical repository after build and CloudXR tests succeed
+    if: >-
+      ${{
+        github.repository == 'NVIDIA/IsaacTeleop'
+        && needs.build-ubuntu.result == 'success'
+        && needs.test-cloudxr.result == 'success'
+        && needs.test-teleop-ros2.result == 'success'
+      }}
 
     steps:
     - name: Set up Python

--- a/.github/workflows/docs-deploy-preview.yaml
+++ b/.github/workflows/docs-deploy-preview.yaml
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Deploy PR docs preview to GitHub Pages after manual approval.
+#
+# Triggered by the "Build & deploy docs" workflow completing on a pull request.
+# Uses a "docs-preview" environment with required reviewers so that someone with
+# write access must approve before the deploy runs — this lets fork PRs get
+# previews without giving their GITHUB_TOKEN write access to the base repo.
+#
+# Setup: create a "docs-preview" environment in repo Settings → Environments,
+# then add required reviewers (anyone with write access to the repo).
+
+name: Deploy docs PR preview
+
+on:
+  workflow_run:
+    workflows: ["Build & deploy docs"]
+    types: [completed]
+
+concurrency:
+  group: >-
+    deploy-preview-${{ github.event.workflow_run.head_repository.id }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    name: Deploy PR preview
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion == 'success'
+    environment: docs-preview
+    permissions:
+      actions: read     # download artifacts from the triggering run
+      contents: write   # push to gh-pages
+    steps:
+      - name: Download PR metadata
+        uses: actions/download-artifact@v7
+        with:
+          name: pr-metadata
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Download docs artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: docs-html
+          path: ./docs/build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download web app artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: webapp
+          path: ./webapp
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Place web app under subpath
+        run: |
+          mkdir -p ./docs/build/current/client
+          cp -r ./webapp/. ./docs/build/current/client/
+
+      - name: Deploy PR preview to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/build/current
+          destination_dir: preview/pr-${{ steps.pr.outputs.number }}
+          keep_files: true
+
+      - name: Add preview URL to workflow summary
+        run: |
+          base="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/preview/pr-${{ steps.pr.outputs.number }}/"
+          client_url="${base}client/"
+          {
+            echo "## Docs preview"
+            echo
+            echo "Built docs for this PR are available at:"
+            echo
+            echo "**${base}**"
+            echo
+            echo "Teleop web app (subpath \`/client/\`): **${client_url}**"
+            echo
+            echo "(It may take a minute to appear after the workflow completes.)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Build docs and Teleop web app, then deploy to GitHub Pages.
-# - Push to main (canonical repo): deploy docs at site root, web app at /client/.
-# - Pull requests: deploy to preview/pr-<N>/ (docs at root of preview, app at preview/pr-<N>/client/).
+# - Push to main/release (canonical repo): build + deploy docs at site root, web app at /client/.
+# - Pull requests: build only; preview deploy is handled by docs-deploy-preview.yaml
+#   via workflow_run (runs in base-repo context so fork PRs get write access).
 #
 # PR: docs always built; web client (npm) built with public SDK for all, or private SDK only for allowlisted authors.
 # Main/release (push): key used → private NGC for SDK.
@@ -95,6 +96,17 @@ jobs:
           name: docs-html
           path: ./docs/build
 
+      - name: Save PR number
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      - name: Upload PR metadata
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v6
+        with:
+          name: pr-metadata
+          path: pr-number.txt
+
   build-app:
     name: Build Teleop Web App
     runs-on: ubuntu-latest
@@ -151,7 +163,9 @@ jobs:
     name: Deploy docs
     runs-on: ubuntu-latest
     needs: [check-repo, build-docs, build-app]
-    if: needs.check-repo.outputs.is-canonical-repo == 'true' && (needs.check-repo.outputs.is-deploy-branch == 'true' || github.event_name == 'pull_request')
+    if: >-
+      needs.check-repo.outputs.is-canonical-repo == 'true'
+      && needs.check-repo.outputs.is-deploy-branch == 'true'
     permissions:
       contents: write  # push to gh-pages
     steps:
@@ -169,44 +183,12 @@ jobs:
 
       - name: Place web app under subpath
         run: |
-          if [ "${{ github.event_name }}" = 'pull_request' ]; then
-            CLIENT_DIR=./docs/build/current/client
-          else
-            CLIENT_DIR=./docs/build/client
-          fi
-          mkdir -p "$CLIENT_DIR"
-          cp -r ./webapp/. "$CLIENT_DIR/"
+          mkdir -p ./docs/build/client
+          cp -r ./webapp/. ./docs/build/client/
 
-      - name: Deploy to gh-pages (main branch)
-        if: github.event_name == 'push' && needs.check-repo.outputs.is-deploy-branch == 'true'
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build
           keep_files: true
-
-      - name: Deploy PR preview to gh-pages
-        if: github.event_name == 'pull_request'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/build/current
-          destination_dir: preview/pr-${{ github.event.pull_request.number }}
-          keep_files: true
-
-      - name: Add preview URL to workflow summary
-        if: github.event_name == 'pull_request'
-        run: |
-          base="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/preview/pr-${{ github.event.pull_request.number }}/"
-          client_url="${base}client/"
-          {
-            echo "## Docs preview"
-            echo
-            echo "Built docs for this PR are available at:"
-            echo
-            echo "**${base}**"
-            echo
-            echo "Teleop web app (subpath \`/client/\`): **${client_url}**"
-            echo
-            echo "(It may take a minute to appear after the workflow completes.)"
-          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
# Docs PR Preview Deploy — How It Works

## The fork PR problem

When a PR comes from a fork, GitHub runs the `pull_request`-triggered workflow **in the fork's context**. The `GITHUB_TOKEN` it gets is scoped to the fork — it can read the base repo but **cannot write** to it. That's why `git push origin gh-pages` on `NVIDIA/IsaacTeleop` returns 403.

## Why `workflow_run` fixes it

`workflow_run` is special: it **always runs in the base repo's context**, even when the triggering workflow ran on a fork PR. So:

| | `pull_request` trigger | `workflow_run` trigger |
|---|---|---|
| Runs as | Fork repo | **Base repo** (`NVIDIA/IsaacTeleop`) |
| `GITHUB_TOKEN` can write to base? | No | **Yes** |
| Has access to repo secrets? | No | **Yes** |

By splitting build (safe, no write needed) from deploy (needs write), the deploy runs with base-repo permissions.

## Why the two-artifact handoff?

Since this is a separate workflow run, it doesn't share the workspace of the build workflow. The three `download-artifact` steps use `run-id` to reach back and grab artifacts from the *triggering* build run. That's also why `actions: read` permission is needed — downloading artifacts cross-run requires it.

## Why the PR number is passed via artifact

In a `workflow_run` context, `github.event.pull_request` doesn't exist — the event payload is about the *workflow run*, not the PR. So the build workflow saves the PR number to a file, and this workflow reads it back to construct the `preview/pr-<N>/` destination path.

## The `environment: docs-preview` gate

This is the manual approval layer. Without it, the deploy would run automatically for every fork PR — which means untrusted code could generate arbitrary HTML and push it to your GitHub Pages. The environment's required reviewers ensure someone with write access eyeballs the build before it goes live.

### Setup

Create a `docs-preview` environment in repo **Settings → Environments**, then add required reviewers (anyone with write access to the repo).

## Does this block PR merging?

No. `workflow_run` is completely decoupled from the PR's status checks. It runs as a separate workflow associated with the *default branch*, not the PR's head commit.

- **Never approved** → sits pending indefinitely, PR is unaffected
- **Approved but fails** → PR is unaffected
- **Approved and succeeds** → PR is unaffected (preview just appears)

Only workflows triggered directly by `pull_request` / `push` events can appear as status checks on a PR, and only those added to branch protection's "required status checks" can block merging. The `workflow_run` workflow won't show up there at all.

The preview deploy is entirely opt-in / best-effort — it never gates merging.

## Flow summary

```
Fork PR opened
  → "Build & deploy docs" runs (fork context, read-only)
    → builds docs + webapp, uploads artifacts + PR number
    → deploy-docs job: skipped (not a deploy branch)
    → workflow completes with conclusion=success
  → "Deploy docs PR preview" fires (base repo context, write access)
    → waits for "docs-preview" environment approval
    → reviewer approves
    → downloads artifacts from the build run
    → pushes to gh-pages at preview/pr-<N>/
```
