### PR TITLE
[Replay] Add latest channel support in schema_tracker.

### DIFF
--- a/src/core/live_trackers/cpp/inc/live_trackers/schema_tracker.hpp
+++ b/src/core/live_trackers/cpp/inc/live_trackers/schema_tracker.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -9,6 +9,7 @@
 #include <mcap/tracker_channels.hpp>
 
 #include <memory>
+#include <optional>
 
 namespace core
 {
@@ -33,15 +34,21 @@ public:
      * @param mcap_channels Non-owning pointer to the MCAP channel writer. Must outlive
      *        this SchemaTracker. Owned by the live tracker impl that also owns this
      *        SchemaTracker instance. Null when recording is disabled.
-     * @param mcap_channel_index 0-based sub-channel index within mcap_channels.
+     * @param mcap_channel_index 0-based sub-channel index within mcap_channels
+     *        used for per-sample recording.
+     * @param mcap_channel_latest_index If set, an additional write of only the final
+     *        sample per update() call is made to this sub-channel index within the
+     *        same mcap_channels. Unset to disable.
      */
     SchemaTracker(const OpenXRSessionHandles& handles,
                   SchemaTrackerConfig config,
                   Channels* mcap_channels = nullptr,
-                  size_t mcap_channel_index = 0)
+                  size_t mcap_channel_index = 0,
+                  std::optional<size_t> mcap_channel_latest_index = std::nullopt)
         : SchemaTrackerBase(handles, std::move(config)),
           mcap_channels_(mcap_channels),
-          mcap_channel_index_(mcap_channel_index)
+          mcap_channel_index_(mcap_channel_index),
+          mcap_channel_latest_index_(mcap_channel_latest_index)
     {
     }
 
@@ -74,6 +81,7 @@ public:
             return;
         }
 
+        DeviceDataTimestamp last_timestamp{};
         for (const auto& sample : samples_)
         {
             auto fb = flatbuffers::GetRoot<DataTableT>(sample.buffer.data());
@@ -87,6 +95,7 @@ public:
                 out_latest = std::make_shared<NativeDataT>();
             }
             fb->UnPackTo(out_latest.get());
+            last_timestamp = sample.timestamp;
 
             // write() serializes synchronously and does not retain the shared_ptr,
             // so reusing out_latest across loop iterations is safe.
@@ -95,11 +104,17 @@ public:
                 mcap_channels_->write(mcap_channel_index_, sample.timestamp, out_latest);
             }
         }
+
+        if (mcap_channel_latest_index_ && mcap_channels_ && out_latest)
+        {
+            mcap_channels_->write(*mcap_channel_latest_index_, last_timestamp, out_latest);
+        }
     }
 
 private:
     Channels* mcap_channels_;
     size_t mcap_channel_index_;
+    std::optional<size_t> mcap_channel_latest_index_;
     std::vector<SampleResult> samples_;
 };
 

--- a/src/core/live_trackers/cpp/inc/live_trackers/schema_tracker.hpp
+++ b/src/core/live_trackers/cpp/inc/live_trackers/schema_tracker.hpp
@@ -36,7 +36,7 @@ public:
      *        SchemaTracker instance. Null when recording is disabled.
      * @param mcap_channel_index 0-based sub-channel index within mcap_channels
      *        used for per-sample recording.
-     * @param mcap_channel_latest_index If set, an additional write of only the final
+     * @param mcap_channel_tracked_index If set, an additional write of only the final
      *        sample per update() call is made to this sub-channel index within the
      *        same mcap_channels. Unset to disable.
      */
@@ -44,11 +44,11 @@ public:
                   SchemaTrackerConfig config,
                   Channels* mcap_channels = nullptr,
                   size_t mcap_channel_index = 0,
-                  std::optional<size_t> mcap_channel_latest_index = std::nullopt)
+                  std::optional<size_t> mcap_channel_tracked_index = std::nullopt)
         : SchemaTrackerBase(handles, std::move(config)),
           mcap_channels_(mcap_channels),
           mcap_channel_index_(mcap_channel_index),
-          mcap_channel_latest_index_(mcap_channel_latest_index)
+          mcap_channel_tracked_index_(mcap_channel_tracked_index)
     {
     }
 
@@ -105,16 +105,16 @@ public:
             }
         }
 
-        if (mcap_channel_latest_index_ && mcap_channels_ && out_latest)
+        if (mcap_channel_tracked_index_ && mcap_channels_ && out_latest)
         {
-            mcap_channels_->write(*mcap_channel_latest_index_, last_timestamp, out_latest);
+            mcap_channels_->write(*mcap_channel_tracked_index_, last_timestamp, out_latest);
         }
     }
 
 private:
     Channels* mcap_channels_;
     size_t mcap_channel_index_;
-    std::optional<size_t> mcap_channel_latest_index_;
+    std::optional<size_t> mcap_channel_tracked_index_;
     std::vector<SampleResult> samples_;
 };
 

--- a/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
@@ -40,7 +40,11 @@ LiveGeneric3AxisPedalTrackerImpl::LiveGeneric3AxisPedalTrackerImpl(const OpenXRS
                                                                    const Generic3AxisPedalTracker* tracker,
                                                                    std::unique_ptr<PedalMcapChannels> mcap_channels)
     : mcap_channels_(std::move(mcap_channels)),
-      m_schema_reader(handles, make_pedal_tensor_config(tracker), mcap_channels_.get(), 0, 1)
+      m_schema_reader(handles,
+                      make_pedal_tensor_config(tracker),
+                      mcap_channels_.get(),
+                      /*mcap_channel_index=*/0,
+                      /*mcap_channel_tracked_index=*/1)
 {
 }
 

--- a/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "live_generic_3axis_pedal_tracker_impl.hpp"
@@ -40,7 +40,7 @@ LiveGeneric3AxisPedalTrackerImpl::LiveGeneric3AxisPedalTrackerImpl(const OpenXRS
                                                                    const Generic3AxisPedalTracker* tracker,
                                                                    std::unique_ptr<PedalMcapChannels> mcap_channels)
     : mcap_channels_(std::move(mcap_channels)),
-      m_schema_reader(handles, make_pedal_tensor_config(tracker), mcap_channels_.get(), 0)
+      m_schema_reader(handles, make_pedal_tensor_config(tracker), mcap_channels_.get(), 0, 1)
 {
 }
 

--- a/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
+++ b/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -44,7 +44,7 @@ struct FullBodyPicoRecordingTraits
 struct PedalRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.Generic3AxisPedalOutputRecord";
-    static constexpr std::array channels = { "pedals" };
+    static constexpr std::array channels = { "pedals", "pedals_latest" };
 };
 
 struct OakRecordingTraits

--- a/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
+++ b/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
@@ -44,7 +44,7 @@ struct FullBodyPicoRecordingTraits
 struct PedalRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.Generic3AxisPedalOutputRecord";
-    static constexpr std::array channels = { "pedals", "pedals_latest" };
+    static constexpr std::array channels = { "pedals", "pedals_tracked" };
 };
 
 struct OakRecordingTraits


### PR DESCRIPTION
- Enable pedals to write the latest channel

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced MCAP recording to support optional latest-value tracking for pedal data, enabling efficient access to the most recent pedal data during playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->