### PR TITLE
feat(webclient): Add headless option

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
+++ b/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
@@ -18,6 +18,11 @@
 /** Per-project settings that override ancestor defaults. */
 export interface TeleopProjectSettings {
   panelHiddenAtStart?: boolean;
+  /**
+   * When true, the WebXR client runs headless (no local WebGL / CloudXR frame blit)
+   * for this teleop application. Omitted on a node means inherit; treat undefined after merge as false.
+   */
+  headless?: boolean;
 }
 
 /**
@@ -73,21 +78,21 @@ export function saveStoredTeleopPath(path: string): void {
 export const TELEOP_PROJECTS: TeleopProjectRegistry = {
   sim: {
     label: 'Simulation',
-    settings: { panelHiddenAtStart: false },
+    settings: { panelHiddenAtStart: false, headless: false },
     children: {
       isaacsim: { label: 'IsaacSim' },
     },
   },
   real: {
     label: 'Real Robot',
-    settings: { panelHiddenAtStart: true },
+    settings: { panelHiddenAtStart: true, headless: false },
     children: {
       ros: { label: 'ROS' },
       isaacros: { label: 'IsaacROS' },
       gear: {
         label: 'GEAR',
         children: {
-          dexmate: { label: 'Dexmate' },
+          dexmate: { label: 'Dexmate', settings: { headless: true } },
           g1_sonic: { label: 'G1 SONIC' },
           g1_homie: { label: 'G1 HOMIE' },
         },

--- a/deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx
+++ b/deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx
@@ -88,6 +88,9 @@ interface CloudXRComponentProps {
     /** Window size for pose-to-render latency rolling average. Default: 20 */
     poseToRenderWindow?: number;
   };
+
+  /** When true, skip WebGL rendering. */
+  headless?: boolean;
 }
 
 // React component that integrates CloudXR with Three.js/WebXR
