### PR TITLE
[Replay] Replay API in TeleopSession

### DIFF
--- a/src/core/deviceio_session/python/session_bindings.cpp
+++ b/src/core/deviceio_session/python/session_bindings.cpp
@@ -70,8 +70,21 @@ PYBIND11_MODULE(_deviceio_session, m)
                      }
                      return config;
                  }),
-             py::arg("filename"), py::arg("tracker_names"))
-        .def_readwrite("filename", &core::McapReplayConfig::filename);
+             py::arg("filename"),
+             py::arg("tracker_names") = std::vector<std::pair<std::shared_ptr<core::ITracker>, std::string>>{})
+        .def_readwrite("filename", &core::McapReplayConfig::filename)
+        .def(
+            "get_tracker_names",
+            [](const core::McapReplayConfig& c)
+            {
+                py::list result;
+                for (const auto& [tracker, name] : c.tracker_names)
+                {
+                    result.append(py::make_tuple(py::cast(tracker), name));
+                }
+                return result;
+            },
+            "Return the list of (tracker, channel_name) pairs.");
 
     // ---- DeviceIOSession (live) ----
     py::class_<core::PyDeviceIOSession, core::ITrackerSession, std::unique_ptr<core::PyDeviceIOSession>>(

--- a/src/core/deviceio_session/python/session_bindings.cpp
+++ b/src/core/deviceio_session/python/session_bindings.cpp
@@ -38,8 +38,21 @@ PYBIND11_MODULE(_deviceio_session, m)
                      }
                      return config;
                  }),
