### PR TITLE
feat(oob): Support USB only local connection with TURN server

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx
+++ b/deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx
@@ -91,6 +91,13 @@ interface CloudXRComponentProps {
 
   /** When true, skip WebGL rendering. */
   headless?: boolean;
+
+  /**
+   * Custom ICE server configuration (STUN/TURN) for WebRTC.
+   * In USB-local mode, set this to a TURN server accessible via adb reverse
+   * with iceTransportPolicy 'relay' so WebRTC can gather candidates without WiFi.
+   */
+  iceServers?: CloudXR.SessionOptions['iceServers'];
 }
 
 // React component that integrates CloudXR with Three.js/WebXR
@@ -107,6 +114,7 @@ export default function CloudXRComponent({
   onStreamingPerformanceMetrics,
   metricsSettings = {},
   headless = false,
+  iceServers,
 }: CloudXRComponentProps) {
   const threeRenderer: WebGLRenderer = useThree().gl;
   const { session } = useXR();
@@ -242,6 +250,7 @@ export default function CloudXRComponent({
             useQuestColorWorkaround: config.useQuestColorWorkaround,
             mediaAddress: config.mediaAddress,
             mediaPort: config.mediaPort,
+            iceServers: iceServers,
             glBinding: glBinding,
             telemetry: {
               enabled: true,

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -351,7 +351,7 @@ function App() {
     // URL query params override localStorage so bookmarked links always win.
     const urlSeeds: Record<string, string> = {};
     const p = new URLSearchParams(window.location.search);
-    for (const key of ['serverIP', 'port', 'codec', 'panelHiddenAtStart', 'headless']) {
+    for (const key of ['serverIP', 'port', 'codec', 'panelHiddenAtStart', 'headless', 'turnServer', 'turnUsername', 'turnCredential']) {
       const v = p.get(key);
       if (v !== null) urlSeeds[key] = v;
     }
@@ -723,6 +723,25 @@ function App() {
     [cloudXR2DUI, configVersion]
   );
 
+  // Build ICE server config from URL params (set in USB-local mode by oob_teleop_env.py).
+  // turnServer e.g. "turn:127.0.0.1:3478?transport=tcp", iceRelayOnly=1 forces relay-only ICE.
+  const iceServersConfig = useMemo<CloudXR.SessionOptions['iceServers'] | undefined>(() => {
+    const p = new URLSearchParams(window.location.search);
+    const turnServer = p.get('turnServer');
+    if (!turnServer) return undefined;
+    const turnUsername = p.get('turnUsername') ?? undefined;
+    const turnCredential = p.get('turnCredential') ?? undefined;
+    const iceRelayOnly = p.get('iceRelayOnly') === '1';
+    return {
+      iceServers: [{
+        urls: turnServer,
+        ...(turnUsername !== undefined && { username: turnUsername }),
+        ...(turnCredential !== undefined && { credential: turnCredential }),
+      }],
+      ...(iceRelayOnly && { iceTransportPolicy: 'relay' as RTCIceTransportPolicy }),
+    };
+  }, []);
+
   // Calculate panel position from config and memoize it as the vector used in CloudXR3DUI.
   const controlPanelPositionVector = useMemo(
     () =>
@@ -862,6 +881,7 @@ function App() {
               <CloudXRComponent
                 config={config}
                 applicationName={`Isaac Teleop Web Client (${config.teleopPath})`}
+                iceServers={iceServersConfig}
                 onStatusChange={handleStatusChange}
                 onError={error => {
                   if (cloudXR2DUI) {

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -38,6 +38,16 @@ the list of dependencies. On **Ubuntu**, install build tools and clang-format:
    sudo apt-get update
    sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf
 
+Runtime-only dependencies (needed to actually run teleop, not to build):
+
+.. code-block:: bash
+
+   # adb — required for OOB teleop (``--setup-oob``) to talk to the headset over USB.
+   # coturn — required for USB-local mode (``--usb-local``); runs a local TURN server
+   #          so WebRTC ICE can relay traffic from the headset to the CloudXR backend
+   #          over the USB cable.
+   sudo apt-get install -y android-tools-adb coturn
+
 Our build system uses `uv`_ for Python version and dependency management. Install `uv`_ if not already installed:
 
 .. code-block:: bash

--- a/docs/source/references/oob_teleop_control.rst
+++ b/docs/source/references/oob_teleop_control.rst
@@ -357,3 +357,114 @@ Environment variables
      - Default video codec for headset bookmarks
    * - ``TELEOP_CLIENT_PANEL_HIDDEN_AT_START``
      - Hide control panel on load (``true`` / ``false``)
+
+USB-local mode
+--------------
+
+``--usb-local`` routes teleop signalling, the web client, and WebRTC media
+over the USB cable on the headset's loopback via ``adb reverse``. Add it to
+``--setup-oob``:
+
+.. code-block:: bash
+
+   python -m isaacteleop.cloudxr --accept-eula --setup-oob --usb-local
+
+On startup the launcher:
+
+1. Pre-flights: ``adb`` on PATH, ``coturn`` installed, exactly one device
+   connected, headset has at least one non-loopback IP (Wi-Fi up — see
+   troubleshooting below for why this is required even though no packets
+   traverse the network).
+2. Resolves the WebXR static directory from
+   ``TELEOP_WEB_CLIENT_STATIC_DIR`` (default ``~/.cloudxr/static-client``)
+   and downloads ``index.html`` / ``bundle.js`` from
+   ``https://nvidia.github.io/IsaacTeleop/client/`` if either is missing.
+3. Serves that directory over HTTPS on 127.0.0.1:8080 with the same PEM
+   the WSS proxy uses (Python ``http.server`` in a daemon thread).
+4. ``adb reverse`` for 8080 (static UI), 48322 (WSS), 49100 (backend),
+   3478 (coturn TURN).
+5. Starts coturn locally on 127.0.0.1:3478 for WebRTC ICE relay.
+6. Launches the teleop URL on the headset and auto-clicks CONNECT via CDP.
+
+Required apt packages: ``adb`` (``android-tools-adb``) and ``coturn``.
+No Node.js / ``npm`` is required at runtime.
+
+Troubleshooting
+---------------
+
+Teleop client error: "No local connection candidates" (0xC0F2220F)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Cause:** Chromium's WebRTC ``rtc::NetworkManager`` excludes loopback
+interfaces when enumerating networks for ICE. If the only active network
+on the headset is ``lo``, ICE gathering hangs at ``gathering`` forever —
+no local candidates are emitted and no error fires — until the CloudXR
+session times out with this code.
+
+**Fix:** Connect the headset to any Wi-Fi network. It does not need
+internet access — a phone hotspot with no data plan is sufficient. The
+packets still route over USB (kernel short-circuits loopback regardless
+of source interface); the Wi-Fi interface just needs to *exist* so
+WebRTC's enumeration is non-empty.
+
+The ``--usb-local`` launcher now pre-flights this via
+``adb shell ip -o -4 addr show`` and refuses to start if no non-loopback
+interface is present.
+
+CDP: startButton marked failed / not actionable
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Cause:** The web client's capability check (``App.tsx``) sets the button
+label to ``CONNECT (capability check failed)`` and disables it when a
+required feature is missing (WebGL2, ``requestVideoFrameCallback``,
+immersive-VR support). ADB automation detects this and aborts instead of
+clicking a dead button.
+
+**Fix:** Open the teleop URL on the headset manually and read the
+``errorMessageBox`` — it names the specific missing capability. Common
+causes: launched in WebLayer instead of Meta Quest Browser (no WebXR
+support → IWER fallback silently activates); WebGL2 disabled by device
+policy.
+
+``coturn`` not found / TURN server failed to start
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Cause:** ``--usb-local`` requires coturn to relay WebRTC media between
+the headset (TCP via adb reverse) and the CloudXR backend (UDP on
+loopback).
+
+**Fix:** ``sudo apt-get install -y coturn``. The launcher starts its own
+``turnserver`` process on 127.0.0.1:3478; no systemd service is needed
+(and may conflict — stop the system ``coturn.service`` if enabled).
+
+Inspect ``/tmp/coturn-cloudxr-3478.log`` for bind errors or credential
+mismatches; the launcher truncates this file on every start so only the
+current session's output is present.
+
+Tab not found within timeout
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Cause:** The headset's default URL handler is something other than Meta
+Quest Browser (e.g. WebLayer on Meta Quest) and did not open the teleop
+URL in a browser with remote-debugging exposed.
+
+**Fix:** Open ``chrome://inspect#devices`` on this PC, inspect the
+headset tab manually, and click CONNECT. Or set a different default
+browser on the headset.
+
+WebXR static download fails (offline / proxy)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Cause:** The launcher fetches ``index.html`` / ``bundle.js`` from
+``https://nvidia.github.io/IsaacTeleop/client/`` into the static dir on
+first run.  Behind a proxy or with no internet, this fails and
+``--usb-local`` aborts.
+
+**Fix:** Pre-stage the files (any way you like — ``curl``, container
+build step, internal mirror) into the static dir, then re-run.  The
+launcher only downloads when a file is missing or empty.  Override the
+target directory via ``TELEOP_WEB_CLIENT_STATIC_DIR``.
+
+**Fix:** Set the SDK versions in ``deps/cloudxr/.env`` (copy from
+``.env.default``) so the download script can resolve the right version,
+or stage ``nvidia-cloudxr-<version>.tgz`` in ``deps/cloudxr/`` manually.

--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -16,9 +16,17 @@ from isaacteleop.cloudxr.runtime import latest_runtime_log, runtime_version
 from isaacteleop.cloudxr.oob_teleop_adb import (
     OobAdbError,
     assert_exactly_one_adb_device,
+    assert_headset_awake,
     require_adb_on_path,
+    require_coturn_available,
+    require_headset_non_loopback_network,
 )
 from isaacteleop.cloudxr.oob_teleop_env import (
+    USB_BACKEND_PORT,
+    USB_HOST,
+    USB_TURN_PORT,
+    USB_UI_PORT,
+    WSS_PROXY_DEFAULT_PORT,
     print_oob_hub_startup_banner,
     resolve_lan_host_for_oob,
 )
@@ -57,6 +65,24 @@ def _parse_args() -> argparse.Namespace:
             'See docs: "Out-of-band teleop control".'
         ),
     )
+    parser.add_argument(
+        "--usb-local",
+        action="store_true",
+        default=False,
+        help=(
+            "Route teleop traffic over the USB cable on headset loopback "
+            "(127.0.0.1) via adb reverse.  Requires --setup-oob.  Orchestrates "
+            "adb reverse for WSS proxy "
+            f"({WSS_PROXY_DEFAULT_PORT}/tcp), CloudXR backend "
+            f"({USB_BACKEND_PORT}/tcp), coturn ({USB_TURN_PORT}/tcp), and "
+            f"HTTPS static WebXR UI on port {USB_UI_PORT}.  Files live under "
+            "TELEOP_WEB_CLIENT_STATIC_DIR or ~/.cloudxr/static-client; missing "
+            "index.html / bundle.js are downloaded from nvidia.github.io/IsaacTeleop/client/.  "
+            "The launcher serves them with the same PEM as the WSS proxy.  "
+            "Requirements: `coturn`, `adb` on PATH.  WebRTC ICE still needs a "
+            "non-loopback interface on the headset (WiFi stays connected)."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -64,16 +90,41 @@ def main() -> None:
     """Launch the CloudXR runtime and WSS proxy, then block until interrupted."""
     args = _parse_args()
 
+    if args.usb_local and not args.setup_oob:
+        print(
+            "error: --usb-local requires --setup-oob",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
     if args.setup_oob:
         require_adb_on_path()
-        resolve_lan_host_for_oob()
+        if not args.usb_local:
+            resolve_lan_host_for_oob()
+        else:
+            # Fail fast with clear errors instead of letting the headset
+            # silently time out on WebRTC ICE later.
+            try:
+                require_coturn_available()
+            except OobAdbError as exc:
+                print(f"\n\033[31m{exc}\033[0m\n", file=sys.stderr)
+                raise SystemExit(1) from exc
         assert_exactly_one_adb_device()
+        assert_headset_awake()
+        if args.usb_local:
+            # adb must be usable (just asserted) before we probe the headset.
+            try:
+                require_headset_non_loopback_network()
+            except OobAdbError as exc:
+                print(f"\n\033[31m{exc}\033[0m\n", file=sys.stderr)
+                raise SystemExit(1) from exc
 
     with CloudXRLauncher(
         install_dir=args.cloudxr_install_dir,
         env_config=args.cloudxr_env_config,
         accept_eula=args.accept_eula,
         setup_oob=args.setup_oob,
+        usb_local=args.usb_local,
     ) as launcher:
         cxr_ver = runtime_version()
         print(
@@ -91,10 +142,16 @@ def main() -> None:
             f"CloudXR WSS proxy: \033[36mrunning\033[0m, log file: \033[90m{wss_log}\033[0m"
         )
         if args.setup_oob:
-            print(
-                "        oob:       \033[32menabled\033[0m  (hub + USB adb automation — see OOB TELEOP block)"
-            )
-            print_oob_hub_startup_banner(lan_host=resolve_lan_host_for_oob())
+            if args.usb_local:
+                print(
+                    "        oob:       \033[32menabled\033[0m  (hub + USB-local: adb reverse + coturn)"
+                )
+                print_oob_hub_startup_banner(lan_host=USB_HOST, usb_local=True)
+            else:
+                print(
+                    "        oob:       \033[32menabled\033[0m  (hub + USB adb automation — see OOB TELEOP block)"
+                )
+                print_oob_hub_startup_banner(lan_host=resolve_lan_host_for_oob())
         print(
             f"Activate CloudXR environment in another terminal: \033[1;32msource {env_cfg.env_filepath()}\033[0m"
         )

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -74,6 +74,7 @@ class CloudXRLauncher:
         env_config: str | Path | None = None,
         accept_eula: bool = False,
         setup_oob: bool = False,
+        usb_local: bool = False,
     ) -> None:
         """Launch the CloudXR runtime and WSS proxy.
 
@@ -92,6 +93,14 @@ class CloudXRLauncher:
                 does not exist, the user is prompted on stdin.
             setup_oob: Enable the OOB teleop control hub and USB
                 adb automation in the WSS proxy.
+            usb_local: Route teleop traffic over USB on headset loopback
+                via ``adb reverse`` (requires *setup_oob*).  Sets up
+                ``adb reverse`` for WSS proxy, CloudXR backend, and
+                coturn TURN ports, and starts coturn locally for WebRTC
+                ICE relay.  WebXR static files use ``TELEOP_WEB_CLIENT_STATIC_DIR`` or
+                ``~/.cloudxr/static-client``; missing ``index.html`` / ``bundle.js`` are
+                fetched from GitHub Pages.  Python serves them over HTTPS on port 8080
+                with the same PEM as the WSS proxy.
 
         Raises:
             RuntimeError: If the EULA is not accepted or the runtime
@@ -101,6 +110,12 @@ class CloudXRLauncher:
         self._env_config = str(env_config) if env_config is not None else None
         self._accept_eula = accept_eula
         self._setup_oob = setup_oob
+        self._usb_local = usb_local
+
+        if self._usb_local:
+            from .oob_teleop_env import require_usb_local_webxr_static_dir  # noqa: PLC0415
+
+            require_usb_local_webxr_static_dir()
 
         self._runtime_proc: subprocess.Popen | None = None
         self._wss_thread: threading.Thread | None = None
@@ -370,6 +385,7 @@ class CloudXRLauncher:
         self._wss_stop_future = stop_future
 
         setup_oob = self._setup_oob
+        usb_local = self._usb_local
 
         def _run_wss() -> None:
             asyncio.set_event_loop(loop)
@@ -379,6 +395,7 @@ class CloudXRLauncher:
                         log_file_path=log_path,
                         stop_future=stop_future,
                         setup_oob=setup_oob,
+                        usb_local=usb_local,
                     )
                 )
             except Exception:

--- a/src/core/cloudxr/python/oob_teleop_adb.py
+++ b/src/core/cloudxr/python/oob_teleop_adb.py
@@ -3,9 +3,20 @@
 
 """ADB automation for OOB teleop (``--setup-oob``): open the headset bookmark URL via USB adb.
 
-The headset is connected via USB cable for adb commands only.  Streaming and
-web-page access use WiFi.  ``adb forward`` is used temporarily for CDP
-automation (DevTools socket); no ``adb reverse`` or USB tethering.
+Default mode (WiFi streaming):
+    The headset is connected via USB cable for adb commands only.  Streaming and
+    web-page access use WiFi.  ``adb forward`` is used temporarily for CDP
+    automation (DevTools socket).
+
+USB-local mode (``--usb-local``):
+    Teleop signalling and streaming travel over USB via ``adb reverse`` on the
+    headset's loopback.  The headset URL uses ``serverIP=127.0.0.1`` and loads
+    the WebXR client from ``https://localhost:8080`` (Python ``http.server``
+    in :mod:`~.oob_teleop_env` serves the prebuilt static client over HTTPS,
+    reusing the WSS proxy's PEM).  coturn runs locally and is reachable from
+    the headset through adb reverse for WebRTC ICE relay.  Note: WebRTC
+    requires a non-loopback interface on the headset, so WiFi must remain
+    connected (no traffic traverses it).
 """
 
 from __future__ import annotations
@@ -18,9 +29,9 @@ import re
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 import urllib.request
-
 from .oob_teleop_env import (
     DEFAULT_WEB_CLIENT_ORIGIN,
     parse_env_port,
@@ -95,6 +106,152 @@ def require_adb_on_path() -> None:
     )
 
 
+def headset_non_loopback_interfaces() -> list[tuple[str, str]]:
+    """Return ``(iface, ipv4)`` for each non-loopback interface with an address.
+
+    Uses ``adb shell ip -o -4 addr show`` on the connected headset.  Returns
+    an empty list when the command fails (no device, adb broken, etc.) — the
+    caller decides whether that's fatal.
+    """
+    try:
+        proc = subprocess.run(
+            ["adb", "shell", "ip", "-o", "-4", "addr", "show"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return []
+    if proc.returncode != 0:
+        return []
+    out: list[tuple[str, str]] = []
+    for line in proc.stdout.splitlines():
+        # Example: "20: wlan0    inet 10.0.0.42/24 brd 10.0.0.255 scope global wlan0"
+        parts = line.split()
+        if len(parts) < 4:
+            continue
+        iface = parts[1]
+        if iface == "lo":
+            continue
+        # Find the "inet <addr>/<cidr>" pair wherever it lands.
+        try:
+            idx = parts.index("inet")
+        except ValueError:
+            continue
+        if idx + 1 >= len(parts):
+            continue
+        addr = parts[idx + 1].split("/")[0]
+        out.append((iface, addr))
+    return out
+
+
+def require_headset_non_loopback_network() -> None:
+    """Fail fast when the headset has no non-loopback IP (USB-local blocker).
+
+    Chromium's WebRTC ``rtc::NetworkManager`` excludes loopback interfaces
+    when enumerating networks for ICE.  Without at least one non-loopback
+    interface with an IP, ICE gathering hangs forever (``iceGatheringState``
+    stuck at ``gathering``, no candidates, no errors), and the teleop
+    session fails with "No local connection candidates" (0xC0F2220F).
+
+    The packets don't actually traverse the reported interface in USB-local
+    mode — the kernel short-circuits loopback regardless of source — but
+    the interface must *exist* for WebRTC's enumeration to be non-empty.
+    """
+    ifaces = headset_non_loopback_interfaces()
+    if not ifaces:
+        raise OobAdbError(
+            "--usb-local: the headset has no non-loopback network interface "
+            "with an IP address.\n\n"
+            "Chromium's WebRTC needs at least one non-loopback interface to "
+            "enumerate ICE sockets, even when all traffic routes over USB "
+            "via adb reverse. Without it, ICE hangs and the session errors "
+            'out with "No local connection candidates" (0xC0F2220F).\n\n'
+            "Fix: connect the headset to any Wi-Fi network (it does not need "
+            "internet access — a phone hotspot with no data plan works). "
+            "Then retry."
+        )
+    log.info(
+        "USB-local: headset has %d non-loopback interface(s): %s",
+        len(ifaces),
+        ", ".join(f"{i}={ip}" for i, ip in ifaces),
+    )
+
+
+def headset_wakefulness() -> str:
+    """Return ``mWakefulness`` from ``adb shell dumpsys power``, or ``""`` on failure.
+
+    Typical values: ``Awake`` | ``Asleep`` | ``Dreaming`` | ``Dozing``.
+    """
+    try:
+        proc = subprocess.run(
+            ["adb", "shell", "dumpsys", "power"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    m = re.search(r"mWakefulness=(\w+)", proc.stdout or "")
+    return m.group(1) if m else ""
+
+
+def assert_headset_awake(*, timeout: float = 15.0) -> None:
+    """Warn-and-wait when the headset is asleep before launching OOB automation.
+
+    Quest / PICO devices sleep when the proximity sensor is uncovered
+    (e.g. the headset is sitting on a desk).  In that state, ``am start``
+    may still register but the screen can return to sleep before the
+    CONNECT click lands, and WebXR session entry will fail.
+
+    Sends ``KEYCODE_WAKEUP`` once and then polls ``mWakefulness`` for up to
+    ``timeout`` seconds.  Returns silently once the device is ``Awake``.
+    Otherwise logs a warning and returns — downstream automation may still
+    succeed if ``am start`` wakes the device.
+    """
+    wake = headset_wakefulness()
+    if wake == "Awake":
+        return
+
+    try:
+        subprocess.run(
+            ["adb", "shell", "input", "keyevent", "KEYCODE_WAKEUP"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+
+    print(
+        "\n\033[33mHeadset appears to be asleep "
+        f"(wakefulness={wake or '?'}).\n"
+        "Please put on the headset, or cover the proximity sensor "
+        "(e.g. with a piece of tape) so the device stays awake.\n"
+        f"Waiting up to {timeout:.0f}s for the device to wake...\033[0m\n",
+        file=sys.stderr,
+    )
+
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        time.sleep(1.0)
+        wake = headset_wakefulness()
+        if wake == "Awake":
+            log.info("Headset is awake (wakefulness=%s)", wake)
+            return
+
+    log.warning(
+        "Headset still appears asleep after %.0fs (wakefulness=%s); continuing anyway.",
+        timeout,
+        wake or "?",
+    )
+
+
 def assert_exactly_one_adb_device() -> None:
     """Fail unless exactly one device is in ``device`` state."""
     try:
@@ -147,34 +304,170 @@ def assert_exactly_one_adb_device() -> None:
         )
 
 
-def run_adb_headset_bookmark(*, resolved_port: int) -> tuple[int, str]:
-    """Open the teleop bookmark URL on the headset via ``am start``.
-
-    Uses the PC's LAN address — the headset reaches the proxy over WiFi.
-    ``resolved_port`` is used as the stream port unless ``TELEOP_STREAM_PORT``
-    is set explicitly.  Returns ``(exit_code, diagnostic)``.
-    """
+def build_teleop_url(*, resolved_port: int, usb_local: bool = False) -> str:
+    """Build the headset teleop bookmark URL for ``am start`` and CDP automation."""
     env_port = os.environ.get("TELEOP_STREAM_PORT", "").strip()
     signaling_port = (
         parse_env_port("TELEOP_STREAM_PORT", env_port) if env_port else resolved_port
     )
-    proxy_host = resolve_lan_host_for_oob()
-    stream_cfg: dict = {
-        "serverIP": proxy_host,
-        "port": signaling_port,
-        **client_ui_fields_from_env(),
-    }
 
-    ovr = web_client_base_override_from_env()
-    web_base = ovr if ovr else DEFAULT_WEB_CLIENT_ORIGIN
+    if usb_local:
+        from .oob_teleop_env import (  # noqa: PLC0415
+            USB_HOST,
+            USB_UI_PORT,
+            USB_TURN_PORT,
+            USB_TURN_USER,
+            USB_TURN_CREDENTIAL,
+        )
+
+        stream_cfg: dict = {
+            "serverIP": USB_HOST,
+            "port": signaling_port,
+            # No mediaAddress: it's a NAT-override that bypasses ICE and would
+            # short-circuit the TURN-relayed media path. Let the SDK discover
+            # the media endpoint through ICE via coturn.
+            "turnServer": f"turn:{USB_HOST}:{USB_TURN_PORT}?transport=tcp",
+            "turnUsername": USB_TURN_USER,
+            "turnCredential": USB_TURN_CREDENTIAL,
+            "iceRelayOnly": True,
+            **client_ui_fields_from_env(),
+        }
+        ovr = web_client_base_override_from_env()
+        web_base = ovr if ovr else f"https://localhost:{USB_UI_PORT}"
+    else:
+        stream_cfg = {
+            "serverIP": resolve_lan_host_for_oob(),
+            "port": signaling_port,
+            **client_ui_fields_from_env(),
+        }
+        ovr = web_client_base_override_from_env()
+        web_base = ovr if ovr else DEFAULT_WEB_CLIENT_ORIGIN
+
     token = os.environ.get("CONTROL_TOKEN") or None
-    url = build_headset_bookmark_url(
+    return build_headset_bookmark_url(
         web_client_base=web_base,
         stream_config=stream_cfg,
         control_token=token,
     )
 
-    shell_cmd = "am start -a android.intent.action.VIEW -d " + shlex.quote(url)
+
+def _adb_getprop(prop: str) -> str:
+    """Read an Android system property via adb. Returns "" on failure."""
+    try:
+        proc = subprocess.run(
+            ["adb", "shell", "getprop", prop],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return ""
+    return (proc.stdout or "").strip() if proc.returncode == 0 else ""
+
+
+def _adb_pkg_installed(package: str) -> bool:
+    """Return ``True`` iff *package* is installed on the connected headset.
+
+    Uses ``pm list packages <pkg>`` (a prefix filter) and matches the exact
+    ``package:<pkg>`` line so a query for ``com.pico.browser`` doesn't
+    accidentally report success when only ``com.pico.browser.overseas`` is
+    present (or vice versa).
+    """
+    if not package:
+        return False
+    try:
+        proc = subprocess.run(
+            ["adb", "shell", "pm", "list", "packages", package],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+    if proc.returncode != 0:
+        return False
+    target = f"package:{package}"
+    return any(line.strip() == target for line in (proc.stdout or "").splitlines())
+
+
+def _first_installed_pkg(candidates: tuple[str, ...]) -> str | None:
+    """Return the first package from *candidates* that's installed, or ``None``."""
+    for pkg in candidates:
+        if _adb_pkg_installed(pkg):
+            return pkg
+    return None
+
+
+def headset_browser_package() -> str | None:
+    """Return the Android package of the full-fat WebXR browser on this headset.
+
+    WebLayer (the default VIEW-intent handler on Meta Quest + PICO) ships a
+    minimal Chromium that accepts ``navigator.xr.requestSession`` but does
+    not fully plumb controller input sources through to ``@react-three/xr``.
+    Forcing the real vendor browser fixes controller rays and clicks.
+
+    Resolution order:
+
+    1. ``TELEOP_HEADSET_BROWSER_PACKAGE`` env var (explicit override; not
+       validated against ``pm list packages`` — caller is trusted).
+    2. Vendor map based on ``ro.product.manufacturer`` / ``ro.product.brand``,
+       then probed against ``pm list packages`` so we never return a package
+       that isn't actually installed:
+
+       * Meta / Oculus → ``com.oculus.browser``.
+       * PICO         → ``com.pico.browser.overseas`` (global firmware) if
+         present, else ``com.pico.browser`` (domestic / China firmware).
+    3. ``None`` (fall back to the generic VIEW intent).
+
+    On current PICO firmware both browser variants are thin shells over the
+    system WebLayer (same ``@weblayer_devtools_remote`` socket), so forcing
+    the package does not actually escape WebLayer today.  We still target
+    them for correctness and forward-compatibility with any future PICO
+    build that ships an independent Chromium.
+    """
+    override = os.environ.get("TELEOP_HEADSET_BROWSER_PACKAGE", "").strip()
+    if override:
+        return override
+    vendor = (
+        _adb_getprop("ro.product.manufacturer") + " " + _adb_getprop("ro.product.brand")
+    ).lower()
+    if "meta" in vendor or "oculus" in vendor:
+        # Full-fat Chromium, distinct from WebLayer — forcing it fixes WebXR
+        # controller plumbing that WebLayer handles incompletely.
+        return "com.oculus.browser"
+    if "pico" in vendor:
+        # Prefer the overseas/global package when both are installed; the
+        # global firmware tends to ship the more capable Chromium build.
+        # Probe via `pm list packages` so we don't try to `am start` into a
+        # missing package on the wrong-region firmware.
+        return _first_installed_pkg(("com.pico.browser.overseas", "com.pico.browser"))
+    return None
+
+
+def run_adb_headset_bookmark(
+    *, resolved_port: int, usb_local: bool = False
+) -> tuple[int, str]:
+    """Launch the browser on the headset via ``am start`` (used when browser is not yet running).
+
+    When a known vendor browser is detected (Meta / PICO), launches into it
+    explicitly via ``-p <package>`` so the URL opens in the full Chromium
+    (with working WebXR controller input), not Android WebLayer.  Falls
+    back to the generic VIEW intent on unknown vendors.
+
+    Returns ``(exit_code, diagnostic)``.
+    """
+    url = build_teleop_url(resolved_port=resolved_port, usb_local=usb_local)
+    package = headset_browser_package()
+    if package:
+        log.info("ADB automation: launching into %s (bypass WebLayer)", package)
+        shell_cmd = (
+            f"am start -p {shlex.quote(package)} "
+            f"-a android.intent.action.VIEW -d {shlex.quote(url)}"
+        )
+    else:
+        shell_cmd = "am start -a android.intent.action.VIEW -d " + shlex.quote(url)
     full = ["adb", "shell", shell_cmd]
     redacted = " ".join(shlex.quote(c) for c in full)
     redacted = re.sub(r"(controlToken=)[^&\s'\"]+", r"\1<REDACTED>", redacted)
@@ -199,18 +492,256 @@ def run_adb_headset_bookmark(*, resolved_port: int) -> tuple[int, str]:
 
 
 # ---------------------------------------------------------------------------
+# USB-local mode: adb reverse port-forwarding + coturn TURN relay
+# ---------------------------------------------------------------------------
+
+
+def setup_adb_reverse_ports() -> None:
+    """Set up ``adb reverse`` for the USB-local TCP ports.
+
+    Reverse-maps headset loopback ports to the PC so the headset can reach
+    the WebXR static HTTPS server, WSS proxy, and CloudXR backend over USB.
+
+    Ports reversed: :data:`~.oob_teleop_env.USB_UI_PORT` (8080, the static
+    HTTPS server started by
+    :func:`~.oob_teleop_env.start_usb_local_https_server`), the WSS proxy
+    port (resolved via :func:`~.oob_teleop_env.wss_proxy_port`), and
+    :data:`~.oob_teleop_env.USB_BACKEND_PORT` (49100).
+
+    Raises:
+        subprocess.CalledProcessError: If any ``adb reverse`` call fails.
+    """
+    from .oob_teleop_env import USB_UI_PORT, USB_BACKEND_PORT, wss_proxy_port  # noqa: PLC0415
+
+    ports = [USB_UI_PORT, wss_proxy_port(), USB_BACKEND_PORT]
+    for port in ports:
+        subprocess.run(
+            ["adb", "reverse", f"tcp:{port}", f"tcp:{port}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        log.info("adb reverse tcp:%d -> tcp:%d (PC)", port, port)
+
+
+def teardown_adb_reverse_ports() -> None:
+    """Remove the ``adb reverse`` rules set by :func:`setup_adb_reverse_ports`."""
+    from .oob_teleop_env import USB_UI_PORT, USB_BACKEND_PORT, wss_proxy_port  # noqa: PLC0415
+
+    ports = [USB_UI_PORT, wss_proxy_port(), USB_BACKEND_PORT]
+    for port in ports:
+        subprocess.run(
+            ["adb", "reverse", "--remove", f"tcp:{port}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        log.info("adb reverse removed tcp:%d", port)
+
+
+def setup_adb_reverse_turn(turn_port: int) -> None:
+    """Set up ``adb reverse`` for the TURN server port.
+
+    Maps ``headset tcp:turn_port`` → ``PC tcp:turn_port`` so the headset
+    browser can reach the coturn TURN server at ``127.0.0.1:turn_port``
+    without WiFi.
+
+    Raises:
+        subprocess.CalledProcessError: If the ``adb reverse`` call fails.
+    """
+    subprocess.run(
+        ["adb", "reverse", f"tcp:{turn_port}", f"tcp:{turn_port}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+    log.info("adb reverse tcp:%d (TURN) -> tcp:%d (PC coturn)", turn_port, turn_port)
+
+
+def teardown_adb_reverse_turn(turn_port: int) -> None:
+    """Remove the TURN ``adb reverse`` rule."""
+    subprocess.run(
+        ["adb", "reverse", "--remove", f"tcp:{turn_port}"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    log.info("adb reverse removed tcp:%d (TURN)", turn_port)
+
+
+def coturn_binary_path() -> str | None:
+    """Return the path to the ``turnserver`` binary, or ``None`` if not found."""
+    # Prefer PATH lookup; fall back to the common Debian/Ubuntu package path.
+    return shutil.which("turnserver") or (
+        "/usr/bin/turnserver" if os.path.exists("/usr/bin/turnserver") else None
+    )
+
+
+def require_coturn_available() -> None:
+    """Fail fast if coturn is not installed.
+
+    Raises :class:`OobAdbError` with install instructions when
+    ``turnserver`` is not on PATH and not at the default Debian/Ubuntu
+    location.  Call this early (before starting the launcher) in
+    ``--usb-local`` mode so the user gets a clear error instead of a
+    silent WebRTC-gather-timeout later.
+    """
+    if coturn_binary_path() is not None:
+        return
+    raise OobAdbError(
+        "--usb-local requires coturn (TURN server) but `turnserver` was not found.\n\n"
+        "Install it with:\n"
+        "    sudo apt-get install -y coturn\n\n"
+        "coturn runs locally (no systemd service needed — the launcher starts its "
+        "own instance on port 3478 and shuts it down on exit)."
+    )
+
+
+def start_coturn(turn_port: int, user: str, credential: str) -> subprocess.Popen | None:
+    """Start a coturn TURN server for USB-local ICE relay.
+
+    coturn listens on ``127.0.0.1:turn_port`` (TCP + UDP).  ``adb reverse``
+    exposes this port to the headset so WebRTC can obtain TURN relay
+    candidates.  ``--allow-loopback-peers`` lets coturn relay between the
+    headset (via adb reverse) and the CloudXR backend (UDP on PC loopback).
+
+    Args:
+        turn_port: TCP/UDP port for coturn (default :data:`~.oob_teleop_env.USB_TURN_PORT`).
+        user: TURN username.
+        credential: TURN credential (password).
+
+    Returns:
+        :class:`subprocess.Popen` handle, or ``None`` if coturn failed to
+        start.  Callers should treat ``None`` as non-fatal (TURN-less
+        streaming may still work on LAN) but warn the operator prominently.
+    """
+    coturn_bin = coturn_binary_path()
+    if coturn_bin is None:
+        log.warning(
+            "coturn: `turnserver` not on PATH — install with `sudo apt-get install coturn`"
+        )
+        return None
+
+    # Write a config file — easier to maintain than a long arg list and avoids
+    # shell quoting issues with special characters in credentials.
+    conf_path = f"/tmp/turnserver-cloudxr-{turn_port}.conf"
+    log_path = f"/tmp/coturn-cloudxr-{turn_port}.log"
+    conf_content = f"""\
+listening-port={turn_port}
+listening-ip=127.0.0.1
+external-ip=127.0.0.1
+min-port=49152
+max-port=49200
+lt-cred-mech
+fingerprint
+user={user}:{credential}
+realm=cloudxr
+allow-loopback-peers
+cli-password=cloudxr-internal
+no-tls
+no-dtls
+no-stdout-log
+log-file={log_path}
+simple-log
+"""
+    try:
+        with open(conf_path, "w") as f:
+            f.write(conf_content)
+    except OSError as exc:
+        log.warning("coturn: failed to write config file %s: %s", conf_path, exc)
+        return None
+
+    # Truncate the log so operators only see lines from this run.
+    try:
+        open(log_path, "w").close()
+    except OSError:
+        pass
+
+    try:
+        proc = subprocess.Popen(
+            [coturn_bin, "-c", conf_path],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError as exc:
+        log.warning("coturn failed to start (%s): %s", coturn_bin, exc)
+        return None
+
+    # Give coturn a moment to start (or exit with a config error)
+    time.sleep(0.5)
+    if proc.poll() is not None:
+        log.warning(
+            "coturn exited immediately (exit code %d). Tail of %s:\n%s",
+            proc.returncode,
+            log_path,
+            _tail_file(log_path, 10),
+        )
+        return None
+
+    log.info(
+        "coturn TURN server started (pid=%d) at 127.0.0.1:%d (log: %s)",
+        proc.pid,
+        turn_port,
+        log_path,
+    )
+    return proc
+
+
+def _tail_file(path: str, lines: int) -> str:
+    """Return the last *lines* lines of *path* (empty string on read failure)."""
+    try:
+        with open(path, "r") as f:
+            return "".join(f.readlines()[-lines:]).rstrip()
+    except OSError:
+        return ""
+
+
+def stop_coturn(proc: subprocess.Popen | None) -> None:
+    """Terminate the coturn process started by :func:`start_coturn`."""
+    if proc is None:
+        return
+    try:
+        proc.terminate()
+        proc.wait(timeout=5)
+    except (subprocess.TimeoutExpired, OSError):
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    log.info("coturn TURN server stopped")
+
+
+# ---------------------------------------------------------------------------
 # CDP automation — click the CONNECT button via Chrome DevTools Protocol
 # ---------------------------------------------------------------------------
 
 _CDP_LOCAL_PORT = 9223  # avoid clashing with any pre-existing 9222 forward
 
 
+_DEVTOOLS_SOCKET_RE = re.compile(r"@([A-Za-z0-9._+-]*_devtools_remote(?:_\d+)?)")
+
+
 def _discover_devtools_socket() -> str | None:
     """Return the bare name of the browser's DevTools abstract socket, or None.
 
-    Pico Browser (WebLayer/Chromium) exposes a socket like
-    ``@weblayer_devtools_remote_<pid>`` in ``/proc/net/unix``.
-    The PID suffix changes every time the browser starts.
+    Chromium-based Android browsers expose a Unix abstract socket matching
+    ``@<prefix>_devtools_remote[_<pid>]`` in ``/proc/net/unix``.  Known
+    prefixes in the wild:
+
+    * ``weblayer_devtools_remote_<pid>`` — WebLayer (Meta Quest / Pico
+      default VIEW handler for some OS versions)
+    * ``chrome_devtools_remote`` — full Chrome builds
+    * ``com.oculus.browser_devtools_remote`` — Meta Quest Browser
+    * ``<package>_devtools_remote`` — custom Chromium embedders
+
+    This matcher accepts any of them.  If multiple candidates exist,
+    WebLayer / Quest Browser sockets are preferred over generic ones (the
+    teleop page is most likely to live there rather than an unrelated
+    WebView from another app).
     """
     try:
         proc = subprocess.run(
@@ -222,12 +753,22 @@ def _discover_devtools_socket() -> str | None:
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         return None
+    candidates: list[str] = []
     for line in proc.stdout.splitlines():
-        if "weblayer_devtools_remote" in line:
-            for token in line.split():
-                if token.startswith("@weblayer_devtools_remote"):
-                    return token[1:]  # strip leading @
-    return None
+        for token in line.split():
+            m = _DEVTOOLS_SOCKET_RE.fullmatch(token)
+            if m:
+                candidates.append(m.group(1))
+    if not candidates:
+        return None
+    # Prefer teleop-relevant prefixes in this order, otherwise fall back to
+    # the first discovered socket.
+    priority = ("weblayer", "com.oculus.browser", "chrome", "webview")
+    for prefix in priority:
+        for cand in candidates:
+            if cand.startswith(prefix):
+                return cand
+    return candidates[0]
 
 
 def _adb_forward_cdp(socket_name: str, local_port: int) -> None:
@@ -353,36 +894,103 @@ async def _cdp_session_click_connect(ws_url: str) -> None:
                 )
                 await asyncio.sleep(3.0)
 
-        # ---- find CONNECT button with retries --------------------------------
-        val: dict = {}
-        for attempt in range(1, 4):
+        # ---- bring tab to foreground so WebXR requestSession() succeeds ------
+        # WebXR requires the page to be visible; Page.bringToFront activates the tab.
+        try:
+            await send(ws, "Page.bringToFront")
+            log.info("CDP: tab brought to foreground")
+        except Exception as exc:
+            log.debug("CDP: Page.bringToFront failed (%s), continuing", exc)
+
+        # ---- wait for #startButton to become actionable ----------------------
+        # State machine returned each poll:
+        #   {state: 'loading'}       — document / button not ready yet
+        #   {state: 'initializing'}  — button exists but disabled (IWER +
+        #                              capability checks still running)
+        #   {state: 'failed', text}  — capability check set a "failed" label;
+        #                              we will never be able to click, error out
+        #   {state: 'ready', x, y, text, disabled}
+        #                            — text === 'CONNECT' and not disabled
+        _READINESS_TIMEOUT = 30.0  # capability/IWER checks can be slow
+        loop = asyncio.get_running_loop()
+        deadline_ready = loop.time() + _READINESS_TIMEOUT
+        start_ready = loop.time()
+        val: dict | None = None
+        last_state: str | None = None
+        while loop.time() < deadline_ready:
             r = await send(
                 ws,
                 "Runtime.evaluate",
                 {
                     "expression": """(function() {
-                    const btn = Array.from(document.querySelectorAll('button,[role=button]'))
-                        .find(e => e.textContent.trim().toUpperCase() === 'CONNECT');
-                    if (!btn) return {found: false};
+                    if (document.readyState !== 'complete') return {state: 'loading'};
+                    const btn = document.getElementById('startButton');
+                    if (!btn) return {state: 'loading'};
+                    const text = btn.textContent?.trim() || '';
+                    const disabled = !!btn.disabled;
+                    if (text.toUpperCase().includes('FAIL')) {
+                        return {state: 'failed', text, disabled};
+                    }
+                    if (disabled || text.toUpperCase() !== 'CONNECT') {
+                        return {state: 'initializing', text, disabled};
+                    }
                     const rc = btn.getBoundingClientRect();
-                    return {found: true, x: rc.left + rc.width / 2, y: rc.top + rc.height / 2};
+                    return {
+                        state: 'ready',
+                        text, disabled,
+                        x: rc.left + rc.width / 2,
+                        y: rc.top + rc.height / 2,
+                    };
                 })()""",
                     "returnByValue": True,
                 },
             )
-            val = (r.get("result") or {}).get("value") or {}
-            if val.get("found"):
+            val = (r.get("result") or {}).get("value") or {"state": "loading"}
+            state = val.get("state")
+            if state != last_state:
+                log.info(
+                    "CDP: page state=%s text=%r disabled=%s",
+                    state,
+                    val.get("text"),
+                    val.get("disabled"),
+                )
+                last_state = state
+            if state == "ready":
                 break
-            log.info("CDP: CONNECT button not found yet (attempt %d/3)", attempt)
-            if attempt < 3:
-                await asyncio.sleep(2.0)
+            if state == "failed":
+                raise OobAdbError(
+                    f"CDP: startButton marked failed (text={val.get('text')!r}). "
+                    "The web client's capability check failed — inspect the headset."
+                )
+            await asyncio.sleep(0.5)
 
-        if not val.get("found"):
+        if val is None or val.get("state") != "ready":
             raise OobAdbError(
-                "CDP: CONNECT button not found on the teleop page.\n"
-                "The page may not have finished loading — check the headset."
+                f"CDP: startButton not actionable within {_READINESS_TIMEOUT:.0f}s "
+                f"(state={val.get('state') if val else 'unknown'!r}, "
+                f"text={val.get('text') if val else None!r}). "
+                "The page may still be initializing — check the headset."
             )
 
+        log.info("CDP: page ready in %.1fs", loop.time() - start_ready)
+
+        # Extra grace period: the CONNECT button can become enabled before the
+        # React <XR> store is fully mounted, which causes "XR is not available"
+        # errors if clicked immediately.
+        await asyncio.sleep(2.0)
+
+        # Click in two phases:
+        #
+        # 1. Input.dispatchMouseEvent (mousePressed + mouseReleased) — this
+        #    is a *trusted* input event, so the browser grants a user-
+        #    activation token (required for navigator.xr.requestSession()).
+        #    PICO Browser's onClick also fires from this path, so on PICO
+        #    phase 2 is effectively a no-op.
+        # 2. element.click() — programmatic follow-up needed on Meta Quest
+        #    Browser, where the synthesized mouse event grants activation
+        #    but does not fire React's onClick handler (touch-first routing).
+        #    By running inside the user-activation window opened in phase 1,
+        #    requestSession() still sees activation when onClick runs.
         x, y = val["x"], val["y"]
         log.info("CDP: clicking CONNECT at (%.0f, %.0f)", x, y)
         for event_type in ("mousePressed", "mouseReleased"):
@@ -397,72 +1005,127 @@ async def _cdp_session_click_connect(ws_url: str) -> None:
                     "clickCount": 1,
                 },
             )
-        log.info("CDP: CONNECT click dispatched")
+        # Follow-up DOM click (safety net for Quest Browser) — inside the
+        # user-activation window opened by the trusted mouse events above.
+        await send(
+            ws,
+            "Runtime.evaluate",
+            {
+                "expression": "document.getElementById('startButton')?.click()",
+            },
+        )
+        log.info("CDP: CONNECT click dispatched (mouse + DOM)")
 
         # ---- monitor connection outcome -------------------------------------
-        # DOM facts learned from page inspection:
-        #   - Start/stop button: id="startButton", text "CONNECT" when idle
-        #   - Error box: first [role=alert] is empty validation-message-box;
-        #     error text lives in the *second* [role=alert] (error-message-box)
+        # DOM facts:
+        #   - Button:     id="startButton", textContent "CONNECT" when idle,
+        #                 changes to "DISCONNECT" / other while streaming.
+        #   - Error text: id="errorMessageText" (child of the error box).
+        #                 textContent is used (not innerText) so the text is
+        #                 readable even when the box has display:none.
         _CONNECT_TIMEOUT = 30.0
         loop = asyncio.get_running_loop()
         deadline = loop.time() + _CONNECT_TIMEOUT
         while loop.time() < deadline:
-            await asyncio.sleep(2.0)
+            await asyncio.sleep(1.0)
             r = await send(
                 ws,
                 "Runtime.evaluate",
                 {
                     "expression": """(function() {
-                    const alertText = Array.from(document.querySelectorAll('[role=alert]'))
-                        .map(e => e.innerText?.trim()).find(t => !!t) || null;
                     const btn = document.getElementById('startButton');
                     const btnText = btn?.textContent?.trim()?.toUpperCase() || null;
-                    return {alertText, btnText};
+                    const box = document.getElementById('errorMessageBox');
+                    // Only treat as error when the box is shown with type 'error'
+                    // (not 'success' or 'info' which are non-fatal status messages).
+                    const isError = box?.classList?.contains('show') &&
+                                   !box?.classList?.contains('success') &&
+                                   !box?.classList?.contains('info');
+                    const errorText = isError
+                        ? (document.getElementById('errorMessageText')?.textContent?.trim() || null)
+                        : null;
+                    return {btnText, errorText};
                 })()""",
                     "returnByValue": True,
                 },
             )
             state = (r.get("result") or {}).get("value") or {}
             btn_text = state.get("btnText")
+            error_text = state.get("errorText") or None
+
+            if error_text:
+                raise OobAdbError(f"Teleop connection failed: {error_text}")
             if btn_text is not None and btn_text != "CONNECT":
                 log.info("CDP: start button changed to %r — session active", btn_text)
                 return
-            if state.get("alertText"):
-                raise OobAdbError(f"Teleop connection failed: {state['alertText']}")
+
         log.warning(
             "CDP: connection state unknown after %.0fs — check headset",
             _CONNECT_TIMEOUT,
         )
 
 
-async def run_oob_connect(*, resolved_port: int, timeout: float = 60.0) -> None:
-    """Open the teleop page on the headset and click CONNECT via CDP.
-
-    Combines the ``am start`` bookmark step with CDP automation so that the
-    new tab can be identified unambiguously by diffing tab IDs before and after
-    ``am start`` — regardless of how many other tabs are already open.
+async def run_oob_connect(
+    *, resolved_port: int, timeout: float = 60.0, usb_local: bool = False
+) -> asyncio.Task | None:
+    """Open the teleop page on the headset via ``am start`` and click CONNECT via CDP.
 
     Flow:
-      1. Discover the Pico Browser DevTools abstract socket and forward it.
-      2. Snapshot existing tab IDs.
-      3. Run ``am start`` to open the teleop bookmark URL.
-      4. Wait for a new tab (ID not in snapshot) to appear.
-      5. Handle self-signed cert interstitial if present.
+      1. Launch the teleop URL on the headset via ``adb shell am start``.
+      2. Wait for the browser's DevTools abstract socket to appear and forward it
+         (WebLayer / Meta Quest Browser / Chrome all supported).
+      3. Find the teleop tab in ``/json`` (by URL content or recent navigation).
+      4. Bring the tab to the foreground (required by WebXR ``requestSession``).
+      5. Handle the self-signed cert interstitial if present.
       6. Find the CONNECT button and click it via ``Input.dispatchMouseEvent``.
-      7. Clean up the ``adb forward``.
+      7. Start a background monitor that forwards mid-stream errors from the
+         web client's ``errorMessageBox`` into the server log.
 
-    Raises :exc:`OobAdbError` on any unrecoverable failure; callers should
-    treat this as non-fatal and ask the user to tap CONNECT manually.
+    Args:
+        resolved_port: WSS proxy port used for signalling.
+        timeout: Maximum seconds to wait for the browser/tab to appear.
+        usb_local: When ``True``, the headset URL uses ``serverIP=127.0.0.1``
+            and the local webxr_client dev-server at ``https://localhost:8080``.
+
+    Returns:
+        A running :class:`asyncio.Task` that monitors the headset's error
+        banner and keeps the ``adb forward`` alive.  Callers should cancel
+        it at shutdown (``task.cancel()``).  Returns ``None`` if the click
+        phase succeeded but the monitor could not be spawned.
+
+    Raises :exc:`OobAdbError` on any unrecoverable failure during the click
+    phase; callers should treat this as non-fatal and ask the user to tap
+    CONNECT manually.
     """
     deadline = time.monotonic() + timeout
 
-    # --- DevTools socket discovery -------------------------------------------
-    socket_name = _discover_devtools_socket()
+    # --- Step 1: launch browser with the teleop URL --------------------------
+    rc, diag = await asyncio.to_thread(
+        run_adb_headset_bookmark, resolved_port=resolved_port, usb_local=usb_local
+    )
+    if rc != 0:
+        hint = adb_automation_failure_hint(diag)
+        raise OobAdbError(oob_adb_automation_message(rc, diag, hint))
+    log.info("ADB: am start completed")
+
+    # --- Step 2: wait for DevTools socket ------------------------------------
+    socket_name = None
+    while time.monotonic() < deadline:
+        socket_name = _discover_devtools_socket()
+        if socket_name:
+            break
+        log.info("CDP: waiting for browser DevTools socket...")
+        await asyncio.sleep(2.0)
+
     if not socket_name:
         raise OobAdbError(
-            "CDP: Pico Browser DevTools socket not found.\n"
-            "Ensure the browser is open on the headset, then retry or tap CONNECT manually."
+            "CDP: no *_devtools_remote abstract socket found on the headset "
+            "after opening the teleop URL.\n\n"
+            "Chromium-based headset browsers (WebLayer, Meta Quest Browser, "
+            "Chrome) expose one when remote debugging is enabled. Check that "
+            "USB debugging is authorized, the browser actually launched from "
+            "`am start`, and `adb shell cat /proc/net/unix | grep devtools_remote` "
+            "lists a socket."
         )
     log.info("CDP: found socket @%s", socket_name)
 
@@ -472,44 +1135,157 @@ async def run_oob_connect(*, resolved_port: int, timeout: float = 60.0) -> None:
         raise OobAdbError(f"CDP: adb forward failed: {exc}") from exc
 
     try:
-        # --- snapshot existing tabs before am start --------------------------
-        tabs_before = {t["id"] for t in _cdp_list_tabs(_CDP_LOCAL_PORT) if "id" in t}
-        log.info("CDP: %d tab(s) open before am start", len(tabs_before))
+        # --- Step 3: find the teleop tab -------------------------------------
+        # Teleop URL substrings match on the happy path.  We also accept
+        # ``chrome-error://`` URLs because Chromium parks the tab there when
+        # the self-signed cert is blocked — the cert-bypass in
+        # ``_cdp_session_click_connect`` recovers from that state.
+        def _is_candidate_tab(tab: dict) -> bool:
+            url = tab.get("url") or ""
+            if not tab.get("webSocketDebuggerUrl") or not url:
+                return False
+            return (
+                "oobEnable" in url
+                or "localhost" in url
+                or "IsaacTeleop" in url
+                or url.startswith("chrome-error://")
+            )
 
-        # --- open URL on headset ---------------------------------------------
-        rc, diag = await asyncio.to_thread(
-            run_adb_headset_bookmark, resolved_port=resolved_port
-        )
-        if rc != 0:
-            hint = adb_automation_failure_hint(diag)
-            raise OobAdbError(oob_adb_automation_message(rc, diag, hint))
-        log.info("ADB: am start completed; waiting for new tab")
+        # Snapshot {id → url} BEFORE we look for changes so we can detect both
+        # new tabs and existing tabs that were navigated to the new URL by am start.
+        tabs_url_before = {
+            t["id"]: (t.get("url") or "")
+            for t in _cdp_list_tabs(_CDP_LOCAL_PORT)
+            if "id" in t
+        }
+        log.info("CDP: %d tab(s) before navigation", len(tabs_url_before))
 
-        # --- wait for the newly opened tab (not in pre-snapshot) -------------
         ws_url: str | None = None
-        while time.monotonic() < deadline:
-            for tab in _cdp_list_tabs(_CDP_LOCAL_PORT):
-                if "id" not in tab:
-                    continue
-                if tab["id"] not in tabs_before and tab.get("webSocketDebuggerUrl"):
-                    ws_url = tab["webSocketDebuggerUrl"]
-                    log.info("CDP: new tab %r url=%s", tab.get("title"), tab.get("url"))
-                    break
-            if ws_url:
-                break
+        while ws_url is None and time.monotonic() < deadline:
             await asyncio.sleep(1.0)
+            for tab in _cdp_list_tabs(_CDP_LOCAL_PORT):
+                if "id" not in tab or not tab.get("webSocketDebuggerUrl"):
+                    continue
+                old_url = tabs_url_before.get(tab["id"])
+                current_url = tab.get("url") or ""
+                # Case A: brand-new tab — accept only if it looks like our page
+                # (happy path) or is a cert-error page (recoverable).
+                if old_url is None:
+                    if not _is_candidate_tab(tab):
+                        continue
+                    ws_url = tab["webSocketDebuggerUrl"]
+                    log.info("CDP: new tab %r url=%s", tab.get("title"), current_url)
+                    break
+                # Case B: existing tab whose URL changed after am start — this
+                # is ours (the VIEW intent just navigated it).  Trust the diff
+                # even if the new URL is chrome-error://.
+                if old_url != current_url:
+                    ws_url = tab["webSocketDebuggerUrl"]
+                    log.info(
+                        "CDP: navigated tab %r url=%s (was %s)",
+                        tab.get("title"),
+                        current_url,
+                        old_url or "<new>",
+                    )
+                    break
 
         if ws_url is None:
             raise OobAdbError(
-                "CDP: new browser tab not found within timeout.\n"
-                "The browser may not have opened the teleop page — tap CONNECT manually."
+                "CDP: browser tab for the teleop page not found within timeout.\n"
+                "The page may not have loaded — open the teleop URL on the headset manually "
+                "and tap CONNECT."
             )
 
-        # Give the page JS time to finish initializing before we interact with it
-        log.info("CDP: waiting for page to initialize...")
-        await asyncio.sleep(4.0)
-
-        # --- cert interstitial + CONNECT click --------------------------------
+        # --- Step 4: cert interstitial + bring to front + readiness + click --
+        # _cdp_session_click_connect polls the DOM for document.readyState +
+        # #startButton (up to 10s) so no fixed page-init sleep is needed here.
         await _cdp_session_click_connect(ws_url)
-    finally:
+
+        # --- Step 5: background monitor for mid-stream error banners ---------
+        # Keep the adb forward alive; the monitor tears it down on exit.
+        monitor_task = asyncio.create_task(
+            _monitor_teleop_error_banner(ws_url, _CDP_LOCAL_PORT),
+            name="cloudxr-oob-error-monitor",
+        )
+        return monitor_task
+    except BaseException:
+        # Any failure after the forward is set up but before we hand ownership
+        # of it to the monitor task must clean the forward up here.
         _adb_forward_remove(_CDP_LOCAL_PORT)
+        raise
+
+
+async def _monitor_teleop_error_banner(ws_url: str, local_port: int) -> None:
+    """Forward ``errorMessageBox`` content from the web client into the server log.
+
+    Opens its own CDP session and polls the DOM once per second, logging at
+    WARNING level whenever the error banner shows new text with class
+    ``error`` (not ``success``/``info``, which are non-fatal status messages).
+    De-dupes identical messages so a banner that remains displayed logs once.
+
+    Runs until the task is cancelled (normal shutdown) or the WebSocket
+    drops (tab closed / headset disconnected).  Always tears down the
+    ``adb forward`` on exit.
+    """
+    from websockets.asyncio.client import connect as ws_connect  # noqa: PLC0415
+
+    _seq = 0
+    last_banner = ""
+
+    async def send(ws, method: str, params: dict | None = None) -> dict:
+        nonlocal _seq
+        _seq += 1
+        req_id = _seq
+        await ws.send(
+            json.dumps({"id": req_id, "method": method, "params": params or {}})
+        )
+        while True:
+            msg = json.loads(await asyncio.wait_for(ws.recv(), timeout=10.0))
+            if msg.get("id") == req_id:
+                return msg.get("result", {})
+
+    try:
+        async with ws_connect(ws_url) as ws:
+            # Keep errors suppressed so the tab never stops rendering because of
+            # a stray cert hiccup on a later navigation.
+            try:
+                await send(ws, "Security.setIgnoreCertificateErrors", {"ignore": True})
+            except Exception as exc:
+                log.debug("monitor: Security domain unavailable (%s)", exc)
+            log.info("monitor: tracking errorMessageBox on the teleop page")
+            while True:
+                await asyncio.sleep(1.0)
+                r = await send(
+                    ws,
+                    "Runtime.evaluate",
+                    {
+                        "expression": """(function() {
+                            const box = document.getElementById('errorMessageBox');
+                            if (!box || !box.classList.contains('show')) return '';
+                            if (box.classList.contains('success') ||
+                                box.classList.contains('info')) return '';
+                            return document.getElementById('errorMessageText')
+                                       ?.textContent?.trim() || '';
+                        })()""",
+                        "returnByValue": True,
+                    },
+                )
+                banner = (r.get("result") or {}).get("value") or ""
+                if banner and banner != last_banner:
+                    log.warning("Teleop client error: %s", banner)
+                    # Mirror to stderr so the operator sees mid-stream errors
+                    # in the console, not only in the server log file.
+                    print(
+                        f"\n\033[33mTeleop client error: {banner}\033[0m\n",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                last_banner = banner
+    except asyncio.CancelledError:
+        log.info("monitor: cancelled")
+        raise
+    except Exception as exc:
+        # WS drop, CDP error, etc. — expected at tab close; log and exit quietly.
+        log.info("monitor: exiting (%s)", exc)
+    finally:
+        _adb_forward_remove(local_port)

--- a/src/core/cloudxr/python/oob_teleop_env.py
+++ b/src/core/cloudxr/python/oob_teleop_env.py
@@ -5,19 +5,249 @@
 
 from __future__ import annotations
 
+import http.server
+import logging
 import os
 import socket
-from urllib.parse import urlencode
+import ssl
+import threading
+import time
+from pathlib import Path
+from urllib.error import URLError
+from urllib.parse import urlencode, urljoin
+from urllib.request import Request, urlopen
 
 from .oob_teleop_hub import OOB_WS_PATH
+
+log = logging.getLogger("oob-teleop-env")
 
 WSS_PROXY_DEFAULT_PORT = 48322
 
 DEFAULT_WEB_CLIENT_ORIGIN = "https://nvidia.github.io/IsaacTeleop/client/"
 
+# Published WebXR client files (same origin as ``DEFAULT_WEB_CLIENT_ORIGIN``).
+USB_LOCAL_STATIC_INDEX_URL = urljoin(DEFAULT_WEB_CLIENT_ORIGIN, "index.html")
+USB_LOCAL_STATIC_BUNDLE_URL = urljoin(DEFAULT_WEB_CLIENT_ORIGIN, "bundle.js")
+
+# Upper bound for downloaded client assets (supply-chain / accident guard).
+_USB_LOCAL_ASSET_MAX_BYTES = 32 * 1024 * 1024
+
 TELEOP_WEB_CLIENT_BASE_ENV = "TELEOP_WEB_CLIENT_BASE"
 
+# Directory with prebuilt WebXR assets (``index.html`` + ``bundle.js``). Optional for ``--usb-local``:
+# defaults to ``~/.cloudxr/static-client``; missing files are fetched from published URLs.
+TELEOP_WEB_CLIENT_STATIC_DIR_ENV = "TELEOP_WEB_CLIENT_STATIC_DIR"
+
 CHROME_INSPECT_DEVICES_URL = "chrome://inspect/#devices"
+
+# ---------------------------------------------------------------------------
+# USB-local mode constants
+#
+# "USB-local" means: the headset reaches the PC over loopback (127.0.0.1) via
+# ``adb reverse``.  Static assets live under ``TELEOP_WEB_CLIENT_STATIC_DIR`` or
+# default ``~/.cloudxr/static-client`` (downloaded from NVIDIA GitHub Pages if missing).
+# Python serves them over HTTPS on :USB_UI_PORT with the same PEM as the WSS proxy.
+# ---------------------------------------------------------------------------
+
+USB_HOST = "127.0.0.1"  # serverIP seen by the headset (its own localhost)
+USB_UI_PORT = 8080  # HTTPS static WebXR UI (loopback)
+USB_BACKEND_PORT = 49100  # CloudXR backend (native client direct connection)
+USB_TURN_PORT = 3478  # coturn TURN server port (adb reverse'd to headset)
+USB_TURN_USER = "cloudxr"  # TURN username
+USB_TURN_CREDENTIAL = "cloudxrpass"  # TURN credential
+
+
+def default_usb_local_webxr_static_dir() -> Path:
+    """Default directory for USB-local WebXR static files (under ``~/.cloudxr``)."""
+    return Path.home() / ".cloudxr" / "static-client"
+
+
+def resolve_usb_local_webxr_static_dir() -> Path:
+    """Directory for USB-local WebXR assets: :envvar:`TELEOP_WEB_CLIENT_STATIC_DIR` or default.
+
+    Raises:
+        RuntimeError: If ``TELEOP_WEB_CLIENT_STATIC_DIR`` points at a non-directory path.
+    """
+    raw = os.environ.get(TELEOP_WEB_CLIENT_STATIC_DIR_ENV, "").strip()
+    if raw:
+        p = Path(os.path.expanduser(raw)).resolve()
+        if p.exists() and not p.is_dir():
+            raise RuntimeError(
+                f"{TELEOP_WEB_CLIENT_STATIC_DIR_ENV} is not a directory: {p}"
+            )
+        return p
+    return default_usb_local_webxr_static_dir()
+
+
+def _fetch_url_bytes(url: str, *, timeout: float = 120.0) -> bytes:
+    """Download *url* into memory (WebXR client assets only; size-capped)."""
+    req = Request(url, headers={"User-Agent": "isaacteleop-cloudxr"})
+    try:
+        with urlopen(req, timeout=timeout) as resp:
+            cl = resp.headers.get("Content-Length")
+            if cl is not None:
+                try:
+                    n = int(cl)
+                except ValueError:
+                    pass
+                else:
+                    if n > _USB_LOCAL_ASSET_MAX_BYTES:
+                        raise RuntimeError(
+                            f"Refusing download larger than {_USB_LOCAL_ASSET_MAX_BYTES} bytes "
+                            f"(Content-Length={n}): {url}"
+                        )
+            data = resp.read(_USB_LOCAL_ASSET_MAX_BYTES + 1)
+    except URLError as exc:
+        raise RuntimeError(f"Could not download {url}: {exc}") from exc
+    if len(data) > _USB_LOCAL_ASSET_MAX_BYTES:
+        raise RuntimeError(
+            f"Download exceeded {_USB_LOCAL_ASSET_MAX_BYTES} bytes (no trusted Content-Length): {url}"
+        )
+    return data
+
+
+def _write_atomic_bytes(dest: Path, data: bytes) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_name(dest.name + ".part")
+    try:
+        tmp.write_bytes(data)
+        tmp.replace(dest)
+    except OSError:
+        if tmp.is_file():
+            try:
+                tmp.unlink()
+            except OSError:
+                pass
+        raise
+
+
+def require_usb_local_webxr_static_dir() -> Path:
+    """Ensure USB-local WebXR static assets exist under :func:`resolve_usb_local_webxr_static_dir`.
+
+    Creates the directory if needed. If ``index.html`` or ``bundle.js`` is missing or empty,
+    downloads from the published Isaac Teleop client URLs.
+
+    Idempotent: safe to call from both :class:`~.launcher.CloudXRLauncher` and ``wss.run``
+    (second call skips network when files are present).
+
+    Raises:
+        RuntimeError: If the path is invalid or downloads/final validation fail.
+    """
+    p = resolve_usb_local_webxr_static_dir()
+
+    try:
+        p.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"Cannot create USB-local WebXR static directory {p}: {exc}"
+        ) from exc
+
+    assets = (
+        ("index.html", USB_LOCAL_STATIC_INDEX_URL),
+        ("bundle.js", USB_LOCAL_STATIC_BUNDLE_URL),
+    )
+    for name, url in assets:
+        dest = p / name
+        if dest.is_file() and dest.stat().st_size > 0:
+            continue
+        log.info("USB-local: fetching %s → %s", url, dest)
+        data = _fetch_url_bytes(url)
+        if not data:
+            raise RuntimeError(f"Downloaded empty body from {url}")
+        try:
+            _write_atomic_bytes(dest, data)
+        except OSError as exc:
+            raise RuntimeError(f"Failed to write {dest}: {exc}") from exc
+
+    for name in ("index.html", "bundle.js"):
+        fp = p / name
+        if not fp.is_file() or fp.stat().st_size == 0:
+            raise RuntimeError(
+                f"USB-local WebXR client file missing or empty after fetch: {fp}"
+            )
+    return p
+
+
+def _wait_for_port(host: str, port: int, timeout: float) -> bool:
+    """Return ``True`` once *host:port* accepts a TCP connection, else ``False``."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return True
+        except OSError:
+            time.sleep(0.5)
+    return False
+
+
+def _usb_local_static_handler_class(
+    static_root: Path,
+) -> type[http.server.SimpleHTTPRequestHandler]:
+    root = str(static_root.resolve())
+
+    class _Handler(http.server.SimpleHTTPRequestHandler):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, directory=root, **kwargs)
+
+        def log_message(self, fmt: str, *args) -> None:
+            log.debug("%s - %s", self.address_string(), fmt % args)
+
+    return _Handler
+
+
+def start_usb_local_https_server(
+    static_root: Path,
+    *,
+    cert_file: Path,
+    key_file: Path,
+    port: int = USB_UI_PORT,
+    ready_timeout: float = 15.0,
+) -> tuple[threading.Thread, http.server.ThreadingHTTPServer]:
+    """Serve *static_root* over HTTPS on loopback using the same PEM as the WSS proxy."""
+    handler_cls = _usb_local_static_handler_class(static_root)
+    httpd = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler_cls)
+    httpd.daemon_threads = True
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.minimum_version = ssl.TLSVersion.TLSv1_2
+    ctx.load_cert_chain(str(cert_file), str(key_file))
+    httpd.socket = ctx.wrap_socket(httpd.socket, server_side=True)
+
+    thread = threading.Thread(
+        target=httpd.serve_forever, name="usb-local-https", daemon=True
+    )
+    thread.start()
+    log.info(
+        "USB-local static HTTPS starting — waiting up to %.0fs for :%d",
+        ready_timeout,
+        port,
+    )
+    if not _wait_for_port("127.0.0.1", port, ready_timeout):
+        try:
+            httpd.shutdown()
+        finally:
+            httpd.server_close()
+        thread.join(timeout=2.0)
+        raise RuntimeError(
+            f"USB-local static HTTPS did not accept connections on 127.0.0.1:{port} "
+            f"within {ready_timeout:.0f}s"
+        )
+    log.info("USB-local static HTTPS ready on https://127.0.0.1:%d", port)
+    return thread, httpd
+
+
+def stop_usb_local_https_server(
+    thread: threading.Thread | None,
+    httpd: http.server.ThreadingHTTPServer | None,
+) -> None:
+    """Shut down the thread HTTP server from :func:`start_usb_local_https_server`."""
+    if httpd is not None:
+        try:
+            httpd.shutdown()
+        finally:
+            httpd.server_close()
+    if thread is not None:
+        thread.join(timeout=5.0)
+    log.info("USB-local static HTTPS server stopped")
 
 
 def web_client_base_override_from_env() -> str | None:
@@ -119,6 +349,17 @@ def build_headset_bookmark_url(
     v = cfg.get("panelHiddenAtStart")
     if isinstance(v, bool):
         params["panelHiddenAtStart"] = "true" if v else "false"
+    v = cfg.get("turnServer")
+    if v is not None and str(v).strip() != "":
+        params["turnServer"] = str(v).strip()
+    v = cfg.get("turnUsername")
+    if v is not None and str(v).strip() != "":
+        params["turnUsername"] = str(v).strip()
+    v = cfg.get("turnCredential")
+    if v is not None and str(v).strip() != "":
+        params["turnCredential"] = str(v).strip()
+    if cfg.get("iceRelayOnly"):
+        params["iceRelayOnly"] = "1"
     q = urlencode(params)
     base = web_client_base.rstrip("/")
     sep = "&" if "?" in base else "?"
@@ -137,18 +378,41 @@ def resolve_lan_host_for_oob() -> str:
     return h
 
 
-def print_oob_hub_startup_banner(*, lan_host: str | None = None) -> None:
-    """Print operator instructions for OOB + USB adb automation."""
+def print_oob_hub_startup_banner(
+    *, lan_host: str | None = None, usb_local: bool = False
+) -> None:
+    """Print operator instructions for OOB + USB adb automation.
+
+    Args:
+        lan_host: PC LAN address (WiFi mode) or ``"127.0.0.1"`` (USB-local mode).
+        usb_local: When ``True``, adjust the banner to describe the USB-local
+            topology: everything reachable from the headset via ``adb reverse``
+            on loopback; WebXR UI from ``TELEOP_WEB_CLIENT_STATIC_DIR`` (HTTPS, same PEM as WSS).
+    """
     port = wss_proxy_port()
     token = os.environ.get("CONTROL_TOKEN") or None
 
     if not lan_host:
-        lan_host = resolve_lan_host_for_oob()
+        lan_host = resolve_lan_host_for_oob() if not usb_local else "127.0.0.1"
     primary_host = lan_host
 
-    web_base = DEFAULT_WEB_CLIENT_ORIGIN
-    stream_cfg = default_initial_stream_config(port)
-    stream_cfg = {**stream_cfg, "serverIP": primary_host}
+    if usb_local:
+        web_base = (
+            os.environ.get("TELEOP_WEB_CLIENT_BASE", "").strip()
+            or f"https://localhost:{USB_UI_PORT}"
+        )
+    else:
+        web_base = DEFAULT_WEB_CLIENT_ORIGIN
+
+    stream_cfg: dict = {"serverIP": primary_host, "port": port}
+    if usb_local:
+        # No mediaAddress: it's a NAT-override that bypasses ICE and would
+        # short-circuit the TURN-relayed media path. Let the SDK discover
+        # the media endpoint through ICE via coturn.
+        stream_cfg["turnServer"] = f"turn:{USB_HOST}:{USB_TURN_PORT}?transport=tcp"
+        stream_cfg["turnUsername"] = USB_TURN_USER
+        stream_cfg["turnCredential"] = USB_TURN_CREDENTIAL
+        stream_cfg["iceRelayOnly"] = True
 
     web_client_base_override = web_client_base_override_from_env()
     if web_client_base_override:
@@ -168,21 +432,42 @@ def print_oob_hub_startup_banner(*, lan_host: str | None = None) -> None:
 
     bar = "=" * 72
     print(bar)
-    print("OOB TELEOP — enabled (out-of-band control hub is running in this WSS proxy)")
+    if usb_local:
+        print("OOB TELEOP (USB-local) — headset reaches PC on loopback via adb reverse")
+    else:
+        print(
+            "OOB TELEOP — enabled (out-of-band control hub is running in this WSS proxy)"
+        )
     print(bar)
     print()
     print(
         f"  The hub shares the CloudXR proxy TLS port {port} on this machine "
         f"(control WebSocket: {wss_primary})."
     )
-    print(
-        "  Same steps as docs: references/oob_teleop_control.rst — "
-        '"End-to-end workflow (the usual path)".'
-    )
+    if usb_local:
+        print(
+            "  USB-local mode: adb reverse active for ports "
+            f"{USB_UI_PORT}/tcp (WebXR static UI — HTTPS), "
+            f"{port}/tcp (WSS), "
+            f"{USB_BACKEND_PORT}/tcp (backend), "
+            f"{USB_TURN_PORT}/tcp (TURN relay — coturn)."
+        )
+        print(
+            "  The launcher has started the WebXR static HTTPS server + coturn automatically "
+            "(see coturn-cloudxr-3478.log if CONNECT fails)."
+        )
+    else:
+        print(
+            "  Same steps as docs: references/oob_teleop_control.rst — "
+            '"End-to-end workflow (the usual path)".'
+        )
     print()
-    print(
-        "  adb: USB cable — headset connected via USB for adb; streaming and web page over WiFi."
-    )
+    if usb_local:
+        print("  adb: USB cable required — headset reaches this PC via adb reverse.")
+    else:
+        print(
+            "  adb: USB cable — headset connected via USB for adb; streaming and web page over WiFi."
+        )
     print()
     print("  Step 1 — Open teleop page on headset (adb)")
     print(

--- a/src/core/cloudxr/python/wss.py
+++ b/src/core/cloudxr/python/wss.py
@@ -462,6 +462,7 @@ async def run(
     backend_port: int = 49100,
     proxy_port: int | None = None,
     setup_oob: bool = False,
+    usb_local: bool = False,
 ) -> None:
     logger = log
     logger.setLevel(logging.INFO)
@@ -475,11 +476,12 @@ async def run(
         _handler = logging.StreamHandler(sys.stderr)
     _handler.setFormatter(_log_fmt)
     logger.addHandler(_handler)
-    # Route oob-teleop-adb logs (ADB/CDP automation) to the same destination
-    _adb_log = logging.getLogger("oob-teleop-adb")
-    _adb_log.setLevel(logging.INFO)
-    _adb_log.propagate = False
-    _adb_log.addHandler(_handler)
+    # Route oob-teleop-adb and oob-teleop-env logs to the same destination
+    for _extra_log_name in ("oob-teleop-adb", "oob-teleop-env"):
+        _extra_log = logging.getLogger(_extra_log_name)
+        _extra_log.setLevel(logging.INFO)
+        _extra_log.propagate = False
+        _extra_log.addHandler(_handler)
 
     try:
         resolved_port = wss_proxy_port() if proxy_port is None else proxy_port
@@ -530,10 +532,81 @@ async def run(
             close_timeout=10,
         ):
             log.info("WSS proxy listening on port %d", resolved_port)
+
+            # ------------------------------------------------------------------
+            # USB-local: HTTPS static client (:oob_teleop_env.USB_UI_PORT) +
+            # adb reverse (WSS / backend / TURN) + coturn. Assets are ensured in
+            # require_usb_local_webxr_static_dir (also called from launcher).
+            # ------------------------------------------------------------------
+            _usb_coturn_proc = None
+            _usb_https_thread = None
+            _usb_https_httpd = None
+
+            if usb_local:
+                from .oob_teleop_env import (  # noqa: PLC0415
+                    USB_TURN_PORT,
+                    USB_TURN_USER,
+                    USB_TURN_CREDENTIAL,
+                    USB_UI_PORT,
+                    require_usb_local_webxr_static_dir,
+                    start_usb_local_https_server,
+                    stop_usb_local_https_server,
+                )
+                from .oob_teleop_adb import (  # noqa: PLC0415
+                    setup_adb_reverse_ports,
+                    teardown_adb_reverse_ports,
+                    setup_adb_reverse_turn,
+                    teardown_adb_reverse_turn,
+                    start_coturn,
+                    stop_coturn,
+                )
+
+                static_root = require_usb_local_webxr_static_dir()
+                _usb_https_thread, _usb_https_httpd = start_usb_local_https_server(
+                    static_root,
+                    cert_file=cert_paths.cert_file,
+                    key_file=cert_paths.key_file,
+                    port=USB_UI_PORT,
+                )
+
+                # 2. adb reverse for TCP ports (WebXR UI, WSS proxy, backend)
+                try:
+                    setup_adb_reverse_ports()
+                    log.info("USB-local: adb reverse TCP ports active")
+                except subprocess.CalledProcessError as exc:
+                    log.warning("USB-local: adb reverse TCP setup failed: %s", exc)
+                    print(
+                        f"\n\033[33mUSB-local: adb reverse failed — {exc}\033[0m\n",
+                        file=sys.stderr,
+                    )
+
+                # 3. coturn TURN server (ICE relay required for WebRTC)
+                _usb_coturn_proc = start_coturn(
+                    USB_TURN_PORT, USB_TURN_USER, USB_TURN_CREDENTIAL
+                )
+                if _usb_coturn_proc is None:
+                    print(
+                        "\n\033[33mUSB-local: coturn not found — install with: "
+                        "sudo apt install coturn\033[0m\n",
+                        file=sys.stderr,
+                    )
+
+                # 4. adb reverse for TURN port (headset → PC coturn)
+                try:
+                    setup_adb_reverse_turn(USB_TURN_PORT)
+                    log.info(
+                        "USB-local: adb reverse TURN active (port %d)", USB_TURN_PORT
+                    )
+                except subprocess.CalledProcessError as exc:
+                    log.warning("USB-local: adb reverse TURN setup failed: %s", exc)
+
+            oob_monitor_task: asyncio.Task | None = None
             if setup_oob:
                 log.info("Starting OOB ADB+CDP automation")
                 try:
-                    await run_oob_connect(resolved_port=resolved_port)
+                    oob_monitor_task = await run_oob_connect(
+                        resolved_port=resolved_port, usb_local=usb_local
+                    )
                     log.info("OOB automation completed — CONNECT clicked")
                 except OobAdbError as err:
                     log.warning("OOB automation failed (non-fatal): %s", err)
@@ -546,7 +619,23 @@ async def run(
                         "\n\033[33mOOB automation error — tap CONNECT on the headset manually.\033[0m\n",
                         file=sys.stderr,
                     )
-            await stop_future
+
+            try:
+                await stop_future
+            finally:
+                if oob_monitor_task is not None:
+                    oob_monitor_task.cancel()
+                    try:
+                        await oob_monitor_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+                if usb_local:
+                    stop_coturn(_usb_coturn_proc)
+                    teardown_adb_reverse_turn(USB_TURN_PORT)
+                    teardown_adb_reverse_ports()
+                    stop_usb_local_https_server(_usb_https_thread, _usb_https_httpd)
+                    log.info("USB-local: cleanup complete")
+
             log.info("Shutting down ...")
     except OSError as e:
         if e.errno == errno.EADDRINUSE:

--- a/src/core/cloudxr_tests/python/test_oob_teleop_env.py
+++ b/src/core/cloudxr_tests/python/test_oob_teleop_env.py
@@ -7,16 +7,19 @@ from __future__ import annotations
 
 from urllib.parse import parse_qs, urlparse
 
+import cloudxr_py_test_ns.oob_teleop_env as oob_teleop_env_under_test
 import pytest
 
 from cloudxr_py_test_ns.oob_teleop_env import (
     TELEOP_WEB_CLIENT_BASE_ENV,
+    TELEOP_WEB_CLIENT_STATIC_DIR_ENV,
     WSS_PROXY_DEFAULT_PORT,
     build_headset_bookmark_url,
     client_ui_fields_from_env,
     default_initial_stream_config,
     guess_lan_ipv4,
     print_oob_hub_startup_banner,
+    require_usb_local_webxr_static_dir,
     resolve_lan_host_for_oob,
     web_client_base_override_from_env,
     wss_proxy_port,
@@ -35,6 +38,7 @@ def clear_teleop_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TELEOP_WEB_CLIENT_BASE",
         "TELEOP_PROXY_HOST",
         "CONTROL_TOKEN",
+        TELEOP_WEB_CLIENT_STATIC_DIR_ENV,
     )
     for k in keys:
         monkeypatch.delenv(k, raising=False)
@@ -157,6 +161,61 @@ def test_resolve_lan_host_from_env(
 def test_guess_lan_ipv4_returns_string_or_none() -> None:
     result = guess_lan_ipv4()
     assert result is None or isinstance(result, str)
+
+
+def test_require_usb_local_webxr_static_dir_default_downloads(
+    clear_teleop_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    # Path.home() consults $HOME on POSIX but %USERPROFILE% on Windows
+    # (ntpath.expanduser ignores $HOME when USERPROFILE is set). Patch both
+    # so the redirect works on every platform.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    def fake_fetch(url: str, *, timeout: float = 120.0) -> bytes:
+        if url.endswith("index.html"):
+            return b"<!doctype html><title>t</title>"
+        if url.endswith("bundle.js"):
+            return b"console.log(1);"
+        raise AssertionError(url)
+
+    monkeypatch.setattr(
+        oob_teleop_env_under_test,
+        "_fetch_url_bytes",
+        fake_fetch,
+    )
+    out = require_usb_local_webxr_static_dir()
+    expected = (tmp_path / ".cloudxr" / "static-client").resolve()
+    assert out == expected
+    assert (out / "index.html").read_bytes().startswith(b"<!doctype")
+    assert b"console.log" in (out / "bundle.js").read_bytes()
+
+
+def test_require_usb_local_webxr_static_dir_ok(
+    clear_teleop_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    (tmp_path / "index.html").write_text(
+        "<!doctype html><title>x</title>", encoding="utf-8"
+    )
+    (tmp_path / "bundle.js").write_text("// bundle", encoding="utf-8")
+    monkeypatch.setenv(TELEOP_WEB_CLIENT_STATIC_DIR_ENV, str(tmp_path))
+    assert require_usb_local_webxr_static_dir() == tmp_path.resolve()
+
+
+def test_require_usb_local_webxr_static_dir_not_a_directory(
+    clear_teleop_env: None,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    bogus = tmp_path / "file_not_dir"
+    bogus.write_text("x", encoding="utf-8")
+    monkeypatch.setenv(TELEOP_WEB_CLIENT_STATIC_DIR_ENV, str(bogus))
+    with pytest.raises(RuntimeError, match="not a directory"):
+        require_usb_local_webxr_static_dir()
 
 
 def test_print_oob_hub_startup_banner(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added USB-local mode for WebRTC connectivity over USB with automatic relay configuration.
  * Added custom ICE/STUN/TURN server support via URL parameters (`turnServer`, `turnUsername`, `turnCredential`, `iceRelayOnly`).
  * Added media server address and port configuration via URL parameters.
  * Improved out-of-band teleop with automatic headset browser detection and enhanced error handling.

* **Documentation**
  * Added Ubuntu setup prerequisites for USB-local mode.
  * Added comprehensive USB-local mode guide with setup checklist and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->