### PR TITLE
[Replay] Add McapTrackerViewers to read mcap file.

### DIFF
--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -111,12 +111,14 @@ private:
 };
 
 /**
- * @brief Type-safe MCAP channel reader for FlatBuffer record types.
+ * @brief Type-safe MCAP channel reader returning deserialized Tracked wrappers.
  *
- * @tparam RecordT   The FlatBuffer record wrapper type (e.g. HeadPoseRecord).
- *                   Must expose a data() accessor returning the FlatBuffer data table.
- * @tparam DataTableT The FlatBuffer data table type (e.g. HeadPose).
- *                   Must expose UnPackTo() and NativeTableType.
+ * @tparam RecordT       The FlatBuffer record wrapper stored in MCAP (e.g. HeadPoseRecord).
+ *                       Must expose a data() accessor returning the inner data table.
+ * @tparam DataTableT    The FlatBuffer data table type (e.g. HeadPose).
+ *                       Must expose UnPackTo() and NativeTableType.
+ * @tparam TrackedTableT The FlatBuffer tracked wrapper returned to callers
+ *                       (e.g. HeadPoseTracked). Must share the same data table as RecordT.
  *
  * Read-side counterpart to McapTrackerChannels. Takes an externally-owned
  * McapReader& and a list of sub-channel names, creating one LinearMessageView
@@ -124,38 +126,41 @@ private:
  * reads directly from the McapReader's data source without copying message data.
  * Callers pull deserialized records one at a time via read(channel_index).
  *
+ * Returning the Tracked native type mirrors the live tracker query API
+ * (e.g. HandTracker::get_left_hand returns HandPoseTrackedT&), keeping
+ * live and replay consumers type-compatible.
+ *
  * MCAP message data pointers are only valid until the iterator advances,
- * so read() fully deserializes each record into a shared_ptr before stepping
- * the iterator forward.
+ * so read() fully deserializes each record before stepping the iterator forward.
  */
-template <typename RecordT, typename DataTableT>
+template <typename RecordT, typename DataTableT, typename TrackedTableT>
 class McapTrackerViewers
 {
 public:
     using NativeDataT = typename DataTableT::NativeTableType;
+    using NativeTrackedT = typename TrackedTableT::NativeTableType;
 
     McapTrackerViewers(mcap::McapReader& reader, std::string_view base_name, const std::vector<std::string>& sub_channels)
         : reader_(&reader)
     {
         auto on_problem = [](const mcap::Status& s) { std::cerr << "McapTrackerViewers: " << s.message << std::endl; };
 
-        channels_.reserve(sub_channels.size());
         for (const auto& sub : sub_channels)
         {
             std::string topic = mcap_topic(base_name, sub);
             mcap::ReadMessageOptions options;
             options.topicFilter = [topic](std::string_view t) { return t == topic; };
-            channels_.emplace_back(reader_->readMessages(on_problem, options));
+            channels_.push_back(std::make_unique<ChannelView>(reader_->readMessages(on_problem, options)));
         }
     }
 
     /**
-     * @brief Read and deserialize the next data payload from the given channel.
+     * @brief Read and deserialize the next record as a Tracked wrapper.
      * @param channel_index Index into the sub_channels list passed at construction.
-     * @return shared_ptr to the deserialized data (null if the record had no data),
-     *         or std::nullopt when no more messages remain.
+     * @return The deserialized Tracked object (data member is null when the tracker
+     *         was inactive), or std::nullopt when no more messages remain.
      */
-    std::optional<std::shared_ptr<NativeDataT>> read(size_t channel_index)
+    std::optional<NativeTrackedT> read(size_t channel_index)
     {
         if (channel_index >= channels_.size())
         {
@@ -163,7 +168,7 @@ public:
                                     " but only " + std::to_string(channels_.size()) + " channels registered");
         }
 
-        auto& ch = channels_[channel_index];
+        auto& ch = *channels_[channel_index];
         if (ch.it == ch.view.end())
         {
             return std::nullopt;
@@ -171,18 +176,21 @@ public:
 
         auto* fb_record = flatbuffers::GetRoot<RecordT>(ch.it->message.data);
 
-        std::shared_ptr<NativeDataT> data;
+        NativeTrackedT tracked;
         if (fb_record->data())
         {
-            data = std::make_shared<NativeDataT>();
-            fb_record->data()->UnPackTo(data.get());
+            tracked.data = std::make_unique<NativeDataT>();
+            fb_record->data()->UnPackTo(tracked.data.get());
         }
 
         ++ch.it;
-        return data;
+        return tracked;
     }
 
 private:
+    // ChannelView stores an iterator (`it`) that points into its own `view`.
+    // Held via unique_ptr so that vector reallocation never moves the object,
+    // keeping the self-referential iterator valid.
     struct ChannelView
     {
         mcap::LinearMessageView view;
@@ -194,7 +202,7 @@ private:
     };
 
     mcap::McapReader* reader_;
-    std::vector<ChannelView> channels_;
+    std::vector<std::unique_ptr<ChannelView>> channels_;
 };
 
 } // namespace core

