### PR TITLE
fix(webclient): Fix webpack

### DIFF
--- a/deps/cloudxr/webxr_client/webpack.common.js
+++ b/deps/cloudxr/webxr_client/webpack.common.js
@@ -102,17 +102,29 @@ module.exports = {
       patterns: [
         ...(webxrAssetsPackagePath
           ? [
-              'meta-quest-touch-plus',
-              'meta-quest-touch-plus-v2',
-              'oculus-touch-v2',
-              'oculus-touch-v3',
-              'pico-4u',
-              'generic-hand',
-              'generic-trigger-squeeze-thumbstick',
-            ].map(profile => ({
-              from: path.join(path.dirname(webxrAssetsPackagePath), 'dist', 'profiles', profile),
-              to: `npm/@webxr-input-profiles/assets@${WEBXR_ASSETS_VERSION}/dist/profiles/${profile}`,
-            }))
+              {
+                from: path.join(
+                  path.dirname(webxrAssetsPackagePath),
+                  'dist',
+                  'profiles',
+                  'profilesList.json'
+                ),
+                to: `npm/@webxr-input-profiles/assets@${WEBXR_ASSETS_VERSION}/dist/profiles/profilesList.json`,
+                toType: 'file',
+              },
+              ...[
+                'meta-quest-touch-plus',
+                'meta-quest-touch-plus-v2',
+                'oculus-touch-v2',
+                'oculus-touch-v3',
+                'pico-4u',
+                'generic-hand',
+                'generic-trigger-squeeze-thumbstick',
+              ].map(profile => ({
+                from: path.join(path.dirname(webxrAssetsPackagePath), 'dist', 'profiles', profile),
+                to: `npm/@webxr-input-profiles/assets@${WEBXR_ASSETS_VERSION}/dist/profiles/${profile}`,
+              })),
+            ]
           : []),
         {
           from: 'public',

--- a/deps/cloudxr/webxr_client/webpack.dev.js
+++ b/deps/cloudxr/webxr_client/webpack.dev.js
@@ -63,11 +63,13 @@ module.exports = merge(common, {
       // (http://<host>:8080). Sentinels per webpack-dev-server:
       //   hostname '0.0.0.0' -> window.location.hostname
       //   port     0         -> window.location.port
-      //   protocol 'auto'    -> ws for http, wss for https
+      //   protocol 'auto:'   -> ws for http, wss for https (must include the colon
+      //     so the dev-server client matches the same as URL#protocol, not the
+      //     string "auto" which the browser WebSocket API rejects)
       webSocketURL: {
         hostname: '0.0.0.0',
         port: 0,
-        protocol: 'auto',
+        protocol: 'auto:',
         pathname: '/ws',
       },
     },


### PR DESCRIPTION
The profile files were causing an error if the folder didn't exist ( GET http://localhost:8080/npm/@webxr-input-profiles/assets@1.0.19/dist/profiles/profilesList.json 404 (Not Found)   This fixes it.

Also fixes issue with websockets in localhost:8080 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved asset handling for WebXR input profiles, ensuring all necessary profile resources are properly bundled.
  * Fixed development server WebSocket connection configuration to properly establish connections in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->