### PR TITLE
[Replay] Add replay trackers

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -29,6 +29,7 @@ add_subdirectory(pusherio)
 add_subdirectory(deviceio_base)
 add_subdirectory(deviceio_trackers)
 add_subdirectory(live_trackers)
+add_subdirectory(replay_trackers)
 add_subdirectory(deviceio_session)
 
 # Build MCAP library (depends on deviceio for DeviceIOSession and tracker interfaces)

--- a/src/core/live_trackers/cpp/live_controller_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_controller_tracker_impl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "live_controller_tracker_impl.hpp"
@@ -180,7 +180,7 @@ std::unique_ptr<ControllerMcapChannels> LiveControllerTrackerImpl::create_mcap_c
 {
     return std::make_unique<ControllerMcapChannels>(
         writer, base_name, ControllerRecordingTraits::schema_name,
-        std::vector<std::string>(ControllerRecordingTraits::channels.begin(), ControllerRecordingTraits::channels.end()));
+        std::vector<std::string>(ControllerRecordingTraits::recording_channels.begin(), ControllerRecordingTraits::recording_channels.end()));
 }
 
 LiveControllerTrackerImpl::LiveControllerTrackerImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_controller_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_controller_tracker_impl.cpp
@@ -180,7 +180,8 @@ std::unique_ptr<ControllerMcapChannels> LiveControllerTrackerImpl::create_mcap_c
 {
     return std::make_unique<ControllerMcapChannels>(
         writer, base_name, ControllerRecordingTraits::schema_name,
-        std::vector<std::string>(ControllerRecordingTraits::recording_channels.begin(), ControllerRecordingTraits::recording_channels.end()));
+        std::vector<std::string>(ControllerRecordingTraits::recording_channels.begin(),
+                                 ControllerRecordingTraits::recording_channels.end()));
 }
 
 LiveControllerTrackerImpl::LiveControllerTrackerImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.cpp
+++ b/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.cpp
@@ -22,9 +22,10 @@ namespace core
 std::unique_ptr<FullBodyMcapChannels> LiveFullBodyTrackerPicoImpl::create_mcap_channels(mcap::McapWriter& writer,
                                                                                         std::string_view base_name)
 {
-    return std::make_unique<FullBodyMcapChannels>(writer, base_name, FullBodyPicoRecordingTraits::schema_name,
-                                                  std::vector<std::string>(FullBodyPicoRecordingTraits::recording_channels.begin(),
-                                                                           FullBodyPicoRecordingTraits::recording_channels.end()));
+    return std::make_unique<FullBodyMcapChannels>(
+        writer, base_name, FullBodyPicoRecordingTraits::schema_name,
+        std::vector<std::string>(FullBodyPicoRecordingTraits::recording_channels.begin(),
+                                 FullBodyPicoRecordingTraits::recording_channels.end()));
 }
 
 LiveFullBodyTrackerPicoImpl::LiveFullBodyTrackerPicoImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.cpp
+++ b/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "live_full_body_tracker_pico_impl.hpp"
@@ -23,8 +23,8 @@ std::unique_ptr<FullBodyMcapChannels> LiveFullBodyTrackerPicoImpl::create_mcap_c
                                                                                         std::string_view base_name)
 {
     return std::make_unique<FullBodyMcapChannels>(writer, base_name, FullBodyPicoRecordingTraits::schema_name,
-                                                  std::vector<std::string>(FullBodyPicoRecordingTraits::channels.begin(),
-                                                                           FullBodyPicoRecordingTraits::channels.end()));
+                                                  std::vector<std::string>(FullBodyPicoRecordingTraits::recording_channels.begin(),
+                                                                           FullBodyPicoRecordingTraits::recording_channels.end()));
 }
 
 LiveFullBodyTrackerPicoImpl::LiveFullBodyTrackerPicoImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
@@ -31,9 +31,9 @@ SchemaTrackerConfig make_pedal_tensor_config(const Generic3AxisPedalTracker* tra
 std::unique_ptr<PedalMcapChannels> LiveGeneric3AxisPedalTrackerImpl::create_mcap_channels(mcap::McapWriter& writer,
                                                                                           std::string_view base_name)
 {
-    return std::make_unique<PedalMcapChannels>(
-        writer, base_name, PedalRecordingTraits::schema_name,
-        std::vector<std::string>(PedalRecordingTraits::recording_channels.begin(), PedalRecordingTraits::recording_channels.end()));
+    return std::make_unique<PedalMcapChannels>(writer, base_name, PedalRecordingTraits::schema_name,
+                                               std::vector<std::string>(PedalRecordingTraits::recording_channels.begin(),
+                                                                        PedalRecordingTraits::recording_channels.end()));
 }
 
 LiveGeneric3AxisPedalTrackerImpl::LiveGeneric3AxisPedalTrackerImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<PedalMcapChannels> LiveGeneric3AxisPedalTrackerImpl::create_mcap
 {
     return std::make_unique<PedalMcapChannels>(
         writer, base_name, PedalRecordingTraits::schema_name,
-        std::vector<std::string>(PedalRecordingTraits::channels.begin(), PedalRecordingTraits::channels.end()));
+        std::vector<std::string>(PedalRecordingTraits::recording_channels.begin(), PedalRecordingTraits::recording_channels.end()));
 }
 
 LiveGeneric3AxisPedalTrackerImpl::LiveGeneric3AxisPedalTrackerImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_hand_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_hand_tracker_impl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "live_hand_tracker_impl.hpp"
@@ -25,7 +25,7 @@ std::unique_ptr<HandMcapChannels> LiveHandTrackerImpl::create_mcap_channels(mcap
 {
     return std::make_unique<HandMcapChannels>(
         writer, base_name, HandRecordingTraits::schema_name,
-        std::vector<std::string>(HandRecordingTraits::channels.begin(), HandRecordingTraits::channels.end()));
+        std::vector<std::string>(HandRecordingTraits::recording_channels.begin(), HandRecordingTraits::recording_channels.end()));
 }
 
 LiveHandTrackerImpl::LiveHandTrackerImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_hand_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_hand_tracker_impl.cpp
@@ -23,9 +23,9 @@ namespace core
 std::unique_ptr<HandMcapChannels> LiveHandTrackerImpl::create_mcap_channels(mcap::McapWriter& writer,
                                                                             std::string_view base_name)
 {
-    return std::make_unique<HandMcapChannels>(
-        writer, base_name, HandRecordingTraits::schema_name,
-        std::vector<std::string>(HandRecordingTraits::recording_channels.begin(), HandRecordingTraits::recording_channels.end()));
+    return std::make_unique<HandMcapChannels>(writer, base_name, HandRecordingTraits::schema_name,
+                                              std::vector<std::string>(HandRecordingTraits::recording_channels.begin(),
+                                                                       HandRecordingTraits::recording_channels.end()));
 }
 
 LiveHandTrackerImpl::LiveHandTrackerImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_head_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_head_tracker_impl.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "live_head_tracker_impl.hpp"