--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -111,14 +111,10 @@ private:
 };
 
 /**
- * @brief Type-safe MCAP channel reader returning deserialized Tracked wrappers.
+ * @brief Type-safe MCAP channel reader returning deserialized Record native types.
  *
- * @tparam RecordT       The FlatBuffer record wrapper stored in MCAP (e.g. HeadPoseRecord).
- *                       Must expose a data() accessor returning the inner data table.
- * @tparam DataTableT    The FlatBuffer data table type (e.g. HeadPose).
- *                       Must expose UnPackTo() and NativeTableType.
- * @tparam TrackedTableT The FlatBuffer tracked wrapper returned to callers
- *                       (e.g. HeadPoseTracked). Must share the same data table as RecordT.
+ * @tparam RecordT The FlatBuffer record wrapper stored in MCAP (e.g. HeadPoseRecord).
+ *                 Must expose NativeTableType with UnPackTo().
  *
  * Read-side counterpart to McapTrackerChannels. Takes an externally-owned
  * McapReader& and a list of sub-channel names, creating one LinearMessageView
@@ -126,19 +122,14 @@ private:
  * reads directly from the McapReader's data source without copying message data.
  * Callers pull deserialized records one at a time via read(channel_index).
  *
- * Returning the Tracked native type mirrors the live tracker query API
- * (e.g. HandTracker::get_left_hand returns HandPoseTrackedT&), keeping
- * live and replay consumers type-compatible.
- *
  * MCAP message data pointers are only valid until the iterator advances,
  * so read() fully deserializes each record before stepping the iterator forward.
  */
-template <typename RecordT, typename DataTableT, typename TrackedTableT>
+template <typename RecordT>
 class McapTrackerViewers
 {
 public:
-    using NativeDataT = typename DataTableT::NativeTableType;
-    using NativeTrackedT = typename TrackedTableT::NativeTableType;
+    using NativeRecordT = typename RecordT::NativeTableType;
 
     McapTrackerViewers(mcap::McapReader& reader, std::string_view base_name, const std::vector<std::string>& sub_channels)
         : reader_(&reader)
@@ -155,12 +146,12 @@ public:
     }
 
     /**
-     * @brief Read and deserialize the next record as a Tracked wrapper.
+     * @brief Read and deserialize the next record.
      * @param channel_index Index into the sub_channels list passed at construction.
-     * @return The deserialized Tracked object (data member is null when the tracker
+     * @return The deserialized Record (data member is null when the tracker
      *         was inactive), or std::nullopt when no more messages remain.
      */
-    std::optional<NativeTrackedT> read(size_t channel_index)
+    std::optional<NativeRecordT> read(size_t channel_index)
     {
         if (channel_index >= channels_.size())
         {
@@ -175,16 +166,11 @@ public:
         }
 
         auto* fb_record = flatbuffers::GetRoot<RecordT>(ch.it->message.data);
-
-        NativeTrackedT tracked;
-        if (fb_record->data())
-        {
-            tracked.data = std::make_unique<NativeDataT>();
-            fb_record->data()->UnPackTo(tracked.data.get());
-        }
+        NativeRecordT record;
+        fb_record->UnPackTo(&record);
 
         ++ch.it;
-        return tracked;
+        return record;
     }
 
 private:

--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
 #include <flatbuffers/flatbuffers.h>
+#include <mcap/reader.hpp>
 #include <mcap/writer.hpp>
 #include <schema/timestamp_generated.h>
 
@@ -11,6 +12,7 @@
 #include <cstdint>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <string_view>
@@ -101,6 +103,100 @@ private:
     mcap::McapWriter* writer_;
     std::vector<mcap::ChannelId> channel_ids_;
     uint32_t sequence_ = 0;
+};
+
+/**
+ * @brief Type-safe MCAP channel reader for FlatBuffer record types.
+ *
+ * @tparam RecordT   The FlatBuffer record wrapper type (e.g. HeadPoseRecord).
+ *                   Must expose a data() accessor returning the FlatBuffer data table.
+ * @tparam DataTableT The FlatBuffer data table type (e.g. HeadPose).
+ *                   Must expose UnPackTo() and NativeTableType.
+ *
+ * Read-side counterpart to McapTrackerChannels. Takes an externally-owned
+ * McapReader& and a list of sub-channel names, creating one LinearMessageView
+ * per channel. Each LinearMessageView is a lightweight, non-owning view that
+ * reads directly from the McapReader's data source without copying message data.
+ * Callers pull deserialized records one at a time via read(channel_index).
+ *
+ * MCAP message data pointers are only valid until the iterator advances,
+ * so read() fully deserializes each record into a shared_ptr before stepping
+ * the iterator forward.
+ */
+template <typename RecordT, typename DataTableT>
+class McapTrackerViewers
+{
+public:
+    using NativeDataT = typename DataTableT::NativeTableType;
+
+    McapTrackerViewers(mcap::McapReader& reader,
+                       std::string_view base_name,
+                       const std::vector<std::string>& sub_channels)
+        : reader_(&reader)
+    {
+        auto on_problem = [](const mcap::Status& s) {
+            std::cerr << "McapTrackerViewers: " << s.message << std::endl;
+        };
+
+        channels_.reserve(sub_channels.size());
+        for (const auto& sub : sub_channels)
+        {
+            std::string topic = std::string(base_name) + "/" + sub;
+            mcap::ReadMessageOptions options;
+            options.topicFilter = [topic](std::string_view t) { return t == topic; };
+            channels_.emplace_back(reader_->readMessages(on_problem, options));
+        }
+    }
+
+    /**
+     * @brief Read and deserialize the next data payload from the given channel.
+     * @param channel_index Index into the sub_channels list passed at construction.
+     * @return shared_ptr to the deserialized data (null if the record had no data),
+     *         or std::nullopt when no more messages remain.
+     */
+    std::optional<std::shared_ptr<NativeDataT>> read(size_t channel_index)
+    {
+        if (channel_index >= channels_.size())
+        {
+            throw std::out_of_range(
+                "McapTrackerViewers: read called with channel_index=" + std::to_string(channel_index) + " but only " +
+                std::to_string(channels_.size()) + " channels registered");
+        }
+
+        auto& ch = channels_[channel_index];
+        if (ch.it == ch.view.end())
+        {
+            return std::nullopt;
+        }
+
+        auto* fb_record = flatbuffers::GetRoot<RecordT>(ch.it->message.data);
+
+        std::shared_ptr<NativeDataT> data;
+        if (fb_record->data())
+        {
+            data = std::make_shared<NativeDataT>();
+            fb_record->data()->UnPackTo(data.get());
+        }
+
+        ++ch.it;
+        return data;
+    }
+
+private:
+    struct ChannelView
+    {
+        mcap::LinearMessageView view;
+        mcap::LinearMessageView::Iterator it;
+
+        explicit ChannelView(mcap::LinearMessageView&& v)
+            : view(std::move(v))
+            , it(view.begin())
+        {
+        }
+    };
+
+    mcap::McapReader* reader_;
+    std::vector<ChannelView> channels_;
 };
 
 } // namespace core

