### PR TITLE
ci: enable sonarqube scanning on ego4robo/* branches

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,6 +34,7 @@ build-sonar:
     - if: $CI_COMMIT_BRANCH == 'main'
     - if: $CI_COMMIT_BRANCH == 'develop'
     - if: '$CI_COMMIT_BRANCH =~ /^release\/.*/'
+    - if: '$CI_COMMIT_BRANCH =~ /^ego4robo\/.*/'
 
 sonarqube-vulnerability-report:
   stage: sonarqube-vulnerability-report
@@ -49,6 +50,7 @@ sonarqube-vulnerability-report:
     - if: $CI_COMMIT_BRANCH == 'main'
     - if: $CI_COMMIT_BRANCH == 'develop'
     - if: '$CI_COMMIT_BRANCH =~ /^release\/.*/'
+    - if: '$CI_COMMIT_BRANCH =~ /^ego4robo\/.*/'
   artifacts:
     expire_in: 1 day
     reports:


### PR DESCRIPTION
Add ego4robo/* to the branch rules for both the build-sonar and sonarqube-vulnerability-report jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration to extend automated build and security scanning processes to additional branch patterns, ensuring consistent quality checks across more development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->