-             py::arg("filename"), py::arg("tracker_names"))
-        .def_readwrite("filename", &core::McapRecordingConfig::filename);
+             py::arg("filename"),
+             py::arg("tracker_names") = std::vector<std::pair<std::shared_ptr<core::ITracker>, std::string>>{})
+        .def_readwrite("filename", &core::McapRecordingConfig::filename)
+        .def(
+            "get_tracker_names",
+            [](const core::McapRecordingConfig& c)
+            {
+                py::list result;
+                for (const auto& [tracker, name] : c.tracker_names)
+                {
+                    result.append(py::make_tuple(py::cast(tracker), name));
+                }
+                return result;
+            },
+            "Return the list of (tracker, channel_name) pairs.");
 
     // ---- McapReplayConfig (replay) ----
     py::class_<core::McapReplayConfig>(m, "McapReplayConfig",

--- a/src/core/teleop_session_manager/python/__init__.py
+++ b/src/core/teleop_session_manager/python/__init__.py
@@ -1,8 +1,9 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 from .teleop_session import TeleopSession
 from .config import (
+    SessionMode,
     TeleopSessionConfig,
     PluginConfig,
 )
@@ -26,6 +27,7 @@ from .input_selector import create_bool_selector
 __all__ = [
     "TeleopSession",
     "TeleopSessionConfig",
+    "SessionMode",
     "PluginConfig",
     "create_standard_inputs",
     "get_required_oxr_extensions_from_pipeline",

--- a/src/core/teleop_session_manager/python/config.py
+++ b/src/core/teleop_session_manager/python/config.py
@@ -85,9 +85,12 @@ class TeleopSessionConfig:
             instead of creating its own OpenXR session via OpenXRSession.create().
             Construct with ``OpenXRSessionHandles(instance, session, space, proc_addr)``
             where each argument is a ``uint64`` handle value.
-        mcap_config: Optional McapConfig for MCAP recording. When provided, the live
-            DeviceIO session will record tracker data to the specified MCAP file.
-            Construct with ``McapConfig(filename, [(tracker, channel_name), ...])``.
+        mcap_config: Optional McapConfig for MCAP recording. When
+            ``tracker_names`` is empty (e.g. ``McapConfig("out.mcap")``),
+            TeleopSession auto-populates it from the pipeline's discovered
+            DeviceIO sources, using each source's ``name`` as the MCAP channel
+            name. When ``tracker_names`` is explicitly provided, it is used
+            as-is.
 
     Example (auto-discovery):
         # Source creates its own tracker automatically!

--- a/src/core/teleop_session_manager/python/config.py
+++ b/src/core/teleop_session_manager/python/config.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
     GraphExecutable,
@@ -22,7 +22,7 @@ from isaacteleop.retargeting_engine.tensor_types import BoolType
 from .teleop_state_manager_types import teleop_control_states
 
 if TYPE_CHECKING:
-    from isaacteleop.deviceio_session import McapRecordingConfig
+    from isaacteleop.deviceio_session import McapRecordingConfig, McapReplayConfig
     from teleopcore.oxr import OpenXRSessionHandles
 
 
@@ -136,7 +136,7 @@ class TeleopSessionConfig:
     plugins: List[PluginConfig] = field(default_factory=list)
     verbose: bool = True
     oxr_handles: Optional[OpenXRSessionHandles] = None
-    mcap_config: Optional[McapRecordingConfig] = None
+    mcap_config: Optional[Union[McapRecordingConfig, McapReplayConfig]] = None
 
     def __post_init__(self) -> None:
         """Validate configuration consistency."""

--- a/src/core/teleop_session_manager/python/config.py
+++ b/src/core/teleop_session_manager/python/config.py
@@ -85,12 +85,15 @@ class TeleopSessionConfig:
             instead of creating its own OpenXR session via OpenXRSession.create().
             Construct with ``OpenXRSessionHandles(instance, session, space, proc_addr)``
             where each argument is a ``uint64`` handle value.
-        mcap_config: Optional McapRecordingConfig for MCAP recording. When
-            ``tracker_names`` is empty (e.g. ``McapRecordingConfig("out.mcap")``),
-            TeleopSession auto-populates it from the pipeline's discovered
-            DeviceIO sources, using each source's ``name`` as the MCAP channel
-            name. When ``tracker_names`` is explicitly provided, it is used
-            as-is.
+        mcap_config: MCAP configuration — ``McapRecordingConfig`` for live
+            recording, ``McapReplayConfig`` for replay.  **Required** when
+            ``mode`` is ``SessionMode.REPLAY``; optional in ``LIVE`` mode.
+            In both cases, when ``tracker_names`` is empty
+            (e.g. ``McapRecordingConfig("out.mcap")`` or
+            ``McapReplayConfig("recording.mcap")``), TeleopSession
+            auto-populates it from the pipeline's discovered DeviceIO sources,
+            using each source's ``name`` as the MCAP channel name. When
+            ``tracker_names`` is explicitly provided, it is used as-is.
 
     Example (auto-discovery):
         # Source creates its own tracker automatically!

--- a/src/core/teleop_session_manager/python/config.py
+++ b/src/core/teleop_session_manager/python/config.py
@@ -22,7 +22,7 @@ from isaacteleop.retargeting_engine.tensor_types import BoolType
 from .teleop_state_manager_types import teleop_control_states
 
 if TYPE_CHECKING:
-    from isaacteleop.deviceio_session import McapConfig
+    from isaacteleop.deviceio_session import McapRecordingConfig
     from teleopcore.oxr import OpenXRSessionHandles
 
 
@@ -85,8 +85,8 @@ class TeleopSessionConfig:
             instead of creating its own OpenXR session via OpenXRSession.create().
             Construct with ``OpenXRSessionHandles(instance, session, space, proc_addr)``
             where each argument is a ``uint64`` handle value.
-        mcap_config: Optional McapConfig for MCAP recording. When
-            ``tracker_names`` is empty (e.g. ``McapConfig("out.mcap")``),
+        mcap_config: Optional McapRecordingConfig for MCAP recording. When
+            ``tracker_names`` is empty (e.g. ``McapRecordingConfig("out.mcap")``),
             TeleopSession auto-populates it from the pipeline's discovered
             DeviceIO sources, using each source's ``name`` as the MCAP channel
             name. When ``tracker_names`` is explicitly provided, it is used
@@ -136,7 +136,7 @@ class TeleopSessionConfig:
     plugins: List[PluginConfig] = field(default_factory=list)
     verbose: bool = True
     oxr_handles: Optional[OpenXRSessionHandles] = None
-    mcap_config: Optional[McapConfig] = None
+    mcap_config: Optional[McapRecordingConfig] = None
 
     def __post_init__(self) -> None:
         """Validate configuration consistency."""

--- a/src/core/teleop_session_manager/python/config.py
+++ b/src/core/teleop_session_manager/python/config.py
@@ -88,12 +88,11 @@ class TeleopSessionConfig:
         mcap_config: MCAP configuration — ``McapRecordingConfig`` for live
             recording, ``McapReplayConfig`` for replay.  **Required** when
             ``mode`` is ``SessionMode.REPLAY``; optional in ``LIVE`` mode.
-            In both cases, when ``tracker_names`` is empty
-            (e.g. ``McapRecordingConfig("out.mcap")`` or
-            ``McapReplayConfig("recording.mcap")``), TeleopSession
-            auto-populates it from the pipeline's discovered DeviceIO sources,
-            using each source's ``name`` as the MCAP channel name. When
-            ``tracker_names`` is explicitly provided, it is used as-is.
+            TeleopSession always auto-populates tracker names from the
+            pipeline's discovered DeviceIO sources (using each source's
+            ``name`` as the MCAP channel name).  Any ``tracker_names``
+            explicitly provided in the config are **appended** after the
+            auto-discovered sources.
 
     Example (auto-discovery):
         # Source creates its own tracker automatically!

--- a/src/core/teleop_session_manager/python/config.py
+++ b/src/core/teleop_session_manager/python/config.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -10,6 +10,7 @@ These classes provide a clean, declarative way to configure teleop sessions.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, List, Optional
 
@@ -21,7 +22,15 @@ from isaacteleop.retargeting_engine.tensor_types import BoolType
 from .teleop_state_manager_types import teleop_control_states
 
 if TYPE_CHECKING:
+    from isaacteleop.deviceio_session import McapConfig
     from teleopcore.oxr import OpenXRSessionHandles
+
+
+class SessionMode(Enum):
+    """Determines whether the teleop session runs live or replays from an MCAP file."""
+
+    LIVE = "live"
+    REPLAY = "replay"
 
 
 @dataclass
@@ -60,6 +69,9 @@ class TeleopSessionConfig:
     Attributes:
         app_name: Name of the OpenXR application
         pipeline: Main retargeting pipeline.
+        mode: Whether to run a live OpenXR session or replay from an MCAP file.
+            Defaults to ``SessionMode.LIVE``. When ``REPLAY``, ``mcap_config`` is required
+            and OpenXR/plugin initialization is skipped.
         teleop_control_pipeline: Optional control pipeline whose outputs are
             decoded into ComputeContext.execution_events before running ``pipeline``.
             Expected outputs:
@@ -73,6 +85,9 @@ class TeleopSessionConfig:
             instead of creating its own OpenXR session via OpenXRSession.create().
             Construct with ``OpenXRSessionHandles(instance, session, space, proc_addr)``
             where each argument is a ``uint64`` handle value.
+        mcap_config: Optional McapConfig for MCAP recording. When provided, the live
+            DeviceIO session will record tracker data to the specified MCAP file.
+            Construct with ``McapConfig(filename, [(tracker, channel_name), ...])``.
 
     Example (auto-discovery):
         # Source creates its own tracker automatically!
@@ -112,14 +127,19 @@ class TeleopSessionConfig:
 
     app_name: str
     pipeline: GraphExecutable
+    mode: SessionMode = SessionMode.LIVE
     teleop_control_pipeline: Optional[GraphExecutable] = None
     trackers: List[Any] = field(default_factory=list)
     plugins: List[PluginConfig] = field(default_factory=list)
     verbose: bool = True
     oxr_handles: Optional[OpenXRSessionHandles] = None
+    mcap_config: Optional[McapConfig] = None
 
     def __post_init__(self) -> None:
-        """Validate optional teleop control pipeline output contract."""
+        """Validate configuration consistency."""
+        if self.mode == SessionMode.REPLAY and self.mcap_config is None:
+            raise ValueError("mcap_config is required when mode is SessionMode.REPLAY")
+
         if self.teleop_control_pipeline is None:
             return
 

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -528,9 +528,7 @@ class TeleopSession:
 
             # Create DeviceIO session with all trackers
             self.deviceio_session = self._exit_stack.enter_context(
-                deviceio.DeviceIOSession.run(
-                    trackers, handles, mcap_config
-                )
+                deviceio.DeviceIOSession.run(trackers, handles, mcap_config)
             )
 
         # Initialize plugins (if any)

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -517,10 +517,19 @@ class TeleopSession:
                 )
                 handles = self._oxr_session.get_handles()
 