@@ -24,7 +24,7 @@ std::unique_ptr<HeadMcapChannels> LiveHeadTrackerImpl::create_mcap_channels(mcap
 {
     return std::make_unique<HeadMcapChannels>(
         writer, base_name, HeadRecordingTraits::schema_name,
-        std::vector<std::string>(HeadRecordingTraits::channels.begin(), HeadRecordingTraits::channels.end()));
+        std::vector<std::string>(HeadRecordingTraits::recording_channels.begin(), HeadRecordingTraits::recording_channels.end()));
 }
 
 LiveHeadTrackerImpl::LiveHeadTrackerImpl(const OpenXRSessionHandles& handles,

--- a/src/core/live_trackers/cpp/live_head_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_head_tracker_impl.cpp
@@ -22,9 +22,9 @@ namespace core
 std::unique_ptr<HeadMcapChannels> LiveHeadTrackerImpl::create_mcap_channels(mcap::McapWriter& writer,
                                                                             std::string_view base_name)
 {
-    return std::make_unique<HeadMcapChannels>(
-        writer, base_name, HeadRecordingTraits::schema_name,
-        std::vector<std::string>(HeadRecordingTraits::recording_channels.begin(), HeadRecordingTraits::recording_channels.end()));
+    return std::make_unique<HeadMcapChannels>(writer, base_name, HeadRecordingTraits::schema_name,
+                                              std::vector<std::string>(HeadRecordingTraits::recording_channels.begin(),
+                                                                       HeadRecordingTraits::recording_channels.end()));
 }
 
 LiveHeadTrackerImpl::LiveHeadTrackerImpl(const OpenXRSessionHandles& handles,

--- a/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
+++ b/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
@@ -20,31 +20,36 @@ namespace core
 struct HeadRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.HeadPoseRecord";
-    static constexpr std::array channels = { "head" };
+    static constexpr std::array recording_channels = { "head" };
+    static constexpr std::array replay_channels = { "head" };
 };
 
 struct HandRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.HandPoseRecord";
-    static constexpr std::array channels = { "left_hand", "right_hand" };
+    static constexpr std::array recording_channels = { "left_hand", "right_hand" };
+    static constexpr std::array replay_channels = { "left_hand", "right_hand" };
 };
 
 struct ControllerRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.ControllerSnapshotRecord";
-    static constexpr std::array channels = { "left_controller", "right_controller" };
+    static constexpr std::array recording_channels = { "left_controller", "right_controller" };
+    static constexpr std::array replay_channels = { "left_controller", "right_controller" };
 };
 
 struct FullBodyPicoRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.FullBodyPosePicoRecord";
-    static constexpr std::array channels = { "full_body" };
+    static constexpr std::array recording_channels = { "full_body" };
+    static constexpr std::array replay_channels = { "full_body" };
 };
 
 struct PedalRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.Generic3AxisPedalOutputRecord";
     static constexpr std::array channels = { "pedals", "pedals_tracked" };
+    static constexpr std::array replay_channels = { "pedals_tracked" };
 };
 
 struct OakRecordingTraits

--- a/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
+++ b/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
@@ -48,7 +48,7 @@ struct FullBodyPicoRecordingTraits
 struct PedalRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.Generic3AxisPedalOutputRecord";
-    static constexpr std::array channels = { "pedals", "pedals_tracked" };
+    static constexpr std::array recording_channels = { "pedals", "pedals_tracked" };
     static constexpr std::array replay_channels = { "pedals_tracked" };
 };
 

--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -122,6 +122,10 @@ private:
  * reads directly from the McapReader's data source without copying message data.
  * Callers pull deserialized records one at a time via read(channel_index).
  *
+ * Returning the Tracked native type mirrors the live tracker query API
+ * (e.g. HandTracker::get_left_hand returns HandPoseTrackedT&), keeping
+ * live and replay consumers type-compatible.
+ *
  * MCAP message data pointers are only valid until the iterator advances,
  * so read() fully deserializes each record before stepping the iterator forward.
  */

--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -131,14 +131,19 @@ class McapTrackerViewers
 public:
     using NativeRecordT = typename RecordT::NativeTableType;
 
