### PR TITLE
Wire up ExecutionEvents.reset in stateful retargeters

### DIFF
--- a/src/core/retargeting_engine_tests/python/pyproject.toml
+++ b/src/core/retargeting_engine_tests/python/pyproject.toml
@@ -12,12 +12,14 @@ dev = [
     "pytest",
     "mypy",
     "numpy",
+    "scipy",
     "types-PyYAML",
     "scipy-stubs",
 ]
 test = [
     "pytest",
     "numpy",
+    "scipy",
 ]
 
 [tool.pytest.ini_options]

--- a/src/core/retargeting_engine_tests/python/test_retargeter_reset.py
+++ b/src/core/retargeting_engine_tests/python/test_retargeter_reset.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for retargeter reset behaviour via ExecutionEvents.
+
+Verifies that stateful retargeters (GripperRetargeter,
+LocomotionRootCmdRetargeter, Se3AbsRetargeter, Se3RelRetargeter)
+correctly reinitialize their cross-step state when
+``context.execution_events.reset`` is True.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+from isaacteleop.retargeting_engine.interface import (
+    ComputeContext,
+    ExecutionEvents,
+    ExecutionState,
+    OptionalTensorGroup,
+    TensorGroup,
+)
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import GraphTime
+from isaacteleop.retargeting_engine.interface.tensor_group_type import (
+    OptionalTensorGroupType,
+)
+
+from isaacteleop.retargeters import (
+    GripperRetargeter,
+    GripperRetargeterConfig,
+    LocomotionRootCmdRetargeter,
+    LocomotionRootCmdRetargeterConfig,
+    Se3AbsRetargeter,
+    Se3RelRetargeter,
+    Se3RetargeterConfig,
+)
+
+
+def _make_context(*, reset: bool = False) -> ComputeContext:
+    return ComputeContext(
+        graph_time=GraphTime(sim_time_ns=0, real_time_ns=0),
+        execution_events=ExecutionEvents(
+            reset=reset, execution_state=ExecutionState.RUNNING
+        ),
+    )
+
+
+def _build_io(retargeter):
+    """Build inputs/outputs for a retargeter, using OptionalTensorGroup for optional specs."""
+    inputs = {}
+    for k, v in retargeter.input_spec().items():
+        if isinstance(v, OptionalTensorGroupType):
+            inputs[k] = OptionalTensorGroup(v)
+        else:
+            inputs[k] = TensorGroup(v)
+    outputs = {}
+    for k, v in retargeter.output_spec().items():
+        if isinstance(v, OptionalTensorGroupType):
+            outputs[k] = OptionalTensorGroup(v)
+        else:
+            outputs[k] = TensorGroup(v)
+    return inputs, outputs
+
+
+# ---------------------------------------------------------------------------
+# LocomotionRootCmdRetargeter
+# ---------------------------------------------------------------------------
+
+
+class TestLocomotionRootCmdRetargeterReset:
+    """LocomotionRootCmdRetargeter must restore initial_hip_height on reset."""
+
+    @pytest.fixture()
+    def retargeter(self):
+        cfg = LocomotionRootCmdRetargeterConfig(initial_hip_height=0.72)
+        return LocomotionRootCmdRetargeter(cfg, name="loco")
+
+    def test_reset_restores_hip_height(self, retargeter):
+        inputs, outputs = _build_io(retargeter)
+
+        retargeter._hip_height = 0.95
+
+        retargeter.compute(inputs, outputs, _make_context(reset=True))
+
+        cmd = np.from_dlpack(outputs["root_command"][0])
+        assert cmd[3] == pytest.approx(0.72), "hip_height should be reset to initial"
+
+    def test_no_reset_preserves_hip_height(self, retargeter):
+        inputs, outputs = _build_io(retargeter)
+
+        retargeter._hip_height = 0.95
+
+        retargeter.compute(inputs, outputs, _make_context(reset=False))
+
+        cmd = np.from_dlpack(outputs["root_command"][0])
+        assert cmd[3] == pytest.approx(0.95), (
+            "hip_height should not change without reset"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Se3AbsRetargeter
+# ---------------------------------------------------------------------------
+
+
+class TestSe3AbsRetargeterReset:
+    """Se3AbsRetargeter must reinitialize _last_pose on reset."""
+
+    @pytest.fixture()
+    def retargeter(self):
+        cfg = Se3RetargeterConfig(input_device="controller_right")
+        return Se3AbsRetargeter(cfg, name="se3abs")
+
+    def test_reset_clears_last_pose(self, retargeter):
+        """After reset with no input, output should be identity pose."""
+        inputs, outputs = _build_io(retargeter)
+
+        retargeter._last_pose = np.array(
+            [1.0, 2.0, 3.0, 0.5, 0.5, 0.5, 0.5], dtype=np.float32
+        )
+
+        retargeter.compute(inputs, outputs, _make_context(reset=True))
+
+        pose = np.from_dlpack(outputs["ee_pose"][0])
+        identity = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0], dtype=np.float32)
+        npt.assert_array_almost_equal(pose, identity)
+
+    def test_no_reset_returns_stale_pose(self, retargeter):
+        """Without reset and no input, output should be the stale _last_pose."""
+        inputs, outputs = _build_io(retargeter)
+
+        stale = np.array([1.0, 2.0, 3.0, 0.5, 0.5, 0.5, 0.5], dtype=np.float32)
+        retargeter._last_pose = stale.copy()
+
+        retargeter.compute(inputs, outputs, _make_context(reset=False))
+
+        pose = np.from_dlpack(outputs["ee_pose"][0])
+        npt.assert_array_almost_equal(pose, stale)
+
+
+# ---------------------------------------------------------------------------
+# Se3RelRetargeter
+# ---------------------------------------------------------------------------
+
+
+class TestSe3RelRetargeterReset:
+    """Se3RelRetargeter must reinitialize all cross-step state on reset."""
+
+    @pytest.fixture()
+    def retargeter(self):
+        cfg = Se3RetargeterConfig(input_device="controller_right")
+        return Se3RelRetargeter(cfg, name="se3rel")
+
+    def test_reset_restores_first_frame(self, retargeter):
+        retargeter._first_frame = False
+        retargeter._smoothed_delta_pos = np.array([1.0, 2.0, 3.0])
+        retargeter._smoothed_delta_rot = np.array([0.1, 0.2, 0.3])
+
+        inputs, outputs = _build_io(retargeter)
+        retargeter.compute(inputs, outputs, _make_context(reset=True))
+
+        assert retargeter._first_frame is True
+        npt.assert_array_equal(retargeter._smoothed_delta_pos, np.zeros(3))
+        npt.assert_array_equal(retargeter._smoothed_delta_rot, np.zeros(3))
+        assert retargeter._previous_thumb_tip is None
+        assert retargeter._previous_index_tip is None
+
+    def test_no_reset_preserves_state(self, retargeter):
+        stale_pos = np.array([1.0, 2.0, 3.0])
+        stale_rot = np.array([0.1, 0.2, 0.3])
+        stale_wrist = np.array([0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 1.0])
+
+        retargeter._first_frame = False
+        retargeter._smoothed_delta_pos = stale_pos.copy()
+        retargeter._smoothed_delta_rot = stale_rot.copy()
+        retargeter._previous_wrist = stale_wrist.copy()
+
+        inputs, outputs = _build_io(retargeter)
+        retargeter.compute(inputs, outputs, _make_context(reset=False))
+
+        assert retargeter._first_frame is False
+        npt.assert_array_equal(retargeter._smoothed_delta_pos, stale_pos)
+        npt.assert_array_equal(retargeter._smoothed_delta_rot, stale_rot)
+        npt.assert_array_equal(retargeter._previous_wrist, stale_wrist)
+
+
+# ---------------------------------------------------------------------------
+# GripperRetargeter
+# ---------------------------------------------------------------------------
+
+
+class TestGripperRetargeterReset:
+    """GripperRetargeter must restore _previous_gripper_command on reset."""
+
+    @pytest.fixture()
+    def retargeter(self):
+        cfg = GripperRetargeterConfig(hand_side="right")
+        return GripperRetargeter(cfg, name="gripper")
+
+    def test_reset_reopens_gripper(self, retargeter):
+        """After reset with no input, gripper should output open (1.0)."""
+        inputs, outputs = _build_io(retargeter)
+
+        retargeter._previous_gripper_command = True  # closed
+
+        retargeter.compute(inputs, outputs, _make_context(reset=True))
+
+        cmd = outputs["gripper_command"][0]
+        assert cmd == pytest.approx(1.0), "gripper should be open after reset"
+
+    def test_no_reset_preserves_closed_gripper(self, retargeter):
+        """Without reset, _previous_gripper_command stays True (closed)."""
+        inputs, outputs = _build_io(retargeter)
+
+        retargeter._previous_gripper_command = True  # closed
+
+        retargeter.compute(inputs, outputs, _make_context(reset=False))
+
+        assert retargeter._previous_gripper_command is True, (
+            "gripper state should stay closed without reset"
+        )