+            # Auto-populate MCAP tracker names from discovered sources
+            # when the user provided only a filename.
+            mcap_config = self.config.mcap_config
+            if mcap_config is not None and not mcap_config.get_tracker_names():
+                mcap_config = deviceio.McapConfig(
+                    mcap_config.filename,
+                    [(source.get_tracker(), source.name) for source in self._sources],
+                )
+
             # Create DeviceIO session with all trackers
             self.deviceio_session = self._exit_stack.enter_context(
                 deviceio.DeviceIOSession.run(
-                    trackers, handles, self.config.mcap_config
+                    trackers, handles, mcap_config
                 )
             )
 

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -32,6 +32,7 @@ import isaacteleop.oxr as oxr
 import isaacteleop.plugin_manager as pm
 
 from .config import (
+    SessionMode,
     TeleopSessionConfig,
 )
 from .teleop_state_manager_types import teleop_control_states
@@ -478,7 +479,10 @@ class TeleopSession:
         Creates OpenXR session (unless external handles were provided),
         DeviceIO session, plugins, and UI. All preparation was done in __init__.
 
-        When ``config.oxr_handles`` is set, the provided handles are passed
+        When ``config.mode`` is ``SessionMode.REPLAY``, an OpenXR session is **not**
+        created; instead a replay DeviceIO session is opened from ``config.mcap_config``.
+
+        When ``config.oxr_handles`` is set (live mode), the provided handles are passed
         directly to ``DeviceIOSession.run()`` and no internal OpenXR session
         is created.  The caller is responsible for the external session lifetime.
 
@@ -489,30 +493,36 @@ class TeleopSession:
         self.plugin_managers = []
         self.plugin_contexts = []
 
-        # Collect trackers from source nodes and config
-        trackers = [source.get_tracker() for source in self._sources]
-        if self.config.trackers:
-            trackers.extend(self.config.trackers)
-
-        # Get required extensions from all trackers
-        required_extensions = deviceio.DeviceIOSession.get_required_extensions(trackers)
-
-        # Resolve OpenXR handles
-        if self.config.oxr_handles is not None:
-            # Use externally provided handles.
-            # The caller owns the OpenXR session lifetime; we only consume handles.
-            handles = self.config.oxr_handles
-        else:
-            # Create our own OpenXR session (standalone mode)
-            self._oxr_session = self._exit_stack.enter_context(
-                oxr.OpenXRSession(self.config.app_name, required_extensions)
+        if self.config.mode == SessionMode.REPLAY:
+            self.deviceio_session = self._exit_stack.enter_context(
+                deviceio.DeviceIOSession.replay(self.config.mcap_config)
             )
-            handles = self._oxr_session.get_handles()
+        else:
+            # Collect trackers from source nodes and config
+            trackers = [source.get_tracker() for source in self._sources]
+            if self.config.trackers:
+                trackers.extend(self.config.trackers)
 
-        # Create DeviceIO session with all trackers
-        self.deviceio_session = self._exit_stack.enter_context(
-            deviceio.DeviceIOSession.run(trackers, handles)
-        )
+            # Get required extensions from all trackers
+            required_extensions = deviceio.DeviceIOSession.get_required_extensions(
+                trackers
+            )
+
+            # Resolve OpenXR handles
+            if self.config.oxr_handles is not None:
+                handles = self.config.oxr_handles
+            else:
+                self._oxr_session = self._exit_stack.enter_context(
+                    oxr.OpenXRSession(self.config.app_name, required_extensions)
+                )
+                handles = self._oxr_session.get_handles()
+
+            # Create DeviceIO session with all trackers
+            self.deviceio_session = self._exit_stack.enter_context(
+                deviceio.DeviceIOSession.run(
+                    trackers, handles, self.config.mcap_config
+                )
+            )
 
         # Initialize plugins (if any)
         if self.config.plugins:

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -494,8 +494,14 @@ class TeleopSession:
         self.plugin_contexts = []
 
         if self.config.mode == SessionMode.REPLAY:
+            mcap_config = self.config.mcap_config
+            if not mcap_config.get_tracker_names():
+                mcap_config = deviceio.McapReplayConfig(
+                    mcap_config.filename,
+                    [(source.get_tracker(), source.name) for source in self._sources],
+                )
             self.deviceio_session = self._exit_stack.enter_context(
-                deviceio.ReplaySession.run(self.config.mcap_config)
+                deviceio.ReplaySession.run(mcap_config)
             )
         else:
             # Collect trackers from source nodes and config

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -493,13 +493,25 @@ class TeleopSession:
         self.plugin_managers = []
         self.plugin_contexts = []
 
-        if self.config.mode == SessionMode.REPLAY:
-            mcap_config = self.config.mcap_config
-            if not mcap_config.get_tracker_names():
+        # Auto-populate mcap_config from pipeline sources if recording or replaying.
+        mcap_config = None
+        if self.config.mcap_config is not None:
+            mcap_tracker_names = [
+                (source.get_tracker(), source.name) for source in self._sources
+            ]
+            mcap_tracker_names.extend(self.config.mcap_config.get_tracker_names())
+            if self.config.mode == SessionMode.REPLAY:
                 mcap_config = deviceio.McapReplayConfig(
-                    mcap_config.filename,
-                    [(source.get_tracker(), source.name) for source in self._sources],
+                    self.config.mcap_config.filename,
+                    mcap_tracker_names,
                 )
+            else:
+                mcap_config = deviceio.McapRecordingConfig(
+                    self.config.mcap_config.filename,
+                    mcap_tracker_names,
+                )
+
+        if self.config.mode == SessionMode.REPLAY:
             self.deviceio_session = self._exit_stack.enter_context(
                 deviceio.ReplaySession.run(mcap_config)
             )
@@ -522,15 +534,6 @@ class TeleopSession:
                     oxr.OpenXRSession(self.config.app_name, required_extensions)
                 )
                 handles = self._oxr_session.get_handles()