@@ -103,6 +106,7 @@ export default function CloudXRComponent({
   onRenderPerformanceMetrics,
   onStreamingPerformanceMetrics,
   metricsSettings = {},
+  headless = false,
 }: CloudXRComponentProps) {
   const threeRenderer: WebGLRenderer = useThree().gl;
   const { session } = useXR();
@@ -380,13 +384,15 @@ export default function CloudXRComponent({
       // Access the current WebXR XRFrame
       const xrFrame = state.gl.xr.getFrame();
       if (xrFrame) {
-        // Get THREE WebXRManager from the the useFrame state.
+        // Get THREE WebXRManager from the useFrame state.
         const webXRManager = state.gl.xr;
 
         if (!cxrSessionRef || !cxrSessionRef.current) {
           console.debug('Skipping frame, no session yet');
-          // Clear the framebuffer as we've set autoClear to false.
-          threeRenderer.clear();
+          if (!headless) {
+            // Clear the framebuffer as we've set autoClear to false.
+            threeRenderer.clear();
+          }
           return;
         }
 
@@ -396,8 +402,10 @@ export default function CloudXRComponent({
         // If the CloudXR session is not connected, skip the frame.
         if (cxrSession.state !== CloudXR.SessionState.Connected) {
           console.debug('Skipping frame, session not connected, state:', cxrSession.state);
-          // Clear the framebuffer as we've set autoClear to false.
-          threeRenderer.clear();
+          if (!headless) {
+            // Clear the framebuffer as we've set autoClear to false.
+            threeRenderer.clear();
+          }
           return;
         }
 
@@ -405,14 +413,14 @@ export default function CloudXRComponent({
         const timestamp: DOMHighResTimeStamp = state.clock.elapsedTime * 1000;
 
         try {
-          // Send the tracking state (including viewer pose and hand/controller data) to the server, this will trigger server-side rendering for frame.
+          // Send the tracking state (including viewer pose and hand/controller data) to the server;
+          // that triggers server-side rendering for the frame.
           cxrSession.sendTrackingStateToServer(timestamp, xrFrame);
 
-          // Get the WebXR layer from THREE WebXRManager.
-          let layer: XRWebGLLayer = webXRManager.getBaseLayer() as XRWebGLLayer;
-
-          // Render the current streamed CloudXR frame (not the frame that was just sent to the server).
-          cxrSession.render(timestamp, xrFrame, layer);
+          if (!headless) {
+            const layer: XRWebGLLayer = webXRManager.getBaseLayer() as XRWebGLLayer;
+            cxrSession.render(timestamp, xrFrame, layer);
+          }
         } catch (error) {
           // Handle deferred exceptions from callbacks or render errors
           const errorMessage = error instanceof Error ? error.message : String(error);

--- a/deps/cloudxr/webxr_client/helpers/react/utils.ts
+++ b/deps/cloudxr/webxr_client/helpers/react/utils.ts
@@ -62,6 +62,8 @@ export interface ReactUIConfig {
   controlPanelPosition?: ControlPanelPosition;
   /** When true, the control panel is hidden at immersive XR enter (small “show control panel” control only). */
   panelHiddenAtStart?: boolean;
+  /** When true, all WebGL rendering is skipped. */
+  headless?: boolean;
   /** Active teleop project path (a key path in `TELEOP_PROJECTS`). */
   teleopPath: string;
 }

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -38,6 +38,7 @@ import { kPerformanceOptions } from '@helpers/PerformanceProfiles';
 import CloudXRComponent from '@helpers/react/CloudXRComponent';
 import { SimpleEnvironment } from '@helpers/react/SimpleEnvironment';
 import { getControlPanelPositionVector } from '@helpers/react/utils';
+import { SuppressWebGLRendererWhenHeadless } from './SuppressWebGLRendererWhenHeadless';
 import {
   DEFAULT_TELEOP_PATH,
   loadStoredTeleopPath,
@@ -851,6 +852,7 @@ function App() {
           e.preventDefault();
         }}
       >
+        <SuppressWebGLRendererWhenHeadless headless={!!config?.headless} />
         <PointerEvents batchEvents={false} />
         <XR store={store}>
           <SimpleEnvironment />
@@ -871,33 +873,36 @@ function App() {
                 onServerAddress={setServerAddress}
                 onRenderPerformanceMetrics={handleRenderPerformanceMetrics}
                 onStreamingPerformanceMetrics={handleStreamingPerformanceMetrics}
+                headless={!!config.headless}
               />
-              <CloudXR3DUI
-                onStartTeleop={handleStartTeleop}
-                onDisconnect={handleDisconnect}
-                onResetTeleop={handleResetTeleop}
-                isXRMode={isXRMode}
-                panelHiddenAtStart={config.panelHiddenAtStart ?? false}
-                serverAddress={serverAddress || config.serverIP}
-                sessionStatus={sessionStatus}
-                playLabel={
-                  isTeleopRunning
-                    ? 'Running'
-                    : isCountingDown
-                      ? `Starting in ${countdownRemaining} sec...`
-                      : 'Play'
-                }
-                playInProgress={isCountingDown || isTeleopRunning}
-                countdownSeconds={countdownDuration}
-                onCountdownIncrease={handleIncreaseCountdown}
-                onCountdownDecrease={handleDecreaseCountdown}
-                countdownDisabled={isCountingDown}
-                position={controlPanelPositionVector}
-                rotation={[0, 0, 0]}
-                renderFpsText={renderFpsText}
-                streamingFpsText={streamingFpsText}
-                poseToRenderText={poseToRenderText}
-              />
+              {!config.headless && (
+                <CloudXR3DUI
+                  onStartTeleop={handleStartTeleop}
+                  onDisconnect={handleDisconnect}
+                  onResetTeleop={handleResetTeleop}
+                  isXRMode={isXRMode}
+                  panelHiddenAtStart={config.panelHiddenAtStart ?? false}
+                  serverAddress={serverAddress || config.serverIP}
+                  sessionStatus={sessionStatus}
+                  playLabel={
+                    isTeleopRunning
+                      ? 'Running'
+                      : isCountingDown
+                        ? `Starting in ${countdownRemaining} sec...`
+                        : 'Play'
+                  }
+                  playInProgress={isCountingDown || isTeleopRunning}
+                  countdownSeconds={countdownDuration}
+                  onCountdownIncrease={handleIncreaseCountdown}
+                  onCountdownDecrease={handleDecreaseCountdown}
+                  countdownDisabled={isCountingDown}
+                  position={controlPanelPositionVector}
+                  rotation={[0, 0, 0]}
+                  renderFpsText={renderFpsText}
+                  streamingFpsText={streamingFpsText}
+                  poseToRenderText={poseToRenderText}
+                />
+              )}
             </>
           )}
         </XR>

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -351,7 +351,7 @@ function App() {
     // URL query params override localStorage so bookmarked links always win.
     const urlSeeds: Record<string, string> = {};
     const p = new URLSearchParams(window.location.search);
-    for (const key of ['serverIP', 'port', 'codec', 'panelHiddenAtStart']) {
+    for (const key of ['serverIP', 'port', 'codec', 'panelHiddenAtStart', 'headless']) {
       const v = p.get(key);
       if (v !== null) urlSeeds[key] = v;
     }

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -152,6 +152,8 @@ export class CloudXR2DUI {
   private mediaPortInput!: HTMLInputElement;
   /** Dropdown for controller model visibility (show / hide) */
   private controllerModelVisibilitySelect!: HTMLSelectElement;
+  /** Skip client CloudXR `render` (headless: client blit off; tracking on) */
+  private headlessInput!: HTMLInputElement;
   /** Breadcrumb subtitle in header (e.g. "for Real Robot › GEAR › Dexmate"). */
   private teleopModeSubtitle!: HTMLElement;
   /** Hierarchical project selector in header */
@@ -243,12 +245,20 @@ export class CloudXR2DUI {
   /** Loads per-project-path settings (falling back to registry defaults) into their form controls. */
   private applyPerProjectSettings(): void {
     const settings = getProjectSettings(this.teleopPath);
+    const boolFromStorage = (raw: string) =>
+      raw === 'true' ? true : raw === 'false' ? false : undefined;
     const panelHidden = loadPerProject<boolean>(
       'panelHiddenAtStart', this.teleopPath,
-      raw => (raw === 'true' ? true : raw === 'false' ? false : undefined),
+      boolFromStorage,
       settings.panelHiddenAtStart ?? false,
     );
     this.panelHiddenAtStartSelect.value = String(panelHidden);
+    const headless = loadPerProject<boolean>(
+      'headless', this.teleopPath,
+      boolFromStorage,
+      settings.headless ?? false,
+    );
+    this.headlessInput.checked = headless;
   }
 
   /**
@@ -256,15 +266,14 @@ export class CloudXR2DUI {
    * teleop application, so users can tell at a glance which fields switch when
    * they change the active project. No hover text: the UI runs on VR headsets
    * where hover is not reliable, so the marker itself must be self-describing.
-   * When a second per-project field lands, factor these into a
-   * PER_PROJECT_FIELDS registry (see TeleopProjects.ts) and loop.
    */
   private decoratePerProjectLabels(): void {
-    const label = this.panelHiddenAtStartSelect.labels?.[0];
-    if (!label) return;
     const marker = ' (saved per teleop application)';
-    if (label.textContent?.includes(marker)) return;
-    label.appendChild(document.createTextNode(marker));
+    for (const el of [this.panelHiddenAtStartSelect, this.headlessInput]) {
+      const label = el.labels?.[0];
+      if (!label || label.textContent?.includes(marker)) continue;
+      label.appendChild(document.createTextNode(marker));
+    }
   }
 
   /** Builds the hierarchical dropdown options from the project registry. */
@@ -316,6 +325,11 @@ export class CloudXR2DUI {
     if (panelHidden !== undefined) {
       this.panelHiddenAtStartSelect.value = panelHidden;
       savePerProject('panelHiddenAtStart', this.teleopPath, panelHidden);
+    }
+    const headlessSeed = seeds['headless'];
+    if (headlessSeed === 'true' || headlessSeed === 'false') {
+      this.headlessInput.checked = headlessSeed === 'true';
+      savePerProject('headless', this.teleopPath, headlessSeed);
     }
   }
 
@@ -376,6 +390,7 @@ export class CloudXR2DUI {
     this.controllerModelVisibilitySelect = this.getElement<HTMLSelectElement>(
       'controllerModelVisibility'
     );
+    this.headlessInput = this.getElement<HTMLInputElement>('cloudxrHeadless');
     this.teleopModeSubtitle = this.getElement<HTMLElement>('teleopModeSubtitle');
     this.teleopProjectSelect = this.getElement<HTMLSelectElement>('teleopProjectSelect');
   }
@@ -425,6 +440,7 @@ export class CloudXR2DUI {
       enableTexSubImage2D: false,
       useQuestColorWorkaround: false,
       hideControllerModel: false,
+      headless: false,
       teleopPath: DEFAULT_TELEOP_PATH,
     };
   }
@@ -571,6 +587,10 @@ export class CloudXR2DUI {
     addListener(this.mediaPortInput, 'input', updateConfig);
     addListener(this.mediaPortInput, 'change', updateConfig);
     addListener(this.controllerModelVisibilitySelect, 'change', updateConfig);
+    addListener(this.headlessInput, 'change', () => {
+      savePerProject('headless', this.teleopPath, this.headlessInput.checked ? 'true' : 'false');
+      this.updateConfiguration();
+    });
 
     addListener(this.deviceProfileSelect, 'change', () => {
       this.applyDeviceProfileToForm(resolveDeviceProfileId(this.deviceProfileSelect.value));
@@ -745,6 +765,7 @@ export class CloudXR2DUI {
         return !isNaN(v) ? v : undefined;
       })(),
       hideControllerModel: this.controllerModelVisibilitySelect.value === 'hide',
+      headless: this.headlessInput.checked,
       panelHiddenAtStart: this.panelHiddenAtStartSelect.value === 'true',
       teleopPath: this.teleopPath,
     };

--- a/deps/cloudxr/webxr_client/src/SuppressWebGLRendererWhenHeadless.tsx
+++ b/deps/cloudxr/webxr_client/src/SuppressWebGLRendererWhenHeadless.tsx
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * When `headless` is true, no-ops only the per-frame `WebGLRenderer.render` on the R3F-owned
+ * renderer. That is the main per-frame WebGL path for the scene (and WebXR submit in that call).
+ * Startup and one-time GL (context init, `createSession`, uploads, etc.) are not touched.
+ *
+ * R3F still advances the frame so `useFrame` can use `getFrame()` and `sendTrackingStateToServer`.
+ * Does not modify @react-three/fiber source.
+ */
+import { useThree } from '@react-three/fiber';
+import { useEffect, useRef } from 'react';
+import type { WebGLRenderer } from 'three';
+
+export function SuppressWebGLRendererWhenHeadless({ headless }: { headless: boolean }) {
+  const gl = useThree(s => s.gl) as WebGLRenderer;
+  const origRender = useRef<WebGLRenderer['render'] | null>(null);
+
+  useEffect(() => {
+    if (headless) {
+      if (!origRender.current) {
+        origRender.current = gl.render.bind(gl) as WebGLRenderer['render'];
+      }
+      const noop: WebGLRenderer['render'] = () => {};
+      gl.render = noop;
+      return () => {
+        if (origRender.current) {
+          gl.render = origRender.current;
+        }
+      };
+    }
+    if (origRender.current) {
+      gl.render = origRender.current;
+    }
+    return undefined;
+  }, [headless, gl]);
+
+  return null;
+}

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -683,6 +683,14 @@ limitations under the License.
                 </div>
 
                 <div class="config-section">
+                    <label for="cloudxrHeadless" class="input-label">Headless</label>
+                    <div class="config-text">
+                        <input type="checkbox" id="cloudxrHeadless" class="config-input" style="width: auto; margin-right: 0.5em" aria-label="Headless: skip per-frame CloudXR and canvas render">
+                        <span>Per frame: skip all render code in WebXR client.</span>
+                    </div>
+                </div>
+
+                <div class="config-section">
                     <label class="input-label">Proxy Configuration</label>
                     <label for="proxyUrl" class="input-label">Proxy URL</label>
                     <input id="proxyUrl" class="ui-input config-input" type="text" placeholder="" spellcheck="false">


### PR DESCRIPTION
Adds headless option that disables all rendering, when not needed.  Made that default for Dexmate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a "Headless" mode that suppresses local WebGL rendering while maintaining server-side tracking.
  * Added a Headless checkbox in Debug Settings to toggle this mode on a per-project basis.
  * Headless configuration supports URL query parameter seeding and persistent per-project storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->