### PR TITLE
Requires-Python must be the same for all wheels

### DIFF
--- a/src/core/python/pyproject.toml.in
+++ b/src/core/python/pyproject.toml.in
@@ -17,7 +17,7 @@ name = "isaacteleop"
 version = "@ISAAC_TELEOP_PYPROJECT_VERSION@"
 description = "Isaac Teleop - Teleoperation with Device I/O"
 readme = "README.md"
-requires-python = "==@ISAAC_TELEOP_PYTHON_VERSION@.*"
+requires-python = ">=3.10"
 license = "Apache-2.0"
 authors = [
     {name = "NVIDIA"}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python version requirement to support Python 3.10 and later, enabling broader compatibility across different Python environments instead of a fixed version constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->