-
-            # Auto-populate MCAP tracker names from discovered sources
-            # when the user provided only a filename.
-            mcap_config = self.config.mcap_config
-            if mcap_config is not None and not mcap_config.get_tracker_names():
-                mcap_config = deviceio.McapRecordingConfig(
-                    mcap_config.filename,
-                    [(source.get_tracker(), source.name) for source in self._sources],
-                )
 
             # Create DeviceIO session with all trackers
             self.deviceio_session = self._exit_stack.enter_context(

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -495,7 +495,7 @@ class TeleopSession:
 
         if self.config.mode == SessionMode.REPLAY:
             self.deviceio_session = self._exit_stack.enter_context(
-                deviceio.DeviceIOSession.replay(self.config.mcap_config)
+                deviceio.ReplaySession.run(self.config.mcap_config)
             )
         else:
             # Collect trackers from source nodes and config

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -521,7 +521,7 @@ class TeleopSession:
             # when the user provided only a filename.
             mcap_config = self.config.mcap_config
             if mcap_config is not None and not mcap_config.get_tracker_names():
-                mcap_config = deviceio.McapConfig(
+                mcap_config = deviceio.McapRecordingConfig(
                     mcap_config.filename,
                     [(source.get_tracker(), source.name) for source in self._sources],
                 )

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1341,6 +1341,7 @@ def mock_replay_dependencies(mock_pm=None):
         - create_replay: the mock replacing ReplaySession.run
         - create_live: the mock replacing DeviceIOSession.run
         - oxr_cls: the mock replacing OpenXRSession
+        - replay_config_cls: the mock replacing McapReplayConfig
     """
     mock_dio_session = MockDeviceIOSession()
 
@@ -1356,13 +1357,20 @@ def mock_replay_dependencies(mock_pm=None):
             return_value=MagicMock(),
         ) as create_live,
         patch("isaacteleop.oxr.OpenXRSession", return_value=MagicMock()) as oxr_cls,
+        patch(
+            "isaacteleop.deviceio.DeviceIOSession.get_required_extensions",
+            return_value=[],
+        ),
         patch("isaacteleop.plugin_manager.PluginManager", return_value=mock_pm),
+        patch("isaacteleop.deviceio.McapReplayConfig") as replay_config_cls,
     ):
+        replay_config_cls.return_value = MagicMock()
         ns = MagicMock()
         ns.replay_session = mock_dio_session
         ns.create_replay = create_replay
         ns.create_live = create_live
         ns.oxr_cls = oxr_cls
+        ns.replay_config_cls = replay_config_cls
         yield ns
 
 
@@ -1412,16 +1420,20 @@ class TestReplayModeSessionEnter:
         )
 
     def test_calls_create_replay_session(self):
-        """DeviceIOSession.replay is called with the mcap_config."""
+        """ReplaySession.run is called in replay mode."""
         config = self._make_replay_config()
 
         with mock_replay_dependencies() as mocks:
-            session = TeleopSession(config)
-            session.__enter__()
-            try:
-                mocks.create_replay.assert_called_once_with(config.mcap_config)
-            finally:
-                session.__exit__(None, None, None)
+            with patch("isaacteleop.deviceio.McapReplayConfig") as mock_replay_cls:
+                mock_replay_cls.return_value = MagicMock()
+                session = TeleopSession(config)
+                session.__enter__()
+                try:
+                    mocks.create_replay.assert_called_once_with(
+                        mock_replay_cls.return_value
+                    )
+                finally:
+                    session.__exit__(None, None, None)
 
     def test_skips_oxr_session_creation(self):
         """OpenXRSession is NOT instantiated in replay mode."""
@@ -1543,10 +1555,11 @@ class TestReplayModeAutoPopulate:
                 finally:
                     session.__exit__(None, None, None)
 
-    def test_passes_through_when_tracker_names_present(self):
-        """Non-empty get_tracker_names() passes the original config through."""
+    def test_merges_sources_with_explicit_tracker_names(self):
+        """Explicit get_tracker_names() are appended after auto-discovered sources."""
         mcap_config = MagicMock()
-        mcap_config.get_tracker_names.return_value = [("tracker", "ch")]
+        mcap_config.filename = "recording.mcap"
+        mcap_config.get_tracker_names.return_value = [("extra_tracker", "extra")]
 
         head_source = MockHeadSource(name="head")
         pipeline = MockPipeline(leaf_nodes=[head_source])
@@ -1559,12 +1572,23 @@ class TestReplayModeAutoPopulate:
         )
 
         with mock_replay_dependencies() as mocks:
-            session = TeleopSession(config)
-            session.__enter__()
-            try:
-                mocks.create_replay.assert_called_once_with(mcap_config)
-            finally:
-                session.__exit__(None, None, None)
+            with patch("isaacteleop.deviceio.McapReplayConfig") as mock_replay_cls:
+                mock_replay_cls.return_value = MagicMock()
+                session = TeleopSession(config)
+                session.__enter__()
+                try:
+                    mock_replay_cls.assert_called_once_with(
+                        "recording.mcap",
+                        [
+                            (head_source.get_tracker(), "head"),
+                            ("extra_tracker", "extra"),
+                        ],
+                    )
+                    mocks.create_replay.assert_called_once_with(
+                        mock_replay_cls.return_value
+                    )
+                finally:
+                    session.__exit__(None, None, None)
 
 
 # ============================================================================
@@ -1579,6 +1603,7 @@ def mock_live_dependencies_with_args():
     Yields a namespace with:
         - create_live: the mock replacing DeviceIOSession.run (inspect call_args)
         - dio_session: the mock DeviceIO session returned by DeviceIOSession.run
+        - recording_config_cls: the mock replacing McapRecordingConfig
     """
     mock_dio_session = MockDeviceIOSession()
 
@@ -1595,10 +1620,13 @@ def mock_live_dependencies_with_args():
             return_value=[],
         ),
         patch("isaacteleop.plugin_manager.PluginManager", return_value=MagicMock()),
+        patch("isaacteleop.deviceio.McapRecordingConfig") as recording_config_cls,
     ):
+        recording_config_cls.return_value = MagicMock()
         ns = MagicMock()
         ns.create_live = create_live
         ns.dio_session = mock_dio_session
+        ns.recording_config_cls = recording_config_cls
         yield ns
 
 
@@ -1641,26 +1669,26 @@ class TestLiveModeWithMcapRecording:
         )
 
         with mock_live_dependencies_with_args() as mocks:
-            with patch("isaacteleop.deviceio.McapRecordingConfig") as mock_mcap_cls:
-                session = TeleopSession(config)
-                session.__enter__()
-                try:
-                    mock_mcap_cls.assert_called_once_with(
-                        "test.mcap",
-                        [
-                            (head_source.get_tracker(), "head"),
-                            (hands_source.get_tracker(), "hands"),
-                        ],
-                    )
-                    actual_mcap = mocks.create_live.call_args[0][2]
-                    assert actual_mcap is mock_mcap_cls.return_value
-                finally:
-                    session.__exit__(None, None, None)
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                mocks.recording_config_cls.assert_called_once_with(
+                    "test.mcap",
+                    [
+                        (head_source.get_tracker(), "head"),
+                        (hands_source.get_tracker(), "hands"),
+                    ],
+                )
+                actual_mcap = mocks.create_live.call_args[0][2]
+                assert actual_mcap is mocks.recording_config_cls.return_value
+            finally:
+                session.__exit__(None, None, None)
 