+    McapTrackerViewers(const McapTrackerViewers&) = delete;
+    McapTrackerViewers& operator=(const McapTrackerViewers&) = delete;
+    McapTrackerViewers(McapTrackerViewers&&) = delete;
+    McapTrackerViewers& operator=(McapTrackerViewers&&) = delete;
+
     McapTrackerViewers(mcap::McapReader& reader, std::string_view base_name, const std::vector<std::string>& sub_channels)
         : reader_(&reader)
     {
-        auto on_problem = [](const mcap::Status& s) { std::cerr << "McapTrackerViewers: " << s.message << std::endl; };
-
         for (const auto& sub : sub_channels)
         {
             std::string topic = mcap_topic(base_name, sub);
+            auto on_problem = [topic](const mcap::Status& s)
+            { throw std::runtime_error("McapTrackerViewers [" + topic + "]: " + s.message); };
             mcap::ReadMessageOptions options;
             options.topicFilter = [topic](std::string_view t) { return t == topic; };
             channels_.push_back(std::make_unique<ChannelView>(reader_->readMessages(on_problem, options)));
@@ -163,6 +168,13 @@ public:
         if (ch.it == ch.view.end())
         {
             return std::nullopt;
+        }
+
+        flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(ch.it->message.data), ch.it->message.dataSize);
+        if (!verifier.VerifyBuffer<RecordT>())
+        {
+            throw std::runtime_error("McapTrackerViewers: corrupt FlatBuffer in channel " + std::to_string(channel_index) +
+                                     " at sequence " + std::to_string(ch.it->message.sequence));
         }
 
         auto* fb_record = flatbuffers::GetRoot<RecordT>(ch.it->message.data);

--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -122,10 +122,6 @@ private:
  * reads directly from the McapReader's data source without copying message data.
  * Callers pull deserialized records one at a time via read(channel_index).
  *
- * Returning the Tracked native type mirrors the live tracker query API
- * (e.g. HandTracker::get_left_hand returns HandPoseTrackedT&), keeping
- * live and replay consumers type-compatible.
- *
  * MCAP message data pointers are only valid until the iterator advances,
  * so read() fully deserializes each record before stepping the iterator forward.
  */

--- a/src/core/replay_trackers/CMakeLists.txt
+++ b/src/core/replay_trackers/CMakeLists.txt
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+add_subdirectory(cpp)

--- a/src/core/replay_trackers/cpp/CMakeLists.txt
+++ b/src/core/replay_trackers/cpp/CMakeLists.txt
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+add_library(replay_trackers STATIC
+    replay_deviceio_factory.cpp
+    replay_hand_tracker_impl.cpp
+    replay_head_tracker_impl.cpp
+    replay_controller_tracker_impl.cpp
+    replay_full_body_tracker_pico_impl.cpp
+    replay_generic_3axis_pedal_tracker_impl.cpp
+    inc/replay_trackers/replay_deviceio_factory.hpp
+    replay_hand_tracker_impl.hpp
+    replay_head_tracker_impl.hpp
+    replay_controller_tracker_impl.hpp
+    replay_full_body_tracker_pico_impl.hpp
+    replay_generic_3axis_pedal_tracker_impl.hpp
+)
+
+target_include_directories(replay_trackers
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+)
+
+target_link_libraries(replay_trackers
+    PUBLIC
+        deviceio::deviceio_base
+        deviceio::deviceio_trackers
+        mcap::mcap_core
+        oxr::oxr_utils
+)
+
+add_library(deviceio::replay_trackers ALIAS replay_trackers)

--- a/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
+++ b/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace mcap
+{
+class McapReader;
+} // namespace mcap
+
+namespace core
+{
+
+class ITracker;
+class ITrackerImpl;
+class ControllerTracker;
+class IControllerTrackerImpl;
+class FullBodyTrackerPico;
+class IFullBodyTrackerPicoImpl;
+class Generic3AxisPedalTracker;
+class IGeneric3AxisPedalTrackerImpl;
+class HandTracker;
+class IHandTrackerImpl;
+class HeadTracker;
+class IHeadTrackerImpl;
+
+/**
+ * @brief Factory for replay (MCAP-backed) tracker implementations.
+ *
+ * Counterpart to LiveDeviceIOFactory. Instead of OpenXR handles, takes an
+ * McapReader and constructs Replay*TrackerImpl instances that read recorded
+ * data from the MCAP file.
+ */
+class ReplayDeviceIOFactory
+{
+public:
+    ReplayDeviceIOFactory(mcap::McapReader& reader,
+                          const std::vector<std::pair<const ITracker*, std::string>>& tracker_names);
+
+    /** Create tracker impl from a tracker instance using dynamic dispatch. */
+    std::unique_ptr<ITrackerImpl> create_tracker_impl(const ITracker& tracker);
+
+    std::unique_ptr<IHeadTrackerImpl> create_head_tracker_impl(const HeadTracker* tracker);
+    std::unique_ptr<IHandTrackerImpl> create_hand_tracker_impl(const HandTracker* tracker);
+    std::unique_ptr<IControllerTrackerImpl> create_controller_tracker_impl(const ControllerTracker* tracker);
+    std::unique_ptr<IFullBodyTrackerPicoImpl> create_full_body_tracker_pico_impl(const FullBodyTrackerPico* tracker);
+    std::unique_ptr<IGeneric3AxisPedalTrackerImpl> create_generic_3axis_pedal_tracker_impl(
+        const Generic3AxisPedalTracker* tracker);
+
+private:
+    std::string_view get_name(const ITracker* tracker) const;
+
+    mcap::McapReader& reader_;
+    std::unordered_map<const ITracker*, std::string> name_map_;
+};
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
@@ -4,7 +4,6 @@
 #include "replay_controller_tracker_impl.hpp"
 
 #include <mcap/recording_traits.hpp>
-#include <oxr_utils/oxr_funcs.hpp>
 #include <schema/controller_bfbs_generated.h>
 #include <schema/timestamp_generated.h>
 

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
@@ -18,17 +18,12 @@ namespace core
 // ReplayControllerTrackerImpl
 // ============================================================================
 
-std::unique_ptr<ControllerMcapViewers> ReplayControllerTrackerImpl::create_mcap_viewers(mcap::McapReader& reader,
-                                                                                        std::string_view base_name)
-{
-    return std::make_unique<ControllerMcapViewers>(
-        reader, base_name,
-        std::vector<std::string>(
-            ControllerRecordingTraits::replay_channels.begin(), ControllerRecordingTraits::replay_channels.end()));
-}
-
 ReplayControllerTrackerImpl::ReplayControllerTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
-    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+    : mcap_viewers_(std::make_unique<ControllerMcapViewers>(
+          reader,
+          base_name,
+          std::vector<std::string>(
+              ControllerRecordingTraits::replay_channels.begin(), ControllerRecordingTraits::replay_channels.end())))
 {
 }
 
@@ -44,29 +39,26 @@ const ControllerSnapshotTrackedT& ReplayControllerTrackerImpl::get_right_control
 
 void ReplayControllerTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
-    if (mcap_viewers_)
+    auto left_record = mcap_viewers_->read(0);
+    auto right_record = mcap_viewers_->read(1);
+    if (left_record)
     {
-        auto left_record = mcap_viewers_->read(0);
-        auto right_record = mcap_viewers_->read(1);
-        if (left_record)
-        {
-            left_tracked_.data = std::move(left_record->data);
-        }
-        else
-        {
-            std::cerr << "ReplayControllerTrackerImpl: left controller data not found" << std::endl;
-            left_tracked_.data.reset();
-        }
+        left_tracked_.data = std::move(left_record->data);
+    }
+    else
+    {
+        std::cerr << "ReplayControllerTrackerImpl: left controller data not found" << std::endl;
+        left_tracked_.data.reset();
+    }
 
-        if (right_record)
-        {
-            right_tracked_.data = std::move(right_record->data);
-        }
-        else
-        {
-            std::cerr << "ReplayControllerTrackerImpl: right controller data not found" << std::endl;
-            right_tracked_.data.reset();
-        }
+    if (right_record)
+    {
+        right_tracked_.data = std::move(right_record->data);
+    }
+    else
+    {
+        std::cerr << "ReplayControllerTrackerImpl: right controller data not found" << std::endl;
+        right_tracked_.data.reset();
     }
 }
 

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
@@ -46,11 +46,11 @@ void ReplayControllerTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto left_result = mcap_viewers_->read(0);
-        auto right_result = mcap_viewers_->read(1);
-        if (left_result)
+        auto left_record = mcap_viewers_->read(0);
+        auto right_record = mcap_viewers_->read(1);
+        if (left_record)
         {
-            left_tracked_ = std::move(*left_result);
+            left_tracked_.data = std::move(left_record->data);
         }
         else
         {
@@ -58,9 +58,9 @@ void ReplayControllerTrackerImpl::update(int64_t /*monotonic_time_ns*/)
             left_tracked_.data.reset();
         }
 
-        if (right_result)
+        if (right_record)
         {
-            right_tracked_ = std::move(*right_result);
+            right_tracked_.data = std::move(right_record->data);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "replay_controller_tracker_impl.hpp"
+
+#include <mcap/recording_traits.hpp>
+#include <oxr_utils/oxr_funcs.hpp>
+#include <schema/controller_bfbs_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+
+namespace core
+{
+
+// ============================================================================
+// ReplayControllerTrackerImpl
+// ============================================================================
+
+std::unique_ptr<ControllerMcapViewers> ReplayControllerTrackerImpl::create_mcap_viewers(mcap::McapReader& reader,
+                                                                                        std::string_view base_name)
+{
+    return std::make_unique<ControllerMcapViewers>(
+        reader, base_name,
+        std::vector<std::string>(
+            ControllerRecordingTraits::replay_channels.begin(), ControllerRecordingTraits::replay_channels.end()));
+}
+
+ReplayControllerTrackerImpl::ReplayControllerTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
+    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+{
+}
+
+const ControllerSnapshotTrackedT& ReplayControllerTrackerImpl::get_left_controller() const
+{
+    return left_tracked_;
+}
+
+const ControllerSnapshotTrackedT& ReplayControllerTrackerImpl::get_right_controller() const
+{
+    return right_tracked_;
+}
+
+void ReplayControllerTrackerImpl::update(int64_t /*monotonic_time_ns*/)
+{
+    if (mcap_viewers_)
+    {
+        auto left_data = mcap_viewers_->read(0);
+        auto right_data = mcap_viewers_->read(1);
+        if (left_data)
+        {
+            left_tracked_.data = *left_data;
+        }
+        else
+        {
+            std::cerr << "ReplayControllerTrackerImpl: left controller data not found" << std::endl;
+            left_tracked_.data.reset();
+        }
+
+        if (right_data)
+        {
+            right_tracked_.data = *right_data;
+        }
+        else
+        {
+            std::cerr << "ReplayControllerTrackerImpl: right controller data not found" << std::endl;
+            right_tracked_.data.reset();
+        }
+    }
+}
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
@@ -46,11 +46,11 @@ void ReplayControllerTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto left_data = mcap_viewers_->read(0);
-        auto right_data = mcap_viewers_->read(1);
-        if (left_data)
+        auto left_result = mcap_viewers_->read(0);
+        auto right_result = mcap_viewers_->read(1);
+        if (left_result)
         {
-            left_tracked_.data = *left_data;
+            left_tracked_ = std::move(*left_result);
         }
         else
         {
@@ -58,9 +58,9 @@ void ReplayControllerTrackerImpl::update(int64_t /*monotonic_time_ns*/)
             left_tracked_.data.reset();
         }
 
-        if (right_data)
+        if (right_result)
         {
-            right_tracked_.data = *right_data;
+            right_tracked_ = std::move(*right_result);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
@@ -36,8 +36,6 @@ public:
 private:
     ControllerSnapshotTrackedT left_tracked_;
     ControllerSnapshotTrackedT right_tracked_;
-    int64_t last_update_time_ = 0;
-
     std::unique_ptr<ControllerMcapViewers> mcap_viewers_;
 };
 

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_base/controller_tracker_base.hpp>
+#include <mcap/tracker_channels.hpp>
+#include <schema/controller_generated.h>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace core
+{
+
+using ControllerMcapViewers = McapTrackerViewers<ControllerSnapshotRecord, ControllerSnapshot>;
+
+class ReplayControllerTrackerImpl : public IControllerTrackerImpl
+{
+public:
+    static std::unique_ptr<ControllerMcapViewers> create_mcap_viewers(mcap::McapReader& reader,
+                                                                      std::string_view base_name);
+
+    ReplayControllerTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayControllerTrackerImpl(const ReplayControllerTrackerImpl&) = delete;
+    ReplayControllerTrackerImpl& operator=(const ReplayControllerTrackerImpl&) = delete;
+    ReplayControllerTrackerImpl(ReplayControllerTrackerImpl&&) = delete;
+    ReplayControllerTrackerImpl& operator=(ReplayControllerTrackerImpl&&) = delete;
+
+    void update(int64_t monotonic_time_ns) override;
+    const ControllerSnapshotTrackedT& get_left_controller() const override;
+    const ControllerSnapshotTrackedT& get_right_controller() const override;
+
+private:
+    ControllerSnapshotTrackedT left_tracked_;
+    ControllerSnapshotTrackedT right_tracked_;
+    int64_t last_update_time_ = 0;
+
+    std::unique_ptr<ControllerMcapViewers> mcap_viewers_;
+};
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
@@ -19,9 +19,6 @@ using ControllerMcapViewers = McapTrackerViewers<ControllerSnapshotRecord>;
 class ReplayControllerTrackerImpl : public IControllerTrackerImpl
 {
 public:
-    static std::unique_ptr<ControllerMcapViewers> create_mcap_viewers(mcap::McapReader& reader,
-                                                                      std::string_view base_name);
-
     ReplayControllerTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
 
     ReplayControllerTrackerImpl(const ReplayControllerTrackerImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
@@ -14,7 +14,7 @@
 namespace core
 {
 
-using ControllerMcapViewers = McapTrackerViewers<ControllerSnapshotRecord, ControllerSnapshot, ControllerSnapshotTracked>;
+using ControllerMcapViewers = McapTrackerViewers<ControllerSnapshotRecord>;
 
 class ReplayControllerTrackerImpl : public IControllerTrackerImpl
 {

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
@@ -14,7 +14,7 @@
 namespace core
 {
 
-using ControllerMcapViewers = McapTrackerViewers<ControllerSnapshotRecord, ControllerSnapshot>;
+using ControllerMcapViewers = McapTrackerViewers<ControllerSnapshotRecord, ControllerSnapshot, ControllerSnapshotTracked>;
 
 class ReplayControllerTrackerImpl : public IControllerTrackerImpl
 {

--- a/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
+++ b/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "inc/replay_trackers/replay_deviceio_factory.hpp"
+
+#include "replay_controller_tracker_impl.hpp"
+#include "replay_full_body_tracker_pico_impl.hpp"
+#include "replay_generic_3axis_pedal_tracker_impl.hpp"
+#include "replay_hand_tracker_impl.hpp"
+#include "replay_head_tracker_impl.hpp"
+
+#include <deviceio_trackers/controller_tracker.hpp>
+#include <deviceio_trackers/full_body_tracker_pico.hpp>
+#include <deviceio_trackers/generic_3axis_pedal_tracker.hpp>
+#include <deviceio_trackers/hand_tracker.hpp>
+#include <deviceio_trackers/head_tracker.hpp>
+
+#include <cassert>
+#include <stdexcept>
+#include <string>
+
+namespace core
+{
+
+namespace
+{
+
+std::unique_ptr<ITrackerImpl> try_create_head_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
+{
+    auto* typed = dynamic_cast<const HeadTracker*>(&tracker);
+    return typed ? factory.create_head_tracker_impl(typed) : nullptr;
+}
+
+std::unique_ptr<ITrackerImpl> try_create_hand_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
+{
+    auto* typed = dynamic_cast<const HandTracker*>(&tracker);
+    return typed ? factory.create_hand_tracker_impl(typed) : nullptr;
+}
+
+std::unique_ptr<ITrackerImpl> try_create_controller_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
+{
+    auto* typed = dynamic_cast<const ControllerTracker*>(&tracker);
+    return typed ? factory.create_controller_tracker_impl(typed) : nullptr;
+}
+
+std::unique_ptr<ITrackerImpl> try_create_full_body_pico_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
+{
+    auto* typed = dynamic_cast<const FullBodyTrackerPico*>(&tracker);
+    return typed ? factory.create_full_body_tracker_pico_impl(typed) : nullptr;
+}
+
+std::unique_ptr<ITrackerImpl> try_create_generic_pedal_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
+{
+    auto* typed = dynamic_cast<const Generic3AxisPedalTracker*>(&tracker);
+    return typed ? factory.create_generic_3axis_pedal_tracker_impl(typed) : nullptr;
+}
+
+using TryCreateFn = std::unique_ptr<ITrackerImpl> (*)(ReplayDeviceIOFactory&, const ITracker&);
+
+inline const TryCreateFn k_tracker_dispatch[] = {
+    &try_create_head_impl,           &try_create_hand_impl,          &try_create_controller_impl,
+    &try_create_full_body_pico_impl, &try_create_generic_pedal_impl,
+};
+
+} // namespace
+
+ReplayDeviceIOFactory::ReplayDeviceIOFactory(mcap::McapReader& reader,
+                                             const std::vector<std::pair<const ITracker*, std::string>>& tracker_names)
+    : reader_(reader)
+{
+    for (const auto& [tracker, name] : tracker_names)
+    {
+        auto [it, inserted] = name_map_.emplace(tracker, name);
+        if (!inserted)
+        {
+            throw std::invalid_argument("ReplayDeviceIOFactory: duplicate tracker pointer for channel name '" + name +
+                                        "' (already mapped as '" + it->second + "')");
+        }
+    }
+}
+
+std::unique_ptr<ITrackerImpl> ReplayDeviceIOFactory::create_tracker_impl(const ITracker& tracker)
+{
+    for (const auto& try_create : k_tracker_dispatch)
+    {
+        if (std::unique_ptr<ITrackerImpl> impl = try_create(*this, tracker))
+        {
+            return impl;
+        }
+    }
+    throw std::invalid_argument("ReplayDeviceIOFactory::create_tracker_impl: unsupported tracker type '" +
+                                std::string(tracker.get_name()) + "'");
+}
+
+std::string_view ReplayDeviceIOFactory::get_name(const ITracker* tracker) const
+{
+    auto it = name_map_.find(tracker);
+    assert(it != name_map_.end() && "get_name called for tracker not in name_map_");
+    return it->second;
+}
+
+std::unique_ptr<IHeadTrackerImpl> ReplayDeviceIOFactory::create_head_tracker_impl(const HeadTracker* tracker)
+{
+    return std::make_unique<ReplayHeadTrackerImpl>(reader_, get_name(tracker));
+}
+
+std::unique_ptr<IHandTrackerImpl> ReplayDeviceIOFactory::create_hand_tracker_impl(const HandTracker* tracker)
+{
+    return std::make_unique<ReplayHandTrackerImpl>(reader_, get_name(tracker));
+}
+
+std::unique_ptr<IControllerTrackerImpl> ReplayDeviceIOFactory::create_controller_tracker_impl(const ControllerTracker* tracker)
+{
+    return std::make_unique<ReplayControllerTrackerImpl>(reader_, get_name(tracker));
+}
+
+std::unique_ptr<IFullBodyTrackerPicoImpl> ReplayDeviceIOFactory::create_full_body_tracker_pico_impl(
+    const FullBodyTrackerPico* tracker)
+{
+    return std::make_unique<ReplayFullBodyTrackerPicoImpl>(reader_, get_name(tracker));
+}
+
+std::unique_ptr<IGeneric3AxisPedalTrackerImpl> ReplayDeviceIOFactory::create_generic_3axis_pedal_tracker_impl(
+    const Generic3AxisPedalTracker* tracker)
+{
+    return std::make_unique<ReplayGeneric3AxisPedalTrackerImpl>(reader_, get_name(tracker));
+}
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
@@ -18,17 +18,12 @@ namespace core
 // ReplayFullBodyTrackerPicoImpl
 // ============================================================================
 
-std::unique_ptr<FullBodyMcapViewers> ReplayFullBodyTrackerPicoImpl::create_mcap_viewers(mcap::McapReader& reader,
-                                                                                        std::string_view base_name)
-{
-    return std::make_unique<FullBodyMcapViewers>(
-        reader, base_name,
-        std::vector<std::string>(
-            FullBodyPicoRecordingTraits::replay_channels.begin(), FullBodyPicoRecordingTraits::replay_channels.end()));
-}
-
 ReplayFullBodyTrackerPicoImpl::ReplayFullBodyTrackerPicoImpl(mcap::McapReader& reader, std::string_view base_name)
-    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+    : mcap_viewers_(std::make_unique<FullBodyMcapViewers>(
+          reader,
+          base_name,
+          std::vector<std::string>(FullBodyPicoRecordingTraits::replay_channels.begin(),
+                                   FullBodyPicoRecordingTraits::replay_channels.end())))
 {
 }
 
@@ -39,18 +34,15 @@ const FullBodyPosePicoTrackedT& ReplayFullBodyTrackerPicoImpl::get_body_pose() c
 
 void ReplayFullBodyTrackerPicoImpl::update(int64_t /*monotonic_time_ns*/)
 {
-    if (mcap_viewers_)
+    auto record = mcap_viewers_->read(0);
+    if (record)
     {
-        auto record = mcap_viewers_->read(0);
-        if (record)
-        {
-            tracked_.data = std::move(record->data);
-        }
-        else
-        {
-            std::cerr << "ReplayFullBodyTrackerPicoImpl: body data not found" << std::endl;
-            tracked_.data.reset();
-        }
+        tracked_.data = std::move(record->data);
+    }
+    else
+    {
+        std::cerr << "ReplayFullBodyTrackerPicoImpl: body data not found" << std::endl;
+        tracked_.data.reset();
     }
 }
 

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "replay_full_body_tracker_pico_impl.hpp"
+
+#include <mcap/recording_traits.hpp>
+#include <oxr_utils/oxr_funcs.hpp>
+#include <schema/full_body_bfbs_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+
+namespace core
+{
+
+// ============================================================================
+// ReplayFullBodyTrackerPicoImpl
+// ============================================================================
+
+std::unique_ptr<FullBodyMcapViewers> ReplayFullBodyTrackerPicoImpl::create_mcap_viewers(mcap::McapReader& reader,
+                                                                                        std::string_view base_name)
+{
+    return std::make_unique<FullBodyMcapViewers>(
+        reader, base_name,
+        std::vector<std::string>(
+            FullBodyPicoRecordingTraits::replay_channels.begin(), FullBodyPicoRecordingTraits::replay_channels.end()));
+}
+
+ReplayFullBodyTrackerPicoImpl::ReplayFullBodyTrackerPicoImpl(mcap::McapReader& reader, std::string_view base_name)
+    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+{
+}
+
+const FullBodyPosePicoTrackedT& ReplayFullBodyTrackerPicoImpl::get_body_pose() const
+{
+    return tracked_;
+}
+
+void ReplayFullBodyTrackerPicoImpl::update(int64_t /*monotonic_time_ns*/)
+{
+    if (mcap_viewers_)
+    {
+        auto body_data = mcap_viewers_->read(0);
+        if (body_data)
+        {
+            tracked_.data = *body_data;
+        }
+        else
+        {
+            std::cerr << "ReplayFullBodyTrackerPicoImpl: body data not found" << std::endl;
+            tracked_.data.reset();
+        }
+    }
+}
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
@@ -4,7 +4,6 @@
 #include "replay_full_body_tracker_pico_impl.hpp"
 
 #include <mcap/recording_traits.hpp>
-#include <oxr_utils/oxr_funcs.hpp>
 #include <schema/full_body_bfbs_generated.h>
 #include <schema/timestamp_generated.h>
 

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
@@ -41,10 +41,10 @@ void ReplayFullBodyTrackerPicoImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto body_data = mcap_viewers_->read(0);
-        if (body_data)
+        auto result = mcap_viewers_->read(0);
+        if (result)
         {
-            tracked_.data = *body_data;
+            tracked_ = std::move(*result);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
@@ -41,10 +41,10 @@ void ReplayFullBodyTrackerPicoImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto result = mcap_viewers_->read(0);
-        if (result)
+        auto record = mcap_viewers_->read(0);
+        if (record)
         {
-            tracked_ = std::move(*result);
+            tracked_.data = std::move(record->data);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
@@ -14,7 +14,7 @@
 namespace core
 {
 
-using FullBodyMcapViewers = McapTrackerViewers<FullBodyPosePicoRecord, FullBodyPosePico>;
+using FullBodyMcapViewers = McapTrackerViewers<FullBodyPosePicoRecord, FullBodyPosePico, FullBodyPosePicoTracked>;
 
 class ReplayFullBodyTrackerPicoImpl : public IFullBodyTrackerPicoImpl
 {

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
@@ -19,8 +19,6 @@ using FullBodyMcapViewers = McapTrackerViewers<FullBodyPosePicoRecord>;
 class ReplayFullBodyTrackerPicoImpl : public IFullBodyTrackerPicoImpl
 {
 public:
-    static std::unique_ptr<FullBodyMcapViewers> create_mcap_viewers(mcap::McapReader& reader, std::string_view base_name);
-
     ReplayFullBodyTrackerPicoImpl(mcap::McapReader& reader, std::string_view base_name);
 
     ReplayFullBodyTrackerPicoImpl(const ReplayFullBodyTrackerPicoImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
@@ -33,8 +33,6 @@ public:
 
 private:
     FullBodyPosePicoTrackedT tracked_;
-    int64_t last_update_time_ = 0;
-
     std::unique_ptr<FullBodyMcapViewers> mcap_viewers_;
 };
 

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
@@ -14,7 +14,7 @@
 namespace core
 {
 
-using FullBodyMcapViewers = McapTrackerViewers<FullBodyPosePicoRecord, FullBodyPosePico, FullBodyPosePicoTracked>;
+using FullBodyMcapViewers = McapTrackerViewers<FullBodyPosePicoRecord>;
 
 class ReplayFullBodyTrackerPicoImpl : public IFullBodyTrackerPicoImpl
 {

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_base/full_body_tracker_pico_base.hpp>
+#include <mcap/tracker_channels.hpp>
+#include <schema/full_body_generated.h>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace core
+{
+
+using FullBodyMcapViewers = McapTrackerViewers<FullBodyPosePicoRecord, FullBodyPosePico>;
+
+class ReplayFullBodyTrackerPicoImpl : public IFullBodyTrackerPicoImpl
+{
+public:
+    static std::unique_ptr<FullBodyMcapViewers> create_mcap_viewers(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayFullBodyTrackerPicoImpl(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayFullBodyTrackerPicoImpl(const ReplayFullBodyTrackerPicoImpl&) = delete;
+    ReplayFullBodyTrackerPicoImpl& operator=(const ReplayFullBodyTrackerPicoImpl&) = delete;
+    ReplayFullBodyTrackerPicoImpl(ReplayFullBodyTrackerPicoImpl&&) = delete;
+    ReplayFullBodyTrackerPicoImpl& operator=(ReplayFullBodyTrackerPicoImpl&&) = delete;
+
+    void update(int64_t monotonic_time_ns) override;
+    const FullBodyPosePicoTrackedT& get_body_pose() const override;
+
+private:
+    FullBodyPosePicoTrackedT tracked_;
+    int64_t last_update_time_ = 0;
+
+    std::unique_ptr<FullBodyMcapViewers> mcap_viewers_;
+};
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
@@ -18,17 +18,13 @@ namespace core
 // ReplayGeneric3AxisPedalTrackerImpl
 // ============================================================================
 
-std::unique_ptr<PedalMcapViewers> ReplayGeneric3AxisPedalTrackerImpl::create_mcap_viewers(mcap::McapReader& reader,
-                                                                                          std::string_view base_name)
-{
-    return std::make_unique<PedalMcapViewers>(reader, base_name,
-                                              std::vector<std::string>(PedalRecordingTraits::replay_channels.begin(),
-                                                                       PedalRecordingTraits::replay_channels.end()));
-}
-
 ReplayGeneric3AxisPedalTrackerImpl::ReplayGeneric3AxisPedalTrackerImpl(mcap::McapReader& reader,
                                                                        std::string_view base_name)
-    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+    : mcap_viewers_(
+          std::make_unique<PedalMcapViewers>(reader,
+                                             base_name,
+                                             std::vector<std::string>(PedalRecordingTraits::replay_channels.begin(),
+                                                                      PedalRecordingTraits::replay_channels.end())))
 {
 }
 
@@ -39,18 +35,15 @@ const Generic3AxisPedalOutputTrackedT& ReplayGeneric3AxisPedalTrackerImpl::get_d
 
 void ReplayGeneric3AxisPedalTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
-    if (mcap_viewers_)
+    auto record = mcap_viewers_->read(0);
+    if (record)
     {
-        auto record = mcap_viewers_->read(0);
-        if (record)
-        {
-            tracked_.data = std::move(record->data);
-        }
-        else
-        {
-            std::cerr << "ReplayGeneric3AxisPedalTrackerImpl: pedal data not found" << std::endl;
-            tracked_.data.reset();
-        }
+        tracked_.data = std::move(record->data);
+    }
+    else
+    {
+        std::cerr << "ReplayGeneric3AxisPedalTrackerImpl: pedal data not found" << std::endl;
+        tracked_.data.reset();
     }
 }
 

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
@@ -4,7 +4,6 @@
 #include "replay_generic_3axis_pedal_tracker_impl.hpp"
 
 #include <mcap/recording_traits.hpp>
-#include <oxr_utils/oxr_funcs.hpp>
 #include <schema/pedals_bfbs_generated.h>
 #include <schema/timestamp_generated.h>
 

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "replay_generic_3axis_pedal_tracker_impl.hpp"
+
+#include <mcap/recording_traits.hpp>
+#include <oxr_utils/oxr_funcs.hpp>
+#include <schema/pedals_bfbs_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+
+namespace core
+{
+
+// ============================================================================
+// ReplayGeneric3AxisPedalTrackerImpl
+// ============================================================================
+
+std::unique_ptr<PedalMcapViewers> ReplayGeneric3AxisPedalTrackerImpl::create_mcap_viewers(mcap::McapReader& reader,
+                                                                                          std::string_view base_name)
+{
+    return std::make_unique<PedalMcapViewers>(reader, base_name,
+                                              std::vector<std::string>(PedalRecordingTraits::replay_channels.begin(),
+                                                                       PedalRecordingTraits::replay_channels.end()));
+}
+
+ReplayGeneric3AxisPedalTrackerImpl::ReplayGeneric3AxisPedalTrackerImpl(mcap::McapReader& reader,
+                                                                       std::string_view base_name)
+    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+{
+}
+
+const Generic3AxisPedalOutputTrackedT& ReplayGeneric3AxisPedalTrackerImpl::get_data() const
+{
+    return tracked_;
+}
+
+void ReplayGeneric3AxisPedalTrackerImpl::update(int64_t /*monotonic_time_ns*/)
+{
+    if (mcap_viewers_)
+    {
+        auto pedal_data = mcap_viewers_->read(0);
+        if (pedal_data)
+        {
+            tracked_.data = *pedal_data;
+        }
+        else
+        {
+            std::cerr << "ReplayGeneric3AxisPedalTrackerImpl: pedal data not found" << std::endl;
+            tracked_.data.reset();
+        }
+    }
+}
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
@@ -41,10 +41,10 @@ void ReplayGeneric3AxisPedalTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto pedal_data = mcap_viewers_->read(0);
-        if (pedal_data)
+        auto result = mcap_viewers_->read(0);
+        if (result)
         {
-            tracked_.data = *pedal_data;
+            tracked_ = std::move(*result);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
@@ -41,10 +41,10 @@ void ReplayGeneric3AxisPedalTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto result = mcap_viewers_->read(0);
-        if (result)
+        auto record = mcap_viewers_->read(0);
+        if (record)
         {
-            tracked_ = std::move(*result);
+            tracked_.data = std::move(record->data);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
@@ -33,8 +33,6 @@ public:
 
 private:
     Generic3AxisPedalOutputTrackedT tracked_;
-    int64_t last_update_time_ = 0;
-
     std::unique_ptr<PedalMcapViewers> mcap_viewers_;
 };
 

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
@@ -14,8 +14,7 @@
 namespace core
 {
 
-using PedalMcapViewers =
-    McapTrackerViewers<Generic3AxisPedalOutputRecord, Generic3AxisPedalOutput, Generic3AxisPedalOutputTracked>;
+using PedalMcapViewers = McapTrackerViewers<Generic3AxisPedalOutputRecord>;
 
 class ReplayGeneric3AxisPedalTrackerImpl : public IGeneric3AxisPedalTrackerImpl
 {

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
@@ -19,8 +19,6 @@ using PedalMcapViewers = McapTrackerViewers<Generic3AxisPedalOutputRecord>;
 class ReplayGeneric3AxisPedalTrackerImpl : public IGeneric3AxisPedalTrackerImpl
 {
 public:
-    static std::unique_ptr<PedalMcapViewers> create_mcap_viewers(mcap::McapReader& reader, std::string_view base_name);
-
     ReplayGeneric3AxisPedalTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
 
     ReplayGeneric3AxisPedalTrackerImpl(const ReplayGeneric3AxisPedalTrackerImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
@@ -14,7 +14,8 @@
 namespace core
 {
 
-using PedalMcapViewers = McapTrackerViewers<Generic3AxisPedalOutputRecord, Generic3AxisPedalOutput>;
+using PedalMcapViewers =
+    McapTrackerViewers<Generic3AxisPedalOutputRecord, Generic3AxisPedalOutput, Generic3AxisPedalOutputTracked>;
 
 class ReplayGeneric3AxisPedalTrackerImpl : public IGeneric3AxisPedalTrackerImpl
 {

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_base/generic_3axis_pedal_tracker_base.hpp>
+#include <mcap/tracker_channels.hpp>
+#include <schema/pedals_generated.h>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace core
+{
+
+using PedalMcapViewers = McapTrackerViewers<Generic3AxisPedalOutputRecord, Generic3AxisPedalOutput>;
+
+class ReplayGeneric3AxisPedalTrackerImpl : public IGeneric3AxisPedalTrackerImpl
+{
+public:
+    static std::unique_ptr<PedalMcapViewers> create_mcap_viewers(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayGeneric3AxisPedalTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayGeneric3AxisPedalTrackerImpl(const ReplayGeneric3AxisPedalTrackerImpl&) = delete;
+    ReplayGeneric3AxisPedalTrackerImpl& operator=(const ReplayGeneric3AxisPedalTrackerImpl&) = delete;
+    ReplayGeneric3AxisPedalTrackerImpl(ReplayGeneric3AxisPedalTrackerImpl&&) = delete;
+    ReplayGeneric3AxisPedalTrackerImpl& operator=(ReplayGeneric3AxisPedalTrackerImpl&&) = delete;
+
+    void update(int64_t monotonic_time_ns) override;
+    const Generic3AxisPedalOutputTrackedT& get_data() const override;
+
+private:
+    Generic3AxisPedalOutputTrackedT tracked_;
+    int64_t last_update_time_ = 0;
+
+    std::unique_ptr<PedalMcapViewers> mcap_viewers_;
+};
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
@@ -18,16 +18,12 @@ namespace core
 // ReplayHandTrackerImpl
 // ============================================================================
 
-std::unique_ptr<HandMcapViewers> ReplayHandTrackerImpl::create_mcap_viewers(mcap::McapReader& reader,
-                                                                            std::string_view base_name)
-{
-    return std::make_unique<HandMcapViewers>(reader, base_name,
-                                             std::vector<std::string>(HandRecordingTraits::replay_channels.begin(),
-                                                                      HandRecordingTraits::replay_channels.end()));
-}
-
 ReplayHandTrackerImpl::ReplayHandTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
-    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+    : mcap_viewers_(
+          std::make_unique<HandMcapViewers>(reader,
+                                            base_name,
+                                            std::vector<std::string>(HandRecordingTraits::replay_channels.begin(),
+                                                                     HandRecordingTraits::replay_channels.end())))
 {
 }
 
@@ -43,29 +39,26 @@ const HandPoseTrackedT& ReplayHandTrackerImpl::get_right_hand() const
 
 void ReplayHandTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
-    if (mcap_viewers_)
+    auto left_record = mcap_viewers_->read(0);
+    auto right_record = mcap_viewers_->read(1);
+    if (left_record)
     {
-        auto left_record = mcap_viewers_->read(0);
-        auto right_record = mcap_viewers_->read(1);
-        if (left_record)
-        {
-            left_tracked_.data = std::move(left_record->data);
-        }
-        else
-        {
-            std::cerr << "ReplayHandTrackerImpl: left hand data not found" << std::endl;
-            left_tracked_.data.reset();
-        }
+        left_tracked_.data = std::move(left_record->data);
+    }
+    else
+    {
+        std::cerr << "ReplayHandTrackerImpl: left hand data not found" << std::endl;
+        left_tracked_.data.reset();
+    }
 
-        if (right_record)
-        {
-            right_tracked_.data = std::move(right_record->data);
-        }
-        else
-        {
-            std::cerr << "ReplayHandTrackerImpl: right hand data not found" << std::endl;
-            right_tracked_.data.reset();
-        }
+    if (right_record)
+    {
+        right_tracked_.data = std::move(right_record->data);
+    }
+    else
+    {
+        std::cerr << "ReplayHandTrackerImpl: right hand data not found" << std::endl;
+        right_tracked_.data.reset();
     }
 }
 

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
@@ -45,11 +45,11 @@ void ReplayHandTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto left_hand_data = mcap_viewers_->read(0);
-        auto right_hand_data = mcap_viewers_->read(1);
-        if (left_hand_data)
+        auto left_result = mcap_viewers_->read(0);
+        auto right_result = mcap_viewers_->read(1);
+        if (left_result)
         {
-            left_tracked_.data = *left_hand_data;
+            left_tracked_ = std::move(*left_result);
         }
         else
         {
@@ -57,9 +57,9 @@ void ReplayHandTrackerImpl::update(int64_t /*monotonic_time_ns*/)
             left_tracked_.data.reset();
         }
 
-        if (right_hand_data)
+        if (right_result)
         {
-            right_tracked_.data = *right_hand_data;
+            right_tracked_ = std::move(*right_result);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "replay_hand_tracker_impl.hpp"
+
+#include <mcap/recording_traits.hpp>
+#include <oxr_utils/oxr_funcs.hpp>
+#include <schema/hand_bfbs_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+
+namespace core
+{
+
+// ============================================================================
+// ReplayHandTrackerImpl
+// ============================================================================
+
+std::unique_ptr<HandMcapViewers> ReplayHandTrackerImpl::create_mcap_viewers(mcap::McapReader& reader,
+                                                                            std::string_view base_name)
+{
+    return std::make_unique<HandMcapViewers>(reader, base_name,
+                                             std::vector<std::string>(HandRecordingTraits::replay_channels.begin(),
+                                                                      HandRecordingTraits::replay_channels.end()));
+}
+
+ReplayHandTrackerImpl::ReplayHandTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
+    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+{
+}
+
+const HandPoseTrackedT& ReplayHandTrackerImpl::get_left_hand() const
+{
+    return left_tracked_;
+}
+
+const HandPoseTrackedT& ReplayHandTrackerImpl::get_right_hand() const
+{
+    return right_tracked_;
+}
+
+void ReplayHandTrackerImpl::update(int64_t /*monotonic_time_ns*/)
+{
+    if (mcap_viewers_)
+    {
+        auto left_hand_data = mcap_viewers_->read(0);
+        auto right_hand_data = mcap_viewers_->read(1);
+        if (left_hand_data)
+        {
+            left_tracked_.data = *left_hand_data;
+        }
+        else
+        {
+            std::cerr << "ReplayHandTrackerImpl: left hand data not found" << std::endl;
+            left_tracked_.data.reset();
+        }
+
+        if (right_hand_data)
+        {
+            right_tracked_.data = *right_hand_data;
+        }
+        else
+        {
+            std::cerr << "ReplayHandTrackerImpl: right hand data not found" << std::endl;
+            right_tracked_.data.reset();
+        }
+    }
+}
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
@@ -45,11 +45,11 @@ void ReplayHandTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto left_result = mcap_viewers_->read(0);
-        auto right_result = mcap_viewers_->read(1);
-        if (left_result)
+        auto left_record = mcap_viewers_->read(0);
+        auto right_record = mcap_viewers_->read(1);
+        if (left_record)
         {
-            left_tracked_ = std::move(*left_result);
+            left_tracked_.data = std::move(left_record->data);
         }
         else
         {
@@ -57,9 +57,9 @@ void ReplayHandTrackerImpl::update(int64_t /*monotonic_time_ns*/)
             left_tracked_.data.reset();
         }
 
-        if (right_result)
+        if (right_record)
         {
-            right_tracked_ = std::move(*right_result);
+            right_tracked_.data = std::move(right_record->data);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
@@ -4,7 +4,6 @@
 #include "replay_hand_tracker_impl.hpp"
 
 #include <mcap/recording_traits.hpp>
-#include <oxr_utils/oxr_funcs.hpp>
 #include <schema/hand_bfbs_generated.h>
 #include <schema/timestamp_generated.h>
 

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
@@ -35,8 +35,6 @@ public:
 private:
     HandPoseTrackedT left_tracked_;
     HandPoseTrackedT right_tracked_;
-    int64_t last_update_time_ = 0;
-
     std::unique_ptr<HandMcapViewers> mcap_viewers_;
 };
 

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_base/hand_tracker_base.hpp>
+#include <mcap/tracker_channels.hpp>
+#include <schema/hand_generated.h>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace core
+{
+
+using HandMcapViewers = McapTrackerViewers<HandPoseRecord, HandPose>;
+
+class ReplayHandTrackerImpl : public IHandTrackerImpl
+{
+public:
+    static std::unique_ptr<HandMcapViewers> create_mcap_viewers(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayHandTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayHandTrackerImpl(const ReplayHandTrackerImpl&) = delete;
+    ReplayHandTrackerImpl& operator=(const ReplayHandTrackerImpl&) = delete;
+    ReplayHandTrackerImpl(ReplayHandTrackerImpl&&) = delete;
+    ReplayHandTrackerImpl& operator=(ReplayHandTrackerImpl&&) = delete;
+
+    void update(int64_t monotonic_time_ns) override;
+    const HandPoseTrackedT& get_left_hand() const override;
+    const HandPoseTrackedT& get_right_hand() const override;
+
+private:
+    HandPoseTrackedT left_tracked_;
+    HandPoseTrackedT right_tracked_;
+    int64_t last_update_time_ = 0;
+
+    std::unique_ptr<HandMcapViewers> mcap_viewers_;
+};
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
@@ -19,8 +19,6 @@ using HandMcapViewers = McapTrackerViewers<HandPoseRecord>;
 class ReplayHandTrackerImpl : public IHandTrackerImpl
 {
 public:
-    static std::unique_ptr<HandMcapViewers> create_mcap_viewers(mcap::McapReader& reader, std::string_view base_name);
-
     ReplayHandTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
 
     ReplayHandTrackerImpl(const ReplayHandTrackerImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
@@ -14,7 +14,7 @@
 namespace core
 {
 
-using HandMcapViewers = McapTrackerViewers<HandPoseRecord, HandPose>;
+using HandMcapViewers = McapTrackerViewers<HandPoseRecord, HandPose, HandPoseTracked>;
 
 class ReplayHandTrackerImpl : public IHandTrackerImpl
 {

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
@@ -14,7 +14,7 @@
 namespace core
 {
 
-using HandMcapViewers = McapTrackerViewers<HandPoseRecord, HandPose, HandPoseTracked>;
+using HandMcapViewers = McapTrackerViewers<HandPoseRecord>;
 
 class ReplayHandTrackerImpl : public IHandTrackerImpl
 {

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
@@ -40,10 +40,10 @@ void ReplayHeadTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto result = mcap_viewers_->read(0);
-        if (result)
+        auto record = mcap_viewers_->read(0);
+        if (record)
         {
-            tracked_ = std::move(*result);
+            tracked_.data = std::move(record->data);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
@@ -40,10 +40,10 @@ void ReplayHeadTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
     if (mcap_viewers_)
     {
-        auto head_data = mcap_viewers_->read(0);
-        if (head_data)
+        auto result = mcap_viewers_->read(0);
+        if (result)
         {
-            tracked_.data = *head_data;
+            tracked_ = std::move(*result);
         }
         else
         {

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
@@ -4,7 +4,6 @@
 #include "replay_head_tracker_impl.hpp"
 
 #include <mcap/recording_traits.hpp>
-#include <oxr_utils/oxr_funcs.hpp>
 #include <schema/head_bfbs_generated.h>
 #include <schema/timestamp_generated.h>
 

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
@@ -18,16 +18,12 @@ namespace core
 // ReplayHeadTrackerImpl
 // ============================================================================
 
-std::unique_ptr<HeadMcapViewers> ReplayHeadTrackerImpl::create_mcap_viewers(mcap::McapReader& reader,
-                                                                            std::string_view base_name)
-{
-    return std::make_unique<HeadMcapViewers>(reader, base_name,
-                                             std::vector<std::string>(HeadRecordingTraits::replay_channels.begin(),
-                                                                      HeadRecordingTraits::replay_channels.end()));
-}
-
 ReplayHeadTrackerImpl::ReplayHeadTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
-    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+    : mcap_viewers_(
+          std::make_unique<HeadMcapViewers>(reader,
+                                            base_name,
+                                            std::vector<std::string>(HeadRecordingTraits::replay_channels.begin(),
+                                                                     HeadRecordingTraits::replay_channels.end())))
 {
 }
 
@@ -38,18 +34,15 @@ const HeadPoseTrackedT& ReplayHeadTrackerImpl::get_head() const
 
 void ReplayHeadTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
-    if (mcap_viewers_)
+    auto record = mcap_viewers_->read(0);
+    if (record)
     {
-        auto record = mcap_viewers_->read(0);
-        if (record)
-        {
-            tracked_.data = std::move(record->data);
-        }
-        else
-        {
-            std::cerr << "ReplayHeadTrackerImpl: head data not found" << std::endl;
-            tracked_.data.reset();
-        }
+        tracked_.data = std::move(record->data);
+    }
+    else
+    {
+        std::cerr << "ReplayHeadTrackerImpl: head data not found" << std::endl;
+        tracked_.data.reset();
     }
 }
 

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "replay_head_tracker_impl.hpp"
+
+#include <mcap/recording_traits.hpp>
+#include <oxr_utils/oxr_funcs.hpp>
+#include <schema/head_bfbs_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <cassert>
+#include <cstring>
+#include <iostream>
+
+namespace core
+{
+
+// ============================================================================
+// ReplayHeadTrackerImpl
+// ============================================================================
+
+std::unique_ptr<HeadMcapViewers> ReplayHeadTrackerImpl::create_mcap_viewers(mcap::McapReader& reader,
+                                                                            std::string_view base_name)
+{
+    return std::make_unique<HeadMcapViewers>(reader, base_name,
+                                             std::vector<std::string>(HeadRecordingTraits::replay_channels.begin(),
+                                                                      HeadRecordingTraits::replay_channels.end()));
+}
+
+ReplayHeadTrackerImpl::ReplayHeadTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
+    : mcap_viewers_(create_mcap_viewers(reader, base_name))
+{
+}
+
+const HeadPoseTrackedT& ReplayHeadTrackerImpl::get_head() const
+{
+    return tracked_;
+}
+
+void ReplayHeadTrackerImpl::update(int64_t /*monotonic_time_ns*/)
+{
+    if (mcap_viewers_)
+    {
+        auto head_data = mcap_viewers_->read(0);
+        if (head_data)
+        {
+            tracked_.data = *head_data;
+        }
+        else
+        {
+            std::cerr << "ReplayHeadTrackerImpl: head data not found" << std::endl;
+            tracked_.data.reset();
+        }
+    }
+}
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_base/head_tracker_base.hpp>
+#include <mcap/tracker_channels.hpp>
+#include <schema/head_generated.h>
+
+#include <cstdint>
+#include <memory>
+#include <string_view>
+
+namespace core
+{
+
+using HeadMcapViewers = McapTrackerViewers<HeadPoseRecord, HeadPose>;
+
+class ReplayHeadTrackerImpl : public IHeadTrackerImpl
+{
+public:
+    static std::unique_ptr<HeadMcapViewers> create_mcap_viewers(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayHeadTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
+
+    ReplayHeadTrackerImpl(const ReplayHeadTrackerImpl&) = delete;
+    ReplayHeadTrackerImpl& operator=(const ReplayHeadTrackerImpl&) = delete;
+    ReplayHeadTrackerImpl(ReplayHeadTrackerImpl&&) = delete;
+    ReplayHeadTrackerImpl& operator=(ReplayHeadTrackerImpl&&) = delete;
+
+    void update(int64_t monotonic_time_ns) override;
+    const HeadPoseTrackedT& get_head() const override;
+
+private:
+    HeadPoseTrackedT tracked_;
+    int64_t last_update_time_ = 0;
+
+    std::unique_ptr<HeadMcapViewers> mcap_viewers_;
+};
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
@@ -19,8 +19,6 @@ using HeadMcapViewers = McapTrackerViewers<HeadPoseRecord>;
 class ReplayHeadTrackerImpl : public IHeadTrackerImpl
 {
 public:
-    static std::unique_ptr<HeadMcapViewers> create_mcap_viewers(mcap::McapReader& reader, std::string_view base_name);
-
     ReplayHeadTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
 
     ReplayHeadTrackerImpl(const ReplayHeadTrackerImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
@@ -14,7 +14,7 @@
 namespace core
 {
 
-using HeadMcapViewers = McapTrackerViewers<HeadPoseRecord, HeadPose, HeadPoseTracked>;
+using HeadMcapViewers = McapTrackerViewers<HeadPoseRecord>;
 
 class ReplayHeadTrackerImpl : public IHeadTrackerImpl
 {

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
@@ -33,8 +33,6 @@ public:
 
 private:
     HeadPoseTrackedT tracked_;
-    int64_t last_update_time_ = 0;
-
     std::unique_ptr<HeadMcapViewers> mcap_viewers_;
 };
 

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
@@ -14,7 +14,7 @@
 namespace core
 {
 
-using HeadMcapViewers = McapTrackerViewers<HeadPoseRecord, HeadPose>;
+using HeadMcapViewers = McapTrackerViewers<HeadPoseRecord, HeadPose, HeadPoseTracked>;
 
 class ReplayHeadTrackerImpl : public IHeadTrackerImpl
 {


### PR DESCRIPTION
Each replay tracker keeps a McapTrackerViewers object to be able to iterate mcap channels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added replay functionality to playback tracker data from archived MCAP file recordings.
  * Support for replaying data streams from head, hand, controller, full-body, and generic 3-axis pedal trackers.
  * New tracker replay factory system for managing multiple tracker type replay sessions.
  * Tracker recording framework updated to support both recording and replay modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->