### PR TITLE
feat(oob): Adds USB ADB automation for OOB teleop

### DIFF
--- a/docs/source/references/oob_teleop_control.rst
+++ b/docs/source/references/oob_teleop_control.rst
@@ -1,7 +1,7 @@
 .. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 .. SPDX-License-Identifier: Apache-2.0
 
-Out-of-band teleop control
+Out-of-Band Teleop Control
 ==========================
 
 The **OOB (out-of-band) teleop control hub** lets you coordinate Isaac Teleop
@@ -17,6 +17,12 @@ Quick start
 
 **Step 1 — Start the streaming host with OOB enabled**
 
+On first use, it is recommended to run once **without** ``--setup-oob`` to
+confirm ``adb devices`` sees the headset, verify USB debugging is enabled, and
+accept the self-signed certificate in the headset browser manually (both the
+web client page and the ``https://<host>:48322`` proxy page). Once that
+baseline works, add ``--setup-oob`` to automate the full flow.
+
 Launch the CloudXR runtime with the ``--setup-oob`` flag (add ``--accept-eula``
 on first run):
 
@@ -29,6 +35,8 @@ This will:
 1. Verify a USB-connected headset is available via ``adb devices``
 2. Start the WSS proxy with the OOB control hub
 3. Open the teleop page on the headset via ``adb shell am start``
+4. Accept the self-signed certificate and click CONNECT automatically
+   via Chrome DevTools Protocol (CDP)
 
 You should see output confirming the hub is running:
 
@@ -45,7 +53,8 @@ You should see output confirming the hub is running:
    - **Connected to WiFi** on the same network as the streaming host (for web
      page access and CloudXR streaming)
 
-   No ``adb reverse`` or USB tethering is used.
+   Streaming and web page access use WiFi, not USB tethering.
+   ``adb forward`` is used only temporarily for CDP automation.
 
 **Step 2 — (Manual fallback) Open the web client on the headset**
 
@@ -110,11 +119,12 @@ configuration overrides via the HTTP config API:
 
 See ``GET /api/oob/v1/config`` below for all supported keys.
 
-**Step 5 — Connect and stream; poll for metrics**
+**Step 5 — Stream and poll for metrics**
 
-Press **CONNECT** on the headset to start the CloudXR streaming session. Once
-streaming begins, the headset reports metrics to the hub every 500 ms. Poll the
-state endpoint from a PC to collect them:
+With ``--setup-oob``, CONNECT is clicked automatically via CDP.  If running
+without it, press **CONNECT** on the headset manually.  Once streaming begins,
+the headset reports metrics to the hub every 500 ms.  Poll the state endpoint
+from a PC to collect them:
 
 .. code-block:: bash
 
@@ -128,12 +138,16 @@ ADB automation
 
 The ``--setup-oob`` flag automates headset setup via USB ``adb``:
 
-1. **adb devices** — verifies exactly one device is connected
-2. **am start** — opens the teleop bookmark URL in the headset browser with
+1. **adb devices** verifies exactly one device is connected
+2. **am start** opens the teleop bookmark URL in the headset browser with
    the correct ``oobEnable=1``, ``serverIP``, and ``port`` parameters
+3. **CDP connect** forwards the browser's DevTools socket over ``adb``,
+   accepts the self-signed certificate interstitial, and clicks CONNECT
+   via Chrome DevTools Protocol (``Input.dispatchMouseEvent``)
 
-No ``adb reverse`` ports or USB tethering is used.  The headset reaches the
-streaming host directly over WiFi.
+Streaming and web page access use WiFi, not USB tethering.  The headset
+reaches the streaming host directly over WiFi.  ``adb forward`` is used only
+temporarily during CDP automation to reach the browser's DevTools socket.
 
 Prerequisites:
 
@@ -141,8 +155,9 @@ Prerequisites:
 - The headset must be connected via USB with USB debugging enabled
 - The headset must be on the same WiFi network as the streaming host
 
-If adb automation fails, the hub still starts and you can open the URL
-on the headset manually.
+If any step fails, the hub still starts.  Fall back to
+``chrome://inspect/#devices`` from the PC or tap CONNECT on the headset
+directly.
 
 Architecture
 ------------
@@ -161,7 +176,7 @@ Architecture
    * - **Streaming host**
      - ``python -m isaacteleop.cloudxr --setup-oob``
      - Runs CloudXR runtime + WSS proxy + OOB hub on a single TLS port.
-       Opens the teleop page on the headset via USB adb.
+       Opens the teleop page and clicks CONNECT via USB adb + CDP.
    * - **Operator / scripts**
      - ``curl``, browser, or custom tooling
      - Reads state via HTTP, optionally pushes config via HTTP.
@@ -312,10 +327,10 @@ The following URL parameters override their corresponding form fields (and
 ``localStorage`` values) so that bookmarked links always take priority over
 previously saved settings:
 
-- ``serverIP`` — CloudXR server IP address
-- ``port`` — CloudXR server port
-- ``codec`` — video codec
-- ``panelHiddenAtStart`` — hide the control panel on load
+- ``serverIP`` CloudXR server IP address
+- ``port`` CloudXR server port
+- ``codec`` video codec
+- ``panelHiddenAtStart`` hide the control panel on load
 
 Environment variables
 ---------------------
@@ -342,7 +357,3 @@ Environment variables
      - Default video codec for headset bookmarks
    * - ``TELEOP_CLIENT_PANEL_HIDDEN_AT_START``
      - Hide control panel on load (``true`` / ``false``)
-   * - ``TELEOP_CLIENT_PER_EYE_WIDTH``
-     - Per-eye render width override
-   * - ``TELEOP_CLIENT_PER_EYE_HEIGHT``
-     - Per-eye render height override

--- a/docs/source/references/oob_teleop_control.rst
+++ b/docs/source/references/oob_teleop_control.rst
@@ -24,17 +24,34 @@ on first run):
 
    python -m isaacteleop.cloudxr --accept-eula --setup-oob
 
+This will:
+
+1. Verify a USB-connected headset is available via ``adb devices``
+2. Start the WSS proxy with the OOB control hub
+3. Open the teleop page on the headset via ``adb shell am start``
+
 You should see output confirming the hub is running:
 
 .. code-block:: text
 
    CloudXR WSS proxy: running, log file: /home/<user>/.cloudxr/logs/wss.2026-04-13T202133Z.log
-           oob:       enabled  (hub running in WSS proxy)
+           oob:       enabled  (hub + USB adb automation — see OOB TELEOP block)
 
-**Step 2 — Open the web client on the headset**
+.. note::
 
-On the XR headset browser, navigate to the client URL with **all three**
-required query parameters — ``oobEnable``, ``serverIP``, and ``port``:
+   The headset must be:
+
+   - **Connected via USB cable** for adb commands (opening the teleop URL)
+   - **Connected to WiFi** on the same network as the streaming host (for web
+     page access and CloudXR streaming)
+
+   No ``adb reverse`` or USB tethering is used.
+
+**Step 2 — (Manual fallback) Open the web client on the headset**
+
+If the adb automation fails (e.g. headset not paired), you can manually open
+the client URL on the headset browser with **all three** required query
+parameters — ``oobEnable``, ``serverIP``, and ``port``:
 
 .. code-block:: text
 
@@ -106,6 +123,27 @@ state endpoint from a PC to collect them:
 
 The ``metricsByCadence`` field on each headset entry will now contain live streaming metrics.
 
+ADB automation
+--------------
+
+The ``--setup-oob`` flag automates headset setup via USB ``adb``:
+
+1. **adb devices** — verifies exactly one device is connected
+2. **am start** — opens the teleop bookmark URL in the headset browser with
+   the correct ``oobEnable=1``, ``serverIP``, and ``port`` parameters
+
+No ``adb reverse`` ports or USB tethering is used.  The headset reaches the
+streaming host directly over WiFi.
+
+Prerequisites:
+
+- ``adb`` must be on ``PATH`` (Android SDK Platform Tools)
+- The headset must be connected via USB with USB debugging enabled
+- The headset must be on the same WiFi network as the streaming host
+
+If adb automation fails, the hub still starts and you can open the URL
+on the headset manually.
+
 Architecture
 ------------
 
@@ -123,6 +161,7 @@ Architecture
    * - **Streaming host**
      - ``python -m isaacteleop.cloudxr --setup-oob``
      - Runs CloudXR runtime + WSS proxy + OOB hub on a single TLS port.