-    def test_mcap_passes_through_when_tracker_names_present(self):
-        """Non-empty get_tracker_names() passes the original config through."""
+    def test_mcap_merges_sources_with_explicit_tracker_names(self):
+        """Explicit get_tracker_names() are appended after auto-discovered sources."""
         mcap_config = MagicMock()
-        mcap_config.get_tracker_names.return_value = [("tracker", "ch")]
+        mcap_config.filename = "test.mcap"
+        mcap_config.get_tracker_names.return_value = [("extra_tracker", "extra")]
 
         head_source = MockHeadSource(name="head")
         pipeline = MockPipeline(leaf_nodes=[head_source])
@@ -1676,8 +1704,15 @@ class TestLiveModeWithMcapRecording:
             session = TeleopSession(config)
             session.__enter__()
             try:
+                mocks.recording_config_cls.assert_called_once_with(
+                    "test.mcap",
+                    [
+                        (head_source.get_tracker(), "head"),
+                        ("extra_tracker", "extra"),
+                    ],
+                )
                 actual_mcap = mocks.create_live.call_args[0][2]
-                assert actual_mcap is mcap_config
+                assert actual_mcap is mocks.recording_config_cls.return_value
             finally:
                 session.__exit__(None, None, None)
 

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1540,27 +1540,7 @@ def mock_live_dependencies_with_args():
 
 
 class TestLiveModeWithMcapRecording:
-    """Tests that mcap_config is forwarded to createLiveSession in live mode."""
-
-    def test_mcap_config_passed_to_create_live_session(self):
-        """createLiveSession receives the mcap_config as third argument."""
-        mcap_config = MagicMock()
-        config = TeleopSessionConfig(
-            app_name="test",
-            pipeline=MockPipeline(leaf_nodes=[]),
-            mode=SessionMode.LIVE,
-            mcap_config=mcap_config,
-        )
-
-        with mock_live_dependencies_with_args() as mocks:
-            session = TeleopSession(config)
-            session.__enter__()
-            try:
-                mocks.create_live.assert_called_once()
-                actual_mcap = mocks.create_live.call_args[0][2]
-                assert actual_mcap is mcap_config
-            finally:
-                session.__exit__(None, None, None)
+    """Tests that mcap_config is built from discovered sources in live mode."""
 
     def test_no_mcap_config_passes_none(self):
         """When mcap_config is not set, None is passed to createLiveSession."""
@@ -1579,6 +1559,102 @@ class TestLiveModeWithMcapRecording:
                 assert actual_mcap is None
             finally:
                 session.__exit__(None, None, None)
+
+    def test_mcap_auto_populates_when_tracker_names_empty(self):
+        """Empty get_tracker_names() triggers auto-populate from pipeline sources."""
+        mcap_config = MagicMock()
+        mcap_config.filename = "test.mcap"
+        mcap_config.get_tracker_names.return_value = []
+
+        head_source = MockHeadSource(name="head")
+        hands_source = MockHandsSource(name="hands")
+        pipeline = MockPipeline(leaf_nodes=[head_source, hands_source])
+
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=pipeline,
+            mode=SessionMode.LIVE,
+            mcap_config=mcap_config,
+        )
+
+        with mock_live_dependencies_with_args() as mocks:
+            with patch("isaacteleop.deviceio.McapConfig") as mock_mcap_cls:
+                session = TeleopSession(config)
+                session.__enter__()
+                try:
+                    mock_mcap_cls.assert_called_once_with(
+                        "test.mcap",
+                        [
+                            (head_source.get_tracker(), "head"),
+                            (hands_source.get_tracker(), "hands"),
+                        ],
+                    )
+                    actual_mcap = mocks.create_live.call_args[0][2]
+                    assert actual_mcap is mock_mcap_cls.return_value
+                finally:
+                    session.__exit__(None, None, None)
+
+    def test_mcap_passes_through_when_tracker_names_present(self):
+        """Non-empty get_tracker_names() passes the original config through."""
+        mcap_config = MagicMock()
+        mcap_config.get_tracker_names.return_value = [("tracker", "ch")]
+
+        head_source = MockHeadSource(name="head")
+        pipeline = MockPipeline(leaf_nodes=[head_source])
+
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=pipeline,
+            mode=SessionMode.LIVE,
+            mcap_config=mcap_config,
+        )
+
+        with mock_live_dependencies_with_args() as mocks:
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                actual_mcap = mocks.create_live.call_args[0][2]
+                assert actual_mcap is mcap_config
+            finally:
+                session.__exit__(None, None, None)
+
+
+class TestMcapConfigGetTrackerNames:
+    """Tests for McapConfig.get_tracker_names() (requires compiled C++ bindings)."""
+
+    @pytest.fixture(autouse=True)
+    def _import_deviceio(self):
+        self.deviceio = pytest.importorskip("isaacteleop.deviceio")
+
+    def test_get_tracker_names_returns_pairs(self):
+        """get_tracker_names() returns the (tracker, name) pairs passed at construction."""
+        hand = self.deviceio.HandTracker()
+        head = self.deviceio.HeadTracker()
+        config = self.deviceio.McapConfig("out.mcap", [(hand, "hands"), (head, "head")])
+
+        result = config.get_tracker_names()
+        assert len(result) == 2
+        assert result[0][0] is hand
+        assert result[0][1] == "hands"
+        assert result[1][0] is head
+        assert result[1][1] == "head"
+
+    def test_get_tracker_names_empty_by_default(self):
+        """McapConfig constructed with only a filename has empty tracker_names."""
+        config = self.deviceio.McapConfig("out.mcap")
+
+        result = config.get_tracker_names()
+        assert result == []
+
+    def test_get_tracker_names_single_tracker(self):
+        """get_tracker_names() works with a single tracker."""
+        head = self.deviceio.HeadTracker()
+        config = self.deviceio.McapConfig("out.mcap", [(head, "tracking")])
+
+        result = config.get_tracker_names()
+        assert len(result) == 1
+        assert result[0][0] is head
+        assert result[0][1] == "tracking"
 
 
 if __name__ == "__main__":

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -1334,11 +1334,11 @@ class TestSessionReuse:
 
 @contextmanager
 def mock_replay_dependencies(mock_pm=None):
-    """Patch DeviceIO and OpenXR so TeleopSession.__enter__ works in replay mode.
+    """Patch ReplaySession, DeviceIOSession, and OpenXR so TeleopSession.__enter__ works in replay mode.
 
     Yields a namespace with:
-        - replay_session: the mock returned by DeviceIOSession.replay
-        - create_replay: the mock replacing DeviceIOSession.replay
+        - replay_session: the mock returned by ReplaySession.run
+        - create_replay: the mock replacing ReplaySession.run
         - create_live: the mock replacing DeviceIOSession.run
         - oxr_cls: the mock replacing OpenXRSession
     """
@@ -1348,7 +1348,7 @@ def mock_replay_dependencies(mock_pm=None):
 
     with (
         patch(
-            "isaacteleop.deviceio.DeviceIOSession.replay",
+            "isaacteleop.deviceio.ReplaySession.run",
             return_value=mock_dio_session,
         ) as create_replay,
         patch(

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1504,6 +1504,69 @@ class TestReplayModePlugins:
                 session.__exit__(None, None, None)
 
 
+class TestReplayModeAutoPopulate:
+    """Tests that replay mode auto-populates tracker names from pipeline sources."""
+
+    def test_auto_populates_when_tracker_names_empty(self):
+        """Empty get_tracker_names() triggers auto-populate from pipeline sources."""
+        mcap_config = MagicMock()
+        mcap_config.filename = "recording.mcap"
+        mcap_config.get_tracker_names.return_value = []
+
+        head_source = MockHeadSource(name="head")
+        hands_source = MockHandsSource(name="hands")
+        pipeline = MockPipeline(leaf_nodes=[head_source, hands_source])
+
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=pipeline,
+            mode=SessionMode.REPLAY,
+            mcap_config=mcap_config,
+        )
+
+        with mock_replay_dependencies() as mocks:
+            with patch("isaacteleop.deviceio.McapReplayConfig") as mock_replay_cls:
+                mock_replay_cls.return_value = MagicMock()
+                session = TeleopSession(config)
+                session.__enter__()
+                try:
+                    mock_replay_cls.assert_called_once_with(
+                        "recording.mcap",
+                        [
+                            (head_source.get_tracker(), "head"),
+                            (hands_source.get_tracker(), "hands"),
+                        ],
+                    )
+                    mocks.create_replay.assert_called_once_with(
+                        mock_replay_cls.return_value
+                    )
+                finally:
+                    session.__exit__(None, None, None)
+
+    def test_passes_through_when_tracker_names_present(self):
+        """Non-empty get_tracker_names() passes the original config through."""
+        mcap_config = MagicMock()
+        mcap_config.get_tracker_names.return_value = [("tracker", "ch")]
+
+        head_source = MockHeadSource(name="head")
+        pipeline = MockPipeline(leaf_nodes=[head_source])
+
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=pipeline,
+            mode=SessionMode.REPLAY,
+            mcap_config=mcap_config,
+        )
+
+        with mock_replay_dependencies() as mocks:
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                mocks.create_replay.assert_called_once_with(mcap_config)
+            finally:
+                session.__exit__(None, None, None)
+
+
 # ============================================================================
 # Live mode with MCAP recording
 # ============================================================================
@@ -1652,6 +1715,46 @@ class TestMcapConfigGetTrackerNames:
         """get_tracker_names() works with a single tracker."""
         head = self.deviceio.HeadTracker()
         config = self.deviceio.McapRecordingConfig("out.mcap", [(head, "tracking")])
+
+        result = config.get_tracker_names()
+        assert len(result) == 1
+        assert result[0][0] is head
+        assert result[0][1] == "tracking"
+
+
+class TestMcapReplayConfigGetTrackerNames:
+    """Tests for McapReplayConfig.get_tracker_names() (requires compiled C++ bindings)."""
+
+    @pytest.fixture(autouse=True)
+    def _import_deviceio(self):
+        self.deviceio = pytest.importorskip("isaacteleop.deviceio")
+
+    def test_get_tracker_names_returns_pairs(self):
+        """get_tracker_names() returns the (tracker, name) pairs passed at construction."""
+        hand = self.deviceio.HandTracker()
+        head = self.deviceio.HeadTracker()
+        config = self.deviceio.McapReplayConfig(
+            "out.mcap", [(hand, "hands"), (head, "head")]
+        )
+
+        result = config.get_tracker_names()
+        assert len(result) == 2
+        assert result[0][0] is hand
+        assert result[0][1] == "hands"
+        assert result[1][0] is head
+        assert result[1][1] == "head"
+
+    def test_get_tracker_names_empty_by_default(self):
+        """McapReplayConfig constructed with only a filename has empty tracker_names."""
+        config = self.deviceio.McapReplayConfig("out.mcap")
+
+        result = config.get_tracker_names()
+        assert result == []
+
+    def test_get_tracker_names_single_tracker(self):
+        """get_tracker_names() works with a single tracker."""
+        head = self.deviceio.HeadTracker()
+        config = self.deviceio.McapReplayConfig("out.mcap", [(head, "tracking")])
 
         result = config.get_tracker_names()
         assert len(result) == 1

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -29,6 +29,7 @@ from isaacteleop.retargeting_engine.deviceio_source_nodes import IDeviceIOSource
 from isaacteleop.retargeting_engine.tensor_types import FloatType
 
 from isaacteleop.teleop_session_manager.config import (
+    SessionMode,
     TeleopSessionConfig,
     PluginConfig,
 )
@@ -1324,6 +1325,260 @@ class TestSessionReuse:
         # Note: plugin_managers list is not cleared on re-entry
         # This is expected behavior - users should create new sessions
         assert first_count == 1
+
+
+# ============================================================================
+# Replay mode (SessionMode.REPLAY)
+# ============================================================================
+
+
+@contextmanager
+def mock_replay_dependencies(mock_pm=None):
+    """Patch DeviceIO and OpenXR so TeleopSession.__enter__ works in replay mode.
+
+    Yields a namespace with:
+        - replay_session: the mock returned by createReplaySession
+        - create_replay: the mock replacing createReplaySession
+        - create_live: the mock replacing createLiveSession
+        - oxr_cls: the mock replacing OpenXRSession
+    """
+    mock_dio_session = MockDeviceIOSession()
+
+    mock_pm = mock_pm or MockPluginManager()
+
+    with (
+        patch(
+            "isaacteleop.deviceio.DeviceIOSession.createReplaySession",
+            return_value=mock_dio_session,
+        ) as create_replay,
+        patch(
+            "isaacteleop.deviceio.DeviceIOSession.createLiveSession",
+            return_value=MagicMock(),
+        ) as create_live,
+        patch("isaacteleop.oxr.OpenXRSession", return_value=MagicMock()) as oxr_cls,
+        patch("isaacteleop.plugin_manager.PluginManager", return_value=mock_pm),
+    ):
+        ns = MagicMock()
+        ns.replay_session = mock_dio_session
+        ns.create_replay = create_replay
+        ns.create_live = create_live
+        ns.oxr_cls = oxr_cls
+        yield ns
+
+
+class TestReplayModeConfigValidation:
+    """Tests for SessionMode field validation in TeleopSessionConfig."""
+
+    def test_replay_mode_requires_mcap_config(self):
+        """REPLAY mode without mcap_config raises ValueError."""
+        with pytest.raises(ValueError, match="mcap_config is required"):
+            TeleopSessionConfig(
+                app_name="test",
+                pipeline=MockPipeline(),
+                mode=SessionMode.REPLAY,
+                mcap_config=None,
+            )
+
+    def test_replay_mode_accepts_mcap_config(self):
+        """REPLAY mode with mcap_config provided succeeds."""
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=MockPipeline(),
+            mode=SessionMode.REPLAY,
+            mcap_config=MagicMock(),
+        )
+        assert config.mode == SessionMode.REPLAY
+        assert config.mcap_config is not None
+
+    def test_default_mode_is_live(self):
+        """Default mode is SessionMode.LIVE."""
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=MockPipeline(),
+        )
+        assert config.mode == SessionMode.LIVE
+
+
+class TestReplayModeSessionEnter:
+    """Tests for TeleopSession.__enter__ when mode is REPLAY."""
+
+    def _make_replay_config(self):
+        mcap_config = MagicMock()
+        return TeleopSessionConfig(
+            app_name="test",
+            pipeline=MockPipeline(leaf_nodes=[]),
+            mode=SessionMode.REPLAY,
+            mcap_config=mcap_config,
+        )
+
+    def test_calls_create_replay_session(self):
+        """createReplaySession is called with the mcap_config."""
+        config = self._make_replay_config()
+
+        with mock_replay_dependencies() as mocks:
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                mocks.create_replay.assert_called_once_with(config.mcap_config)
+            finally:
+                session.__exit__(None, None, None)
+
+    def test_skips_oxr_session_creation(self):
+        """OpenXRSession is NOT instantiated in replay mode."""
+        config = self._make_replay_config()
+
+        with mock_replay_dependencies() as mocks:
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                mocks.oxr_cls.assert_not_called()
+            finally:
+                session.__exit__(None, None, None)
+
+    def test_skips_create_live_session(self):
+        """createLiveSession is NOT called in replay mode."""
+        config = self._make_replay_config()
+
+        with mock_replay_dependencies() as mocks:
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                mocks.create_live.assert_not_called()
+            finally:
+                session.__exit__(None, None, None)
+
+    def test_oxr_session_remains_none(self):
+        """session.oxr_session stays None in replay mode."""
+        config = self._make_replay_config()
+
+        with mock_replay_dependencies():
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                assert session.oxr_session is None
+            finally:
+                session.__exit__(None, None, None)
+
+    def test_deviceio_session_is_set(self):
+        """DeviceIO session is populated in replay mode."""
+        config = self._make_replay_config()
+
+        with mock_replay_dependencies() as mocks:
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                assert session.deviceio_session is mocks.replay_session
+            finally:
+                session.__exit__(None, None, None)
+
+
+class TestReplayModePlugins:
+    """Tests that plugins are initialized in replay mode."""
+
+    def test_plugins_initialized_in_replay_mode(self, tmp_path):
+        """Enabled plugins are started even when mode is REPLAY."""
+        mock_pm = MockPluginManager(plugin_names=["test_plugin"])
+
+        plugin_config = PluginConfig(
+            plugin_name="test_plugin",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            enabled=True,
+        )
+
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=MockPipeline(leaf_nodes=[]),
+            mode=SessionMode.REPLAY,
+            mcap_config=MagicMock(),
+            plugins=[plugin_config],
+        )
+
+        with mock_replay_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                assert len(session.plugin_managers) == 1
+                assert len(session.plugin_contexts) == 1
+            finally:
+                session.__exit__(None, None, None)
+
+
+# ============================================================================
+# Live mode with MCAP recording
+# ============================================================================
+
+
+@contextmanager
+def mock_live_dependencies_with_args():
+    """Patch DeviceIO and OpenXR for live-mode tests that inspect createLiveSession args.
+
+    Yields a namespace with:
+        - create_live: the mock replacing createLiveSession (inspect call_args)
+        - dio_session: the mock DeviceIO session returned by createLiveSession
+    """
+    mock_dio_session = MockDeviceIOSession()
+
+    mock_oxr_session = MockOpenXRSession()
+
+    with (
+        patch(
+            "isaacteleop.deviceio.DeviceIOSession.createLiveSession",
+            return_value=mock_dio_session,
+        ) as create_live,
+        patch("isaacteleop.oxr.OpenXRSession", return_value=mock_oxr_session),
+        patch(
+            "isaacteleop.deviceio.DeviceIOSession.get_required_extensions",
+            return_value=[],
+        ),
+        patch("isaacteleop.plugin_manager.PluginManager", return_value=MagicMock()),
+    ):
+        ns = MagicMock()
+        ns.create_live = create_live
+        ns.dio_session = mock_dio_session
+        yield ns
+
+
+class TestLiveModeWithMcapRecording:
+    """Tests that mcap_config is forwarded to createLiveSession in live mode."""
+
+    def test_mcap_config_passed_to_create_live_session(self):
+        """createLiveSession receives the mcap_config as third argument."""
+        mcap_config = MagicMock()
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=MockPipeline(leaf_nodes=[]),
+            mode=SessionMode.LIVE,
+            mcap_config=mcap_config,
+        )
+
+        with mock_live_dependencies_with_args() as mocks:
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                mocks.create_live.assert_called_once()
+                actual_mcap = mocks.create_live.call_args[0][2]
+                assert actual_mcap is mcap_config
+            finally:
+                session.__exit__(None, None, None)
+
+    def test_no_mcap_config_passes_none(self):
+        """When mcap_config is not set, None is passed to createLiveSession."""
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=MockPipeline(leaf_nodes=[]),
+            mode=SessionMode.LIVE,
+        )
+
+        with mock_live_dependencies_with_args() as mocks:
+            session = TeleopSession(config)
+            session.__enter__()
+            try:
+                mocks.create_live.assert_called_once()
+                actual_mcap = mocks.create_live.call_args[0][2]
+                assert actual_mcap is None
+            finally:
+                session.__exit__(None, None, None)
 
 
 if __name__ == "__main__":

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1337,9 +1337,9 @@ def mock_replay_dependencies(mock_pm=None):
     """Patch DeviceIO and OpenXR so TeleopSession.__enter__ works in replay mode.
 
     Yields a namespace with:
-        - replay_session: the mock returned by createReplaySession
-        - create_replay: the mock replacing createReplaySession
-        - create_live: the mock replacing createLiveSession
+        - replay_session: the mock returned by DeviceIOSession.replay
+        - create_replay: the mock replacing DeviceIOSession.replay
+        - create_live: the mock replacing DeviceIOSession.run
         - oxr_cls: the mock replacing OpenXRSession
     """
     mock_dio_session = MockDeviceIOSession()
@@ -1348,11 +1348,11 @@ def mock_replay_dependencies(mock_pm=None):
 
     with (
         patch(
-            "isaacteleop.deviceio.DeviceIOSession.createReplaySession",
+            "isaacteleop.deviceio.DeviceIOSession.replay",
             return_value=mock_dio_session,
         ) as create_replay,
         patch(
-            "isaacteleop.deviceio.DeviceIOSession.createLiveSession",
+            "isaacteleop.deviceio.DeviceIOSession.run",
             return_value=MagicMock(),
         ) as create_live,
         patch("isaacteleop.oxr.OpenXRSession", return_value=MagicMock()) as oxr_cls,
@@ -1412,7 +1412,7 @@ class TestReplayModeSessionEnter:
         )
 
     def test_calls_create_replay_session(self):
-        """createReplaySession is called with the mcap_config."""
+        """DeviceIOSession.replay is called with the mcap_config."""
         config = self._make_replay_config()
 
         with mock_replay_dependencies() as mocks:
@@ -1436,7 +1436,7 @@ class TestReplayModeSessionEnter:
                 session.__exit__(None, None, None)
 
     def test_skips_create_live_session(self):
-        """createLiveSession is NOT called in replay mode."""
+        """DeviceIOSession.run is NOT called in replay mode."""
         config = self._make_replay_config()
 
         with mock_replay_dependencies() as mocks:
@@ -1511,11 +1511,11 @@ class TestReplayModePlugins:
 
 @contextmanager
 def mock_live_dependencies_with_args():
-    """Patch DeviceIO and OpenXR for live-mode tests that inspect createLiveSession args.
+    """Patch DeviceIO and OpenXR for live-mode tests that inspect DeviceIOSession.run args.
 
     Yields a namespace with:
-        - create_live: the mock replacing createLiveSession (inspect call_args)
-        - dio_session: the mock DeviceIO session returned by createLiveSession
+        - create_live: the mock replacing DeviceIOSession.run (inspect call_args)
+        - dio_session: the mock DeviceIO session returned by DeviceIOSession.run
     """
     mock_dio_session = MockDeviceIOSession()
 
