### PR TITLE
Add web client app profiles

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
+++ b/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
@@ -15,19 +15,14 @@
  * limitations under the License.
  */
 
-import type { ControlPanelPosition, TeleopMode } from './react/utils';
-
-/** Per-project settings that override mode-level defaults. */
+/** Per-project settings that override ancestor defaults. */
 export interface TeleopProjectSettings {
   panelHiddenAtStart?: boolean;
-  controlPanelPosition?: ControlPanelPosition;
 }
 
 /**
- * A node in the project registry tree.
- * Nodes with `settings` are selectable destinations.
- * Nodes with only `children` are organizational groups (rendered as disabled headers in the dropdown).
- * A node can have both (selectable AND has children).
+ * A node in the project registry tree. Nodes with `settings` contribute defaults at
+ * their depth; ancestor settings are merged in priority order (deepest wins).
  */
 export interface TeleopProjectNode {
   label: string;
@@ -35,66 +30,68 @@ export interface TeleopProjectNode {
   children?: Record<string, TeleopProjectNode>;
 }
 
-export type TeleopProjectRegistry = Record<TeleopMode, TeleopProjectNode>;
+export type TeleopProjectRegistry = Record<string, TeleopProjectNode>;
 
+/** Default teleop path when nothing is resolvable from URL hash or localStorage. */
+export const DEFAULT_TELEOP_PATH = 'sim';
+
+/**
+ * Registry of teleop projects, keyed by URL-hash path (e.g. `#/real/gear/dexmate`).
+ *
+ * Keys must be lowercase; URL segments are lowercased before lookup so the
+ * hash is effectively case-insensitive.
+ *
+ * Every node in the tree (top-level keys and their descendants) is selectable,
+ * so a new hardware variant can use a more general path (e.g. `#/real/gear`)
+ * pending adding the specific one to this file. A descendant node's defaults
+ * override its ancestors' defaults at every depth (e.g. `real/gear`'s defaults
+ * override `real`'s). Per-node user overrides (localStorage) are a separate
+ * layer and take priority over any registry defaults.
+ */
 export const TELEOP_PROJECTS: TeleopProjectRegistry = {
   sim: {
-    label: 'IsaacSim',
+    label: 'Simulation',
     settings: { panelHiddenAtStart: false },
+    children: {
+      isaacsim: { label: 'IsaacSim', settings: {} },
+    },
   },
   real: {
     label: 'Real Robot',
     settings: { panelHiddenAtStart: true },
     children: {
+      ros: { label: 'ROS', settings: {} },
+      isaacros: { label: 'IsaacROS', settings: {} },
       gear: {
         label: 'GEAR',
         settings: {},
         children: {
-          dexmate: { label: 'DexMate', settings: {} },
-          g1: { label: 'G1', settings: {} },
-          lerobot: { label: 'LeRobot', settings: { panelHiddenAtStart: false, controlPanelPosition: 'left' } },
+          dexmate: { label: 'Dexmate', settings: {} },
+          g1_sonic: { label: 'G1 Sonic', settings: {} },
+          g1_homie: { label: 'G1 Homie', settings: {} },
         },
       },
     },
   },
 };
 
-/**
- * Walks the registry tree to find the node matching `mode` + optional `subproject` path.
- * @param subproject - Slash-separated path segments after the mode (e.g. "gear/dexmate").
- */
-export function resolveProjectNode(
-  mode: TeleopMode,
-  subproject?: string,
-): TeleopProjectNode | null {
-  const root = TELEOP_PROJECTS[mode];
-  if (!root) return null;
-  if (!subproject) return root;
-
-  const segments = subproject.split('/').filter(Boolean);
-  let current: TeleopProjectNode = root;
-  for (const seg of segments) {
-    if (!current.children?.[seg]) return null;
-    current = current.children[seg];
-  }
-  return current;
+function pathSegments(teleopPath: string | undefined): string[] {
+  if (!teleopPath) return [];
+  return teleopPath.split('/').filter(Boolean);
 }
 
-/** Walks the ancestor chain from root to the target node, merging settings at each level. */
-export function getProjectSettings(
-  mode: TeleopMode,
-  subproject?: string,
-): TeleopProjectSettings {
-  const root = TELEOP_PROJECTS[mode];
+/** Merges node defaults from root to target along the path; deepest non-undefined value wins. */
+export function getProjectSettings(teleopPath: string | undefined): TeleopProjectSettings {
+  const segments = pathSegments(teleopPath);
+  if (segments.length === 0) return {};
+  const root = TELEOP_PROJECTS[segments[0]];
   if (!root) return {};
   let merged: TeleopProjectSettings = { ...root.settings };
-  if (!subproject) return merged;
-
-  const segments = subproject.split('/').filter(Boolean);
   let current: TeleopProjectNode = root;
-  for (const seg of segments) {
-    if (!current.children?.[seg]) break;
-    current = current.children[seg];
+  for (let i = 1; i < segments.length; i++) {
+    const child = current.children?.[segments[i]];
+    if (!child) break;
+    current = child;
     if (current.settings) {
       merged = { ...merged, ...current.settings };
     }
@@ -102,45 +99,73 @@ export function getProjectSettings(
   return merged;
 }
 
-/** Returns the resolved node's label, falling back to the mode root's label. */
-export function getProjectLabel(
-  mode: TeleopMode,
-  subproject?: string,
-): string {
-  const node = resolveProjectNode(mode, subproject);
-  if (node) return node.label;
-  const root = TELEOP_PROJECTS[mode];
-  return root?.label ?? mode;
+/**
+ * Labels for each node along the path, from root to the deepest valid node.
+ * Unknown segments terminate the walk, so `real/fake` yields just `['Real Robot']`,
+ * and an unknown root yields `[]`.
+ */
+export function getProjectBreadcrumb(teleopPath: string | undefined): string[] {
+  const segments = pathSegments(teleopPath);
+  if (segments.length === 0) return [];
+  const root = TELEOP_PROJECTS[segments[0]];
+  if (!root) return [];
+  const labels = [root.label];
+  let current: TeleopProjectNode = root;
+  for (let i = 1; i < segments.length; i++) {
+    const child = current.children?.[segments[i]];
+    if (!child) break;
+    labels.push(child.label);
+    current = child;
+  }
+  return labels;
+}
+
+/**
+ * Extracts a teleop path from a URL hash fragment (e.g. `#/real/gear/dexmate`).
+ * Segments are lowercased before lookup and the walk stops at the deepest valid
+ * registry node, so `#/real/fake/path` canonicalizes to `real`.
+ * @returns a canonicalized slash-separated path, or `null` if no registry match.
+ */
+export function parseTeleopPathFromHash(hash: string): string | null {
+  const cleaned = hash.replace(/^#\/?/, '');
+  if (!cleaned) return null;
+  const segments = cleaned.split('/').filter(Boolean).map(s => s.toLowerCase());
+  if (segments.length === 0) return null;
+  const root = TELEOP_PROJECTS[segments[0]];
+  if (!root) return null;
+  const canonical: string[] = [segments[0]];
+  let current: TeleopProjectNode = root;
+  for (let i = 1; i < segments.length; i++) {
+    const child = current.children?.[segments[i]];
+    if (!child) break;
+    canonical.push(segments[i]);
+    current = child;
+  }
+  return canonical.join('/');
 }
 
 export interface DropdownEntry {
   hash: string;
   label: string;
   depth: number;
-  disabled: boolean;
 }
 
-/** Recursively flattens the registry tree into a list suitable for a `<select>` element. */
-export function flattenRegistryForDropdown(): DropdownEntry[] {
+/**
+ * Pre-flattened registry tree, suitable for a `<select>` element.
+ * Computed once at module load since the registry is static.
+ */
+export const DROPDOWN_ENTRIES: readonly DropdownEntry[] = (() => {
   const entries: DropdownEntry[] = [];
-
   function walk(node: TeleopProjectNode, hashPrefix: string, depth: number): void {
-    const selectable = node.settings !== undefined;
-    entries.push({
-      hash: `#/${hashPrefix}`,
-      label: node.label,
-      depth,
-      disabled: !selectable,
-    });
+    entries.push({ hash: `#/${hashPrefix}`, label: node.label, depth });
     if (node.children) {
       for (const [key, child] of Object.entries(node.children)) {
         walk(child, `${hashPrefix}/${key}`, depth + 1);
       }
     }
   }
-
-  for (const mode of ['sim', 'real'] as TeleopMode[]) {
-    walk(TELEOP_PROJECTS[mode], mode, 0);
+  for (const key of Object.keys(TELEOP_PROJECTS)) {
+    walk(TELEOP_PROJECTS[key], key, 0);
   }
   return entries;
-}
+})();

--- a/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
+++ b/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
@@ -67,8 +67,8 @@ export const TELEOP_PROJECTS: TeleopProjectRegistry = {
         settings: {},
         children: {
           dexmate: { label: 'Dexmate', settings: {} },
-          g1_sonic: { label: 'G1 Sonic', settings: {} },
-          g1_homie: { label: 'G1 Homie', settings: {} },
+          g1_sonic: { label: 'G1 SONIC', settings: {} },
+          g1_homie: { label: 'G1 HOMIE', settings: {} },
         },
       },
     },

--- a/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
+++ b/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ControlPanelPosition, TeleopMode } from './react/utils';
+
+/** Per-project settings that override mode-level defaults. */
+export interface TeleopProjectSettings {
+  panelHiddenAtStart?: boolean;
+  controlPanelPosition?: ControlPanelPosition;
+}
+
+/**
+ * A node in the project registry tree.
+ * Nodes with `settings` are selectable destinations.
+ * Nodes with only `children` are organizational groups (rendered as disabled headers in the dropdown).
+ * A node can have both (selectable AND has children).
+ */
+export interface TeleopProjectNode {
+  label: string;
+  settings?: TeleopProjectSettings;
+  children?: Record<string, TeleopProjectNode>;
+}
+
+export type TeleopProjectRegistry = Record<TeleopMode, TeleopProjectNode>;
+
+export const TELEOP_PROJECTS: TeleopProjectRegistry = {
+  sim: {
+    label: 'IsaacSim',
+    settings: { panelHiddenAtStart: false },
+  },
+  real: {
+    label: 'Real Robot',
+    settings: { panelHiddenAtStart: true },
+    children: {
+      gear: {
+        label: 'GEAR',
+        settings: {},
+        children: {
+          dexmate: { label: 'DexMate', settings: {} },
+          g1: { label: 'G1', settings: {} },
+          lerobot: { label: 'LeRobot', settings: { panelHiddenAtStart: false, controlPanelPosition: 'left' } },
+        },
+      },
+    },
+  },
+};
+
+/**
+ * Walks the registry tree to find the node matching `mode` + optional `subproject` path.
+ * @param subproject - Slash-separated path segments after the mode (e.g. "gear/dexmate").
+ */
+export function resolveProjectNode(
+  mode: TeleopMode,
+  subproject?: string,
+): TeleopProjectNode | null {
+  const root = TELEOP_PROJECTS[mode];
+  if (!root) return null;
+  if (!subproject) return root;
+
+  const segments = subproject.split('/').filter(Boolean);
+  let current: TeleopProjectNode = root;
+  for (const seg of segments) {
+    if (!current.children?.[seg]) return null;
+    current = current.children[seg];
+  }
+  return current;
+}
+
+/** Walks the ancestor chain from root to the target node, merging settings at each level. */
+export function getProjectSettings(
+  mode: TeleopMode,
+  subproject?: string,
+): TeleopProjectSettings {
+  const root = TELEOP_PROJECTS[mode];
+  if (!root) return {};
+  let merged: TeleopProjectSettings = { ...root.settings };
+  if (!subproject) return merged;
+
+  const segments = subproject.split('/').filter(Boolean);
+  let current: TeleopProjectNode = root;
+  for (const seg of segments) {
+    if (!current.children?.[seg]) break;
+    current = current.children[seg];
+    if (current.settings) {
+      merged = { ...merged, ...current.settings };
+    }
+  }
+  return merged;
+}
+
+/** Returns the resolved node's label, falling back to the mode root's label. */
+export function getProjectLabel(
+  mode: TeleopMode,
+  subproject?: string,
+): string {
+  const node = resolveProjectNode(mode, subproject);
+  if (node) return node.label;
+  const root = TELEOP_PROJECTS[mode];
+  return root?.label ?? mode;
+}
+
+export interface DropdownEntry {
+  hash: string;
+  label: string;
+  depth: number;
+  disabled: boolean;
+}
+
+/** Recursively flattens the registry tree into a list suitable for a `<select>` element. */
+export function flattenRegistryForDropdown(): DropdownEntry[] {
+  const entries: DropdownEntry[] = [];
+
+  function walk(node: TeleopProjectNode, hashPrefix: string, depth: number): void {
+    const selectable = node.settings !== undefined;
+    entries.push({
+      hash: `#/${hashPrefix}`,
+      label: node.label,
+      depth,
+      disabled: !selectable,
+    });
+    if (node.children) {
+      for (const [key, child] of Object.entries(node.children)) {
+        walk(child, `${hashPrefix}/${key}`, depth + 1);
+      }
+    }
+  }
+
+  for (const mode of ['sim', 'real'] as TeleopMode[]) {
+    walk(TELEOP_PROJECTS[mode], mode, 0);
+  }
+  return entries;
+}

--- a/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
+++ b/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
@@ -22,7 +22,8 @@ export interface TeleopProjectSettings {
 
 /**
  * A node in the project registry tree. Nodes with `settings` contribute defaults at
- * their depth; ancestor settings are merged in priority order (deepest wins).
+ * their depth; when merged along a path, the deepest *defined* value for each key
+ * wins.
  */
 export interface TeleopProjectNode {
   label: string;
@@ -34,6 +35,27 @@ export type TeleopProjectRegistry = Record<string, TeleopProjectNode>;
 
 /** Default teleop path when nothing is resolvable from URL hash or localStorage. */
 export const DEFAULT_TELEOP_PATH = 'sim';
+
+/** localStorage key that remembers the last-used teleop path across reloads. */
+const PATH_STORAGE_KEY = 'cxr.isaac.teleopPath';
+
+/** Returns the stored teleop path, or `null` when none is saved / localStorage is unavailable. */
+export function loadStoredTeleopPath(): string | null {
+  try {
+    return localStorage.getItem(PATH_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/** Persists the teleop path so a reload without a URL hash restores the same app. */
+export function saveStoredTeleopPath(path: string): void {
+  try {
+    localStorage.setItem(PATH_STORAGE_KEY, path);
+  } catch {
+    /* localStorage unavailable */
+  }
+}
 
 /**
  * Registry of teleop projects, keyed by URL-hash path (e.g. `#/real/gear/dexmate`).
@@ -53,22 +75,21 @@ export const TELEOP_PROJECTS: TeleopProjectRegistry = {
     label: 'Simulation',
     settings: { panelHiddenAtStart: false },
     children: {
-      isaacsim: { label: 'IsaacSim', settings: {} },
+      isaacsim: { label: 'IsaacSim' },
     },
   },
   real: {
     label: 'Real Robot',
     settings: { panelHiddenAtStart: true },
     children: {
-      ros: { label: 'ROS', settings: {} },
-      isaacros: { label: 'IsaacROS', settings: {} },
+      ros: { label: 'ROS' },
+      isaacros: { label: 'IsaacROS' },
       gear: {
         label: 'GEAR',
-        settings: {},
         children: {
-          dexmate: { label: 'Dexmate', settings: {} },
-          g1_sonic: { label: 'G1 SONIC', settings: {} },
-          g1_homie: { label: 'G1 HOMIE', settings: {} },
+          dexmate: { label: 'Dexmate' },
+          g1_sonic: { label: 'G1 SONIC' },
+          g1_homie: { label: 'G1 HOMIE' },
         },
       },
     },
@@ -80,21 +101,31 @@ function pathSegments(teleopPath: string | undefined): string[] {
   return teleopPath.split('/').filter(Boolean);
 }
 
-/** Merges node defaults from root to target along the path; deepest non-undefined value wins. */
+/**
+ * Copies only keys whose value is not `undefined`, so explicit `undefined` on a
+ * descendant node inherits the ancestor's value.
+ */
+function assignDefined(target: TeleopProjectSettings, source: TeleopProjectSettings | undefined): void {
+  if (!source) return;
+  for (const [k, v] of Object.entries(source)) {
+    if (v !== undefined) (target as Record<string, unknown>)[k] = v;
+  }
+}
+
+/** Merges node defaults from root to target along the path; deepest defined value wins. */
 export function getProjectSettings(teleopPath: string | undefined): TeleopProjectSettings {
   const segments = pathSegments(teleopPath);
   if (segments.length === 0) return {};
   const root = TELEOP_PROJECTS[segments[0]];
   if (!root) return {};
-  let merged: TeleopProjectSettings = { ...root.settings };
+  const merged: TeleopProjectSettings = {};
+  assignDefined(merged, root.settings);
   let current: TeleopProjectNode = root;
   for (let i = 1; i < segments.length; i++) {
     const child = current.children?.[segments[i]];
     if (!child) break;
     current = child;
-    if (current.settings) {
-      merged = { ...merged, ...current.settings };
-    }
+    assignDefined(merged, current.settings);
   }
   return merged;
 }

--- a/deps/cloudxr/webxr_client/helpers/react/utils.ts
+++ b/deps/cloudxr/webxr_client/helpers/react/utils.ts
@@ -63,10 +63,10 @@ export interface ReactUIConfig {
   /** When true, the control panel is hidden at immersive XR enter (small “show control panel” control only). */
   panelHiddenAtStart?: boolean;
   /** Active teleop project path (a key path in `TELEOP_PROJECTS`). */
-  teleopPath?: string;
+  teleopPath: string;
 }
 
-export const CONTROL_PANEL_POSITIONS: readonly ControlPanelPosition[] = ['left', 'center', 'right'];
+const CONTROL_PANEL_POSITIONS: readonly ControlPanelPosition[] = ['left', 'center', 'right'];
 
 /**
  * Parses a string into a valid control panel position.

--- a/deps/cloudxr/webxr_client/helpers/react/utils.ts
+++ b/deps/cloudxr/webxr_client/helpers/react/utils.ts
@@ -19,87 +19,39 @@
  * Shared utilities for React examples (e.g. control panel position).
  */
 
-import type { TeleopProjectSettings } from '../TeleopProjects';
-
 export type ControlPanelPosition = 'left' | 'center' | 'right';
 
-export type TeleopMode = 'sim' | 'real';
-
-export interface TeleopModeInfo {
-  mode: TeleopMode;
-  subproject?: string;
-}
-
 /**
- * Extracts teleop mode and optional subproject from a URL hash fragment.
- * Follows the `#/path` convention (e.g. `#/real/gear/dexmate`).
- * @returns mode + optional subproject, or `null` if the hash doesn't start with a known mode.
+ * Loads a per-project-path setting from localStorage (key `cxr.isaac.<key>|<teleopPath>`).
+ * `parse` should return `undefined` for unrecognized input so `fallback` wins.
  */
-export function parseTeleopModeFromHash(hash: string): TeleopModeInfo | null {
-  const cleaned = hash.replace(/^#\/?/, '');
-  if (!cleaned) return null;
-  const slashIndex = cleaned.indexOf('/');
-  const modeStr = (slashIndex === -1 ? cleaned : cleaned.substring(0, slashIndex)).toLowerCase();
-  if (modeStr !== 'sim' && modeStr !== 'real') return null;
-  const subproject = slashIndex === -1 ? undefined : cleaned.substring(slashIndex + 1) || undefined;
-  return { mode: modeStr, subproject };
-}
-
-/** Builds the localStorage key suffix from mode + optional subproject. */
-function projectPath(mode: TeleopMode, subproject?: string): string {
-  return subproject ? `${mode}/${subproject}` : mode;
-}
-
-/**
- * Resolves panelHiddenAtStart for the current project.
- * Priority: per-project localStorage > project registry setting > false.
- */
-export function loadPanelHiddenForMode(
-  mode: TeleopMode,
-  subproject?: string,
-  projectSettings?: TeleopProjectSettings,
-): boolean {
+export function loadPerProject<T>(
+  key: string,
+  teleopPath: string,
+  parse: (raw: string) => T | undefined,
+  fallback: T,
+): T {
   try {
-    const stored = localStorage.getItem(`cxr.isaac.panelHiddenAtStart.${projectPath(mode, subproject)}`);
-    if (stored === 'true') return true;
-    if (stored === 'false') return false;
+    const stored = localStorage.getItem(`cxr.isaac.${key}|${teleopPath}`);
+    if (stored !== null) {
+      const parsed = parse(stored);
+      if (parsed !== undefined) return parsed;
+    }
   } catch {
     /* localStorage unavailable */
   }
-  return projectSettings?.panelHiddenAtStart ?? false;
+  return fallback;
 }
 
-/** Persists panelHiddenAtStart to localStorage keyed by project path. */
-export function savePanelHiddenForMode(mode: TeleopMode, subproject: string | undefined, value: boolean): void {
+/** Generic per-project-path localStorage save. See {@link loadPerProject}. */
+export function savePerProject<T>(
+  key: string,
+  teleopPath: string,
+  value: T,
+  serialize: (v: T) => string = String,
+): void {
   try {
-    localStorage.setItem(`cxr.isaac.panelHiddenAtStart.${projectPath(mode, subproject)}`, String(value));
-  } catch {
-    /* localStorage unavailable */
-  }
-}
-
-/**
- * Resolves controlPanelPosition for the current project.
- * Priority: per-project localStorage > project registry setting > 'center'.
- */
-export function loadControlPanelPositionForProject(
-  mode: TeleopMode,
-  subproject?: string,
-  projectSettings?: TeleopProjectSettings,
-): ControlPanelPosition {
-  try {
-    const stored = localStorage.getItem(`cxr.isaac.controlPanelPosition.${projectPath(mode, subproject)}`);
-    if (stored) return parseControlPanelPosition(stored, 'center');
-  } catch {
-    /* localStorage unavailable */
-  }
-  return projectSettings?.controlPanelPosition ?? 'center';
-}
-
-/** Persists controlPanelPosition to localStorage keyed by project path. */
-export function saveControlPanelPositionForProject(mode: TeleopMode, subproject: string | undefined, value: ControlPanelPosition): void {
-  try {
-    localStorage.setItem(`cxr.isaac.controlPanelPosition.${projectPath(mode, subproject)}`, value);
+    localStorage.setItem(`cxr.isaac.${key}|${teleopPath}`, serialize(value));
   } catch {
     /* localStorage unavailable */
   }
@@ -108,15 +60,13 @@ export function saveControlPanelPositionForProject(mode: TeleopMode, subproject:
 /** React UI options (e.g. in-XR control panel position). */
 export interface ReactUIConfig {
   controlPanelPosition?: ControlPanelPosition;
-  /** When true, the control panel is hidden at immersive XR enter (small \u201cshow control panel\u201d control only). */
+  /** When true, the control panel is hidden at immersive XR enter (small “show control panel” control only). */
   panelHiddenAtStart?: boolean;
-  /** Teleop mode resolved from URL hash or localStorage fallback. */
-  teleopMode?: TeleopMode;
-  /** Optional subproject path from the URL hash (e.g. "gear/dexmate" from #/real/gear/dexmate). */
-  subproject?: string;
+  /** Active teleop project path (a key path in `TELEOP_PROJECTS`). */
+  teleopPath?: string;
 }
 
-const CONTROL_PANEL_POSITIONS: readonly ControlPanelPosition[] = ['left', 'center', 'right'];
+export const CONTROL_PANEL_POSITIONS: readonly ControlPanelPosition[] = ['left', 'center', 'right'];
 
 /**
  * Parses a string into a valid control panel position.

--- a/deps/cloudxr/webxr_client/helpers/react/utils.ts
+++ b/deps/cloudxr/webxr_client/helpers/react/utils.ts
@@ -19,13 +19,101 @@
  * Shared utilities for React examples (e.g. control panel position).
  */
 
+import type { TeleopProjectSettings } from '../TeleopProjects';
+
 export type ControlPanelPosition = 'left' | 'center' | 'right';
+
+export type TeleopMode = 'sim' | 'real';
+
+export interface TeleopModeInfo {
+  mode: TeleopMode;
+  subproject?: string;
+}
+
+/**
+ * Extracts teleop mode and optional subproject from a URL hash fragment.
+ * Follows the `#/path` convention (e.g. `#/real/gear/dexmate`).
+ * @returns mode + optional subproject, or `null` if the hash doesn't start with a known mode.
+ */
+export function parseTeleopModeFromHash(hash: string): TeleopModeInfo | null {
+  const cleaned = hash.replace(/^#\/?/, '');
+  if (!cleaned) return null;
+  const slashIndex = cleaned.indexOf('/');
+  const modeStr = (slashIndex === -1 ? cleaned : cleaned.substring(0, slashIndex)).toLowerCase();
+  if (modeStr !== 'sim' && modeStr !== 'real') return null;
+  const subproject = slashIndex === -1 ? undefined : cleaned.substring(slashIndex + 1) || undefined;
+  return { mode: modeStr, subproject };
+}
+
+/** Builds the localStorage key suffix from mode + optional subproject. */
+function projectPath(mode: TeleopMode, subproject?: string): string {
+  return subproject ? `${mode}/${subproject}` : mode;
+}
+
+/**
+ * Resolves panelHiddenAtStart for the current project.
+ * Priority: per-project localStorage > project registry setting > false.
+ */
+export function loadPanelHiddenForMode(
+  mode: TeleopMode,
+  subproject?: string,
+  projectSettings?: TeleopProjectSettings,
+): boolean {
+  try {
+    const stored = localStorage.getItem(`cxr.isaac.panelHiddenAtStart.${projectPath(mode, subproject)}`);
+    if (stored === 'true') return true;
+    if (stored === 'false') return false;
+  } catch {
+    /* localStorage unavailable */
+  }
+  return projectSettings?.panelHiddenAtStart ?? false;
+}
+
+/** Persists panelHiddenAtStart to localStorage keyed by project path. */
+export function savePanelHiddenForMode(mode: TeleopMode, subproject: string | undefined, value: boolean): void {
+  try {
+    localStorage.setItem(`cxr.isaac.panelHiddenAtStart.${projectPath(mode, subproject)}`, String(value));
+  } catch {
+    /* localStorage unavailable */
+  }
+}
+
+/**
+ * Resolves controlPanelPosition for the current project.
+ * Priority: per-project localStorage > project registry setting > 'center'.
+ */
+export function loadControlPanelPositionForProject(
+  mode: TeleopMode,
+  subproject?: string,
+  projectSettings?: TeleopProjectSettings,
+): ControlPanelPosition {
+  try {
+    const stored = localStorage.getItem(`cxr.isaac.controlPanelPosition.${projectPath(mode, subproject)}`);
+    if (stored) return parseControlPanelPosition(stored, 'center');
+  } catch {
+    /* localStorage unavailable */
+  }
+  return projectSettings?.controlPanelPosition ?? 'center';
+}
+
+/** Persists controlPanelPosition to localStorage keyed by project path. */
+export function saveControlPanelPositionForProject(mode: TeleopMode, subproject: string | undefined, value: ControlPanelPosition): void {
+  try {
+    localStorage.setItem(`cxr.isaac.controlPanelPosition.${projectPath(mode, subproject)}`, value);
+  } catch {
+    /* localStorage unavailable */
+  }
+}
 
 /** React UI options (e.g. in-XR control panel position). */
 export interface ReactUIConfig {
   controlPanelPosition?: ControlPanelPosition;
-  /** When true, the control panel is hidden at immersive XR enter (small “show control panel” control only). */
+  /** When true, the control panel is hidden at immersive XR enter (small \u201cshow control panel\u201d control only). */
   panelHiddenAtStart?: boolean;
+  /** Teleop mode resolved from URL hash or localStorage fallback. */
+  teleopMode?: TeleopMode;
+  /** Optional subproject path from the URL hash (e.g. "gear/dexmate" from #/real/gear/dexmate). */
+  subproject?: string;
 }
 
 const CONTROL_PANEL_POSITIONS: readonly ControlPanelPosition[] = ['left', 'center', 'right'];

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -386,6 +386,13 @@ function App() {
     };
   }, [store]);
 
+  // Address-bar hash edits need a reload to re-run init.
+  useEffect(() => {
+    const onHashChange = () => window.location.reload();
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
   // Update HTML error message display when error state changes
   useEffect(() => {
     if (cloudXR2DUI) {

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -37,7 +37,8 @@ import { overridePressureObserver } from '@helpers/overridePressureObserver';
 import { kPerformanceOptions } from '@helpers/PerformanceProfiles';
 import CloudXRComponent from '@helpers/react/CloudXRComponent';
 import { SimpleEnvironment } from '@helpers/react/SimpleEnvironment';
-import { getControlPanelPositionVector, parseTeleopModeFromHash, type TeleopMode } from '@helpers/react/utils';
+import { getControlPanelPositionVector } from '@helpers/react/utils';
+import { DEFAULT_TELEOP_PATH, parseTeleopPathFromHash } from '@helpers/TeleopProjects';
 import * as CloudXR from '@nvidia/cloudxr';
 import { getResolutionValidationError } from '@nvidia/cloudxr';
 import { signal, computed } from '@preact/signals-react';
@@ -310,14 +311,20 @@ function App() {
     const ui = new CloudXR2DUI(() => {
       setConfigVersion(v => v + 1);
     });
-    // Resolve teleop mode + subproject from URL hash, falling back to localStorage, then 'sim'.
-    const modeInfo = parseTeleopModeFromHash(window.location.hash);
-    const resolvedMode: TeleopMode =
-      modeInfo?.mode ??
-      (localStorage.getItem('cxr.isaac.teleopMode') as TeleopMode | null) ??
-      'sim';
-    const resolvedSubproject = modeInfo?.subproject;
-    try { localStorage.setItem('cxr.isaac.teleopMode', resolvedMode); } catch { /* */ }
+    // Teleop path: URL hash -> last-used (localStorage) -> DEFAULT_TELEOP_PATH.
+    const PATH_STORAGE_KEY = 'cxr.isaac.teleopPath';
+    let resolvedPath = parseTeleopPathFromHash(window.location.hash);
+    if (!resolvedPath) {
+      const storedPath = localStorage.getItem(PATH_STORAGE_KEY);
+      resolvedPath = parseTeleopPathFromHash(`#/${storedPath ?? ''}`) ?? DEFAULT_TELEOP_PATH;
+    }
+    // Reflect canonical form (parse may have lowercased/truncated). `#/…` is a
+    // fragment-relative URL so replaceState preserves path and search.
+    const canonicalHash = `#/${resolvedPath}`;
+    if (window.location.hash !== canonicalHash) {
+      window.history.replaceState(null, '', canonicalHash);
+    }
+    try { localStorage.setItem(PATH_STORAGE_KEY, resolvedPath); } catch { /* localStorage unavailable */ }
 
     // URL query params override localStorage so bookmarked links always win.
     const urlSeeds: Record<string, string> = {};
@@ -326,7 +333,7 @@ function App() {
       const v = p.get(key);
       if (v !== null) urlSeeds[key] = v;
     }
-    ui.initialize(Object.keys(urlSeeds).length > 0 ? urlSeeds : undefined, resolvedMode, resolvedSubproject);
+    ui.initialize(Object.keys(urlSeeds).length > 0 ? urlSeeds : undefined, resolvedPath);
     const doConnect = async () => {
       const config = ui.getConfiguration();
       const resolutionError = getResolutionValidationError(
@@ -833,9 +840,7 @@ function App() {
             <>
               <CloudXRComponent
                 config={config}
-                applicationName={`Isaac Teleop Web Client (${
-                  config.teleopMode === 'real' ? 'Real' : 'Sim'
-                }${config.subproject ? `/${config.subproject}` : ''})`}
+                applicationName={`Isaac Teleop Web Client (${config.teleopPath ?? DEFAULT_TELEOP_PATH})`}
                 onStatusChange={handleStatusChange}
                 onError={error => {
                   if (cloudXR2DUI) {

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -38,7 +38,12 @@ import { kPerformanceOptions } from '@helpers/PerformanceProfiles';
 import CloudXRComponent from '@helpers/react/CloudXRComponent';
 import { SimpleEnvironment } from '@helpers/react/SimpleEnvironment';
 import { getControlPanelPositionVector } from '@helpers/react/utils';
-import { DEFAULT_TELEOP_PATH, parseTeleopPathFromHash } from '@helpers/TeleopProjects';
+import {
+  DEFAULT_TELEOP_PATH,
+  loadStoredTeleopPath,
+  parseTeleopPathFromHash,
+  saveStoredTeleopPath,
+} from '@helpers/TeleopProjects';
 import * as CloudXR from '@nvidia/cloudxr';
 import { getResolutionValidationError } from '@nvidia/cloudxr';
 import { signal, computed } from '@preact/signals-react';
@@ -312,12 +317,10 @@ function App() {
       setConfigVersion(v => v + 1);
     });
     // Teleop path: URL hash -> last-used (localStorage) -> DEFAULT_TELEOP_PATH.
-    const PATH_STORAGE_KEY = 'cxr.isaac.teleopPath';
     let resolvedPath = parseTeleopPathFromHash(window.location.hash);
     if (!resolvedPath) {
-      let storedPath: string | null = null;
-      try { storedPath = localStorage.getItem(PATH_STORAGE_KEY); } catch { /* localStorage unavailable */ }
-      resolvedPath = parseTeleopPathFromHash(`#/${storedPath ?? ''}`) ?? DEFAULT_TELEOP_PATH;
+      resolvedPath =
+        parseTeleopPathFromHash(`#/${loadStoredTeleopPath() ?? ''}`) ?? DEFAULT_TELEOP_PATH;
     }
     // Reflect canonical form (parse may have lowercased/truncated). `#/…` is a
     // fragment-relative URL so replaceState preserves path and search.
@@ -325,7 +328,7 @@ function App() {
     if (window.location.hash !== canonicalHash) {
       window.history.replaceState(null, '', canonicalHash);
     }
-    try { localStorage.setItem(PATH_STORAGE_KEY, resolvedPath); } catch { /* localStorage unavailable */ }
+    saveStoredTeleopPath(resolvedPath);
 
     // URL query params override localStorage so bookmarked links always win.
     const urlSeeds: Record<string, string> = {};
@@ -848,7 +851,7 @@ function App() {
             <>
               <CloudXRComponent
                 config={config}
-                applicationName={`Isaac Teleop Web Client (${config.teleopPath ?? DEFAULT_TELEOP_PATH})`}
+                applicationName={`Isaac Teleop Web Client (${config.teleopPath})`}
                 onStatusChange={handleStatusChange}
                 onError={error => {
                   if (cloudXR2DUI) {

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -37,7 +37,7 @@ import { overridePressureObserver } from '@helpers/overridePressureObserver';
 import { kPerformanceOptions } from '@helpers/PerformanceProfiles';
 import CloudXRComponent from '@helpers/react/CloudXRComponent';
 import { SimpleEnvironment } from '@helpers/react/SimpleEnvironment';
-import { getControlPanelPositionVector } from '@helpers/react/utils';
+import { getControlPanelPositionVector, parseTeleopModeFromHash, type TeleopMode } from '@helpers/react/utils';
 import * as CloudXR from '@nvidia/cloudxr';
 import { getResolutionValidationError } from '@nvidia/cloudxr';
 import { signal, computed } from '@preact/signals-react';
@@ -310,6 +310,15 @@ function App() {
     const ui = new CloudXR2DUI(() => {
       setConfigVersion(v => v + 1);
     });
+    // Resolve teleop mode + subproject from URL hash, falling back to localStorage, then 'sim'.
+    const modeInfo = parseTeleopModeFromHash(window.location.hash);
+    const resolvedMode: TeleopMode =
+      modeInfo?.mode ??
+      (localStorage.getItem('cxr.isaac.teleopMode') as TeleopMode | null) ??
+      'sim';
+    const resolvedSubproject = modeInfo?.subproject;
+    try { localStorage.setItem('cxr.isaac.teleopMode', resolvedMode); } catch { /* */ }
+
     // URL query params override localStorage so bookmarked links always win.
     const urlSeeds: Record<string, string> = {};
     const p = new URLSearchParams(window.location.search);
@@ -317,7 +326,7 @@ function App() {
       const v = p.get(key);
       if (v !== null) urlSeeds[key] = v;
     }
-    ui.initialize(Object.keys(urlSeeds).length > 0 ? urlSeeds : undefined);
+    ui.initialize(Object.keys(urlSeeds).length > 0 ? urlSeeds : undefined, resolvedMode, resolvedSubproject);
     const doConnect = async () => {
       const config = ui.getConfiguration();
       const resolutionError = getResolutionValidationError(
@@ -824,7 +833,9 @@ function App() {
             <>
               <CloudXRComponent
                 config={config}
-                applicationName="Isaac Teleop Web Client"
+                applicationName={`Isaac Teleop Web Client (${
+                  config.teleopMode === 'real' ? 'Real' : 'Sim'
+                }${config.subproject ? `/${config.subproject}` : ''})`}
                 onStatusChange={handleStatusChange}
                 onError={error => {
                   if (cloudXR2DUI) {

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -315,7 +315,8 @@ function App() {
     const PATH_STORAGE_KEY = 'cxr.isaac.teleopPath';
     let resolvedPath = parseTeleopPathFromHash(window.location.hash);
     if (!resolvedPath) {
-      const storedPath = localStorage.getItem(PATH_STORAGE_KEY);
+      let storedPath: string | null = null;
+      try { storedPath = localStorage.getItem(PATH_STORAGE_KEY); } catch { /* localStorage unavailable */ }
       resolvedPath = parseTeleopPathFromHash(`#/${storedPath ?? ''}`) ?? DEFAULT_TELEOP_PATH;
     }
     // Reflect canonical form (parse may have lowercased/truncated). `#/…` is a

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -38,9 +38,20 @@ import {
 } from '@helpers/DeviceProfiles';
 import {
   ControlPanelPosition,
+  loadControlPanelPositionForProject,
+  loadPanelHiddenForMode,
   parseControlPanelPosition,
   ReactUIConfig,
+  saveControlPanelPositionForProject,
+  savePanelHiddenForMode,
+  type TeleopMode,
 } from '@helpers/react/utils';
+import {
+  flattenRegistryForDropdown,
+  getProjectLabel,
+  getProjectSettings,
+  type TeleopProjectSettings,
+} from '@helpers/TeleopProjects';
 import {
   CloudXRConfig,
   enableLocalStorage,
@@ -145,6 +156,18 @@ export class CloudXR2DUI {
   private mediaPortInput!: HTMLInputElement;
   /** Dropdown for controller model visibility (show / hide) */
   private controllerModelVisibilitySelect!: HTMLSelectElement;
+  /** Mode indicator label (e.g. "Simulation" or "Real Robot") -- may be absent if box is commented out */
+  private teleopModeLabel: HTMLElement | null = null;
+  /** Mode switch link (navigates to the other mode's URL path) -- may be absent if box is commented out */
+  private teleopModeSwitch: HTMLAnchorElement | null = null;
+  /** Mode subtitle in header (e.g. "for Simulation") */
+  private teleopModeSubtitle!: HTMLElement;
+  /** Hierarchical project selector in header */
+  private teleopProjectSelect!: HTMLSelectElement;
+  /** Current teleop mode */
+  private teleopMode: TeleopMode = 'sim';
+  /** Optional subproject path from the URL hash (e.g. "gear/dexmate"). */
+  private subproject: string | undefined;
   /** Flag to track if the 2D UI has been initialized */
   private initialized: boolean = false;
 
@@ -175,7 +198,7 @@ export class CloudXR2DUI {
   /**
    * Initializes the CloudXR2DUI with all necessary components and event handlers
    */
-  public initialize(urlSeeds?: Record<string, string>): void {
+  public initialize(urlSeeds?: Record<string, string>, teleopMode?: TeleopMode, subproject?: string): void {
     if (this.initialized) {
       return;
     }
@@ -183,6 +206,13 @@ export class CloudXR2DUI {
     try {
       this.initializeElements();
       this.setupLocalStorage();
+
+      if (teleopMode) {
+        this.teleopMode = teleopMode;
+      }
+      this.subproject = subproject;
+      this.applyTeleopMode();
+
       if (urlSeeds) {
         this.applyUrlSeeds(urlSeeds);
       }
@@ -198,6 +228,68 @@ export class CloudXR2DUI {
       // Continue with default values if initialization fails
       this.showError(`Failed to initialize CloudXR2DUI: ${error}`);
     }
+  }
+
+  /** Sets the mode indicator text/link, populates the dropdown, and loads per-project settings. */
+  private applyTeleopMode(): void {
+    const isSim = this.teleopMode === 'sim';
+    const otherLabel = isSim ? 'Real Robot' : 'IsaacSim';
+    const otherHash = isSim ? '#/real' : '#/sim';
+
+    if (this.teleopModeLabel) {
+      this.teleopModeLabel.textContent = isSim ? 'Simulation' : 'Real Robot';
+    }
+    if (this.teleopModeSwitch) {
+      this.teleopModeSwitch.textContent = `Switch to ${otherLabel}`;
+      this.teleopModeSwitch.href = otherHash;
+    }
+
+    const projectLabel = getProjectLabel(this.teleopMode, this.subproject);
+    const modePrefix = isSim ? 'for' : 'for';
+    const rootLabel = isSim ? 'IsaacSim' : 'Real Robot';
+    if (this.subproject) {
+      this.teleopModeSubtitle.textContent = `${modePrefix} ${rootLabel} / ${projectLabel}`;
+    } else {
+      this.teleopModeSubtitle.textContent = `${modePrefix} ${rootLabel}`;
+    }
+
+    this.populateProjectDropdown();
+
+    const settings = getProjectSettings(this.teleopMode, this.subproject);
+    const panelHidden = loadPanelHiddenForMode(this.teleopMode, this.subproject, settings);
+    this.panelHiddenAtStartSelect.value = String(panelHidden);
+
+    const panelPos = loadControlPanelPositionForProject(this.teleopMode, this.subproject, settings);
+    this.controlPanelPositionSelect.value = panelPos;
+  }
+
+  /** Builds the hierarchical dropdown from the project registry. */
+  private populateProjectDropdown(): void {
+    const select = this.teleopProjectSelect;
+    select.innerHTML = '';
+
+    const INDENT = '\u00A0\u00A0\u00A0';
+    const entries = flattenRegistryForDropdown();
+    const currentHash = `#/${this.teleopMode}${this.subproject ? `/${this.subproject}` : ''}`;
+
+    for (const entry of entries) {
+      const option = document.createElement('option');
+      option.value = entry.hash;
+      option.textContent = INDENT.repeat(entry.depth) + entry.label;
+      option.disabled = entry.disabled;
+      select.appendChild(option);
+    }
+
+    select.value = currentHash;
+    // If the current hash didn't match any option, fall back to the mode root
+    if (select.value !== currentHash) {
+      select.value = `#/${this.teleopMode}`;
+    }
+
+    select.onchange = () => {
+      window.location.hash = select.value.replace(/^#/, '');
+      window.location.reload();
+    };
   }
 
   /**
@@ -276,6 +368,10 @@ export class CloudXR2DUI {
     this.controllerModelVisibilitySelect = this.getElement<HTMLSelectElement>(
       'controllerModelVisibility'
     );
+    this.teleopModeLabel = document.getElementById('teleopModeLabel');
+    this.teleopModeSwitch = document.getElementById('teleopModeSwitch') as HTMLAnchorElement | null;
+    this.teleopModeSubtitle = this.getElement<HTMLElement>('teleopModeSubtitle');
+    this.teleopProjectSelect = this.getElement<HTMLSelectElement>('teleopProjectSelect');
   }
 
   /**
@@ -348,12 +444,12 @@ export class CloudXR2DUI {
     enableLocalStorage(this.useQuestColorWorkaroundSelect, 'useQuestColorWorkaround');
     enableLocalStorage(this.immersiveSelect, 'immersiveMode');
     enableLocalStorage(this.deviceProfileSelect, 'deviceProfile');
-    enableLocalStorage(this.panelHiddenAtStartSelect, 'panelHiddenAtStart');
+    // panelHiddenAtStart and controlPanelPosition are persisted per-project-path
+    // by savePanelHiddenForMode / saveControlPanelPositionForProject, not here.
     enableLocalStorage(this.referenceSpaceSelect, 'referenceSpace');
     enableLocalStorage(this.xrOffsetXInput, 'xrOffsetX');
     enableLocalStorage(this.xrOffsetYInput, 'xrOffsetY');
     enableLocalStorage(this.xrOffsetZInput, 'xrOffsetZ');
-    enableLocalStorage(this.controlPanelPositionSelect, 'controlPanelPosition');
     enableLocalStorage(this.mediaAddressInput, 'mediaAddress');
     enableLocalStorage(this.mediaPortInput, 'mediaPort');
     enableLocalStorage(this.controllerModelVisibilitySelect, 'controllerModelVisibility');
@@ -439,7 +535,10 @@ export class CloudXR2DUI {
     addListener(this.enableTexSubImage2DSelect, 'change', onProfileLinkedChange);
     addListener(this.useQuestColorWorkaroundSelect, 'change', onProfileLinkedChange);
     addListener(this.immersiveSelect, 'change', updateConfig);
-    addListener(this.panelHiddenAtStartSelect, 'change', updateConfig);
+    addListener(this.panelHiddenAtStartSelect, 'change', () => {
+      savePanelHiddenForMode(this.teleopMode, this.subproject, this.panelHiddenAtStartSelect.value === 'true');
+      updateConfig();
+    });
     addListener(this.referenceSpaceSelect, 'change', updateConfig);
     addListener(this.xrOffsetXInput, 'input', updateConfig);
     addListener(this.xrOffsetXInput, 'change', updateConfig);
@@ -447,7 +546,13 @@ export class CloudXR2DUI {
     addListener(this.xrOffsetYInput, 'change', updateConfig);
     addListener(this.xrOffsetZInput, 'input', updateConfig);
     addListener(this.xrOffsetZInput, 'change', updateConfig);
-    addListener(this.controlPanelPositionSelect, 'change', updateConfig);
+    addListener(this.controlPanelPositionSelect, 'change', () => {
+      saveControlPanelPositionForProject(
+        this.teleopMode, this.subproject,
+        parseControlPanelPosition(this.controlPanelPositionSelect.value, 'center'),
+      );
+      updateConfig();
+    });
     addListener(this.proxyUrlInput, 'input', updateConfig);
     addListener(this.proxyUrlInput, 'change', updateConfig);
     addListener(this.mediaAddressInput, 'input', updateConfig);
@@ -630,6 +735,8 @@ export class CloudXR2DUI {
       })(),
       hideControllerModel: this.controllerModelVisibilitySelect.value === 'hide',
       panelHiddenAtStart: this.panelHiddenAtStartSelect.value === 'true',
+      teleopMode: this.teleopMode,
+      subproject: this.subproject,
     };
 
     this.currentConfiguration = newConfiguration;

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -37,20 +37,16 @@ import {
   type DeviceProfileId,
 } from '@helpers/DeviceProfiles';
 import {
-  ControlPanelPosition,
-  loadControlPanelPositionForProject,
-  loadPanelHiddenForMode,
+  loadPerProject,
   parseControlPanelPosition,
   ReactUIConfig,
-  saveControlPanelPositionForProject,
-  savePanelHiddenForMode,
-  type TeleopMode,
+  savePerProject,
 } from '@helpers/react/utils';
 import {
-  flattenRegistryForDropdown,
-  getProjectLabel,
+  DEFAULT_TELEOP_PATH,
+  DROPDOWN_ENTRIES,
+  getProjectBreadcrumb,
   getProjectSettings,
-  type TeleopProjectSettings,
 } from '@helpers/TeleopProjects';
 import {
   CloudXRConfig,
@@ -156,18 +152,12 @@ export class CloudXR2DUI {
   private mediaPortInput!: HTMLInputElement;
   /** Dropdown for controller model visibility (show / hide) */
   private controllerModelVisibilitySelect!: HTMLSelectElement;
-  /** Mode indicator label (e.g. "Simulation" or "Real Robot") -- may be absent if box is commented out */
-  private teleopModeLabel: HTMLElement | null = null;
-  /** Mode switch link (navigates to the other mode's URL path) -- may be absent if box is commented out */
-  private teleopModeSwitch: HTMLAnchorElement | null = null;
-  /** Mode subtitle in header (e.g. "for Simulation") */
+  /** Breadcrumb subtitle in header (e.g. "for Real Robot › GEAR › Dexmate"). */
   private teleopModeSubtitle!: HTMLElement;
   /** Hierarchical project selector in header */
   private teleopProjectSelect!: HTMLSelectElement;
-  /** Current teleop mode */
-  private teleopMode: TeleopMode = 'sim';
-  /** Optional subproject path from the URL hash (e.g. "gear/dexmate"). */
-  private subproject: string | undefined;
+  /** Active teleop project path (a key path in `TELEOP_PROJECTS`, e.g. `real/gear/dexmate`). */
+  private teleopPath: string = DEFAULT_TELEOP_PATH;
   /** Flag to track if the 2D UI has been initialized */
   private initialized: boolean = false;
 
@@ -198,20 +188,20 @@ export class CloudXR2DUI {
   /**
    * Initializes the CloudXR2DUI with all necessary components and event handlers
    */
-  public initialize(urlSeeds?: Record<string, string>, teleopMode?: TeleopMode, subproject?: string): void {
+  public initialize(urlSeeds?: Record<string, string>, teleopPath?: string): void {
     if (this.initialized) {
       return;
     }
 
     try {
       this.initializeElements();
+      this.decoratePerProjectLabels();
       this.setupLocalStorage();
 
-      if (teleopMode) {
-        this.teleopMode = teleopMode;
+      if (teleopPath) {
+        this.teleopPath = teleopPath;
       }
-      this.subproject = subproject;
-      this.applyTeleopMode();
+      this.applyTeleopPath();
 
       if (urlSeeds) {
         this.applyUrlSeeds(urlSeeds);
@@ -230,66 +220,77 @@ export class CloudXR2DUI {
     }
   }
 
-  /** Sets the mode indicator text/link, populates the dropdown, and loads per-project settings. */
-  private applyTeleopMode(): void {
-    const isSim = this.teleopMode === 'sim';
-    const otherLabel = isSim ? 'Real Robot' : 'IsaacSim';
-    const otherHash = isSim ? '#/real' : '#/sim';
-
-    if (this.teleopModeLabel) {
-      this.teleopModeLabel.textContent = isSim ? 'Simulation' : 'Real Robot';
-    }
-    if (this.teleopModeSwitch) {
-      this.teleopModeSwitch.textContent = `Switch to ${otherLabel}`;
-      this.teleopModeSwitch.href = otherHash;
-    }
-
-    const projectLabel = getProjectLabel(this.teleopMode, this.subproject);
-    const modePrefix = isSim ? 'for' : 'for';
-    const rootLabel = isSim ? 'IsaacSim' : 'Real Robot';
-    if (this.subproject) {
-      this.teleopModeSubtitle.textContent = `${modePrefix} ${rootLabel} / ${projectLabel}`;
-    } else {
-      this.teleopModeSubtitle.textContent = `${modePrefix} ${rootLabel}`;
-    }
+  /** Renders the header breadcrumb and rebuilds the project dropdown from the registry. */
+  private applyTeleopPath(): void {
+    const breadcrumb = getProjectBreadcrumb(this.teleopPath);
+    this.teleopModeSubtitle.replaceChildren();
+    this.teleopModeSubtitle.appendChild(document.createTextNode('for '));
+    breadcrumb.forEach((label, i) => {
+      if (i > 0) {
+        // aria-hidden so screen readers skip the chevron glyph.
+        const sep = document.createElement('span');
+        sep.setAttribute('aria-hidden', 'true');
+        sep.textContent = ' \u203A ';
+        this.teleopModeSubtitle.appendChild(sep);
+      }
+      this.teleopModeSubtitle.appendChild(document.createTextNode(label));
+    });
 
     this.populateProjectDropdown();
-
-    const settings = getProjectSettings(this.teleopMode, this.subproject);
-    const panelHidden = loadPanelHiddenForMode(this.teleopMode, this.subproject, settings);
-    this.panelHiddenAtStartSelect.value = String(panelHidden);
-
-    const panelPos = loadControlPanelPositionForProject(this.teleopMode, this.subproject, settings);
-    this.controlPanelPositionSelect.value = panelPos;
+    this.applyPerProjectSettings();
   }
 
-  /** Builds the hierarchical dropdown from the project registry. */
+  /** Loads per-project-path settings (falling back to registry defaults) into their form controls. */
+  private applyPerProjectSettings(): void {
+    const settings = getProjectSettings(this.teleopPath);
+    const panelHidden = loadPerProject<boolean>(
+      'panelHiddenAtStart', this.teleopPath,
+      raw => (raw === 'true' ? true : raw === 'false' ? false : undefined),
+      settings.panelHiddenAtStart ?? false,
+    );
+    this.panelHiddenAtStartSelect.value = String(panelHidden);
+  }
+
+  /**
+   * Appends a visible marker to the label of each setting that persists per
+   * teleop application, so users can tell at a glance which fields switch when
+   * they change the active project. No hover text: the UI runs on VR headsets
+   * where hover is not reliable, so the marker itself must be self-describing.
+   * When a second per-project field lands, factor these into a
+   * PER_PROJECT_FIELDS registry (see TeleopProjects.ts) and loop.
+   */
+  private decoratePerProjectLabels(): void {
+    const label = this.panelHiddenAtStartSelect.labels?.[0];
+    if (!label) return;
+    const marker = ' (saved per teleop app)';
+    if (label.textContent?.includes(marker)) return;
+    label.appendChild(document.createTextNode(marker));
+  }
+
+  /** Builds the hierarchical dropdown options from the project registry. */
   private populateProjectDropdown(): void {
     const select = this.teleopProjectSelect;
-    select.innerHTML = '';
+    select.replaceChildren();
 
     const INDENT = '\u00A0\u00A0\u00A0';
-    const entries = flattenRegistryForDropdown();
-    const currentHash = `#/${this.teleopMode}${this.subproject ? `/${this.subproject}` : ''}`;
+    const currentHash = `#/${this.teleopPath}`;
 
-    for (const entry of entries) {
+    // Static prompt when collapsed (the breadcrumb already shows the current path);
+    // a bullet marks the current path inside the open menu.
+    const prompt = document.createElement('option');
+    prompt.value = '';
+    prompt.textContent = 'Change teleop application';
+    select.appendChild(prompt);
+
+    for (const entry of DROPDOWN_ENTRIES) {
       const option = document.createElement('option');
       option.value = entry.hash;
-      option.textContent = INDENT.repeat(entry.depth) + entry.label;
-      option.disabled = entry.disabled;
+      const marker = entry.hash === currentHash ? '\u2022\u00A0' : '\u00A0\u00A0';
+      option.textContent = INDENT.repeat(entry.depth) + marker + entry.label;
       select.appendChild(option);
     }
 
-    select.value = currentHash;
-    // If the current hash didn't match any option, fall back to the mode root
-    if (select.value !== currentHash) {
-      select.value = `#/${this.teleopMode}`;
-    }
-
-    select.onchange = () => {
-      window.location.hash = select.value.replace(/^#/, '');
-      window.location.reload();
-    };
+    select.selectedIndex = 0;
   }
 
   /**
@@ -301,13 +302,19 @@ export class CloudXR2DUI {
       ['serverIP', this.serverIpInput, 'serverIp'],
       ['port', this.portInput, 'port'],
       ['codec', this.codecSelect, 'codec'],
-      ['panelHiddenAtStart', this.panelHiddenAtStartSelect, 'panelHiddenAtStart'],
     ];
     for (const [paramKey, element, storageKey] of mapping) {
       const v = seeds[paramKey];
       if (v === undefined) continue;
       element.value = v;
-      try { localStorage.setItem(storageKey, v); } catch (_) { /* quota */ }
+      try { localStorage.setItem(storageKey, v); } catch (_) { /* localStorage unavailable */ }
+    }
+    // panelHiddenAtStart persists per-project-path, so route it through savePerProject
+    // rather than the flat localStorage key nothing else reads.
+    const panelHidden = seeds['panelHiddenAtStart'];
+    if (panelHidden !== undefined) {
+      this.panelHiddenAtStartSelect.value = panelHidden;
+      savePerProject('panelHiddenAtStart', this.teleopPath, panelHidden);
     }
   }
 
@@ -368,8 +375,6 @@ export class CloudXR2DUI {
     this.controllerModelVisibilitySelect = this.getElement<HTMLSelectElement>(
       'controllerModelVisibility'
     );
-    this.teleopModeLabel = document.getElementById('teleopModeLabel');
-    this.teleopModeSwitch = document.getElementById('teleopModeSwitch') as HTMLAnchorElement | null;
     this.teleopModeSubtitle = this.getElement<HTMLElement>('teleopModeSubtitle');
     this.teleopProjectSelect = this.getElement<HTMLSelectElement>('teleopProjectSelect');
   }
@@ -444,8 +449,9 @@ export class CloudXR2DUI {
     enableLocalStorage(this.useQuestColorWorkaroundSelect, 'useQuestColorWorkaround');
     enableLocalStorage(this.immersiveSelect, 'immersiveMode');
     enableLocalStorage(this.deviceProfileSelect, 'deviceProfile');
-    // panelHiddenAtStart and controlPanelPosition are persisted per-project-path
-    // by savePanelHiddenForMode / saveControlPanelPositionForProject, not here.
+    // panelHiddenAtStart is persisted per-project-path via savePerProject() in
+    // its change listener, not here.
+    enableLocalStorage(this.controlPanelPositionSelect, 'controlPanelPosition');
     enableLocalStorage(this.referenceSpaceSelect, 'referenceSpace');
     enableLocalStorage(this.xrOffsetXInput, 'xrOffsetX');
     enableLocalStorage(this.xrOffsetYInput, 'xrOffsetY');
@@ -536,7 +542,9 @@ export class CloudXR2DUI {
     addListener(this.useQuestColorWorkaroundSelect, 'change', onProfileLinkedChange);
     addListener(this.immersiveSelect, 'change', updateConfig);
     addListener(this.panelHiddenAtStartSelect, 'change', () => {
-      savePanelHiddenForMode(this.teleopMode, this.subproject, this.panelHiddenAtStartSelect.value === 'true');
+      // Pass the raw select value string through savePerProject; the matching
+      // loadPerProject parses `'true'`/`'false'` back into a boolean.
+      savePerProject('panelHiddenAtStart', this.teleopPath, this.panelHiddenAtStartSelect.value);
       updateConfig();
     });
     addListener(this.referenceSpaceSelect, 'change', updateConfig);
@@ -546,12 +554,17 @@ export class CloudXR2DUI {
     addListener(this.xrOffsetYInput, 'change', updateConfig);
     addListener(this.xrOffsetZInput, 'input', updateConfig);
     addListener(this.xrOffsetZInput, 'change', updateConfig);
-    addListener(this.controlPanelPositionSelect, 'change', () => {
-      saveControlPanelPositionForProject(
-        this.teleopMode, this.subproject,
-        parseControlPanelPosition(this.controlPanelPositionSelect.value, 'center'),
-      );
-      updateConfig();
+    addListener(this.controlPanelPositionSelect, 'change', updateConfig);
+    addListener(this.teleopProjectSelect, 'change', () => {
+      const value = this.teleopProjectSelect.value;
+      if (!value) return;
+      // Reset to the prompt before navigating so if the reload is aborted the
+      // control doesn't end up stuck on the just-picked value.
+      this.teleopProjectSelect.selectedIndex = 0;
+      // Full reload: teleopPath seeds initial per-project state and config;
+      // cheaper to rebuild from scratch than to wire a re-init path here.
+      window.location.hash = value.replace(/^#/, '');
+      window.location.reload();
     });
     addListener(this.proxyUrlInput, 'input', updateConfig);
     addListener(this.proxyUrlInput, 'change', updateConfig);
@@ -735,8 +748,7 @@ export class CloudXR2DUI {
       })(),
       hideControllerModel: this.controllerModelVisibilitySelect.value === 'hide',
       panelHiddenAtStart: this.panelHiddenAtStartSelect.value === 'true',
-      teleopMode: this.teleopMode,
-      subproject: this.subproject,
+      teleopPath: this.teleopPath,
     };
 
     this.currentConfiguration = newConfiguration;

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -276,7 +276,7 @@ export class CloudXR2DUI {
     const currentHash = `#/${this.teleopPath}`;
 
     // Static prompt when collapsed (the breadcrumb already shows the current path);
-    // a bullet marks the current path inside the open menu.
+    // the active entry is suffixed and disabled so it reads as already selected.
     const prompt = document.createElement('option');
     prompt.value = '';
     prompt.textContent = 'Change teleop application';
@@ -285,8 +285,9 @@ export class CloudXR2DUI {
     for (const entry of DROPDOWN_ENTRIES) {
       const option = document.createElement('option');
       option.value = entry.hash;
-      const marker = entry.hash === currentHash ? '\u2022\u00A0' : '\u00A0\u00A0';
-      option.textContent = INDENT.repeat(entry.depth) + marker + entry.label;
+      const isCurrent = entry.hash === currentHash;
+      option.textContent = INDENT.repeat(entry.depth) + entry.label + (isCurrent ? '  (current)' : '');
+      if (isCurrent) option.disabled = true;
       select.appendChild(option);
     }
 
@@ -428,8 +429,9 @@ export class CloudXR2DUI {
   }
 
   /**
-   * Enables localStorage persistence for form inputs
-   * Automatically saves and restores user preferences
+   * Wires up localStorage persistence for global (non-per-project-path) form
+   * inputs. Per-project-path fields are handled separately via
+   * loadPerProject/savePerProject around their own change listeners.
    */
   private setupLocalStorage(): void {
     enableLocalStorage(this.serverTypeSelect, 'serverType');
@@ -449,8 +451,6 @@ export class CloudXR2DUI {
     enableLocalStorage(this.useQuestColorWorkaroundSelect, 'useQuestColorWorkaround');
     enableLocalStorage(this.immersiveSelect, 'immersiveMode');
     enableLocalStorage(this.deviceProfileSelect, 'deviceProfile');
-    // panelHiddenAtStart is persisted per-project-path via savePerProject() in
-    // its change listener, not here.
     enableLocalStorage(this.controlPanelPositionSelect, 'controlPanelPosition');
     enableLocalStorage(this.referenceSpaceSelect, 'referenceSpace');
     enableLocalStorage(this.xrOffsetXInput, 'xrOffsetX');
@@ -561,10 +561,7 @@ export class CloudXR2DUI {
       // Reset to the prompt before navigating so if the reload is aborted the
       // control doesn't end up stuck on the just-picked value.
       this.teleopProjectSelect.selectedIndex = 0;
-      // Full reload: teleopPath seeds initial per-project state and config;
-      // cheaper to rebuild from scratch than to wire a re-init path here.
       window.location.hash = value.replace(/^#/, '');
-      window.location.reload();
     });
     addListener(this.proxyUrlInput, 'input', updateConfig);
     addListener(this.proxyUrlInput, 'change', updateConfig);

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -425,6 +425,7 @@ export class CloudXR2DUI {
       enableTexSubImage2D: false,
       useQuestColorWorkaround: false,
       hideControllerModel: false,
+      teleopPath: DEFAULT_TELEOP_PATH,
     };
   }
 

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -262,7 +262,7 @@ export class CloudXR2DUI {
   private decoratePerProjectLabels(): void {
     const label = this.panelHiddenAtStartSelect.labels?.[0];
     if (!label) return;
-    const marker = ' (saved per teleop app)';
+    const marker = ' (saved per teleop application)';
     if (label.textContent?.includes(marker)) return;
     label.appendChild(document.createTextNode(marker));
   }

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -501,11 +501,58 @@ limitations under the License.
             border-bottom-color: #1b5e20;
         }
 
-        /* Capped so the select doesn't stretch edge-to-edge on wide screens. */
-        .teleop-project-select-row {
-            flex: 0 1 auto;
-            min-width: 300px;
-            max-width: 540px;
+        /* Opt out of the global `select { width: 100% }` so the help toggle fits alongside. */
+        #teleopProjectSelect {
+            width: auto;
+            vertical-align: top;
+        }
+
+        /* line-height matches select's min-height so the summary reads as vertically
+           centered with the select; position: relative anchors the popover body. */
+        .teleop-project-help {
+            display: inline-block;
+            vertical-align: top;
+            margin-left: 12px;
+            line-height: 48px;
+            position: relative;
+        }
+
+        .teleop-project-help > summary {
+            list-style: none;
+            cursor: pointer;
+            color: #666;
+            font-size: 0.85rem;
+            text-decoration: underline dotted;
+        }
+
+        .teleop-project-help > summary::-webkit-details-marker {
+            display: none;
+        }
+
+        /* Popover: out of flow so the details element never grows and the select stays put. */
+        .teleop-project-help-body {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            width: 320px;
+            margin-top: 4px;
+            padding: 10px 12px;
+            background: var(--background-main);
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+            line-height: 1.5;
+            font-size: 0.85rem;
+            color: #666;
+            z-index: 20;
+        }
+
+        .teleop-project-help-body p {
+            margin: 0 0 8px;
+        }
+
+        .teleop-project-help-body p:last-child {
+            margin-bottom: 0;
         }
 
         /* Hide 2D UI when in XR mode */
@@ -524,6 +571,16 @@ limitations under the License.
             </h1>
             <div class="teleop-project-select-row">
                 <select id="teleopProjectSelect" aria-label="Change teleop application"></select>
+                <details class="teleop-project-help">
+                    <summary>Not sure which to pick?</summary>
+                    <div class="teleop-project-help-body">
+                        <p>Pick the most specific entry that accurately describes your setup.
+                        If your specific robot configuration isn't listed, just choose the
+                        backend; if your backend isn't listed either, choose Simulation or
+                        Real Robot.</p>
+                        <p>Used for telemetry and app-specific client settings.</p>
+                    </div>
+                </details>
             </div>
         </header>
 

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -567,7 +567,7 @@ limitations under the License.
         <div class="top-banner"></div>
         <header>
             <h1>NVIDIA Isaac Teleop Web Client
-                <span id="teleopModeSubtitle"></span>
+                <small id="teleopModeSubtitle"></small>
             </h1>
             <div class="teleop-project-select-row">
                 <select id="teleopProjectSelect" aria-label="Change teleop application"></select>

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -495,6 +495,62 @@ limitations under the License.
             border-bottom-color: #1b5e20;
         }
 
+        /* Teleop mode subtitle in header */
+        .teleop-mode-subtitle {
+        }
+
+        .teleop-project-select {
+            font-weight: 400;
+            font-size: 0.55em;
+            color: #1565c0;
+            margin-left: 6px;
+            background: transparent;
+            border: 1px solid transparent;
+            border-radius: 3px;
+            cursor: pointer;
+            padding: 1px 4px;
+            font-family: inherit;
+            min-width: 0;
+            min-height: 0;
+            width: auto;
+        }
+
+        .teleop-project-select:hover,
+        .teleop-project-select:focus {
+            border-color: #1565c0;
+            outline: none;
+        }
+
+        /* Teleop mode indicator */
+        .teleop-mode-indicator {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            background: #f5f5f5;
+            border: 2px solid var(--border-color);
+            border-radius: 4px;
+            padding: 10px 14px;
+            margin-bottom: 16px;
+            font-size: 0.95rem;
+            width: fit-content;
+        }
+
+        .teleop-mode-indicator strong {
+            color: var(--text-main);
+        }
+
+        .teleop-mode-indicator a {
+            color: #1565c0;
+            text-decoration: none;
+            font-weight: 500;
+            font-size: 0.85rem;
+            border-bottom: 1px solid transparent;
+        }
+
+        .teleop-mode-indicator a:hover {
+            border-bottom-color: #1565c0;
+        }
+
         /* Hide 2D UI when in XR mode */
         body.xr-mode #2d-ui {
             display: none;
@@ -506,7 +562,10 @@ limitations under the License.
     <div id="2d-ui">
         <div class="top-banner"></div>
         <header>
-            <h1>NVIDIA Isaac Teleop Web Client</h1>
+            <h1>NVIDIA Isaac Teleop Web Client
+                <span id="teleopModeSubtitle" class="teleop-mode-subtitle">for IsaacSim</span>
+                <select id="teleopProjectSelect" class="teleop-project-select" aria-label="Select teleop project"></select>
+            </h1>
         </header>
 
         <main>
@@ -554,6 +613,13 @@ limitations under the License.
             </aside>
 
             <section>
+                <!-- Alternate mode indicator (kept for reference; header version is active)
+                <div id="teleopModeIndicator" class="teleop-mode-indicator">
+                    <span>Mode: <strong id="teleopModeLabel">Simulation</strong></span>
+                    <a id="teleopModeSwitch" href="#/real">Switch to Real Robot</a>
+                </div>
+                -->
+
                 <h3 class="debug-title">Debug Settings</h3>
 
                 <div class="config-section">

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -71,15 +71,21 @@ limitations under the License.
         /* Header */
         header {
             background: var(--background-main);
-            padding: 16px 0 16px 24px;
+            padding: 16px 24px;
             min-height: unset;
             box-shadow: none;
             border-bottom: 1px solid var(--border-color);
+            /* Title and project dropdown share a row (wraps on narrow screens). */
+            display: flex;
+            flex-wrap: wrap;
+            align-items: center;
+            gap: 12px 24px;
         }
 
         h1 {
             font-size: 1.5rem;
             font-weight: 600;
+            margin: 0;
         }
 
         main {
@@ -495,60 +501,11 @@ limitations under the License.
             border-bottom-color: #1b5e20;
         }
 
-        /* Teleop mode subtitle in header */
-        .teleop-mode-subtitle {
-        }
-
-        .teleop-project-select {
-            font-weight: 400;
-            font-size: 0.55em;
-            color: #1565c0;
-            margin-left: 6px;
-            background: transparent;
-            border: 1px solid transparent;
-            border-radius: 3px;
-            cursor: pointer;
-            padding: 1px 4px;
-            font-family: inherit;
-            min-width: 0;
-            min-height: 0;
-            width: auto;
-        }
-
-        .teleop-project-select:hover,
-        .teleop-project-select:focus {
-            border-color: #1565c0;
-            outline: none;
-        }
-
-        /* Teleop mode indicator */
-        .teleop-mode-indicator {
-            display: flex;
-            align-items: center;
-            gap: 12px;
-            background: #f5f5f5;
-            border: 2px solid var(--border-color);
-            border-radius: 4px;
-            padding: 10px 14px;
-            margin-bottom: 16px;
-            font-size: 0.95rem;
-            width: fit-content;
-        }
-
-        .teleop-mode-indicator strong {
-            color: var(--text-main);
-        }
-
-        .teleop-mode-indicator a {
-            color: #1565c0;
-            text-decoration: none;
-            font-weight: 500;
-            font-size: 0.85rem;
-            border-bottom: 1px solid transparent;
-        }
-
-        .teleop-mode-indicator a:hover {
-            border-bottom-color: #1565c0;
+        /* Capped so the select doesn't stretch edge-to-edge on wide screens. */
+        .teleop-project-select-row {
+            flex: 0 1 auto;
+            min-width: 300px;
+            max-width: 540px;
         }
 
         /* Hide 2D UI when in XR mode */
@@ -563,9 +520,11 @@ limitations under the License.
         <div class="top-banner"></div>
         <header>
             <h1>NVIDIA Isaac Teleop Web Client
-                <span id="teleopModeSubtitle" class="teleop-mode-subtitle">for IsaacSim</span>
-                <select id="teleopProjectSelect" class="teleop-project-select" aria-label="Select teleop project"></select>
+                <span id="teleopModeSubtitle"></span>
             </h1>
+            <div class="teleop-project-select-row">
+                <select id="teleopProjectSelect" aria-label="Change teleop application"></select>
+            </div>
         </header>
 
         <main>
@@ -613,13 +572,6 @@ limitations under the License.
             </aside>
 
             <section>
-                <!-- Alternate mode indicator (kept for reference; header version is active)
-                <div id="teleopModeIndicator" class="teleop-mode-indicator">
-                    <span>Mode: <strong id="teleopModeLabel">Simulation</strong></span>
-                    <a id="teleopModeSwitch" href="#/real">Switch to Real Robot</a>
-                </div>
-                -->
-
                 <h3 class="debug-title">Debug Settings</h3>
 
                 <div class="config-section">

--- a/deps/cloudxr/webxr_client/webpack.dev.js
+++ b/deps/cloudxr/webxr_client/webpack.dev.js
@@ -58,6 +58,18 @@ module.exports = merge(common, {
         errors: true,
         warnings: false,
       },
+      // Derive HMR socket URL from window.location so it works behind the
+      // docker-compose TLS proxy (https://<host>:8443) as well as directly
+      // (http://<host>:8080). Sentinels per webpack-dev-server:
+      //   hostname '0.0.0.0' -> window.location.hostname
+      //   port     0         -> window.location.port
+      //   protocol 'auto'    -> ws for http, wss for https
+      webSocketURL: {
+        hostname: '0.0.0.0',
+        port: 0,
+        protocol: 'auto',
+        pathname: '/ws',
+      },
     },
     devMiddleware: {
       writeToDisk: true,


### PR DESCRIPTION
Adds client application profiles

- Used in telemetry to distinguish use cases
- Can be used for default client settings (currently just the hide panel option) and to remember per-app user settings (if they change hide panel setting for one app, it will persist for that app)

I also made a change to the webpack to fix hot module replacement during testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Select and switch between multiple teleoperation projects via a new dropdown and contextual help
  * Breadcrumb navigation showing the current project hierarchy
  * Per-project settings persisted/restored automatically; active project shown in the app title
  * URL canonicalization for teleop paths with sensible defaults on load

* **Chores**
  * Improved development server WebSocket configuration for more reliable hot-reload behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->