+       Opens the teleop page on the headset via USB adb.
    * - **Operator / scripts**
      - ``curl``, browser, or custom tooling
      - Reads state via HTTP, optionally pushes config via HTTP.
@@ -264,7 +303,7 @@ The client builds ``wss://{serverIP}:{port}/oob/v1/ws`` and:
 
 1. Registers as role ``"headset"``
 2. Reports ``clientMetrics`` periodically (default every 500 ms)
-3. Receives ``config`` pushes (phase 2)
+3. Receives ``config`` pushes from operator
 
 URL query parameter overrides
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -293,3 +332,17 @@ Environment variables
      - Optional auth token for hub access
    * - ``TELEOP_STREAM_SERVER_IP``
      - Override the auto-detected LAN IP in hub initial config
+   * - ``TELEOP_PROXY_HOST``
+     - Override the LAN IP used for headset bookmark URLs
+   * - ``TELEOP_WEB_CLIENT_BASE``
+     - Override the WebXR client origin URL
+   * - ``TELEOP_STREAM_PORT``
+     - Override the signaling port (default same as proxy port)
+   * - ``TELEOP_CLIENT_CODEC``
+     - Default video codec for headset bookmarks
+   * - ``TELEOP_CLIENT_PANEL_HIDDEN_AT_START``
+     - Hide control panel on load (``true`` / ``false``)
+   * - ``TELEOP_CLIENT_PER_EYE_WIDTH``
+     - Per-eye render width override
+   * - ``TELEOP_CLIENT_PER_EYE_HEIGHT``
+     - Per-eye render height override

--- a/src/core/cloudxr/python/CMakeLists.txt
+++ b/src/core/cloudxr/python/CMakeLists.txt
@@ -111,6 +111,8 @@ add_custom_target(cloudxr_python ALL
         "${CMAKE_CURRENT_SOURCE_DIR}/launcher.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/runtime.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/wss.py"
+        "${CMAKE_CURRENT_SOURCE_DIR}/oob_teleop_adb.py"
+        "${CMAKE_CURRENT_SOURCE_DIR}/oob_teleop_env.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/oob_teleop_hub.py"
         "${CLOUDXR_PYTHON_DIR}/"
     COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLOUDXR_PYTHON_DIR}/__pycache__"

--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -51,7 +51,8 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         default=False,
         help=(
-            "Enable OOB teleop control hub and open the teleop page on the headset via USB adb. "
+            "Enable OOB teleop control hub, open the teleop page on the headset via USB adb, "
+            "and auto-click CONNECT via CDP (Chrome DevTools Protocol). "
             "The headset must be connected via USB cable (for adb) and on WiFi (for streaming). "
             'See docs: "Out-of-band teleop control".'
         ),

--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -6,12 +6,22 @@
 import argparse
 import os
 import signal
+import sys
 import time
 
 from isaacteleop import __version__ as isaacteleop_version
 from isaacteleop.cloudxr.env_config import get_env_config
 from isaacteleop.cloudxr.launcher import CloudXRLauncher
 from isaacteleop.cloudxr.runtime import latest_runtime_log, runtime_version
+from isaacteleop.cloudxr.oob_teleop_adb import (
+    OobAdbError,
+    assert_exactly_one_adb_device,
+    require_adb_on_path,
+)
+from isaacteleop.cloudxr.oob_teleop_env import (
+    print_oob_hub_startup_banner,
+    resolve_lan_host_for_oob,
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -41,8 +51,9 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         default=False,
         help=(
-            "Enable OOB teleop control hub in the WSS proxy. "
-            "Exposes WebSocket and HTTP API for headset metrics and remote config."
+            "Enable OOB teleop control hub and open the teleop page on the headset via USB adb. "
+            "The headset must be connected via USB cable (for adb) and on WiFi (for streaming). "
+            'See docs: "Out-of-band teleop control".'
         ),
     )
     return parser.parse_args()
@@ -51,6 +62,11 @@ def _parse_args() -> argparse.Namespace:
 def main() -> None:
     """Launch the CloudXR runtime and WSS proxy, then block until interrupted."""
     args = _parse_args()
+
+    if args.setup_oob:
+        require_adb_on_path()
+        resolve_lan_host_for_oob()
+        assert_exactly_one_adb_device()
 
     with CloudXRLauncher(
         install_dir=args.cloudxr_install_dir,
@@ -75,8 +91,9 @@ def main() -> None:
         )
         if args.setup_oob:
             print(
-                "        oob:       \033[32menabled\033[0m  (hub running in WSS proxy)"
+                "        oob:       \033[32menabled\033[0m  (hub + USB adb automation — see OOB TELEOP block)"
             )
+            print_oob_hub_startup_banner(lan_host=resolve_lan_host_for_oob())
         print(
             f"Activate CloudXR environment in another terminal: \033[1;32msource {env_cfg.env_filepath()}\033[0m"
         )
@@ -99,4 +116,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except OobAdbError as e:
+        print("", file=sys.stderr)
+        print(str(e), file=sys.stderr)
+        print("", file=sys.stderr)
+        raise SystemExit(1) from None

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -90,8 +90,8 @@ class CloudXRLauncher:
             accept_eula: Accept the NVIDIA CloudXR EULA
                 non-interactively.  When ``False`` and the EULA marker
                 does not exist, the user is prompted on stdin.
-            setup_oob: Enable the OOB teleop control hub in the WSS
-                proxy.
+            setup_oob: Enable the OOB teleop control hub and USB
+                adb automation in the WSS proxy.
 
         Raises:
             RuntimeError: If the EULA is not accepted or the runtime