@@ -1523,7 +1523,7 @@ def mock_live_dependencies_with_args():
 
     with (
         patch(
-            "isaacteleop.deviceio.DeviceIOSession.createLiveSession",
+            "isaacteleop.deviceio.DeviceIOSession.run",
             return_value=mock_dio_session,
         ) as create_live,
         patch("isaacteleop.oxr.OpenXRSession", return_value=mock_oxr_session),
@@ -1543,7 +1543,7 @@ class TestLiveModeWithMcapRecording:
     """Tests that mcap_config is built from discovered sources in live mode."""
 
     def test_no_mcap_config_passes_none(self):
-        """When mcap_config is not set, None is passed to createLiveSession."""
+        """When mcap_config is not set, None is passed to DeviceIOSession.run."""
         config = TeleopSessionConfig(
             app_name="test",
             pipeline=MockPipeline(leaf_nodes=[]),
@@ -1578,7 +1578,7 @@ class TestLiveModeWithMcapRecording:
         )
 
         with mock_live_dependencies_with_args() as mocks:
-            with patch("isaacteleop.deviceio.McapConfig") as mock_mcap_cls:
+            with patch("isaacteleop.deviceio.McapRecordingConfig") as mock_mcap_cls:
                 session = TeleopSession(config)
                 session.__enter__()
                 try:
@@ -1620,7 +1620,7 @@ class TestLiveModeWithMcapRecording:
 
 
 class TestMcapConfigGetTrackerNames:
-    """Tests for McapConfig.get_tracker_names() (requires compiled C++ bindings)."""
+    """Tests for McapRecordingConfig.get_tracker_names() (requires compiled C++ bindings)."""
 
     @pytest.fixture(autouse=True)
     def _import_deviceio(self):
@@ -1630,7 +1630,9 @@ class TestMcapConfigGetTrackerNames:
         """get_tracker_names() returns the (tracker, name) pairs passed at construction."""
         hand = self.deviceio.HandTracker()
         head = self.deviceio.HeadTracker()
-        config = self.deviceio.McapConfig("out.mcap", [(hand, "hands"), (head, "head")])
+        config = self.deviceio.McapRecordingConfig(
+            "out.mcap", [(hand, "hands"), (head, "head")]
+        )
 
         result = config.get_tracker_names()
         assert len(result) == 2
@@ -1640,8 +1642,8 @@ class TestMcapConfigGetTrackerNames:
         assert result[1][1] == "head"
 
     def test_get_tracker_names_empty_by_default(self):
-        """McapConfig constructed with only a filename has empty tracker_names."""
-        config = self.deviceio.McapConfig("out.mcap")
+        """McapRecordingConfig constructed with only a filename has empty tracker_names."""
+        config = self.deviceio.McapRecordingConfig("out.mcap")
 
         result = config.get_tracker_names()
         assert result == []
@@ -1649,7 +1651,7 @@ class TestMcapConfigGetTrackerNames:
     def test_get_tracker_names_single_tracker(self):
         """get_tracker_names() works with a single tracker."""
         head = self.deviceio.HeadTracker()
-        config = self.deviceio.McapConfig("out.mcap", [(head, "tracking")])
+        config = self.deviceio.McapRecordingConfig("out.mcap", [(head, "tracking")])
 
         result = config.get_tracker_names()
         assert len(result) == 1


### PR DESCRIPTION
- Add McapConfig to TeleopSession
- Support ReplayDeviceIOSession in TeleopSession

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sessions can now operate in live or replay modes
  * MCAP recording and replay configuration support added

* **Improvements**
  * Tracker discovery made optional in recording configuration with new getter method

* **Tests**
  * Expanded test coverage for replay mode and recording functionality validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->