### PR TITLE
fix: [Replay] MCAP replay corruption at chunk boundaries

### DIFF
--- a/src/core/deviceio_session/cpp/inc/deviceio_session/replay_session.hpp
+++ b/src/core/deviceio_session/cpp/inc/deviceio_session/replay_session.hpp
@@ -12,12 +12,6 @@
 #include <utility>
 #include <vector>
 
-// Forward declaration -- mcap::McapReader is an implementation detail of ReplaySession.
-namespace mcap
-{
-class McapReader;
-} // namespace mcap
-
 namespace core
 {
 
@@ -45,9 +39,6 @@ public:
     // Static factory - Open an MCAP file and create replay tracker implementations.
     static std::unique_ptr<ReplaySession> run(const McapReplayConfig& config);
 
-    // Destructor defined in .cpp where mcap::McapReader is fully defined
-    ~ReplaySession();
-
     /**
      * @brief Advances replay by one frame, feeding the next recorded sample to
      *        each tracker implementation.
@@ -69,9 +60,6 @@ public:
 private:
     explicit ReplaySession(const McapReplayConfig& config);
 
-    // mcap_reader_ declared before tracker_impls_ so impls (which may hold raw
-    // pointers into the reader) are destroyed first in reverse declaration order.
-    std::unique_ptr<mcap::McapReader> mcap_reader_;
     std::unordered_map<const ITracker*, std::unique_ptr<ITrackerImpl>> tracker_impls_;
 };
 

--- a/src/core/deviceio_session/cpp/replay_session.cpp
+++ b/src/core/deviceio_session/cpp/replay_session.cpp
@@ -3,7 +3,6 @@
 
 #include "inc/deviceio_session/replay_session.hpp"
 
-#include <mcap/reader.hpp>
 #include <oxr_utils/os_time.hpp>
 #include <replay_trackers/replay_deviceio_factory.hpp>
 
@@ -15,15 +14,9 @@ namespace core
 
 ReplaySession::ReplaySession(const McapReplayConfig& config)
 {
-    mcap_reader_ = std::make_unique<mcap::McapReader>();
-    auto status = mcap_reader_->open(config.filename);
-    if (!status.ok())
-    {
-        throw std::runtime_error("ReplaySession: failed to open MCAP file '" + config.filename + "': " + status.message);
-    }
     std::cout << "ReplaySession: reading from " << config.filename << std::endl;
 
-    ReplayDeviceIOFactory factory(*mcap_reader_, config.tracker_names);
+    ReplayDeviceIOFactory factory(config.filename, config.tracker_names);
     for (const auto& [tracker_ptr, name] : config.tracker_names)
     {
         if (!tracker_ptr)
@@ -33,8 +26,6 @@ ReplaySession::ReplaySession(const McapReplayConfig& config)
         tracker_impls_.emplace(tracker_ptr, factory.create_tracker_impl(*tracker_ptr));
     }
 }
-
-ReplaySession::~ReplaySession() = default;
 
 std::unique_ptr<ReplaySession> ReplaySession::run(const McapReplayConfig& config)
 {

--- a/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
+++ b/src/core/mcap/cpp/inc/mcap/tracker_channels.hpp
@@ -8,8 +8,10 @@
 #include <mcap/writer.hpp>
 #include <schema/timestamp_generated.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <deque>
 #include <iostream>
 #include <memory>
 #include <optional>
@@ -116,14 +118,14 @@ private:
  * @tparam RecordT The FlatBuffer record wrapper stored in MCAP (e.g. HeadPoseRecord).
  *                 Must expose NativeTableType with UnPackTo().
  *
- * Read-side counterpart to McapTrackerChannels. Takes an externally-owned
- * McapReader& and a list of sub-channel names, creating one LinearMessageView
- * per channel. Each LinearMessageView is a lightweight, non-owning view that
- * reads directly from the McapReader's data source without copying message data.
- * Callers pull deserialized records one at a time via read(channel_index).
+ * Read-side counterpart to McapTrackerChannels. Owns an McapReader and iterates
+ * all registered sub-channels through a single LinearMessageView. Each message
+ * is deserialized (FlatBuffer UnPack) before the iterator advances, because the
+ * underlying FileReader buffer is only valid until the next read() call.
  *
- * MCAP message data pointers are only valid until the iterator advances,
- * so read() fully deserializes each record before stepping the iterator forward.
+ * When the iterator yields a message for a channel other than the one requested
+ * by the caller, the deserialized record is buffered in the corresponding
+ * ChannelBuffer and returned on a subsequent read() for that channel index.
  */
 template <typename RecordT>
 class McapTrackerViewers
@@ -136,18 +138,30 @@ public:
     McapTrackerViewers(McapTrackerViewers&&) = delete;
     McapTrackerViewers& operator=(McapTrackerViewers&&) = delete;
 
-    McapTrackerViewers(mcap::McapReader& reader, std::string_view base_name, const std::vector<std::string>& sub_channels)
-        : reader_(&reader)
+    McapTrackerViewers(std::unique_ptr<mcap::McapReader> reader,
+                       std::string_view base_name,
+                       const std::vector<std::string>& sub_channels)
+        : reader_(std::move(reader))
     {
         for (const auto& sub : sub_channels)
         {
-            std::string topic = mcap_topic(base_name, sub);
-            auto on_problem = [topic](const mcap::Status& s)
-            { throw std::runtime_error("McapTrackerViewers [" + topic + "]: " + s.message); };
-            mcap::ReadMessageOptions options;
-            options.topicFilter = [topic](std::string_view t) { return t == topic; };
-            channels_.push_back(std::make_unique<ChannelView>(reader_->readMessages(on_problem, options)));
+            channels_.push_back({ mcap_topic(base_name, sub), {} });
         }
+
+        auto on_problem = [](const mcap::Status& s) { throw std::runtime_error("McapTrackerViewers:" + s.message); };
+
+        mcap::ReadMessageOptions options;
+        options.topicFilter = [this](std::string_view t)
+        {
+            for (const auto& ch : channels_)
+            {
+                if (ch.topic == t)
+                    return true;
+            }
+            return false;
+        };
+
+        tracker_view_ = std::make_unique<TrackerView>(reader_->readMessages(on_problem, options));
     }
 
     /**
@@ -164,43 +178,82 @@ public:
                                     " but only " + std::to_string(channels_.size()) + " channels registered");
         }
 
-        auto& ch = *channels_[channel_index];
-        if (ch.it == ch.view.end())
+        // Return a previously buffered record if one was stashed while
+        // advancing the shared iterator on behalf of a different channel.
+        if (!channels_[channel_index].buffer.empty())
         {
-            return std::nullopt;
+            auto result = std::move(channels_[channel_index].buffer.front());
+            channels_[channel_index].buffer.pop_front();
+            return result;
         }
 
-        flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(ch.it->message.data), ch.it->message.dataSize);
-        if (!verifier.VerifyBuffer<RecordT>())
+        while (tracker_view_->it != tracker_view_->view.end())
         {
-            throw std::runtime_error("McapTrackerViewers: corrupt FlatBuffer in channel " + std::to_string(channel_index) +
-                                     " at sequence " + std::to_string(ch.it->message.sequence));
+            const auto& msg_view = *(tracker_view_->it);
+            size_t idx = find_channel_idx(msg_view.channel->topic);
+            NativeRecordT record = deserialize(msg_view.message, idx);
+
+            ++(tracker_view_->it);
+
+            // The requested channel; return the record.
+            if (idx == channel_index)
+            {
+                return record;
+            }
+            // Not the requested channel; stash for a future read(idx) call.
+            channels_[idx].buffer.push_back(std::move(record));
         }
 
-        auto* fb_record = flatbuffers::GetRoot<RecordT>(ch.it->message.data);
-        NativeRecordT record;
-        fb_record->UnPackTo(&record);
-
-        ++ch.it;
-        return record;
+        return std::nullopt;
     }
 
 private:
-    // ChannelView stores an iterator (`it`) that points into its own `view`.
-    // Held via unique_ptr so that vector reallocation never moves the object,
-    // keeping the self-referential iterator valid.
-    struct ChannelView
+    struct ChannelBuffer
+    {
+        std::string topic;
+        std::deque<NativeRecordT> buffer;
+    };
+
+    struct TrackerView
     {
         mcap::LinearMessageView view;
         mcap::LinearMessageView::Iterator it;
 
-        explicit ChannelView(mcap::LinearMessageView&& v) : view(std::move(v)), it(view.begin())
+        explicit TrackerView(mcap::LinearMessageView&& v) : view(std::move(v)), it(view.begin())
         {
         }
     };
 
-    mcap::McapReader* reader_;
-    std::vector<std::unique_ptr<ChannelView>> channels_;
+    size_t find_channel_idx(const std::string& topic) const
+    {
+        for (size_t i = 0; i < channels_.size(); ++i)
+        {
+            if (channels_[i].topic == topic)
+            {
+                return i;
+            }
+        }
+        throw std::runtime_error("McapTrackerViewers: unexpected topic '" + topic + "'");
+    }
+
+    NativeRecordT deserialize(const mcap::Message& msg, size_t channel_index) const
+    {
+        flatbuffers::Verifier verifier(reinterpret_cast<const uint8_t*>(msg.data), msg.dataSize);
+        if (!verifier.VerifyBuffer<RecordT>())
+        {
+            throw std::runtime_error("McapTrackerViewers: corrupt FlatBuffer in channel " +
+                                     std::to_string(channel_index) + " at sequence " + std::to_string(msg.sequence));
+        }
+
+        auto* fb_record = flatbuffers::GetRoot<RecordT>(msg.data);
+        NativeRecordT record;
+        fb_record->UnPackTo(&record);
+        return record;
+    }
+
+    std::unique_ptr<mcap::McapReader> reader_;
+    std::vector<ChannelBuffer> channels_;
+    std::unique_ptr<TrackerView> tracker_view_;
 };
 
 } // namespace core

--- a/src/core/mcap_tests/cpp/test_mcap_tracker_channels.cpp
+++ b/src/core/mcap_tests/cpp/test_mcap_tracker_channels.cpp
@@ -63,6 +63,13 @@ std::unique_ptr<mcap::McapWriter> open_writer(const std::string& path)
     return writer;
 }
 
+std::unique_ptr<mcap::McapReader> open_reader(const std::string& path)
+{
+    auto reader = std::make_unique<mcap::McapReader>();
+    REQUIRE(reader->open(path).ok());
+    return reader;
+}
+
 using HeadChannels = core::McapTrackerChannels<core::HeadPoseRecord, core::HeadPose>;
 using HeadViewers = core::McapTrackerViewers<core::HeadPoseRecord>;
 
@@ -283,10 +290,7 @@ TEST_CASE("McapTrackerViewers: reads records from a single channel", "[mcap][tra
         writer->close();
     }
 
-    mcap::McapReader reader;
-    REQUIRE(reader.open(path).ok());
-
-    HeadViewers viewers(reader, "tracking", { "head" });
+    HeadViewers viewers(open_reader(path), "tracking", { "head" });
 
     auto record1 = viewers.read(0);
     REQUIRE(record1.has_value());
@@ -304,7 +308,6 @@ TEST_CASE("McapTrackerViewers: reads records from a single channel", "[mcap][tra
     CHECK(record2->timestamp->sample_time_raw_device_clock() == 84);
 
     CHECK_FALSE(viewers.read(0).has_value());
-    reader.close();
 }
 
 TEST_CASE("McapTrackerViewers: multi-channel reads filter by index", "[mcap][tracker_viewers]")
@@ -324,10 +327,7 @@ TEST_CASE("McapTrackerViewers: multi-channel reads filter by index", "[mcap][tra
         writer->close();
     }
 
-    mcap::McapReader reader;
-    REQUIRE(reader.open(path).ok());
-
-    HeadViewers viewers(reader, "tracking", { "left", "right" });
+    HeadViewers viewers(open_reader(path), "tracking", { "left", "right" });
 
     auto left1 = viewers.read(0);
     REQUIRE(left1.has_value());
@@ -343,7 +343,6 @@ TEST_CASE("McapTrackerViewers: multi-channel reads filter by index", "[mcap][tra
 
     CHECK_FALSE(viewers.read(0).has_value());
     CHECK_FALSE(viewers.read(1).has_value());
-    reader.close();
 }
 
 TEST_CASE("McapTrackerViewers: read subset of written channels", "[mcap][tracker_viewers]")
@@ -364,10 +363,7 @@ TEST_CASE("McapTrackerViewers: read subset of written channels", "[mcap][tracker
         writer->close();
     }
 
-    mcap::McapReader reader;
-    REQUIRE(reader.open(path).ok());
-
-    HeadViewers viewers(reader, "tracking", { "right" });
+    HeadViewers viewers(open_reader(path), "tracking", { "right" });
 
     auto r1 = viewers.read(0);
     REQUIRE(r1.has_value());
@@ -379,7 +375,6 @@ TEST_CASE("McapTrackerViewers: read subset of written channels", "[mcap][tracker
     REQUIRE(r2->data);
 
     CHECK_FALSE(viewers.read(0).has_value());
-    reader.close();
 }
 
 TEST_CASE("McapTrackerViewers: out-of-range channel_index throws", "[mcap][tracker_viewers]")
@@ -396,12 +391,8 @@ TEST_CASE("McapTrackerViewers: out-of-range channel_index throws", "[mcap][track
         writer->close();
     }
 
-    mcap::McapReader reader;
-    REQUIRE(reader.open(path).ok());
-
-    HeadViewers viewers(reader, "tracking", { "head" });
+    HeadViewers viewers(open_reader(path), "tracking", { "head" });
     CHECK_THROWS_AS(viewers.read(99), std::out_of_range);
-    reader.close();
 }
 
 TEST_CASE("McapTrackerViewers: handles null data records", "[mcap][tracker_viewers]")
@@ -416,10 +407,7 @@ TEST_CASE("McapTrackerViewers: handles null data records", "[mcap][tracker_viewe
         writer->close();
     }
 
-    mcap::McapReader reader;
-    REQUIRE(reader.open(path).ok());
-
-    HeadViewers viewers(reader, "tracking", { "head" });
+    HeadViewers viewers(open_reader(path), "tracking", { "head" });
 
     auto record = viewers.read(0);
     REQUIRE(record.has_value());
@@ -428,5 +416,4 @@ TEST_CASE("McapTrackerViewers: handles null data records", "[mcap][tracker_viewe
     CHECK(record->timestamp->sample_time_raw_device_clock() == 10);
 
     CHECK_FALSE(viewers.read(0).has_value());
-    reader.close();
 }

--- a/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
+++ b/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
@@ -10,11 +10,6 @@
 #include <utility>
 #include <vector>
 
-namespace mcap
-{
-class McapReader;
-} // namespace mcap
-
 namespace core
 {
 
@@ -34,14 +29,14 @@ class IHeadTrackerImpl;
 /**
  * @brief Factory for replay (MCAP-backed) tracker implementations.
  *
- * Counterpart to LiveDeviceIOFactory. Instead of OpenXR handles, takes an
- * McapReader and constructs Replay*TrackerImpl instances that read recorded
- * data from the MCAP file.
+ * Opens a fresh McapReader per tracker impl so each tracker has its own
+ * FileReader buffer; crossing an MCAP chunk boundary in one tracker cannot
+ * overwrite another tracker's pre-fetched message data pointer.
  */
 class ReplayDeviceIOFactory
 {
 public:
-    ReplayDeviceIOFactory(mcap::McapReader& reader,
+    ReplayDeviceIOFactory(std::string filename,
                           const std::vector<std::pair<const ITracker*, std::string>>& tracker_names);
 
     /** Create tracker impl from a tracker instance using dynamic dispatch. */
@@ -57,7 +52,7 @@ public:
 private:
     std::string_view get_name(const ITracker* tracker) const;
 
-    mcap::McapReader& reader_;
+    std::string filename_;
     std::unordered_map<const ITracker*, std::string> name_map_;
 };
 

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.cpp
@@ -18,9 +18,10 @@ namespace core
 // ReplayControllerTrackerImpl
 // ============================================================================
 
-ReplayControllerTrackerImpl::ReplayControllerTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
+ReplayControllerTrackerImpl::ReplayControllerTrackerImpl(std::unique_ptr<mcap::McapReader> reader,
+                                                         std::string_view base_name)
     : mcap_viewers_(std::make_unique<ControllerMcapViewers>(
-          reader,
+          std::move(reader),
           base_name,
           std::vector<std::string>(
               ControllerRecordingTraits::replay_channels.begin(), ControllerRecordingTraits::replay_channels.end())))

--- a/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_controller_tracker_impl.hpp
@@ -19,7 +19,7 @@ using ControllerMcapViewers = McapTrackerViewers<ControllerSnapshotRecord>;
 class ReplayControllerTrackerImpl : public IControllerTrackerImpl
 {
 public:
-    ReplayControllerTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
+    ReplayControllerTrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name);
 
     ReplayControllerTrackerImpl(const ReplayControllerTrackerImpl&) = delete;
     ReplayControllerTrackerImpl& operator=(const ReplayControllerTrackerImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
+++ b/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
@@ -14,8 +14,10 @@
 #include <deviceio_trackers/generic_3axis_pedal_tracker.hpp>
 #include <deviceio_trackers/hand_tracker.hpp>
 #include <deviceio_trackers/head_tracker.hpp>
+#include <mcap/reader.hpp>
 
 #include <cassert>
+#include <memory>
 #include <stdexcept>
 #include <string>
 
@@ -24,6 +26,18 @@ namespace core
 
 namespace
 {
+
+std::unique_ptr<mcap::McapReader> open_reader(const std::string& filename)
+{
+    auto reader = std::make_unique<mcap::McapReader>();
+    auto status = reader->open(filename);
+    if (!status.ok())
+    {
+        throw std::runtime_error("ReplayDeviceIOFactory: failed to open MCAP file '" + filename + "': " + status.message);
+    }
+    return reader;
+}
+
 
 std::unique_ptr<ITrackerImpl> try_create_head_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
 {
@@ -64,9 +78,9 @@ inline const TryCreateFn k_tracker_dispatch[] = {
 
 } // namespace
 
-ReplayDeviceIOFactory::ReplayDeviceIOFactory(mcap::McapReader& reader,
+ReplayDeviceIOFactory::ReplayDeviceIOFactory(std::string filename,
                                              const std::vector<std::pair<const ITracker*, std::string>>& tracker_names)
-    : reader_(reader)
+    : filename_(std::move(filename))
 {
     for (const auto& [tracker, name] : tracker_names)
     {
@@ -101,29 +115,29 @@ std::string_view ReplayDeviceIOFactory::get_name(const ITracker* tracker) const
 
 std::unique_ptr<IHeadTrackerImpl> ReplayDeviceIOFactory::create_head_tracker_impl(const HeadTracker* tracker)
 {
-    return std::make_unique<ReplayHeadTrackerImpl>(reader_, get_name(tracker));
+    return std::make_unique<ReplayHeadTrackerImpl>(open_reader(filename_), get_name(tracker));
 }
 
 std::unique_ptr<IHandTrackerImpl> ReplayDeviceIOFactory::create_hand_tracker_impl(const HandTracker* tracker)
 {
-    return std::make_unique<ReplayHandTrackerImpl>(reader_, get_name(tracker));
+    return std::make_unique<ReplayHandTrackerImpl>(open_reader(filename_), get_name(tracker));
 }
 
 std::unique_ptr<IControllerTrackerImpl> ReplayDeviceIOFactory::create_controller_tracker_impl(const ControllerTracker* tracker)
 {
-    return std::make_unique<ReplayControllerTrackerImpl>(reader_, get_name(tracker));
+    return std::make_unique<ReplayControllerTrackerImpl>(open_reader(filename_), get_name(tracker));
 }
 
 std::unique_ptr<IFullBodyTrackerPicoImpl> ReplayDeviceIOFactory::create_full_body_tracker_pico_impl(
     const FullBodyTrackerPico* tracker)
 {
-    return std::make_unique<ReplayFullBodyTrackerPicoImpl>(reader_, get_name(tracker));
+    return std::make_unique<ReplayFullBodyTrackerPicoImpl>(open_reader(filename_), get_name(tracker));
 }
 
 std::unique_ptr<IGeneric3AxisPedalTrackerImpl> ReplayDeviceIOFactory::create_generic_3axis_pedal_tracker_impl(
     const Generic3AxisPedalTracker* tracker)
 {
-    return std::make_unique<ReplayGeneric3AxisPedalTrackerImpl>(reader_, get_name(tracker));
+    return std::make_unique<ReplayGeneric3AxisPedalTrackerImpl>(open_reader(filename_), get_name(tracker));
 }
 
 } // namespace core

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.cpp
@@ -18,9 +18,10 @@ namespace core
 // ReplayFullBodyTrackerPicoImpl
 // ============================================================================
 
-ReplayFullBodyTrackerPicoImpl::ReplayFullBodyTrackerPicoImpl(mcap::McapReader& reader, std::string_view base_name)
+ReplayFullBodyTrackerPicoImpl::ReplayFullBodyTrackerPicoImpl(std::unique_ptr<mcap::McapReader> reader,
+                                                             std::string_view base_name)
     : mcap_viewers_(std::make_unique<FullBodyMcapViewers>(
-          reader,
+          std::move(reader),
           base_name,
           std::vector<std::string>(FullBodyPicoRecordingTraits::replay_channels.begin(),
                                    FullBodyPicoRecordingTraits::replay_channels.end())))

--- a/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_full_body_tracker_pico_impl.hpp
@@ -19,7 +19,7 @@ using FullBodyMcapViewers = McapTrackerViewers<FullBodyPosePicoRecord>;
 class ReplayFullBodyTrackerPicoImpl : public IFullBodyTrackerPicoImpl
 {
 public:
-    ReplayFullBodyTrackerPicoImpl(mcap::McapReader& reader, std::string_view base_name);
+    ReplayFullBodyTrackerPicoImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name);
 
     ReplayFullBodyTrackerPicoImpl(const ReplayFullBodyTrackerPicoImpl&) = delete;
     ReplayFullBodyTrackerPicoImpl& operator=(const ReplayFullBodyTrackerPicoImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.cpp
@@ -18,10 +18,10 @@ namespace core
 // ReplayGeneric3AxisPedalTrackerImpl
 // ============================================================================
 
-ReplayGeneric3AxisPedalTrackerImpl::ReplayGeneric3AxisPedalTrackerImpl(mcap::McapReader& reader,
+ReplayGeneric3AxisPedalTrackerImpl::ReplayGeneric3AxisPedalTrackerImpl(std::unique_ptr<mcap::McapReader> reader,
                                                                        std::string_view base_name)
     : mcap_viewers_(
-          std::make_unique<PedalMcapViewers>(reader,
+          std::make_unique<PedalMcapViewers>(std::move(reader),
                                              base_name,
                                              std::vector<std::string>(PedalRecordingTraits::replay_channels.begin(),
                                                                       PedalRecordingTraits::replay_channels.end())))

--- a/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_generic_3axis_pedal_tracker_impl.hpp
@@ -19,7 +19,7 @@ using PedalMcapViewers = McapTrackerViewers<Generic3AxisPedalOutputRecord>;
 class ReplayGeneric3AxisPedalTrackerImpl : public IGeneric3AxisPedalTrackerImpl
 {
 public:
-    ReplayGeneric3AxisPedalTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
+    ReplayGeneric3AxisPedalTrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name);
 
     ReplayGeneric3AxisPedalTrackerImpl(const ReplayGeneric3AxisPedalTrackerImpl&) = delete;
     ReplayGeneric3AxisPedalTrackerImpl& operator=(const ReplayGeneric3AxisPedalTrackerImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.cpp
@@ -18,9 +18,9 @@ namespace core
 // ReplayHandTrackerImpl
 // ============================================================================
 
-ReplayHandTrackerImpl::ReplayHandTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
+ReplayHandTrackerImpl::ReplayHandTrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name)
     : mcap_viewers_(
-          std::make_unique<HandMcapViewers>(reader,
+          std::make_unique<HandMcapViewers>(std::move(reader),
                                             base_name,
                                             std::vector<std::string>(HandRecordingTraits::replay_channels.begin(),
                                                                      HandRecordingTraits::replay_channels.end())))

--- a/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_hand_tracker_impl.hpp
@@ -19,7 +19,7 @@ using HandMcapViewers = McapTrackerViewers<HandPoseRecord>;
 class ReplayHandTrackerImpl : public IHandTrackerImpl
 {
 public:
-    ReplayHandTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
+    ReplayHandTrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name);
 
     ReplayHandTrackerImpl(const ReplayHandTrackerImpl&) = delete;
     ReplayHandTrackerImpl& operator=(const ReplayHandTrackerImpl&) = delete;

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.cpp
@@ -18,9 +18,9 @@ namespace core
 // ReplayHeadTrackerImpl
 // ============================================================================
 
-ReplayHeadTrackerImpl::ReplayHeadTrackerImpl(mcap::McapReader& reader, std::string_view base_name)
+ReplayHeadTrackerImpl::ReplayHeadTrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name)
     : mcap_viewers_(
-          std::make_unique<HeadMcapViewers>(reader,
+          std::make_unique<HeadMcapViewers>(std::move(reader),
                                             base_name,
                                             std::vector<std::string>(HeadRecordingTraits::replay_channels.begin(),
                                                                      HeadRecordingTraits::replay_channels.end())))

--- a/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_head_tracker_impl.hpp
@@ -19,7 +19,7 @@ using HeadMcapViewers = McapTrackerViewers<HeadPoseRecord>;
 class ReplayHeadTrackerImpl : public IHeadTrackerImpl
 {
 public:
-    ReplayHeadTrackerImpl(mcap::McapReader& reader, std::string_view base_name);
+    ReplayHeadTrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name);
 
     ReplayHeadTrackerImpl(const ReplayHeadTrackerImpl&) = delete;
     ReplayHeadTrackerImpl& operator=(const ReplayHeadTrackerImpl&) = delete;


### PR DESCRIPTION
- The MCAP C++ library's FileReader uses a single read buffer shared across all LinearMessageView iterators. When any iterator crosses a chunk boundary, read() overwrites the buffer, invalidating data pointers held by other iterators -- producing "corrupt FlatBuffer" errors.
- Per-tracker McapReader: each replay tracker impl now opens its own McapReader (~768 KB buffer each), eliminating cross-tracker buffer sharing.
- Single-iterator McapTrackerViewers: within multi-channel trackers (e.g. left/right hand), one shared iterator deserializes before advancing, eliminating within-tracker buffer sharing.


To add a couple of ballpark calculation here. A chunk from FileReader is 765KB and in this fix, we keep a FileReader per tracker. So the memory got loaded would be TRACKER_COUNT * 765KB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal resource management for MCAP file handling by centralizing ownership of file readers within replay tracker components, enabling better isolation and lifecycle management across trackers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->