### PR TITLE
Add docs for mcap record/replay

### DIFF
--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -78,16 +78,26 @@ The main configuration object:
 
    @dataclass
    class TeleopSessionConfig:
-       app_name: str                                       # OpenXR application name
-       pipeline: Any                                       # Connected retargeting pipeline
-       trackers: List[Any] = []                            # Tracker instances (optional)
-       plugins: List[PluginConfig] = []                    # Plugin configurations (optional)
-       verbose: bool = True                                # Print progress info
-       oxr_handles: Optional[OpenXRSessionHandles] = None  # External OpenXR handles (optional)
+       app_name: str                            # OpenXR application name
+       pipeline: Any                            # Connected retargeting pipeline
+       mode: SessionMode = SessionMode.LIVE     # LIVE or REPLAY
+       trackers: List[Any] = []                 # Tracker instances (optional)
+       plugins: List[PluginConfig] = []         # Plugin configurations (optional)
+       verbose: bool = True                     # Print progress info
+       oxr_handles: Optional[...] = None        # External OpenXR handles (optional)
+       mcap_config: Optional[...] = None        # Required for REPLAY, optional for LIVE
 
-When ``oxr_handles`` is provided, ``TeleopSession`` uses the supplied handles
-instead of creating its own OpenXR session. The caller is responsible for the
-external session's lifetime. Construct handles with
+When ``mode`` is ``SessionMode.REPLAY``, ``TeleopSession`` skips OpenXR
+session creation and reads tracking data from the MCAP file specified in
+``mcap_config`` (a ``McapReplayConfig``).  ``mcap_config`` is **required** in
+replay mode — omitting it raises ``ValueError``.  In the default ``LIVE``
+mode, ``mcap_config`` is optional; passing an ``McapRecordingConfig`` enables
+recording to disk.  See :doc:`/references/mcap_record_replay` for full
+details.
+
+When ``oxr_handles`` is provided (live mode), ``TeleopSession`` uses the
+supplied handles instead of creating its own OpenXR session. The caller is
+responsible for the external session's lifetime. Construct handles with
 ``OpenXRSessionHandles(instance, session, space, proc_addr)`` where each
 argument is a ``uint64`` handle value.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -60,6 +60,7 @@ Table of Contents
    references/build
    device/index
    references/retargeting
+   references/mcap_record_replay
    references/oob_teleop_control
    references/license
 

--- a/docs/source/references/mcap_record_replay.rst
+++ b/docs/source/references/mcap_record_replay.rst
@@ -1,0 +1,142 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+MCAP Recording & Replay
+========================
+
+Isaac Teleop supports recording live tracking data to `MCAP <https://mcap.dev/>`_
+files and replaying them offline through the same retargeting pipeline — no
+headset or OpenXR runtime required during replay.
+
+Recording a Live Session
+-------------------------
+
+Pass an ``McapRecordingConfig`` in the ``mcap_config`` field while keeping the
+default ``SessionMode.LIVE``.  ``TeleopSession`` automatically discovers
+trackers from the pipeline, so you only need to provide the output filename:
+
+.. code-block:: python
+
+   from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
+   from isaacteleop.deviceio import McapRecordingConfig
+
+   config = TeleopSessionConfig(
+       app_name="MyApp",
+       pipeline=pipeline,
+       mcap_config=McapRecordingConfig("recording.mcap"),
+   )
+
+   with TeleopSession(config) as session:
+       while True:
+           result = session.step() # The tracker state is recorded to the MCAP file
+
+When the context manager exits, the MCAP file is finalized and closed.
+
+Auto-population and appending of tracker names
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``TeleopSession`` always auto-discovers trackers from the pipeline's DeviceIO
+sources and uses each source's ``name`` as the MCAP channel name.  For
+example, a pipeline with ``HeadSource(name="head")`` and
+``HandsSource(name="hands")`` produces channels ``"head"`` and ``"hands"``.
+
+Any ``(tracker, channel_name)`` pairs you pass explicitly via
+``tracker_names`` are **appended** after the auto-discovered sources.  This is
+useful for recording additional trackers that are not part of the pipeline:
+
+.. code-block:: python
+
+   from isaacteleop.deviceio import McapRecordingConfig
+
+   extra_tracker = deviceio.HandTracker()
+
+   mcap_config = McapRecordingConfig(
+       "recording.mcap",
+       [(extra_tracker, "extra_hands")],
+   )
+
+   # Final tracker list will be:
+   #   [(head_source.tracker, "head"), (hands_source.tracker, "hands"),
+   #    (extra_tracker, "extra_hands")]
+
+Replaying a Recording
+---------------------
+
+Set ``mode=SessionMode.REPLAY`` and pass an ``McapReplayConfig``.  No OpenXR
+session or headset connection is created — data is read directly from the MCAP
+file:
+
+.. code-block:: python
+
+   from isaacteleop.teleop_session_manager import (
+       TeleopSession,
+       TeleopSessionConfig,
+       SessionMode,
+   )
+   from isaacteleop.deviceio import McapReplayConfig
+
+   config = TeleopSessionConfig(
+       app_name="MyApp",
+       pipeline=pipeline,
+       mode=SessionMode.REPLAY,
+       mcap_config=McapReplayConfig("recording.mcap"),
+   )
+
+   with TeleopSession(config) as session:
+       while True:
+           result = session.step()
+           action = result["action"]
+           # Process replayed action ...
+
+Just like recording, trackers are auto-discovered from the pipeline and any
+explicit ``tracker_names`` you provide are **appended** after them.  Use this
+to add extra trackers that aren't part of the pipeline:
+
+.. code-block:: python
+
+   McapReplayConfig(
+       "recording.mcap",
+       [(extra_tracker, "extra_hands")],
+   )
+
+.. important::
+
+   ``mcap_config`` is **required** when ``mode`` is ``SessionMode.REPLAY``.
+   Omitting it raises ``ValueError``.
+
+API Reference
+-------------
+
+``SessionMode``
+^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   class SessionMode(Enum):
+       LIVE = "live"
+       REPLAY = "replay"
+
+Determines whether ``TeleopSession`` creates a live OpenXR session or replays
+from an MCAP file.
+
+``McapRecordingConfig``
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   McapRecordingConfig(filename, tracker_names=None)
+
+- **filename** — Path to the output MCAP file.
+- **tracker_names** — Optional list of ``(tracker, channel_name)`` pairs.
+  When empty, ``TeleopSession`` auto-populates from discovered sources.
+
+``McapReplayConfig``
+^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   McapReplayConfig(filename, tracker_names=None)
+
+- **filename** — Path to an existing MCAP file to replay.
+- **tracker_names** — Optional list of ``(tracker, channel_name)`` pairs.
+  When empty, ``TeleopSession`` auto-populates from discovered sources.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for MCAP-based recording and replay functionality, enabling users to record and replay live tracking data in teleop sessions.
  * Updated configuration documentation to explain the new `LIVE` and `REPLAY` mode options for session configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->