--- a/src/core/cloudxr/python/oob_teleop_adb.py
+++ b/src/core/cloudxr/python/oob_teleop_adb.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ADB automation for OOB teleop (``--setup-oob``): open the headset bookmark URL via USB adb.
+
+The headset is connected via USB cable for adb commands only.  Streaming and
+web-page access use WiFi — no ``adb reverse`` or USB tethering.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import shutil
+import subprocess
+
+from .oob_teleop_env import (
+    DEFAULT_WEB_CLIENT_ORIGIN,
+    build_headset_bookmark_url,
+    client_ui_fields_from_env,
+    resolve_lan_host_for_oob,
+    web_client_base_override_from_env,
+)
+
+log = logging.getLogger("oob-teleop-adb")
+
+
+class OobAdbError(Exception):
+    """``--setup-oob`` adb step failed; ``str(exception)`` is formatted for users (print without traceback)."""
+
+
+def _adb_output_text(proc: subprocess.CompletedProcess[str]) -> str:
+    return (proc.stderr or proc.stdout or "").strip()
+
+
+def adb_automation_failure_hint(diagnostic: str) -> str:
+    """Human-readable next steps for common ``adb`` failures."""
+    d = diagnostic.lower()
+    if "unauthorized" in d:
+        return (
+            "Device is unauthorized: unlock the headset, confirm the USB debugging (RSA) prompt, "
+            "and run `adb devices` until the device shows `device` not `unauthorized`. "
+            "If this persists, try `adb kill-server` and reconnect the cable."
+        )
+    if (
+        "no devices/emulators" in d
+        or "no devices found" in d
+        or "device not found" in d
+    ):
+        return (
+            "No adb device: plug in the USB cable, enable USB debugging on the headset, "
+            "and check `adb devices`."
+        )
+    if "more than one device" in d:
+        return "Multiple adb devices: unplug extras so only one headset shows in `adb devices`."
+    if "offline" in d:
+        return "Device offline: reconnect the USB cable and confirm USB debugging on the headset."
+    return ""
+
+
+def oob_adb_automation_message(rc: int, detail: str, hint: str) -> str:
+    d = detail.strip() if detail else "(no output from adb)"
+    lines = [
+        f"OOB adb automation failed (adb exit code {rc}).",
+        "",
+        d,
+    ]
+    if hint.strip():
+        lines.extend(["", hint])
+    lines.extend(
+        [
+            "",
+            "To run the WSS proxy and OOB hub without adb, omit --setup-oob and open the teleop URL on the headset yourself.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def require_adb_on_path() -> None:
+    """Raise :exc:`OobAdbError` if ``adb`` is missing."""
+    if shutil.which("adb"):
+        return
+    raise OobAdbError(
+        "Cannot use --setup-oob: `adb` was not found on PATH.\n\n"
+        "Install Android Platform Tools and ensure `adb` is available, or omit --setup-oob and open "
+        "the teleop bookmark URL on the headset yourself."
+    )
+
+
+def assert_exactly_one_adb_device() -> None:
+    """Fail unless exactly one device is in ``device`` state."""
+    try:
+        proc = subprocess.run(
+            ["adb", "devices"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+    except FileNotFoundError as e:
+        raise OobAdbError(
+            "Cannot use --setup-oob: `adb` was not found on PATH.\n\n"
+            "Install Android Platform Tools and ensure `adb` is available, or omit --setup-oob."
+        ) from e
+    if proc.returncode != 0:
+        diag = _adb_output_text(proc)
+        raise OobAdbError(
+            f"adb devices failed (exit code {proc.returncode}).\n\n"
+            f"{diag}\n\n"
+            "Check your adb installation and USB connection."
+        )
+    text = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    ready: list[str] = []
+    for line in text.strip().splitlines()[1:]:
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[-1] == "device":
+            ready.append(parts[0])
+    if len(ready) == 0:
+        raise OobAdbError(
+            "No adb device found for --setup-oob.\n\n"
+            "Plug in the USB cable, enable USB debugging on the headset, and check `adb devices`. "
+            "Or omit --setup-oob and open the teleop URL on the headset yourself."
+        )
+    if len(ready) > 1:
+        listed = ", ".join(ready)
+        raise OobAdbError(
+            "Too many adb devices for --setup-oob.\n\n"
+            f"Currently connected: {listed}\n\n"
+            "Unplug extras so only one headset is connected, then retry. "
+            "Or omit --setup-oob and open the teleop URL manually."
+        )
+
+
+def run_adb_headset_bookmark(*, resolved_port: int) -> tuple[int, str]:
+    """Open the teleop bookmark URL on the headset via ``am start``.
+
+    Uses the PC's LAN address — the headset reaches the proxy over WiFi.
+    ``resolved_port`` is used as the stream port unless ``TELEOP_STREAM_PORT``
+    is set explicitly.  Returns ``(exit_code, diagnostic)``.
+    """
+    env_port = os.environ.get("TELEOP_STREAM_PORT", "").strip()
+    signaling_port = int(env_port) if env_port else resolved_port
+    proxy_host = resolve_lan_host_for_oob()
+    stream_cfg: dict = {
+        "serverIP": proxy_host,
+        "port": signaling_port,
+        **client_ui_fields_from_env(),
+    }
+
+    ovr = web_client_base_override_from_env()
+    web_base = ovr if ovr else DEFAULT_WEB_CLIENT_ORIGIN
+    token = os.environ.get("CONTROL_TOKEN") or None
+    url = build_headset_bookmark_url(
+        web_client_base=web_base,
+        stream_config=stream_cfg,
+        control_token=token,
+    )
+
+    shell_cmd = "am start -a android.intent.action.VIEW -d " + shlex.quote(url)
+    full = ["adb", "shell", shell_cmd]
+    log.info("ADB automation: %s", " ".join(shlex.quote(c) for c in full))
+    proc = subprocess.run(full, capture_output=True, text=True)
+    if proc.returncode != 0:
+        diag = _adb_output_text(proc)
+        return proc.returncode, diag
+    log.info("ADB automation: am start completed")
+    return 0, ""

--- a/src/core/cloudxr/python/oob_teleop_adb.py
+++ b/src/core/cloudxr/python/oob_teleop_adb.py
@@ -4,19 +4,26 @@
 """ADB automation for OOB teleop (``--setup-oob``): open the headset bookmark URL via USB adb.
 
 The headset is connected via USB cable for adb commands only.  Streaming and
-web-page access use WiFi — no ``adb reverse`` or USB tethering.
+web-page access use WiFi.  ``adb forward`` is used temporarily for CDP
+automation (DevTools socket); no ``adb reverse`` or USB tethering.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
 import os
+import re
 import shlex
 import shutil
 import subprocess
+import time
+import urllib.request
 
 from .oob_teleop_env import (
     DEFAULT_WEB_CLIENT_ORIGIN,
+    parse_env_port,
     build_headset_bookmark_url,
     client_ui_fields_from_env,
     resolve_lan_host_for_oob,
@@ -103,6 +110,11 @@ def assert_exactly_one_adb_device() -> None:
             "Cannot use --setup-oob: `adb` was not found on PATH.\n\n"
             "Install Android Platform Tools and ensure `adb` is available, or omit --setup-oob."
         ) from e
+    except subprocess.TimeoutExpired as e:
+        raise OobAdbError(
+            "adb command timed out; ensure Android Platform Tools are installed and adb is callable.\n\n"
+            "Try `adb kill-server` and reconnect the USB cable, or omit --setup-oob."
+        ) from e
     if proc.returncode != 0:
         diag = _adb_output_text(proc)
         raise OobAdbError(
@@ -143,7 +155,9 @@ def run_adb_headset_bookmark(*, resolved_port: int) -> tuple[int, str]:
     is set explicitly.  Returns ``(exit_code, diagnostic)``.
     """
     env_port = os.environ.get("TELEOP_STREAM_PORT", "").strip()
-    signaling_port = int(env_port) if env_port else resolved_port
+    signaling_port = (
+        parse_env_port("TELEOP_STREAM_PORT", env_port) if env_port else resolved_port
+    )
     proxy_host = resolve_lan_host_for_oob()
     stream_cfg: dict = {
         "serverIP": proxy_host,
@@ -162,10 +176,340 @@ def run_adb_headset_bookmark(*, resolved_port: int) -> tuple[int, str]:
 
     shell_cmd = "am start -a android.intent.action.VIEW -d " + shlex.quote(url)
     full = ["adb", "shell", shell_cmd]
-    log.info("ADB automation: %s", " ".join(shlex.quote(c) for c in full))
-    proc = subprocess.run(full, capture_output=True, text=True)
+    redacted = " ".join(shlex.quote(c) for c in full)
+    redacted = re.sub(r"(controlToken=)[^&\s'\"]+", r"\1<REDACTED>", redacted)
+    log.info("ADB automation: %s", redacted)
+    try:
+        proc = subprocess.run(full, capture_output=True, text=True, timeout=30)
+    except subprocess.TimeoutExpired as e:
+        partial = (
+            (e.stderr or e.stdout or b"")
+            if isinstance(e.stderr or e.stdout, bytes)
+            else (e.stderr or e.stdout or "")
+        )
+        if isinstance(partial, bytes):
+            partial = partial.decode(errors="replace")
+        diag = f"adb shell timed out after 30s. {partial}".strip()
+        return 1, diag
     if proc.returncode != 0:
         diag = _adb_output_text(proc)
         return proc.returncode, diag
     log.info("ADB automation: am start completed")
     return 0, ""
+
+
+# ---------------------------------------------------------------------------
+# CDP automation — click the CONNECT button via Chrome DevTools Protocol
+# ---------------------------------------------------------------------------
+
+_CDP_LOCAL_PORT = 9223  # avoid clashing with any pre-existing 9222 forward
+
+
+def _discover_devtools_socket() -> str | None:
+    """Return the bare name of the browser's DevTools abstract socket, or None.
+
+    Pico Browser (WebLayer/Chromium) exposes a socket like
+    ``@weblayer_devtools_remote_<pid>`` in ``/proc/net/unix``.
+    The PID suffix changes every time the browser starts.
+    """
+    try:
+        proc = subprocess.run(
+            ["adb", "shell", "cat", "/proc/net/unix"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    for line in proc.stdout.splitlines():
+        if "weblayer_devtools_remote" in line:
+            for token in line.split():
+                if token.startswith("@weblayer_devtools_remote"):
+                    return token[1:]  # strip leading @
+    return None
+
+
+def _adb_forward_cdp(socket_name: str, local_port: int) -> None:
+    subprocess.run(
+        ["adb", "forward", f"tcp:{local_port}", f"localabstract:{socket_name}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+    log.info("CDP: forwarded tcp:%d -> @%s", local_port, socket_name)
+
+
+def _adb_forward_remove(local_port: int) -> None:
+    subprocess.run(
+        ["adb", "forward", "--remove", f"tcp:{local_port}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def _cdp_list_tabs(local_port: int) -> list[dict]:
+    try:
+        with urllib.request.urlopen(
+            f"http://localhost:{local_port}/json", timeout=3
+        ) as resp:
+            return json.loads(resp.read())
+    except Exception as exc:
+        log.debug("CDP: failed to list tabs on port %d: %s", local_port, exc)
+        return []
+
+
+async def _cdp_session_click_connect(ws_url: str) -> None:
+    """Open a single CDP session and click the CONNECT button.
+
+    Handles the self-signed cert interstitial before looking for the button:
+
+    * Primary path — ``Security.setIgnoreCertificateErrors`` + ``Page.navigate``
+      (re-loads the page with cert checking disabled).
+    * Fallback — DOM click-through: ``details-button`` → ``proceed-link``
+      (standard Chromium cert-warning IDs).
+    """
+    from websockets.asyncio.client import connect as ws_connect  # already a dep
+
+    _seq = 0
+
+    async def send(ws, method, params=None):
+        nonlocal _seq
+        _seq += 1
+        req_id = _seq
+        await ws.send(
+            json.dumps({"id": req_id, "method": method, "params": params or {}})
+        )
+        while True:
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=10.0))
+            if msg.get("id") == req_id:
+                return msg.get("result", {})
+
+    async with ws_connect(ws_url) as ws:
+        # ---- cert warning handling ----------------------------------------
+        cert_suppressed = False
+        try:
+            await send(ws, "Security.setIgnoreCertificateErrors", {"ignore": True})
+            cert_suppressed = True
+            log.info("CDP: cert errors suppressed")
+        except Exception as exc:
+            log.debug(
+                "CDP: Security domain unavailable (%s), will try DOM fallback", exc
+            )
+
+        # Detect interstitial: Chromium cert warning pages have #details-button
+        r = await send(
+            ws,
+            "Runtime.evaluate",
+            {
+                "expression": "!!document.getElementById('details-button')",
+                "returnByValue": True,
+            },
+        )
+        on_interstitial = r.get("result", {}).get("value", False)
+
+        if on_interstitial:
+            log.info("CDP: cert interstitial detected")
+            navigated = False
+            if cert_suppressed:
+                r2 = await send(
+                    ws,
+                    "Runtime.evaluate",
+                    {
+                        "expression": "window.location.href",
+                        "returnByValue": True,
+                    },
+                )
+                current_url = r2.get("result", {}).get("value", "")
+                if current_url and not current_url.startswith("chrome-error"):
+                    log.info("CDP: re-navigating to %s", current_url)
+                    await send(ws, "Page.navigate", {"url": current_url})
+                    await asyncio.sleep(3.0)
+                    navigated = True
+                else:
+                    log.warning(
+                        "CDP: interstitial URL is %r, falling back to DOM click-through",
+                        current_url,
+                    )
+
+            if not navigated:
+                await send(
+                    ws,
+                    "Runtime.evaluate",
+                    {
+                        "expression": "document.getElementById('details-button')?.click()",
+                    },
+                )
+                await asyncio.sleep(1.5)
+                await send(
+                    ws,
+                    "Runtime.evaluate",
+                    {
+                        "expression": "document.getElementById('proceed-link')?.click()",
+                    },
+                )
+                await asyncio.sleep(3.0)
+
+        # ---- find CONNECT button with retries --------------------------------
+        val: dict = {}
+        for attempt in range(1, 4):
+            r = await send(
+                ws,
+                "Runtime.evaluate",
+                {
+                    "expression": """(function() {
+                    const btn = Array.from(document.querySelectorAll('button,[role=button]'))
+                        .find(e => e.textContent.trim().toUpperCase() === 'CONNECT');
+                    if (!btn) return {found: false};
+                    const rc = btn.getBoundingClientRect();
+                    return {found: true, x: rc.left + rc.width / 2, y: rc.top + rc.height / 2};
+                })()""",
+                    "returnByValue": True,
+                },
+            )
+            val = (r.get("result") or {}).get("value") or {}
+            if val.get("found"):
+                break
+            log.info("CDP: CONNECT button not found yet (attempt %d/3)", attempt)
+            if attempt < 3:
+                await asyncio.sleep(2.0)
+
+        if not val.get("found"):
+            raise OobAdbError(
+                "CDP: CONNECT button not found on the teleop page.\n"
+                "The page may not have finished loading — check the headset."
+            )
+
+        x, y = val["x"], val["y"]
+        log.info("CDP: clicking CONNECT at (%.0f, %.0f)", x, y)
+        for event_type in ("mousePressed", "mouseReleased"):
+            await send(
+                ws,
+                "Input.dispatchMouseEvent",
+                {
+                    "type": event_type,
+                    "x": x,
+                    "y": y,
+                    "button": "left",
+                    "clickCount": 1,
+                },
+            )
+        log.info("CDP: CONNECT click dispatched")
+
+        # ---- monitor connection outcome -------------------------------------
+        # DOM facts learned from page inspection:
+        #   - Start/stop button: id="startButton", text "CONNECT" when idle
+        #   - Error box: first [role=alert] is empty validation-message-box;
+        #     error text lives in the *second* [role=alert] (error-message-box)
+        _CONNECT_TIMEOUT = 30.0
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + _CONNECT_TIMEOUT
+        while loop.time() < deadline:
+            await asyncio.sleep(2.0)
+            r = await send(
+                ws,
+                "Runtime.evaluate",
+                {
+                    "expression": """(function() {
+                    const alertText = Array.from(document.querySelectorAll('[role=alert]'))
+                        .map(e => e.innerText?.trim()).find(t => !!t) || null;
+                    const btn = document.getElementById('startButton');
+                    const btnText = btn?.textContent?.trim()?.toUpperCase() || null;
+                    return {alertText, btnText};
+                })()""",
+                    "returnByValue": True,
+                },
+            )
+            state = (r.get("result") or {}).get("value") or {}
+            btn_text = state.get("btnText")
+            if btn_text is not None and btn_text != "CONNECT":
+                log.info("CDP: start button changed to %r — session active", btn_text)
+                return
+            if state.get("alertText"):
+                raise OobAdbError(f"Teleop connection failed: {state['alertText']}")
+        log.warning(
+            "CDP: connection state unknown after %.0fs — check headset",
+            _CONNECT_TIMEOUT,
+        )
+
+
+async def run_oob_connect(*, resolved_port: int, timeout: float = 60.0) -> None:
+    """Open the teleop page on the headset and click CONNECT via CDP.
+
+    Combines the ``am start`` bookmark step with CDP automation so that the
+    new tab can be identified unambiguously by diffing tab IDs before and after
+    ``am start`` — regardless of how many other tabs are already open.
+
+    Flow:
+      1. Discover the Pico Browser DevTools abstract socket and forward it.
+      2. Snapshot existing tab IDs.
+      3. Run ``am start`` to open the teleop bookmark URL.
+      4. Wait for a new tab (ID not in snapshot) to appear.
+      5. Handle self-signed cert interstitial if present.
+      6. Find the CONNECT button and click it via ``Input.dispatchMouseEvent``.
+      7. Clean up the ``adb forward``.
+
+    Raises :exc:`OobAdbError` on any unrecoverable failure; callers should
+    treat this as non-fatal and ask the user to tap CONNECT manually.
+    """
+    deadline = time.monotonic() + timeout
+
+    # --- DevTools socket discovery -------------------------------------------
+    socket_name = _discover_devtools_socket()
+    if not socket_name:
+        raise OobAdbError(
+            "CDP: Pico Browser DevTools socket not found.\n"
+            "Ensure the browser is open on the headset, then retry or tap CONNECT manually."
+        )
+    log.info("CDP: found socket @%s", socket_name)
+
+    try:
+        _adb_forward_cdp(socket_name, _CDP_LOCAL_PORT)
+    except subprocess.CalledProcessError as exc:
+        raise OobAdbError(f"CDP: adb forward failed: {exc}") from exc
+
+    try:
+        # --- snapshot existing tabs before am start --------------------------
+        tabs_before = {t["id"] for t in _cdp_list_tabs(_CDP_LOCAL_PORT) if "id" in t}
+        log.info("CDP: %d tab(s) open before am start", len(tabs_before))
+
+        # --- open URL on headset ---------------------------------------------
+        rc, diag = await asyncio.to_thread(
+            run_adb_headset_bookmark, resolved_port=resolved_port
+        )
+        if rc != 0:
+            hint = adb_automation_failure_hint(diag)
+            raise OobAdbError(oob_adb_automation_message(rc, diag, hint))
+        log.info("ADB: am start completed; waiting for new tab")
+
+        # --- wait for the newly opened tab (not in pre-snapshot) -------------
+        ws_url: str | None = None
+        while time.monotonic() < deadline:
+            for tab in _cdp_list_tabs(_CDP_LOCAL_PORT):
+                if "id" not in tab:
+                    continue
+                if tab["id"] not in tabs_before and tab.get("webSocketDebuggerUrl"):
+                    ws_url = tab["webSocketDebuggerUrl"]
+                    log.info("CDP: new tab %r url=%s", tab.get("title"), tab.get("url"))
+                    break
+            if ws_url:
+                break
+            await asyncio.sleep(1.0)
+
+        if ws_url is None:
+            raise OobAdbError(
+                "CDP: new browser tab not found within timeout.\n"
+                "The browser may not have opened the teleop page — tap CONNECT manually."
+            )
+
+        # Give the page JS time to finish initializing before we interact with it
+        log.info("CDP: waiting for page to initialize...")
+        await asyncio.sleep(4.0)
+
+        # --- cert interstitial + CONNECT click --------------------------------
+        await _cdp_session_click_connect(ws_url)
+    finally:
+        _adb_forward_remove(_CDP_LOCAL_PORT)

--- a/src/core/cloudxr/python/oob_teleop_env.py
+++ b/src/core/cloudxr/python/oob_teleop_env.py
@@ -1,0 +1,209 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""OOB teleop environment: proxy port, LAN detection, stream defaults, headset bookmark URLs, startup banner."""
+
+from __future__ import annotations
+
+import os
+import socket
+from urllib.parse import urlencode
+
+from .oob_teleop_hub import OOB_WS_PATH
+
+WSS_PROXY_DEFAULT_PORT = 48322
+
+DEFAULT_WEB_CLIENT_ORIGIN = "https://nvidia.github.io/IsaacTeleop/client/"
+
+TELEOP_WEB_CLIENT_BASE_ENV = "TELEOP_WEB_CLIENT_BASE"
+
+CHROME_INSPECT_DEVICES_URL = "chrome://inspect/#devices"
+
+
+def web_client_base_override_from_env() -> str | None:
+    v = os.environ.get(TELEOP_WEB_CLIENT_BASE_ENV, "").strip()
+    return v or None
+
+
+def wss_proxy_port() -> int:
+    """TCP port for the WSS proxy (``PROXY_PORT`` environment variable if set, else ``48322``)."""
+    raw = os.environ.get("PROXY_PORT", "").strip()
+    if raw:
+        return int(raw)
+    return WSS_PROXY_DEFAULT_PORT
+
+
+def guess_lan_ipv4() -> str | None:
+    """Best-effort LAN IPv4 for operator URLs when headsets reach the PC by IP."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
+            s.settimeout(0.25)
+            s.connect(("192.0.2.1", 1))
+            addr, _ = s.getsockname()
+    except OSError:
+        return None
+    if not addr or addr == "127.0.0.1":
+        return None
+    return addr
+
+
+def default_initial_stream_config(resolved_proxy_port: int) -> dict:
+    """Default hub stream config from env and LAN guess (same host as proxy port by default)."""
+    env_ip = os.environ.get("TELEOP_STREAM_SERVER_IP", "").strip()
+    env_port = os.environ.get("TELEOP_STREAM_PORT", "").strip()
+    server_ip = env_ip or guess_lan_ipv4() or "127.0.0.1"
+    port = int(env_port) if env_port else resolved_proxy_port
+    return {"serverIP": server_ip, "port": port}
+
+
+def client_ui_fields_from_env() -> dict:
+    """Optional WebXR client UI defaults merged into hub ``config`` and bookmarks.
+
+    Keys match query params the WebXR client reads on page load
+    (``serverIP``, ``port``, ``codec``, ``panelHiddenAtStart``).
+    """
+    out: dict = {}
+    codec = os.environ.get("TELEOP_CLIENT_CODEC", "").strip()
+    if codec:
+        out["codec"] = codec
+    ph = os.environ.get("TELEOP_CLIENT_PANEL_HIDDEN_AT_START", "").strip().lower()
+    if ph in ("1", "true", "yes", "on"):
+        out["panelHiddenAtStart"] = True
+    elif ph in ("0", "false", "no", "off"):
+        out["panelHiddenAtStart"] = False
+    return out
+
+
+def build_headset_bookmark_url(
+    *,
+    web_client_base: str,
+    stream_config: dict | None = None,
+    control_token: str | None = None,
+) -> str:
+    """Full WebXR page URL with OOB query params (``oobEnable=1``, stream fields, optional token).
+
+    The client derives ``wss://{serverIP}:{port}/oob/v1/ws`` from ``serverIP`` + ``port`` in the query
+    when ``oobEnable=1``.
+    """
+    cfg = stream_config or {}
+    if not cfg.get("serverIP") or cfg.get("port") is None:
+        raise ValueError(
+            "build_headset_bookmark_url requires stream_config with serverIP and port"
+        )
+    params: dict[str, str] = {"oobEnable": "1"}
+    if control_token:
+        params["controlToken"] = control_token
+    params["serverIP"] = str(cfg["serverIP"])
+    params["port"] = str(int(cfg["port"]))
+    v = cfg.get("codec")
+    if v is not None and str(v).strip() != "":
+        params["codec"] = str(v).strip()
+    v = cfg.get("panelHiddenAtStart")
+    if isinstance(v, bool):
+        params["panelHiddenAtStart"] = "true" if v else "false"
+    q = urlencode(params)
+    base = web_client_base.rstrip("/")
+    sep = "&" if "?" in base else "?"
+    return f"{base}{sep}{q}"
+
+
+def resolve_lan_host_for_oob() -> str:
+    """PC LAN address the headset uses for ``wss://…:PROXY_PORT`` over WiFi."""
+    h = os.environ.get("TELEOP_PROXY_HOST", "").strip() or guess_lan_ipv4()
+    if not h:
+        raise RuntimeError(
+            "--setup-oob needs this PC's LAN IP for WebXR/WSS URLs. "
+            "Set TELEOP_PROXY_HOST to an address the headset can reach over WiFi "
+            "(or fix routing so guess_lan_ipv4() works)."
+        )
+    return h
+
+
+def print_oob_hub_startup_banner(*, lan_host: str | None = None) -> None:
+    """Print operator instructions for OOB + USB adb automation."""
+    port = wss_proxy_port()
+    token = os.environ.get("CONTROL_TOKEN") or None
+
+    if not lan_host:
+        lan_host = resolve_lan_host_for_oob()
+    primary_host = lan_host
+
+    web_base = DEFAULT_WEB_CLIENT_ORIGIN
+    stream_cfg = default_initial_stream_config(port)
+    stream_cfg = {**stream_cfg, "serverIP": primary_host}
+
+    web_client_base_override = web_client_base_override_from_env()
+    if web_client_base_override:
+        web_base = web_client_base_override
+
+    stream_cfg = {**stream_cfg, **client_ui_fields_from_env()}
+
+    primary_base = f"https://{primary_host}:{port}"
+    bookmark_primary = build_headset_bookmark_url(
+        web_client_base=web_base,
+        stream_config=stream_cfg,
+        control_token=token,
+    )
+    wss_primary = f"wss://{primary_host}:{port}{OOB_WS_PATH}"
+
+    bar = "=" * 72
+    print(bar)
+    print("OOB TELEOP — enabled (out-of-band control hub is running in this WSS proxy)")
+    print(bar)
+    print()
+    print(
+        f"  The hub shares the CloudXR proxy TLS port {port} on this machine "
+        f"(control WebSocket: {wss_primary})."
+    )
+    print(
+        "  Same steps as docs: references/oob_teleop_control.rst — "
+        '"End-to-end workflow (the usual path)".'
+    )
+    print()
+    print(
+        "  adb: USB cable — headset connected via USB for adb; streaming and web page over WiFi."
+    )
+    print()
+    print("  Step 1 — Headset: Teleop page URL")
+    print(
+        '           After this process logs "WSS proxy listening on port …", `--setup-oob` runs '
+        "`adb` to open the page on the headset. If that fails, open this URL on the headset yourself:"
+    )
+    print(f"           {bookmark_primary}")
+    if web_client_base_override:
+        print(
+            f"           ({TELEOP_WEB_CLIENT_BASE_ENV} overrides the WebXR origin; "
+            "query still targets this streaming host.)"
+        )
+    print()
+    print("  Step 2 — This PC: Inspect from the PC (Chrome remote debugging)")
+    print(f"           Open {CHROME_INSPECT_DEVICES_URL}")
+    print(
+        "           Under Remote Target, select the headset tab for Isaac Teleop Web Client "
+        "(or the matching URL) and click inspect."
+    )
+    print()
+    print("  Step 3 — This PC: CONNECT (required WebXR user gesture)")
+    print(
+        "           In that DevTools window, click CONNECT on the Teleop UI (same as tapping "
+        "CONNECT on the headset)."
+    )
+    print()
+    print("-" * 72)
+    print("OOB HTTP (optional — operators / curl / scripts on this PC)")
+    print("-" * 72)
+    cfg_q = urlencode(
+        {
+            "serverIP": str(stream_cfg["serverIP"]),
+            "port": str(int(stream_cfg["port"])),
+        }
+    )
+    print(f"  State:  {primary_base}/api/oob/v1/state")
+    print(f"  Config: {primary_base}/api/oob/v1/config?{cfg_q}")
+    if token:
+        print()
+        print(
+            "  CONTROL_TOKEN is set: add ?token=... or header X-Control-Token on OOB HTTP requests."
+        )
+    print(bar)
+    print()

--- a/src/core/cloudxr/python/oob_teleop_env.py
+++ b/src/core/cloudxr/python/oob_teleop_env.py
@@ -25,11 +25,25 @@ def web_client_base_override_from_env() -> str | None:
     return v or None
 
 
+def parse_env_port(env_var: str, raw: str) -> int:
+    """Parse and validate a port string from an environment variable."""
+    try:
+        port = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"{env_var}={raw!r} is not a valid integer; "
+            f"set it to a port number (1–65535) or unset it to use the default."
+        ) from None
+    if not 1 <= port <= 65535:
+        raise ValueError(f"{env_var}={port} is out of range; must be 1–65535.")
+    return port
+
+
 def wss_proxy_port() -> int:
     """TCP port for the WSS proxy (``PROXY_PORT`` environment variable if set, else ``48322``)."""
     raw = os.environ.get("PROXY_PORT", "").strip()
     if raw:
-        return int(raw)
+        return parse_env_port("PROXY_PORT", raw)
     return WSS_PROXY_DEFAULT_PORT
 
 
@@ -52,7 +66,11 @@ def default_initial_stream_config(resolved_proxy_port: int) -> dict:
     env_ip = os.environ.get("TELEOP_STREAM_SERVER_IP", "").strip()
     env_port = os.environ.get("TELEOP_STREAM_PORT", "").strip()
     server_ip = env_ip or guess_lan_ipv4() or "127.0.0.1"
-    port = int(env_port) if env_port else resolved_proxy_port
+    port = (
+        parse_env_port("TELEOP_STREAM_PORT", env_port)
+        if env_port
+        else resolved_proxy_port
+    )
     return {"serverIP": server_ip, "port": port}
 
 
@@ -139,11 +157,13 @@ def print_oob_hub_startup_banner(*, lan_host: str | None = None) -> None:
     stream_cfg = {**stream_cfg, **client_ui_fields_from_env()}
 
     primary_base = f"https://{primary_host}:{port}"
-    bookmark_primary = build_headset_bookmark_url(
+    bookmark_display = build_headset_bookmark_url(
         web_client_base=web_base,
         stream_config=stream_cfg,
-        control_token=token,
+        control_token=None,
     )
+    if token:
+        bookmark_display += "&controlToken=<REDACTED>"
     wss_primary = f"wss://{primary_host}:{port}{OOB_WS_PATH}"
 
     bar = "=" * 72
@@ -164,30 +184,26 @@ def print_oob_hub_startup_banner(*, lan_host: str | None = None) -> None:
         "  adb: USB cable — headset connected via USB for adb; streaming and web page over WiFi."
     )
     print()
-    print("  Step 1 — Headset: Teleop page URL")
+    print("  Step 1 — Open teleop page on headset (adb)")
     print(
-        '           After this process logs "WSS proxy listening on port …", `--setup-oob` runs '
-        "`adb` to open the page on the headset. If that fails, open this URL on the headset yourself:"
+        '           After "WSS proxy listening on port …", `--setup-oob` runs '
+        "`adb` to open the page on the headset. If that fails, open this URL manually:"
     )
-    print(f"           {bookmark_primary}")
+    print(f"           {bookmark_display}")
     if web_client_base_override:
         print(
             f"           ({TELEOP_WEB_CLIENT_BASE_ENV} overrides the WebXR origin; "
             "query still targets this streaming host.)"
         )
     print()
-    print("  Step 2 — This PC: Inspect from the PC (Chrome remote debugging)")
-    print(f"           Open {CHROME_INSPECT_DEVICES_URL}")
+    print("  Step 2 — Accept cert + click CONNECT (CDP automation)")
+    print("           CDP automation will accept the self-signed certificate and click")
+    print("           CONNECT automatically via Chrome DevTools Protocol.")
     print(
-        "           Under Remote Target, select the headset tab for Isaac Teleop Web Client "
-        "(or the matching URL) and click inspect."
+        "           If it fails, fall back to manual: open "
+        f"{CHROME_INSPECT_DEVICES_URL},"
     )
-    print()
-    print("  Step 3 — This PC: CONNECT (required WebXR user gesture)")
-    print(
-        "           In that DevTools window, click CONNECT on the Teleop UI (same as tapping "
-        "CONNECT on the headset)."
-    )
+    print("           inspect the headset tab, and click CONNECT in DevTools.")
     print()
     print("-" * 72)
     print("OOB HTTP (optional — operators / curl / scripts on this PC)")

--- a/src/core/cloudxr/python/oob_teleop_hub.py
+++ b/src/core/cloudxr/python/oob_teleop_hub.py
@@ -234,10 +234,8 @@ class OOBControlHub:
                 ]
                 if not targets:
                     return ("missing", target_id)
-                # Targeted push: send merged snapshot without mutating global state.
                 return ("push", self._config_version, merged, targets)
 
-            # Global push: update shared config and version.
             self._stream_config = merged
             self._config_version += 1
             return (

--- a/src/core/cloudxr/python/oob_teleop_hub.py
+++ b/src/core/cloudxr/python/oob_teleop_hub.py
@@ -234,8 +234,10 @@ class OOBControlHub:
                 ]
                 if not targets:
                     return ("missing", target_id)
+                # Targeted push: send merged snapshot without mutating global state.
                 return ("push", self._config_version, merged, targets)
 
+            # Global push: update shared config and version.
             self._stream_config = merged
             self._config_version += 1
             return (

--- a/src/core/cloudxr/python/wss.py
+++ b/src/core/cloudxr/python/wss.py
@@ -16,38 +16,18 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
-import socket
-
 from .env_config import get_env_config
+from .oob_teleop_adb import (
+    adb_automation_failure_hint,
+    oob_adb_automation_message,
+    run_adb_headset_bookmark,
+)
+from .oob_teleop_env import (
+    client_ui_fields_from_env,
+    default_initial_stream_config,
+    wss_proxy_port,
+)
 from .oob_teleop_hub import OOB_WS_PATH
-
-WSS_PROXY_DEFAULT_PORT = 48322
-
-
-def _wss_proxy_port() -> int:
-    raw = os.environ.get("PROXY_PORT", "").strip()
-    return int(raw) if raw else WSS_PROXY_DEFAULT_PORT
-
-
-def _guess_lan_ipv4() -> str | None:
-    try:
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-            s.settimeout(0.25)
-            s.connect(("192.0.2.1", 1))
-            addr, _ = s.getsockname()
-    except OSError:
-        return None
-    return None if not addr or addr == "127.0.0.1" else addr
-
-
-def _default_initial_config(proxy_port: int) -> dict:
-    server_ip = (
-        os.environ.get("TELEOP_STREAM_SERVER_IP", "").strip()
-        or _guess_lan_ipv4()
-        or "127.0.0.1"
-    )
-    return {"serverIP": server_ip, "port": proxy_port}
-
 
 try:
     import websockets
@@ -469,7 +449,8 @@ async def run(
     logger.addHandler(_handler)
 
     try:
-        resolved_port = _wss_proxy_port() if proxy_port is None else proxy_port
+        resolved_port = wss_proxy_port() if proxy_port is None else proxy_port
+
         logging.getLogger("websockets").setLevel(logging.WARNING)
         cert_paths = default_cert_paths()
 
@@ -481,7 +462,10 @@ async def run(
             from .oob_teleop_hub import OOBControlHub  # noqa: PLC0415
 
             control_token = os.environ.get("CONTROL_TOKEN") or None
-            initial = _default_initial_config(resolved_port)
+            initial = {
+                **default_initial_stream_config(resolved_port),
+                **client_ui_fields_from_env(),
+            }
             hub = OOBControlHub(control_token=control_token, initial_config=initial)
             log.info(
                 "Teleop control hub enabled (token=%s) OOB_WS=%s initial_stream=%s",
@@ -513,6 +497,21 @@ async def run(
             close_timeout=10,
         ):
             log.info("WSS proxy listening on port %d", resolved_port)
+            if setup_oob:
+                rc, adb_diag = await asyncio.to_thread(
+                    run_adb_headset_bookmark,
+                    resolved_port=resolved_port,
+                )
+                if rc != 0:
+                    hint = adb_automation_failure_hint(adb_diag)
+                    detail = adb_diag if adb_diag else ""
+                    msg = oob_adb_automation_message(rc, detail, hint)
+                    log.warning("ADB bookmark failed (non-fatal): %s", msg)
+                    print(
+                        f"\n\033[33mADB automation failed — open the teleop URL on the headset manually.\033[0m\n"
+                        f"{msg}\n",
+                        file=sys.stderr,
+                    )
             await stop_future
             log.info("Shutting down ...")
     except OSError as e:

--- a/src/core/cloudxr/python/wss.py
+++ b/src/core/cloudxr/python/wss.py
@@ -18,9 +18,8 @@ from pathlib import Path
 
 from .env_config import get_env_config
 from .oob_teleop_adb import (
-    adb_automation_failure_hint,
-    oob_adb_automation_message,
-    run_adb_headset_bookmark,
+    OobAdbError,
+    run_oob_connect,
 )
 from .oob_teleop_env import (
     client_ui_fields_from_env,
@@ -447,6 +446,11 @@ async def run(
         _handler = logging.StreamHandler(sys.stderr)
     _handler.setFormatter(_log_fmt)
     logger.addHandler(_handler)
+    # Route oob-teleop-adb logs (ADB/CDP automation) to the same destination
+    _adb_log = logging.getLogger("oob-teleop-adb")
+    _adb_log.setLevel(logging.INFO)
+    _adb_log.propagate = False
+    _adb_log.addHandler(_handler)
 
     try:
         resolved_port = wss_proxy_port() if proxy_port is None else proxy_port
@@ -498,18 +502,19 @@ async def run(
         ):
             log.info("WSS proxy listening on port %d", resolved_port)
             if setup_oob:
-                rc, adb_diag = await asyncio.to_thread(
-                    run_adb_headset_bookmark,
-                    resolved_port=resolved_port,
-                )
-                if rc != 0:
-                    hint = adb_automation_failure_hint(adb_diag)
-                    detail = adb_diag if adb_diag else ""
-                    msg = oob_adb_automation_message(rc, detail, hint)
-                    log.warning("ADB bookmark failed (non-fatal): %s", msg)
+                log.info("Starting OOB ADB+CDP automation")
+                try:
+                    await run_oob_connect(resolved_port=resolved_port)
+                    log.info("OOB automation completed — CONNECT clicked")
+                except OobAdbError as err:
+                    log.warning("OOB automation failed (non-fatal): %s", err)
+                    print(f"\n\033[33m{err}\033[0m\n", file=sys.stderr)
+                except Exception as err:
+                    log.warning(
+                        "OOB automation failed (non-fatal): %s", err, exc_info=True
+                    )
                     print(
-                        f"\n\033[33mADB automation failed — open the teleop URL on the headset manually.\033[0m\n"
-                        f"{msg}\n",
+                        "\n\033[33mOOB automation error — tap CONNECT on the headset manually.\033[0m\n",
                         file=sys.stderr,
                     )
             await stop_future

--- a/src/core/cloudxr_tests/python/conftest.py
+++ b/src/core/cloudxr_tests/python/conftest.py
@@ -1,13 +1,47 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Make CloudXR python sources importable without installing ``isaacteleop``."""
+"""Make CloudXR python sources importable without installing ``isaacteleop``.
+
+* Flat ``sys.path`` entry: ``from oob_teleop_hub import …`` (no relative imports).
+* Synthetic package ``cloudxr_py_test_ns``: ``from cloudxr_py_test_ns.oob_teleop_env import …``
+  so modules that use sibling relative imports load correctly.
+"""
 
 from __future__ import annotations
 
+import importlib.util
 import sys
+import types
 from pathlib import Path
 
 _CLOUDXR_PY = Path(__file__).resolve().parents[2] / "cloudxr" / "python"
 if _CLOUDXR_PY.is_dir() and str(_CLOUDXR_PY) not in sys.path:
     sys.path.insert(0, str(_CLOUDXR_PY))
+
+CLOUDXR_TEST_PKG = "cloudxr_py_test_ns"
+
+
+def _ensure_cloudxr_package() -> None:
+    if CLOUDXR_TEST_PKG in sys.modules:
+        return
+    pkg = types.ModuleType(CLOUDXR_TEST_PKG)
+    pkg.__path__ = [str(_CLOUDXR_PY)]
+    sys.modules[CLOUDXR_TEST_PKG] = pkg
+
+    def load(mod: str) -> None:
+        full = f"{CLOUDXR_TEST_PKG}.{mod}"
+        path = _CLOUDXR_PY / f"{mod}.py"
+        spec = importlib.util.spec_from_file_location(full, path)
+        assert spec and spec.loader
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[full] = module
+        spec.loader.exec_module(module)
+        setattr(sys.modules[CLOUDXR_TEST_PKG], mod, module)
+
+    load("oob_teleop_hub")
+    load("oob_teleop_env")
+    load("oob_teleop_adb")
+
+
+_ensure_cloudxr_package()

--- a/src/core/cloudxr_tests/python/test_oob_teleop_adb.py
+++ b/src/core/cloudxr_tests/python/test_oob_teleop_adb.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for :mod:`oob_teleop_adb` (hints, device validation, bookmark automation with mocked subprocess)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cloudxr_py_test_ns.oob_teleop_adb import (
+    OobAdbError,
+    adb_automation_failure_hint,
+    assert_exactly_one_adb_device,
+    oob_adb_automation_message,
+    require_adb_on_path,
+    run_adb_headset_bookmark,
+)
+
+
+@pytest.mark.parametrize(
+    "diag,needle",
+    [
+        ("device unauthorized", "unauthorized"),
+        ("no devices/emulators found", "No adb device"),
+        ("device not found", "No adb device"),
+        ("more than one device or emulator", "Multiple adb devices"),
+        ("device offline", "offline"),
+    ],
+)
+def test_adb_automation_failure_hint(diag: str, needle: str) -> None:
+    hint = adb_automation_failure_hint(diag)
+    assert needle.lower() in hint.lower()
+
+
+def test_adb_automation_failure_hint_unknown() -> None:
+    assert adb_automation_failure_hint("unknown error") == ""
+
+
+def test_oob_adb_automation_message() -> None:
+    msg = oob_adb_automation_message(1, "device offline", "Device offline hint.")
+    assert "exit code 1" in msg
+    assert "device offline" in msg
+    assert "Device offline hint." in msg
+    assert "omit --setup-oob" in msg
+
+
+def test_oob_adb_automation_message_empty_detail() -> None:
+    msg = oob_adb_automation_message(2, "", "")
+    assert "no output from adb" in msg
+
+
+@patch("cloudxr_py_test_ns.oob_teleop_adb.shutil.which", return_value="/usr/bin/adb")
+def test_require_adb_on_path_found(mock_which: MagicMock) -> None:
+    require_adb_on_path()
+
+
+@patch("cloudxr_py_test_ns.oob_teleop_adb.shutil.which", return_value=None)
+def test_require_adb_on_path_missing(mock_which: MagicMock) -> None:
+    with pytest.raises(OobAdbError, match="not found on PATH"):
+        require_adb_on_path()
+
+
+@patch("cloudxr_py_test_ns.oob_teleop_adb.subprocess.run")
+def test_assert_exactly_one_adb_device_zero_raises(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout="List of devices attached\n\n",
+        stderr="",
+    )
+    with pytest.raises(OobAdbError, match="No adb device"):
+        assert_exactly_one_adb_device()
+
+
+@patch("cloudxr_py_test_ns.oob_teleop_adb.subprocess.run")
+def test_assert_exactly_one_adb_device_one(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout="List of devices attached\nABC123\tdevice\n\n",
+        stderr="",
+    )
+    assert_exactly_one_adb_device()
+
+
+@patch("cloudxr_py_test_ns.oob_teleop_adb.subprocess.run")
+def test_assert_exactly_one_adb_device_two_raises(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout=("List of devices attached\nABC123\tdevice\nDEF456\tdevice\n\n"),
+        stderr="",
+    )
+    with pytest.raises(OobAdbError, match="Too many"):
+        assert_exactly_one_adb_device()
+
+
+@patch("cloudxr_py_test_ns.oob_teleop_adb.subprocess.run")
+def test_assert_exactly_one_ignores_unauthorized(mock_run: MagicMock) -> None:
+    mock_run.return_value = MagicMock(
+        returncode=0,
+        stdout=("List of devices attached\nABC123\tdevice\nDEF456\tunauthorized\n\n"),
+        stderr="",
+    )
+    assert_exactly_one_adb_device()
+
+
+@patch("cloudxr_py_test_ns.oob_teleop_adb.subprocess.run")
+@patch(
+    "cloudxr_py_test_ns.oob_teleop_adb.resolve_lan_host_for_oob",
+    return_value="10.0.0.1",
+)
+def test_run_adb_headset_bookmark_success(
+    mock_lan: MagicMock, mock_run: MagicMock
+) -> None:
+    mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+    rc, diag = run_adb_headset_bookmark(resolved_port=48322)
+    assert rc == 0
+    assert diag == ""
+    args = mock_run.call_args[0][0]
+    assert args[0] == "adb"
+    assert args[1] == "shell"
+    assert "am start" in args[2]
+
+
+@patch("cloudxr_py_test_ns.oob_teleop_adb.subprocess.run")
+@patch(
+    "cloudxr_py_test_ns.oob_teleop_adb.resolve_lan_host_for_oob",
+    return_value="10.0.0.1",
+)
+def test_run_adb_headset_bookmark_failure(
+    mock_lan: MagicMock, mock_run: MagicMock
+) -> None:
+    mock_run.return_value = MagicMock(
+        returncode=1, stdout="", stderr="no devices/emulators found"
+    )
+    rc, diag = run_adb_headset_bookmark(resolved_port=48322)
+    assert rc == 1
+    assert "no devices" in diag

--- a/src/core/cloudxr_tests/python/test_oob_teleop_env.py
+++ b/src/core/cloudxr_tests/python/test_oob_teleop_env.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for :mod:`oob_teleop_env` (bookmark URLs, env-driven defaults, LAN helpers)."""
+
+from __future__ import annotations
+
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from cloudxr_py_test_ns.oob_teleop_env import (
+    TELEOP_WEB_CLIENT_BASE_ENV,
+    WSS_PROXY_DEFAULT_PORT,
+    build_headset_bookmark_url,
+    client_ui_fields_from_env,
+    default_initial_stream_config,
+    guess_lan_ipv4,
+    print_oob_hub_startup_banner,
+    resolve_lan_host_for_oob,
+    web_client_base_override_from_env,
+    wss_proxy_port,
+)
+from cloudxr_py_test_ns.oob_teleop_hub import OOB_WS_PATH
+
+
+@pytest.fixture
+def clear_teleop_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    keys = (
+        "PROXY_PORT",
+        "TELEOP_STREAM_SERVER_IP",
+        "TELEOP_STREAM_PORT",
+        "TELEOP_CLIENT_CODEC",
+        "TELEOP_CLIENT_PANEL_HIDDEN_AT_START",
+        "TELEOP_WEB_CLIENT_BASE",
+        "TELEOP_PROXY_HOST",
+        "CONTROL_TOKEN",
+    )
+    for k in keys:
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_wss_proxy_port_default(clear_teleop_env: None) -> None:
+    assert wss_proxy_port() == WSS_PROXY_DEFAULT_PORT
+
+
+def test_wss_proxy_port_from_env(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("PROXY_PORT", "50000")
+    assert wss_proxy_port() == 50000
+
+
+def test_web_client_base_override_from_env(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    assert web_client_base_override_from_env() is None
+    monkeypatch.setenv(TELEOP_WEB_CLIENT_BASE_ENV, "  https://example.test/app  ")
+    assert web_client_base_override_from_env() == "https://example.test/app"
+
+
+def test_build_headset_bookmark_url_minimal() -> None:
+    u = build_headset_bookmark_url(
+        web_client_base="https://h.test/",
+        stream_config={"serverIP": "10.0.0.1", "port": 48322},
+    )
+    assert urlparse(u).hostname == "h.test"
+    q = parse_qs(urlparse(u).query)
+    assert q["oobEnable"] == ["1"]
+    assert q["serverIP"] == ["10.0.0.1"]
+    assert q["port"] == ["48322"]
+
+
+def test_build_headset_bookmark_url_with_token() -> None:
+    u = build_headset_bookmark_url(
+        web_client_base="https://h.test/",
+        stream_config={"serverIP": "10.0.0.1", "port": 48322},
+        control_token="secret123",
+    )
+    q = parse_qs(urlparse(u).query)
+    assert q["controlToken"] == ["secret123"]
+
+
+def test_build_headset_bookmark_url_with_codec() -> None:
+    u = build_headset_bookmark_url(
+        web_client_base="https://h.test/",
+        stream_config={"serverIP": "10.0.0.1", "port": 48322, "codec": "av1"},
+    )
+    q = parse_qs(urlparse(u).query)
+    assert q["codec"] == ["av1"]
+
+
+def test_build_headset_bookmark_url_panel_hidden() -> None:
+    u = build_headset_bookmark_url(
+        web_client_base="https://h.test/",
+        stream_config={
+            "serverIP": "10.0.0.1",
+            "port": 48322,
+            "panelHiddenAtStart": True,
+        },
+    )
+    q = parse_qs(urlparse(u).query)
+    assert q["panelHiddenAtStart"] == ["true"]
+
+
+def test_build_headset_bookmark_url_requires_server_ip() -> None:
+    with pytest.raises(ValueError, match="serverIP"):
+        build_headset_bookmark_url(
+            web_client_base="https://h.test/",
+            stream_config={"port": 48322},
+        )
+
+
+def test_client_ui_fields_from_env_empty(clear_teleop_env: None) -> None:
+    assert client_ui_fields_from_env() == {}
+
+
+def test_client_ui_fields_from_env_codec(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TELEOP_CLIENT_CODEC", "h265")
+    fields = client_ui_fields_from_env()
+    assert fields["codec"] == "h265"
+
+
+def test_client_ui_fields_from_env_panel_hidden(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TELEOP_CLIENT_PANEL_HIDDEN_AT_START", "true")
+    fields = client_ui_fields_from_env()
+    assert fields["panelHiddenAtStart"] is True
+
+
+def test_default_initial_stream_config_defaults(clear_teleop_env: None) -> None:
+    cfg = default_initial_stream_config(48322)
+    assert cfg["port"] == 48322
+    assert "serverIP" in cfg
+
+
+def test_default_initial_stream_config_env_override(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TELEOP_STREAM_SERVER_IP", "10.0.0.99")
+    monkeypatch.setenv("TELEOP_STREAM_PORT", "50000")
+    cfg = default_initial_stream_config(48322)
+    assert cfg["serverIP"] == "10.0.0.99"
+    assert cfg["port"] == 50000
+
+
+def test_resolve_lan_host_from_env(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TELEOP_PROXY_HOST", "10.0.0.42")
+    assert resolve_lan_host_for_oob() == "10.0.0.42"
+
+
+def test_guess_lan_ipv4_returns_string_or_none() -> None:
+    result = guess_lan_ipv4()
+    assert result is None or isinstance(result, str)
+
+
+def test_print_oob_hub_startup_banner(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setenv("TELEOP_PROXY_HOST", "10.0.0.1")
+    print_oob_hub_startup_banner(lan_host="10.0.0.1")
+    out = capsys.readouterr().out
+    assert "OOB TELEOP" in out
+    assert "10.0.0.1" in out
+    assert OOB_WS_PATH in out


### PR DESCRIPTION
Second phase PR on top of https://github.com/NVIDIA/IsaacTeleop/pull/388. This one adds ADB automation handling but still requires wifi or ethernet network.

Co-Authored-By: default avatar[Claude Sonnet 4.6](mailto:noreply@anthropic.com) <[noreply@anthropic.com](mailto:noreply@anthropic.com)>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added USB ADB automation for OOB teleop to automatically open the teleop interface on connected headsets
  * Added manual fallback option to open the client URL in-browser if ADB automation fails
  * Added environment variable support for teleop and web client configuration overrides

* **Documentation**
  * Enhanced OOB teleop control documentation with detailed setup instructions, ADB automation prerequisites, and environment variable configuration guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->