### PR TITLE
fix(webclient): Updates react package to address CVE-2026-23869

### DIFF
--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -28,8 +28,8 @@
     "@react-three/uikit": "^1.0.0",
     "@react-three/uikit-default": "^1.0.0",
     "@react-three/xr": "^6.6.22",
-    "react": "^19.2.4",
-    "react-dom": "^19.2.4",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "three": "^0.172.0",
     "uuid": "^14.0.0"
   },


### PR DESCRIPTION
See https://github.com/facebook/react/security/advisories/GHSA-479c-33wc-g2pg.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated React dependencies to the latest patch version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->