--- a/src/core/teleop_session_manager_tests/python/test_session_reset.py
+++ b/src/core/teleop_session_manager_tests/python/test_session_reset.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end tests for reset propagation through TeleopSession.
+
+Verifies that ``TeleopSession.step(execution_events=ExecutionEvents(reset=True))``
+correctly propagates the reset signal to stateful retargeters in a real pipeline
+(not mocked). All OpenXR/DeviceIO dependencies are patched out.
+"""
+
+import numpy as np
+import pytest
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+from isaacteleop.retargeting_engine.interface import (
+    ExecutionEvents,
+    ExecutionState,
+    OptionalTensorGroup,
+)
+
+from isaacteleop.retargeters import (
+    GripperRetargeter,
+    GripperRetargeterConfig,
+    LocomotionRootCmdRetargeter,
+    LocomotionRootCmdRetargeterConfig,
+)
+
+from isaacteleop.retargeting_engine.tensor_types import ControllerInput, HandInput
+from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+@contextmanager
+def _mock_session_deps():
+    """Patch OpenXR/DeviceIO/PluginManager so TeleopSession.__enter__ works without hardware."""
+    mock_oxr = MagicMock()
+    mock_oxr.__enter__ = MagicMock(return_value=mock_oxr)
+    mock_oxr.__exit__ = MagicMock(return_value=False)
+    mock_oxr.get_handles.return_value = MagicMock()
+
+    mock_dio = MagicMock()
+    mock_dio.__enter__ = MagicMock(return_value=mock_dio)
+    mock_dio.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("isaacteleop.oxr.OpenXRSession", return_value=mock_oxr),
+        patch("isaacteleop.deviceio.DeviceIOSession.run", return_value=mock_dio),
+        patch(
+            "isaacteleop.deviceio.DeviceIOSession.get_required_extensions",
+            return_value=[],
+        ),
+        patch("isaacteleop.plugin_manager.PluginManager", return_value=MagicMock()),
+    ):
+        yield
+
+
+def _absent_controller_inputs():
+    """Return absent OptionalTensorGroups for both controller slots."""
+    return {
+        "controller_left": OptionalTensorGroup(ControllerInput()),
+        "controller_right": OptionalTensorGroup(ControllerInput()),
+    }
+
+
+def _absent_gripper_inputs(hand_side: str):
+    """Return absent OptionalTensorGroups for gripper retargeter inputs."""
+    inputs = {f"controller_{hand_side}": OptionalTensorGroup(ControllerInput())}
+    inputs[f"hand_{hand_side}"] = OptionalTensorGroup(HandInput())
+    return inputs
+
+
+def _running_events(*, reset: bool = False) -> ExecutionEvents:
+    return ExecutionEvents(reset=reset, execution_state=ExecutionState.RUNNING)
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+
+class TestSessionResetLocomotion:
+    """TeleopSession.step(execution_events=reset) resets LocomotionRootCmdRetargeter state."""
+
+    @pytest.fixture()
+    def retargeter(self):
+        return LocomotionRootCmdRetargeter(
+            LocomotionRootCmdRetargeterConfig(initial_hip_height=0.72),
+            name="loco",
+        )
+
+    def test_reset_restores_hip_height_via_session(self, retargeter):
+        """Hip height is restored to initial value when TeleopSession propagates reset."""
+        config = TeleopSessionConfig(
+            app_name="test_reset",
+            pipeline=retargeter,
+        )
+
+        with _mock_session_deps():
+            with TeleopSession(config) as session:
+                ext = {"loco": _absent_controller_inputs()}
+
+                # Run a step to establish baseline
+                session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(),
+                )
+
+                # Mutate state
+                retargeter._hip_height = 0.95
+
+                # Step with reset=True
+                result = session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(reset=True),
+                )
+
+                cmd = np.from_dlpack(result["root_command"][0])
+                assert cmd[3] == pytest.approx(0.72), (
+                    "hip_height should be restored to initial after reset"
+                )
+
+    def test_no_reset_preserves_state_via_session(self, retargeter):
+        """Hip height stays mutated when reset is not signalled."""
+        config = TeleopSessionConfig(
+            app_name="test_no_reset",
+            pipeline=retargeter,
+        )
+
+        with _mock_session_deps():
+            with TeleopSession(config) as session:
+                ext = {"loco": _absent_controller_inputs()}
+
+                session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(),
+                )
+
+                retargeter._hip_height = 0.95
+
+                result = session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(reset=False),
+                )
+
+                cmd = np.from_dlpack(result["root_command"][0])
+                assert cmd[3] == pytest.approx(0.95), (
+                    "hip_height should stay mutated without reset"
+                )
+
+
+class TestSessionResetGripper:
+    """TeleopSession.step(execution_events=reset) resets GripperRetargeter state."""
+
+    @pytest.fixture()
+    def retargeter(self):
+        return GripperRetargeter(
+            GripperRetargeterConfig(hand_side="right"),
+            name="gripper",
+        )
+
+    def test_reset_reopens_gripper_via_session(self, retargeter):
+        """Gripper outputs open (1.0) after session-level reset."""
+        config = TeleopSessionConfig(
+            app_name="test_gripper_reset",
+            pipeline=retargeter,
+        )
+
+        with _mock_session_deps():
+            with TeleopSession(config) as session:
+                ext = {"gripper": _absent_gripper_inputs("right")}
+
+                session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(),
+                )
+
+                # Close the gripper
+                retargeter._previous_gripper_command = True
+
+                # Reset via session
+                result = session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(reset=True),
+                )
+
+                cmd = result["gripper_command"][0]
+                assert cmd == pytest.approx(1.0), (
+                    "gripper should be open after session-level reset"
+                )
+
+    def test_no_reset_keeps_gripper_closed_via_session(self, retargeter):
+        """Gripper internal state stays closed when reset is not signalled."""
+        config = TeleopSessionConfig(
+            app_name="test_gripper_no_reset",
+            pipeline=retargeter,
+        )
+
+        with _mock_session_deps():
+            with TeleopSession(config) as session:
+                ext = {"gripper": _absent_gripper_inputs("right")}
+
+                session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(),
+                )
+
+                retargeter._previous_gripper_command = True
+
+                session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(reset=False),
+                )
+
+                assert retargeter._previous_gripper_command is True, (
+                    "gripper state should stay closed without reset"
+                )

--- a/src/retargeters/gripper_retargeter.py
+++ b/src/retargeters/gripper_retargeter.py
@@ -82,6 +82,8 @@ class GripperRetargeter(BaseRetargeter):
 
     def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
         """Computes gripper command based on controller trigger (priority) or pinch distance (fallback)."""
+        if context.execution_events.reset:
+            self._previous_gripper_command = False
 
         gripper_out = outputs["gripper_command"]
 

--- a/src/retargeters/locomotion_retargeter.py
+++ b/src/retargeters/locomotion_retargeter.py
@@ -120,6 +120,9 @@ class LocomotionRootCmdRetargeter(BaseRetargeter):
 
     def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
         """Computes root command from controller inputs."""
+        if context.execution_events.reset:
+            self._hip_height = self._config.initial_hip_height
+
         left_thumbstick_x = 0.0
         left_thumbstick_y = 0.0
         right_thumbstick_x = 0.0

--- a/src/retargeters/se3_retargeter.py
+++ b/src/retargeters/se3_retargeter.py
@@ -205,6 +205,13 @@ class Se3AbsRetargeter(BaseRetargeter):
         }
 
     def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
+        if context.execution_events.reset:
+            # Clear to identity; no early return -- valid input arriving this
+            # frame can be processed immediately (no warmup required).
+            self._last_pose = np.array(
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0], dtype=np.float32
+            )
+
         ee_pose = outputs["ee_pose"]
         device_name = self._config.input_device
         inp = inputs[device_name]
@@ -333,6 +340,16 @@ class Se3RelRetargeter(BaseRetargeter):
         }
 
     def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
+        if context.execution_events.reset:
+            # Re-arm the first-frame path so the next input frame captures a
+            # fresh baseline and outputs zero deltas (natural one-frame warmup).
+            self._smoothed_delta_pos = np.zeros(3)
+            self._smoothed_delta_rot = np.zeros(3)
+            self._previous_wrist = np.array([0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0])
+            self._previous_thumb_tip = None
+            self._previous_index_tip = None
+            self._first_frame = True
+
         ee_delta = outputs["ee_delta"]
         device_name = self._config.input_device
         inp = inputs[device_name]


### PR DESCRIPTION
Handle context.execution_events.reset in all stateful retargeters (GripperRetargeter, LocomotionRootCmdRetargeter, Se3AbsRetargeter, Se3RelRetargeter) so cross-step state is reinitialized when the pipeline signals a reset.
Add bilateral tests (reset=True / reset=False) for each retargeter to verify sta

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit and end-to-end tests validating reset behavior across locomotion, absolute/relative pose, and gripper flows to ensure outputs reflect reset vs. non-reset scenarios.

* **Bug Fixes**
  * Improved reset handling so locomotion, pose (abs/rel), and gripper components reliably reinitialize state on system reset, yielding stable and predictable outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->