--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -129,14 +129,10 @@ class McapTrackerViewers
 public:
     using NativeDataT = typename DataTableT::NativeTableType;
 
-    McapTrackerViewers(mcap::McapReader& reader,
-                       std::string_view base_name,
-                       const std::vector<std::string>& sub_channels)
+    McapTrackerViewers(mcap::McapReader& reader, std::string_view base_name, const std::vector<std::string>& sub_channels)
         : reader_(&reader)
     {
-        auto on_problem = [](const mcap::Status& s) {
-            std::cerr << "McapTrackerViewers: " << s.message << std::endl;
-        };
+        auto on_problem = [](const mcap::Status& s) { std::cerr << "McapTrackerViewers: " << s.message << std::endl; };
 
         channels_.reserve(sub_channels.size());
         for (const auto& sub : sub_channels)
@@ -158,9 +154,8 @@ public:
     {
         if (channel_index >= channels_.size())
         {
-            throw std::out_of_range(
-                "McapTrackerViewers: read called with channel_index=" + std::to_string(channel_index) + " but only " +
-                std::to_string(channels_.size()) + " channels registered");
+            throw std::out_of_range("McapTrackerViewers: read called with channel_index=" + std::to_string(channel_index) +
+                                    " but only " + std::to_string(channels_.size()) + " channels registered");
         }
 
         auto& ch = channels_[channel_index];
@@ -188,9 +183,7 @@ private:
         mcap::LinearMessageView view;
         mcap::LinearMessageView::Iterator it;
 
-        explicit ChannelView(mcap::LinearMessageView&& v)
-            : view(std::move(v))
-            , it(view.begin())
+        explicit ChannelView(mcap::LinearMessageView&& v) : view(std::move(v)), it(view.begin())
         {
         }
     };

--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -21,6 +21,11 @@
 namespace core
 {
 
+inline std::string mcap_topic(std::string_view base_name, const std::string& sub_channel)
+{
+    return std::string(base_name) + "/" + sub_channel;
+}
+
 /**
  * @brief Type-safe MCAP channel writer for FlatBuffer record types.
  *
@@ -53,7 +58,7 @@ public:
         channel_ids_.reserve(sub_channels.size());
         for (const auto& sub : sub_channels)
         {
-            mcap::Channel ch(std::string(base_name) + "/" + sub, "flatbuffer", schema.id);
+            mcap::Channel ch(mcap_topic(base_name, sub), "flatbuffer", schema.id);
             writer_->addChannel(ch);
             channel_ids_.push_back(ch.id);
         }
@@ -137,7 +142,7 @@ public:
         channels_.reserve(sub_channels.size());
         for (const auto& sub : sub_channels)
         {
-            std::string topic = std::string(base_name) + "/" + sub;
+            std::string topic = mcap_topic(base_name, sub);
             mcap::ReadMessageOptions options;
             options.topicFilter = [topic](std::string_view t) { return t == topic; };
             channels_.emplace_back(reader_->readMessages(on_problem, options));

--- a/src/core/mcap_tests/cpp/test_mcap_tracker_channels.cpp
+++ b/src/core/mcap_tests/cpp/test_mcap_tracker_channels.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<mcap::McapWriter> open_writer(const std::string& path)
 }
 
 using HeadChannels = core::McapTrackerChannels<core::HeadPoseRecord, core::HeadPose>;
-using HeadViewers = core::McapTrackerViewers<core::HeadPoseRecord, core::HeadPose>;
+using HeadViewers = core::McapTrackerViewers<core::HeadPoseRecord, core::HeadPose, core::HeadPoseTracked>;
 
 } // namespace
 
@@ -288,16 +288,16 @@ TEST_CASE("McapTrackerViewers: reads records from a single channel", "[mcap][tra
 
     HeadViewers viewers(reader, "tracking", { "head" });
 
-    auto data1 = viewers.read(0);
-    REQUIRE(data1.has_value());
-    REQUIRE(*data1);
-    CHECK((*data1)->is_valid == true);
-    REQUIRE((*data1)->pose);
-    CHECK((*data1)->pose->position().x() == 1.0f);
+    auto tracked1 = viewers.read(0);
+    REQUIRE(tracked1.has_value());
+    REQUIRE(tracked1->data);
+    CHECK(tracked1->data->is_valid == true);
+    REQUIRE(tracked1->data->pose);
+    CHECK(tracked1->data->pose->position().x() == 1.0f);
 
-    auto data2 = viewers.read(0);
-    REQUIRE(data2.has_value());
-    REQUIRE(*data2);
+    auto tracked2 = viewers.read(0);
+    REQUIRE(tracked2.has_value());
+    REQUIRE(tracked2->data);
 
     CHECK_FALSE(viewers.read(0).has_value());
     reader.close();
@@ -367,12 +367,12 @@ TEST_CASE("McapTrackerViewers: read subset of written channels", "[mcap][tracker
 
     auto r1 = viewers.read(0);
     REQUIRE(r1.has_value());
-    REQUIRE(*r1);
-    CHECK((*r1)->is_valid == true);
+    REQUIRE(r1->data);
+    CHECK(r1->data->is_valid == true);
 
     auto r2 = viewers.read(0);
     REQUIRE(r2.has_value());
-    REQUIRE(*r2);
+    REQUIRE(r2->data);
 
     CHECK_FALSE(viewers.read(0).has_value());
     reader.close();
@@ -417,9 +417,9 @@ TEST_CASE("McapTrackerViewers: handles null data records", "[mcap][tracker_viewe
 
     HeadViewers viewers(reader, "tracking", { "head" });
 
-    auto data = viewers.read(0);
-    REQUIRE(data.has_value());
-    CHECK(*data == nullptr);
+    auto tracked = viewers.read(0);
+    REQUIRE(tracked.has_value());
+    CHECK(tracked->data == nullptr);
 
     CHECK_FALSE(viewers.read(0).has_value());
     reader.close();

--- a/src/core/mcap_tests/cpp/test_mcap_tracker_channels.cpp
+++ b/src/core/mcap_tests/cpp/test_mcap_tracker_channels.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<mcap::McapWriter> open_writer(const std::string& path)
 }
 
 using HeadChannels = core::McapTrackerChannels<core::HeadPoseRecord, core::HeadPose>;
-using HeadViewers = core::McapTrackerViewers<core::HeadPoseRecord, core::HeadPose, core::HeadPoseTracked>;
+using HeadViewers = core::McapTrackerViewers<core::HeadPoseRecord>;
 
 } // namespace
 
@@ -288,16 +288,20 @@ TEST_CASE("McapTrackerViewers: reads records from a single channel", "[mcap][tra
 
     HeadViewers viewers(reader, "tracking", { "head" });
 
-    auto tracked1 = viewers.read(0);
-    REQUIRE(tracked1.has_value());
-    REQUIRE(tracked1->data);
-    CHECK(tracked1->data->is_valid == true);
-    REQUIRE(tracked1->data->pose);
-    CHECK(tracked1->data->pose->position().x() == 1.0f);
+    auto record1 = viewers.read(0);
+    REQUIRE(record1.has_value());
+    REQUIRE(record1->data);
+    CHECK(record1->data->is_valid == true);
+    REQUIRE(record1->data->pose);
+    CHECK(record1->data->pose->position().x() == 1.0f);
+    REQUIRE(record1->timestamp);
+    CHECK(record1->timestamp->sample_time_raw_device_clock() == 42);
 
-    auto tracked2 = viewers.read(0);
-    REQUIRE(tracked2.has_value());
-    REQUIRE(tracked2->data);
+    auto record2 = viewers.read(0);
+    REQUIRE(record2.has_value());
+    REQUIRE(record2->data);
+    REQUIRE(record2->timestamp);
+    CHECK(record2->timestamp->sample_time_raw_device_clock() == 84);
 
     CHECK_FALSE(viewers.read(0).has_value());
     reader.close();
@@ -417,9 +421,11 @@ TEST_CASE("McapTrackerViewers: handles null data records", "[mcap][tracker_viewe
 
     HeadViewers viewers(reader, "tracking", { "head" });
 
-    auto tracked = viewers.read(0);
-    REQUIRE(tracked.has_value());
-    CHECK(tracked->data == nullptr);
+    auto record = viewers.read(0);
+    REQUIRE(record.has_value());
+    CHECK(record->data == nullptr);
+    REQUIRE(record->timestamp);
+    CHECK(record->timestamp->sample_time_raw_device_clock() == 10);
 
     CHECK_FALSE(viewers.read(0).has_value());
     reader.close();

--- a/src/core/mcap_tests/cpp/test_mcap_tracker_channels.cpp
+++ b/src/core/mcap_tests/cpp/test_mcap_tracker_channels.cpp
@@ -64,6 +64,7 @@ std::unique_ptr<mcap::McapWriter> open_writer(const std::string& path)
 }
 
 using HeadChannels = core::McapTrackerChannels<core::HeadPoseRecord, core::HeadPose>;
+using HeadViewers = core::McapTrackerViewers<core::HeadPoseRecord, core::HeadPose>;
 
 } // namespace
 
@@ -257,5 +258,169 @@ TEST_CASE("McapTrackerChannels: multiple same-type channel instances share one w
     CHECK(topics[0] == "head/pose");
     CHECK(topics[1] == "ctrl/left");
     CHECK(topics[2] == "ctrl/right");
+    reader.close();
+}
+
+// =============================================================================
+// McapTrackerViewers - typed read from specific channels by index
+// =============================================================================
+
+TEST_CASE("McapTrackerViewers: reads records from a single channel", "[mcap][tracker_viewers]")
+{
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+
+    auto head_data = std::make_shared<core::HeadPoseT>();
+    head_data->is_valid = true;
+    head_data->pose =
+        std::make_shared<core::Pose>(core::Point(1.0f, 2.0f, 3.0f), core::Quaternion(0.0f, 0.0f, 0.707f, 0.707f));
+
+    {
+        auto writer = open_writer(path);
+        HeadChannels ch(*writer, "tracking", core::HeadRecordingTraits::schema_name, { "head" });
+        ch.write(0, core::DeviceDataTimestamp(1000000, 1000000, 42), head_data);
+        ch.write(0, core::DeviceDataTimestamp(2000000, 2000000, 84), head_data);
+        writer->close();
+    }
+
+    mcap::McapReader reader;
+    REQUIRE(reader.open(path).ok());
+
+    HeadViewers viewers(reader, "tracking", { "head" });
+
+    auto data1 = viewers.read(0);
+    REQUIRE(data1.has_value());
+    REQUIRE(*data1);
+    CHECK((*data1)->is_valid == true);
+    REQUIRE((*data1)->pose);
+    CHECK((*data1)->pose->position().x() == 1.0f);
+
+    auto data2 = viewers.read(0);
+    REQUIRE(data2.has_value());
+    REQUIRE(*data2);
+
+    CHECK_FALSE(viewers.read(0).has_value());
+    reader.close();
+}
+
+TEST_CASE("McapTrackerViewers: multi-channel reads filter by index", "[mcap][tracker_viewers]")
+{
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+
+    auto data = std::make_shared<core::HeadPoseT>();
+
+    {
+        auto writer = open_writer(path);
+        HeadChannels ch(*writer, "tracking", core::HeadRecordingTraits::schema_name, { "left", "right" });
+        ch.write(0, core::DeviceDataTimestamp(100, 100, 1), data);
+        ch.write(1, core::DeviceDataTimestamp(200, 200, 2), data);
+        ch.write(0, core::DeviceDataTimestamp(300, 300, 3), data);
+        ch.write(1, core::DeviceDataTimestamp(400, 400, 4), data);
+        writer->close();
+    }
+
+    mcap::McapReader reader;
+    REQUIRE(reader.open(path).ok());
+
+    HeadViewers viewers(reader, "tracking", { "left", "right" });
+
+    auto left1 = viewers.read(0);
+    REQUIRE(left1.has_value());
+
+    auto right1 = viewers.read(1);
+    REQUIRE(right1.has_value());
+
+    auto left2 = viewers.read(0);
+    REQUIRE(left2.has_value());
+
+    auto right2 = viewers.read(1);
+    REQUIRE(right2.has_value());
+
+    CHECK_FALSE(viewers.read(0).has_value());
+    CHECK_FALSE(viewers.read(1).has_value());
+    reader.close();
+}
+
+TEST_CASE("McapTrackerViewers: read subset of written channels", "[mcap][tracker_viewers]")
+{
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+
+    auto data = std::make_shared<core::HeadPoseT>();
+    data->is_valid = true;
+
+    {
+        auto writer = open_writer(path);
+        HeadChannels ch(*writer, "tracking", core::HeadRecordingTraits::schema_name, { "left", "right" });
+        ch.write(0, core::DeviceDataTimestamp(100, 100, 1), data);
+        ch.write(1, core::DeviceDataTimestamp(200, 200, 2), data);
+        ch.write(0, core::DeviceDataTimestamp(300, 300, 3), data);
+        ch.write(1, core::DeviceDataTimestamp(400, 400, 4), data);
+        writer->close();
+    }
+
+    mcap::McapReader reader;
+    REQUIRE(reader.open(path).ok());
+
+    HeadViewers viewers(reader, "tracking", { "right" });
+
+    auto r1 = viewers.read(0);
+    REQUIRE(r1.has_value());
+    REQUIRE(*r1);
+    CHECK((*r1)->is_valid == true);
+
+    auto r2 = viewers.read(0);
+    REQUIRE(r2.has_value());
+    REQUIRE(*r2);
+
+    CHECK_FALSE(viewers.read(0).has_value());
+    reader.close();
+}
+
+TEST_CASE("McapTrackerViewers: out-of-range channel_index throws", "[mcap][tracker_viewers]")
+{
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+
+    auto data = std::make_shared<core::HeadPoseT>();
+
+    {
+        auto writer = open_writer(path);
+        HeadChannels ch(*writer, "tracking", core::HeadRecordingTraits::schema_name, { "head" });
+        ch.write(0, core::DeviceDataTimestamp(100, 100, 1), data);
+        writer->close();
+    }
+
+    mcap::McapReader reader;
+    REQUIRE(reader.open(path).ok());
+
+    HeadViewers viewers(reader, "tracking", { "head" });
+    CHECK_THROWS_AS(viewers.read(99), std::out_of_range);
+    reader.close();
+}
+
+TEST_CASE("McapTrackerViewers: handles null data records", "[mcap][tracker_viewers]")
+{
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+
+    {
+        auto writer = open_writer(path);
+        HeadChannels ch(*writer, "tracking", core::HeadRecordingTraits::schema_name, { "head" });
+        ch.write(0, core::DeviceDataTimestamp(500, 500, 10), std::shared_ptr<core::HeadPoseT>{ nullptr });
+        writer->close();
+    }
+
+    mcap::McapReader reader;
+    REQUIRE(reader.open(path).ok());
+
+    HeadViewers viewers(reader, "tracking", { "head" });
+
+    auto data = viewers.read(0);
+    REQUIRE(data.has_value());
+    CHECK(*data == nullptr);
+
+    CHECK_FALSE(viewers.read(0).has_value());
     reader.close();
 }


### PR DESCRIPTION
Following the same pattern of McapTrackerChannels
- it takes a McapReader and a list of channels we want to replay
- internally it keeps the MessageView and iterator to read message one by one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a templated reader component for extracting tracked data from MCAP files with multi-channel filtering support
  * Introduced a utility function for constructing MCAP topic identifiers

* **Tests**
  * Added test coverage for the new reader functionality, including channel filtering and null payload handling

* **Chores**
  * Updated copyright year range

<!-- end of auto-generated comment: release notes by coderabbit.ai -->