### PR TITLE
Add VizSession + VizCompositor + offscreen e2e milestone

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -204,6 +204,11 @@ jobs:
         # job already covered [unit] tests on a CPU-only runner; here we focus
         # on the GPU paths that genuinely need Vulkan/CUDA at runtime.
         #
+        # --allow-running-no-tests makes "no [gpu] tests in this binary" a
+        # success rather than a Catch2 exit-code-2 failure. Some binaries
+        # (e.g. viz_layers_tests today) only have [unit] tests; that's
+        # expected, not a regression.
+        #
         # We retry once on failure: the self-hosted GPU runner is shared with
         # test-cloudxr / test-teleop-ros2, and concurrent Vulkan/CUDA usage
         # can transiently make vkEnumeratePhysicalDevices return no suitable
@@ -211,12 +216,12 @@ jobs:
         # without masking real regressions (a true bug would fail twice).
         run_one() {
           local bin=$1
-          if ./"${bin}" "[gpu]" --reporter compact; then
+          if ./"${bin}" "[gpu]" --reporter compact --allow-running-no-tests; then
             return 0
           fi
           echo "::warning::${bin} [gpu] failed on first attempt; retrying after 5s"
           sleep 5
-          ./"${bin}" "[gpu]" --reporter compact
+          ./"${bin}" "[gpu]" --reporter compact --allow-running-no-tests
         }
         failures=0
         for test_bin in viz_*_tests; do

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -232,6 +232,70 @@ jobs:
           exit 1
         fi
 
+  test-viz-sanitizers:
+    # Builds the viz module with AddressSanitizer + UndefinedBehaviorSanitizer
+    # and runs only the [unit]-tagged Catch2 tests on a GPU-less GitHub-hosted
+    # runner. Catches lifetime / leak / UB bugs that pass the regular build
+    # (validate-then-allocate failures, missed deletes, dangling refs).
+    #
+    # [gpu] tests are intentionally NOT run here: ASAN intercepts mmap /
+    # malloc and clashes with the NVIDIA Vulkan driver's own allocators
+    # in ways that produce false positives. The GPU surface is covered
+    # by test-viz-gpu on the self-hosted runner.
+    runs-on: ubuntu-22.04
+    needs: build-ubuntu
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
+
+    - name: Install uv
+      uses: ./.github/actions/setup-uv
+
+    - name: Install Apt dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache libvulkan-dev
+
+    - name: Cache ccache
+      uses: actions/cache@v5
+      with:
+        path: ~/.cache/ccache
+        key: ccache-${{ runner.os }}-${{ runner.arch }}-sanitizers-${{ hashFiles('**/CMakeLists.txt') }}
+        restore-keys: |
+          ccache-${{ runner.os }}-${{ runner.arch }}-sanitizers-
+
+    - name: Configure CMake (ASAN + UBSAN)
+      run: |
+        cmake -B build-san \
+          -DCMAKE_BUILD_TYPE=Debug \
+          -DBUILD_VIZ=ON \
+          -DBUILD_PLUGINS=OFF \
+          -DBUILD_EXAMPLES=OFF \
+          -DBUILD_PYTHON_BINDINGS=OFF \
+          -DENABLE_CLOUDXR_BUNDLE_CHECK=OFF \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_C_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
+          -DCMAKE_CXX_FLAGS="-fsanitize=address,undefined -fno-omit-frame-pointer -g" \
+          -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=address,undefined" \
+          -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=address,undefined"
+
+    - name: Build viz tests
+      run: |
+        cmake --build build-san --parallel 4 \
+          --target viz_core_tests viz_layers_tests viz_session_tests
+
+    - name: Run viz [unit] tests under sanitizers
+      env:
+        ASAN_OPTIONS: detect_leaks=1:strict_string_checks=1:halt_on_error=1:abort_on_error=1
+        UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+      run: |
+        set -euo pipefail
+        ctest --test-dir build-san -L unit --output-on-failure
+
   test-cloudxr:
     runs-on: [self-hosted, linux, gpu, "${{ matrix.arch }}"]
     needs: build-ubuntu
@@ -465,6 +529,7 @@ jobs:
     needs:
       - build-ubuntu
       - test-viz-gpu
+      - test-viz-sanitizers
       - test-cloudxr
       - test-teleop-ros2
     outputs:
@@ -479,6 +544,7 @@ jobs:
         || github.event.pull_request.head.repo.full_name == github.repository)
       && needs.build-ubuntu.result == 'success'
       && needs.test-viz-gpu.result == 'success'
+      && needs.test-viz-sanitizers.result == 'success'
       && needs.test-cloudxr.result == 'success'
       && needs.test-teleop-ros2.result == 'success'
 

--- a/src/viz/AGENTS.md
+++ b/src/viz/AGENTS.md
@@ -97,6 +97,38 @@ When `BUILD_VIZ=ON` you must have Vulkan headers + loader installed:
   selection.
 - GPU tests **must** use `GpuFixture` or call `is_gpu_available()` and
   `SKIP()` if false. Never assume a GPU is present.
+
+### Required test patterns
+
+Beyond happy-path coverage, every new feature MUST add tests for:
+
+1. **Invalid input rejection** — assert public APIs throw on bad config
+   (zero dimensions, uninitialized dependencies, unsupported modes)
+   *before* any resource is allocated. Helps catch the
+   "validate-then-allocate" failure mode.
+2. **State-machine invariants** — for any class with implicit state
+   (begin/end pairs, init/destroy lifecycles, lock/unlock), explicitly
+   test every invalid transition: double-begin, end-without-begin,
+   destroy-then-use, etc. Expect throw, no silent no-op (no-op masks
+   real bugs in caller code).
+3. **Exception recovery** — for any per-frame / per-iteration loop
+   that includes user code (layer record(), callbacks), inject an
+   exception via `viz::testing::ThrowingLayer` (or equivalent) and
+   verify the *next* call still works. Catches fence-deadlock,
+   leaked-flag, and partial-state bugs that only surface on retry.
+4. **Idempotent destroy** — `destroy()` / cleanup methods must be
+   safe to call twice (and after partial init failure). Test it.
+
+### Test fixtures
+
+Test-only `LayerBase` subclasses and helpers live in
+`viz/layers_tests/cpp/inc/viz/layers/testing/` and ship via the
+`viz::layers_testing` static library. Other test executables link
+that library to compose fixtures. Today:
+- `ClearRectLayer` — paints a rect via `vkCmdClearAttachments` (no
+  shaders); used to verify compositor dispatch produces real pixels.
+- `ThrowingLayer` — throws from `record()` on a configurable schedule;
+  used for exception-recovery tests.
 - Test files live alongside the code they test, in
   `<sub-module>_tests/cpp/`. One executable per sub-module
   (`viz_core_tests`, `viz_layers_tests`, ...). Do **not** dump tests

--- a/src/viz/AGENTS.md
+++ b/src/viz/AGENTS.md
@@ -25,9 +25,16 @@ sibling `<sub-module>_tests/` directory:
 - **`viz/layers/`** — `LayerBase` and concrete layers (`QuadLayer`, etc.).
   Library: `viz_layers` (INTERFACE / header-only today; promoted to
   STATIC when the first concrete layer ships). Depends on `viz_core`.
-- **`viz/session/`** — `VizSession`, `VizCompositor`, `FrameInfo`, display
-  backends (offscreen, GLFW window). Library: `viz_session`. Depends on
-  `viz_core`, `viz_layers`.
+  Test-only fixture layers (`ClearRectLayer`, future `ColoredQuadLayer`)
+  live in `viz/layers_tests/cpp/inc/viz/layers/testing/` and are exposed
+  via the `viz::layers_testing` static library — used by other test
+  binaries (e.g. `viz_session_tests`) to compose into a `VizSession`.
+- **`viz/session/`** — `VizSession`, `VizCompositor`, `FrameInfo`,
+  `FrameTimingStats`, `SessionState`, display backends (today: offscreen
+  only; window/XR added by their respective backends). Library:
+  `viz_session`. Depends on `viz_core`, `viz_layers`. Public API for the
+  whole module — applications interact with Televiz through
+  `VizSession::create()`.
 - **`viz/xr/`** — OpenXR backend (instance/session, swapchain wrapping,
   frame loop, type conversion). Library: `viz_xr`. **Optional** behind
   `BUILD_VIZ_XR`. Depends on `viz_core` + OpenXR.

--- a/src/viz/CMakeLists.txt
+++ b/src/viz/CMakeLists.txt
@@ -27,6 +27,10 @@ add_subdirectory(core)
 # types are added as they ship).
 add_subdirectory(layers)
 
+# Session: VizSession + VizCompositor + frame info — the orchestration
+# layer that drives the per-frame loop and manages the layer registry.
+add_subdirectory(session)
+
 # Python bindings (stub today; pybind11 module added later).
 if(BUILD_PYTHON_BINDINGS)
     add_subdirectory(python)
@@ -35,4 +39,6 @@ endif()
 # Tests for each sub-module live in <module>_tests/ siblings.
 if(BUILD_TESTING)
     add_subdirectory(core_tests)
+    add_subdirectory(layers_tests)
+    add_subdirectory(session_tests)
 endif()

--- a/src/viz/core/cpp/CMakeLists.txt
+++ b/src/viz/core/cpp/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(viz_core STATIC
     frame_sync.cpp
     render_target.cpp
     vk_context.cpp
+    inc/viz/core/device_image.hpp
     inc/viz/core/frame_sync.hpp
     inc/viz/core/host_image.hpp
     inc/viz/core/render_target.hpp

--- a/src/viz/core/cpp/CMakeLists.txt
+++ b/src/viz/core/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(viz_core STATIC
     render_target.cpp
     vk_context.cpp
     inc/viz/core/frame_sync.hpp
+    inc/viz/core/host_image.hpp
     inc/viz/core/render_target.hpp
     inc/viz/core/viz_buffer.hpp
     inc/viz/core/viz_types.hpp

--- a/src/viz/core/cpp/inc/viz/core/device_image.hpp
+++ b/src/viz/core/cpp/inc/viz/core/device_image.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+namespace viz
+{
+
+// Owning device-side 2D pixel buffer with CUDA-Vulkan interop. The
+// symmetric counterpart to HostImage: HostImage owns CPU bytes,
+// DeviceImage will own:
+//   - VkImage / VkBuffer + VkDeviceMemory exported via
+//     VK_KHR_external_memory_fd
+//   - cudaExternalMemory_t imported from that fd, plus the CUDA device
+//     pointer derived from it
+//   - paired cudaExternalSemaphore_t / VkSemaphore for acquire / release
+//     synchronization
+//
+// Returned by Televiz's mode-B submission path (acquire / release) when
+// Televiz allocates the interop buffer for a layer to write into.
+//
+// Intentionally only forward-declared in this milestone — the
+// implementation ships alongside CUDA-Vulkan interop. Callers may pass
+// pointers / references to DeviceImage between modules but cannot
+// instantiate one until then.
+class DeviceImage;
+
+} // namespace viz

--- a/src/viz/core/cpp/inc/viz/core/host_image.hpp
+++ b/src/viz/core/cpp/inc/viz/core/host_image.hpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <viz/core/viz_buffer.hpp>
+#include <viz/core/viz_types.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace viz
+{
+
+// Owning host-side 2D pixel buffer. Returned by readback paths that
+// bring a composited frame back to CPU memory for tests, debug tooling,
+// or non-CUDA consumers. Exposes a VizBuffer view (with
+// MemorySpace::kHost) so the same helpers that operate on GPU
+// VizBuffers (e.g. future save_to_png, image-diff) work on host data
+// without parallel APIs.
+//
+// Layout: tightly packed (row_pitch = width * bytes_per_pixel(format)).
+// Pixel rows are top-to-bottom. Channel order matches `format`.
+class HostImage
+{
+public:
+    HostImage() = default;
+    HostImage(Resolution resolution, PixelFormat format)
+        : resolution_(resolution),
+          format_(format),
+          storage_(static_cast<size_t>(resolution.width) * resolution.height * bytes_per_pixel(format))
+    {
+    }
+
+    // Non-owning view into the storage as a VizBuffer (space = kHost).
+    // Valid as long as this HostImage is alive and not moved-from.
+    VizBuffer view() noexcept
+    {
+        return make_view(storage_.data());
+    }
+
+    // Const view; .data points at non-const memory but the caller should
+    // treat it as read-only — Vulkan/CUDA interfaces want non-const ptrs.
+    VizBuffer view() const noexcept
+    {
+        return make_view(const_cast<uint8_t*>(storage_.data()));
+    }
+
+    Resolution resolution() const noexcept
+    {
+        return resolution_;
+    }
+    PixelFormat format() const noexcept
+    {
+        return format_;
+    }
+
+    uint8_t* data() noexcept
+    {
+        return storage_.data();
+    }
+    const uint8_t* data() const noexcept
+    {
+        return storage_.data();
+    }
+    size_t size_bytes() const noexcept
+    {
+        return storage_.size();
+    }
+
+private:
+    VizBuffer make_view(uint8_t* ptr) const noexcept
+    {
+        VizBuffer b;
+        b.data = ptr;
+        b.width = resolution_.width;
+        b.height = resolution_.height;
+        b.format = format_;
+        b.pitch = static_cast<size_t>(resolution_.width) * bytes_per_pixel(format_);
+        b.space = MemorySpace::kHost;
+        return b;
+    }
+
+    Resolution resolution_{};
+    PixelFormat format_ = PixelFormat::kRGBA8;
+    std::vector<uint8_t> storage_;
+};
+
+} // namespace viz

--- a/src/viz/core/cpp/inc/viz/core/viz_buffer.hpp
+++ b/src/viz/core/cpp/inc/viz/core/viz_buffer.hpp
@@ -19,21 +19,34 @@ enum class PixelFormat
     kD32F, // single-channel float32 depth
 };
 
-// Lightweight, non-owning reference to a 2D pixel buffer on GPU.
+// Where a VizBuffer's data pointer lives. Producer-consumer paths (CUDA
+// interop, Python __cuda_array_interface__, Vulkan VkBuffer mapping)
+// require the device space; host-readback / debug helpers use the host
+// space. Caller must respect the space — there is no runtime check.
+enum class MemorySpace
+{
+    kDevice, // CUDA device memory (default; what production layer interop expects)
+    kHost, // CPU memory (test-grade readback, debug helpers)
+};
+
+// Lightweight, non-owning reference to a 2D pixel buffer.
 //
-// VizBuffer carries no ownership semantics: it does not allocate or free
-// memory. For Mode B submission (acquire/release), the layer owns the
-// underlying interop buffer; VizBuffer is a view into it.
+// Carries no ownership: it does not allocate or free memory. For Mode B
+// submission (acquire/release), the layer owns the underlying interop
+// buffer; VizBuffer is a view into it. For host readback, HostImage owns
+// the bytes and exposes a VizBuffer view via HostImage::view().
 //
-// In Python, VizBuffer exposes __cuda_array_interface__ so CuPy can wrap
-// it zero-copy.
+// In Python, VizBuffer with space == kDevice exposes
+// __cuda_array_interface__ so CuPy can wrap it zero-copy. Host buffers
+// expose __array_interface__ (NumPy) instead.
 struct VizBuffer
 {
-    void* data = nullptr; // CUDA device pointer
+    void* data = nullptr;
     uint32_t width = 0;
     uint32_t height = 0;
     PixelFormat format = PixelFormat::kRGBA8;
     size_t pitch = 0; // Row pitch in bytes (0 = tightly packed)
+    MemorySpace space = MemorySpace::kDevice;
 };
 
 // Returns the number of bytes per pixel for the given format.

--- a/src/viz/core_tests/cpp/CMakeLists.txt
+++ b/src/viz/core_tests/cpp/CMakeLists.txt
@@ -5,6 +5,7 @@ cmake_minimum_required(VERSION 3.20)
 
 add_executable(viz_core_tests
     test_frame_sync.cpp
+    test_host_image.cpp
     test_render_target.cpp
     test_viz_buffer.cpp
     test_viz_types.cpp

--- a/src/viz/core_tests/cpp/test_host_image.cpp
+++ b/src/viz/core_tests/cpp/test_host_image.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for HostImage.
+
+#include <catch2/catch_test_macros.hpp>
+#include <viz/core/host_image.hpp>
+
+#include <cstddef>
+
+using viz::HostImage;
+using viz::MemorySpace;
+using viz::PixelFormat;
+using viz::Resolution;
+
+TEST_CASE("HostImage default-constructed is empty", "[unit][host_image]")
+{
+    HostImage img;
+    CHECK(img.resolution().width == 0);
+    CHECK(img.resolution().height == 0);
+    CHECK(img.format() == PixelFormat::kRGBA8);
+    CHECK(img.size_bytes() == 0);
+    CHECK(img.data() == nullptr);
+}
+
+TEST_CASE("HostImage allocates tightly-packed RGBA8 storage", "[unit][host_image]")
+{
+    HostImage img(Resolution{ 640, 480 }, PixelFormat::kRGBA8);
+    CHECK(img.resolution().width == 640);
+    CHECK(img.resolution().height == 480);
+    CHECK(img.format() == PixelFormat::kRGBA8);
+    CHECK(img.size_bytes() == static_cast<std::size_t>(640) * 480 * 4);
+    CHECK(img.data() != nullptr);
+}
+
+TEST_CASE("HostImage::view returns a kHost VizBuffer pointing at storage", "[unit][host_image]")
+{
+    HostImage img(Resolution{ 16, 16 }, PixelFormat::kRGBA8);
+    const auto v = img.view();
+    CHECK(v.data == img.data());
+    CHECK(v.width == 16);
+    CHECK(v.height == 16);
+    CHECK(v.format == PixelFormat::kRGBA8);
+    CHECK(v.pitch == static_cast<std::size_t>(16) * 4);
+    CHECK(v.space == MemorySpace::kHost);
+}
+
+TEST_CASE("HostImage::view from const yields const-data pointer", "[unit][host_image]")
+{
+    const HostImage img(Resolution{ 4, 4 }, PixelFormat::kRGBA8);
+    const auto v = img.view();
+    CHECK(v.data == img.data());
+    CHECK(v.space == MemorySpace::kHost);
+}
+
+TEST_CASE("HostImage handles depth format size", "[unit][host_image]")
+{
+    HostImage img(Resolution{ 32, 32 }, PixelFormat::kD32F);
+    CHECK(img.format() == PixelFormat::kD32F);
+    // D32F is also 4 bytes/pixel.
+    CHECK(img.size_bytes() == static_cast<std::size_t>(32) * 32 * 4);
+    CHECK(img.view().pitch == static_cast<std::size_t>(32) * 4);
+}

--- a/src/viz/core_tests/cpp/test_viz_buffer.cpp
+++ b/src/viz/core_tests/cpp/test_viz_buffer.cpp
@@ -10,6 +10,7 @@
 
 using viz::bytes_per_pixel;
 using viz::effective_pitch;
+using viz::MemorySpace;
 using viz::PixelFormat;
 using viz::VizBuffer;
 
@@ -21,6 +22,8 @@ TEST_CASE("VizBuffer default construction is zero/null", "[unit][viz_buffer]")
     CHECK(buf.height == 0);
     CHECK(buf.format == PixelFormat::kRGBA8);
     CHECK(buf.pitch == 0);
+    // Production interop default: device memory.
+    CHECK(buf.space == MemorySpace::kDevice);
 }
 
 TEST_CASE("VizBuffer aggregate construction preserves fields", "[unit][viz_buffer]")

--- a/src/viz/layers_tests/CMakeLists.txt
+++ b/src/viz/layers_tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+# Build C++ test fixtures + tests
+add_subdirectory(cpp)

--- a/src/viz/layers_tests/cpp/CMakeLists.txt
+++ b/src/viz/layers_tests/cpp/CMakeLists.txt
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+# Test-only fixture library: concrete LayerBase subclasses that downstream
+# tests (here, viz/session_tests/) compose into VizSession to verify
+# compositor behavior. Not shipped to consumers.
+add_library(viz_layers_testing STATIC
+    clear_rect_layer.cpp
+    inc/viz/layers/testing/clear_rect_layer.hpp
+)
+
+target_include_directories(viz_layers_testing
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+)
+
+target_link_libraries(viz_layers_testing
+    PUBLIC
+        viz::core
+        viz::layers
+)
+
+add_library(viz::layers_testing ALIAS viz_layers_testing)
+
+# Test executable for the layers_testing fixtures themselves.
+add_executable(viz_layers_tests
+    test_clear_rect_layer.cpp
+)
+
+target_link_libraries(viz_layers_tests PRIVATE
+    viz::layers_testing
+    Catch2::Catch2WithMain
+)
+
+message(STATUS "viz_layers_tests target enabled with Catch2")
+
+catch_discover_tests(viz_layers_tests ADD_TAGS_AS_LABELS)

--- a/src/viz/layers_tests/cpp/CMakeLists.txt
+++ b/src/viz/layers_tests/cpp/CMakeLists.txt
@@ -9,6 +9,7 @@ cmake_minimum_required(VERSION 3.20)
 add_library(viz_layers_testing STATIC
     clear_rect_layer.cpp
     inc/viz/layers/testing/clear_rect_layer.hpp
+    inc/viz/layers/testing/throwing_layer.hpp
 )
 
 target_include_directories(viz_layers_testing
@@ -27,6 +28,7 @@ add_library(viz::layers_testing ALIAS viz_layers_testing)
 # Test executable for the layers_testing fixtures themselves.
 add_executable(viz_layers_tests
     test_clear_rect_layer.cpp
+    test_throwing_layer.cpp
 )
 
 target_link_libraries(viz_layers_tests PRIVATE

--- a/src/viz/layers_tests/cpp/clear_rect_layer.cpp
+++ b/src/viz/layers_tests/cpp/clear_rect_layer.cpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <viz/layers/testing/clear_rect_layer.hpp>
+
+namespace viz::testing
+{
+
+ClearRectLayer::ClearRectLayer(Config config) : LayerBase(config.name), config_(std::move(config))
+{
+}
+
+void ClearRectLayer::record(VkCommandBuffer cmd,
+                            const std::vector<viz::ViewInfo>& /*views*/,
+                            const viz::RenderTarget& target)
+{
+    VkClearAttachment attachment{};
+    attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    attachment.colorAttachment = 0;
+    attachment.clearValue.color = { { config_.rgba[0], config_.rgba[1], config_.rgba[2], config_.rgba[3] } };
+
+    const auto target_res = target.resolution();
+    const uint32_t w = (config_.w == 0) ? target_res.width : config_.w;
+    const uint32_t h = (config_.h == 0) ? target_res.height : config_.h;
+
+    VkClearRect rect{};
+    rect.rect.offset = { config_.x, config_.y };
+    rect.rect.extent = { w, h };
+    rect.baseArrayLayer = 0;
+    rect.layerCount = 1;
+
+    vkCmdClearAttachments(cmd, 1, &attachment, 1, &rect);
+}
+
+} // namespace viz::testing

--- a/src/viz/layers_tests/cpp/inc/viz/layers/testing/clear_rect_layer.hpp
+++ b/src/viz/layers_tests/cpp/inc/viz/layers/testing/clear_rect_layer.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <viz/core/render_target.hpp>
+#include <viz/core/viz_types.hpp>
+#include <viz/layers/layer_base.hpp>
+#include <vulkan/vulkan.h>
+
+#include <array>
+#include <cstdint>
+#include <vector>
+
+namespace viz::testing
+{
+
+// Test fixture layer: clears a rectangular region of the active
+// framebuffer to a configured RGBA color via vkCmdClearAttachments.
+//
+// Used to verify the compositor's layer-dispatch + render-pass plumbing
+// without bringing in shaders, graphics pipelines, or vertex buffers
+// (those land with the first real graphics layer alongside CUDA-Vulkan
+// interop). Exercises the same in-pass command-recording surface that
+// real layers use.
+//
+// Coordinates are in framebuffer pixels with origin top-left; w/h
+// default to the full target if both are zero.
+class ClearRectLayer final : public LayerBase
+{
+public:
+    struct Config
+    {
+        int32_t x = 0;
+        int32_t y = 0;
+        uint32_t w = 0; // 0 means "full width of target"
+        uint32_t h = 0; // 0 means "full height of target"
+        std::array<float, 4> rgba{ 1.0f, 1.0f, 1.0f, 1.0f };
+        std::string name = "ClearRectLayer";
+    };
+
+    explicit ClearRectLayer(Config config);
+
+    void record(VkCommandBuffer cmd, const std::vector<viz::ViewInfo>& views, const viz::RenderTarget& target) override;
+
+    const Config& config() const noexcept
+    {
+        return config_;
+    }
+
+private:
+    Config config_;
+};
+
+} // namespace viz::testing

--- a/src/viz/layers_tests/cpp/inc/viz/layers/testing/throwing_layer.hpp
+++ b/src/viz/layers_tests/cpp/inc/viz/layers/testing/throwing_layer.hpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <viz/core/render_target.hpp>
+#include <viz/core/viz_types.hpp>
+#include <viz/layers/layer_base.hpp>
+#include <vulkan/vulkan.h>
+
+#include <atomic>
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace viz::testing
+{
+
+// Test fixture layer that throws from record() on a configurable
+// schedule. Used to verify the compositor / session recover correctly
+// from layer-side exceptions (no fence deadlocks, no leaked Vulkan
+// state, layer registry intact).
+//
+// `throw_after_n_calls` = 0 means "throw on every call".
+// `throw_after_n_calls` = N (>= 1) means "succeed N times, then throw".
+// Once it has thrown, it keeps throwing on every subsequent call unless
+// reset via reset_call_count().
+class ThrowingLayer final : public LayerBase
+{
+public:
+    struct Config
+    {
+        uint32_t throw_after_n_calls = 0; // 0 = throw immediately
+        std::string what = "ThrowingLayer: intentional test failure";
+        std::string name = "ThrowingLayer";
+    };
+
+    explicit ThrowingLayer(Config config) : LayerBase(config.name), config_(std::move(config))
+    {
+    }
+
+    void record(VkCommandBuffer /*cmd*/,
+                const std::vector<viz::ViewInfo>& /*views*/,
+                const viz::RenderTarget& /*target*/) override
+    {
+        const uint32_t prior = call_count_.fetch_add(1);
+        if (prior >= config_.throw_after_n_calls)
+        {
+            throw std::runtime_error(config_.what);
+        }
+    }
+
+    uint32_t call_count() const noexcept
+    {
+        return call_count_.load();
+    }
+    void reset_call_count() noexcept
+    {
+        call_count_.store(0);
+    }
+    const Config& config() const noexcept
+    {
+        return config_;
+    }
+
+private:
+    Config config_;
+    std::atomic<uint32_t> call_count_{ 0 };
+};
+
+} // namespace viz::testing

--- a/src/viz/layers_tests/cpp/test_clear_rect_layer.cpp
+++ b/src/viz/layers_tests/cpp/test_clear_rect_layer.cpp
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <catch2/catch_test_macros.hpp>
+#include <viz/layers/testing/clear_rect_layer.hpp>
+
+using viz::testing::ClearRectLayer;
+
+TEST_CASE("ClearRectLayer constructs with config", "[unit][clear_rect_layer]")
+{
+    ClearRectLayer layer(ClearRectLayer::Config{ 10, 20, 100, 50, { 1.0f, 0.0f, 0.0f, 1.0f }, "test" });
+    CHECK(layer.name() == "test");
+    CHECK(layer.is_visible());
+    CHECK(layer.config().x == 10);
+    CHECK(layer.config().y == 20);
+    CHECK(layer.config().w == 100);
+    CHECK(layer.config().h == 50);
+    CHECK(layer.config().rgba[0] == 1.0f);
+    CHECK(layer.config().rgba[3] == 1.0f);
+}
+
+TEST_CASE("ClearRectLayer defaults to full target + opaque white", "[unit][clear_rect_layer]")
+{
+    ClearRectLayer layer(ClearRectLayer::Config{});
+    CHECK(layer.config().x == 0);
+    CHECK(layer.config().y == 0);
+    CHECK(layer.config().w == 0); // 0 means "match target"
+    CHECK(layer.config().h == 0);
+    CHECK(layer.config().rgba[0] == 1.0f);
+    CHECK(layer.config().rgba[3] == 1.0f);
+}
+
+TEST_CASE("ClearRectLayer visibility toggle works", "[unit][clear_rect_layer]")
+{
+    ClearRectLayer layer(ClearRectLayer::Config{});
+    REQUIRE(layer.is_visible());
+    layer.set_visible(false);
+    CHECK_FALSE(layer.is_visible());
+    layer.set_visible(true);
+    CHECK(layer.is_visible());
+}

--- a/src/viz/layers_tests/cpp/test_throwing_layer.cpp
+++ b/src/viz/layers_tests/cpp/test_throwing_layer.cpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for ThrowingLayer's bookkeeping (call_count + reset).
+// record() exception behavior is exercised by integration tests in
+// viz/session_tests/ where a real RenderTarget is available.
+
+#include <catch2/catch_test_macros.hpp>
+#include <viz/layers/testing/throwing_layer.hpp>
+
+using viz::testing::ThrowingLayer;
+
+TEST_CASE("ThrowingLayer initial state", "[unit][throwing_layer]")
+{
+    ThrowingLayer layer(ThrowingLayer::Config{ 5 });
+    CHECK(layer.call_count() == 0);
+    CHECK(layer.is_visible());
+    CHECK(layer.config().throw_after_n_calls == 5);
+}
+
+TEST_CASE("ThrowingLayer reset_call_count zeroes the counter", "[unit][throwing_layer]")
+{
+    ThrowingLayer layer(ThrowingLayer::Config{});
+    // We can't drive record() here without a real RenderTarget; just
+    // verify the reset method is wired.
+    layer.reset_call_count();
+    CHECK(layer.call_count() == 0);
+}

--- a/src/viz/session/CMakeLists.txt
+++ b/src/viz/session/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+# Build C++ library
+add_subdirectory(cpp)

--- a/src/viz/session/cpp/CMakeLists.txt
+++ b/src/viz/session/cpp/CMakeLists.txt
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+# VizSession + VizCompositor + frame info: orchestration layer that drives
+# the per-frame loop and manages the layer registry.
+add_library(viz_session STATIC
+    viz_compositor.cpp
+    viz_session.cpp
+    inc/viz/session/frame_info.hpp
+    inc/viz/session/viz_compositor.hpp
+    inc/viz/session/viz_session.hpp
+)
+
+target_include_directories(viz_session
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>
+)
+
+target_link_libraries(viz_session
+    PUBLIC
+        viz::core
+        viz::layers
+)
+
+# Aliased as viz::session.
+add_library(viz::session ALIAS viz_session)

--- a/src/viz/session/cpp/inc/viz/session/frame_info.hpp
+++ b/src/viz/session/cpp/inc/viz/session/frame_info.hpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <viz/core/viz_types.hpp>
+
+#include <cstdint>
+#include <vector>
+
+namespace viz
+{
+
+// Lifecycle states for a VizSession. The full set covers XR; window /
+// offscreen modes only transition through:
+//   kUninitialized -> kReady -> kRunning -> kDestroyed
+//
+// XR adds kStopping (session stopping per OpenXR runtime) and kLost
+// (session lost — must destroy and recreate). See the design doc for the
+// full OpenXR-state-to-VizSession-state mapping.
+enum class SessionState
+{
+    kUninitialized, // Before create()
+    kReady, // Vulkan + display initialized; layers can be added
+    kRunning, // Frame loop active
+    kStopping, // XR only: session is stopping; end_frame submits empty
+    kLost, // XR only: session lost; must destroy and recreate
+    kDestroyed, // After destroy(); no operations valid
+};
+
+// Per-frame state surfaced to the caller of render() / begin_frame().
+// Layers should not depend on this directly — it's plumbing for the
+// application's frame loop (logging, stale-content detection, XR pose
+// tracking).
+struct FrameInfo
+{
+    uint64_t frame_index = 0; // Monotonic counter starting at 0
+    int64_t predicted_display_time = 0; // XR time (ns); 0 in window/offscreen
+    float delta_time = 0.0f; // CPU wall-clock seconds since last frame
+    bool should_render = true; // false in kStopping or when XR runtime says skip
+    std::vector<ViewInfo> views; // 1 in window/offscreen, 2 in XR stereo
+    Resolution resolution{}; // Render-target resolution (per view in XR)
+};
+
+// Aggregated timing diagnostics for the most recent frame window.
+// Updated each frame by the session; queried by app for HUD / logging.
+struct FrameTimingStats
+{
+    float render_fps = 0.0f; // Smoothed frames-per-second over the recent window
+    float target_fps = 0.0f; // Display target (60/72/90/120 in XR; vsync rate windowed)
+    uint64_t missed_frames = 0; // Frames where GPU work didn't complete in budget
+    float avg_frame_time_ms = 0.0f;
+    float gpu_time_ms = 0.0f; // Last frame's GPU-side render time
+    uint32_t stale_layers = 0; // Layers whose content missed stale_timeout this frame
+};
+
+} // namespace viz

--- a/src/viz/session/cpp/inc/viz/session/frame_info.hpp
+++ b/src/viz/session/cpp/inc/viz/session/frame_info.hpp
@@ -11,23 +11,6 @@
 namespace viz
 {
 
-// Lifecycle states for a VizSession. The full set covers XR; window /
-// offscreen modes only transition through:
-//   kUninitialized -> kReady -> kRunning -> kDestroyed
-//
-// XR adds kStopping (session stopping per OpenXR runtime) and kLost
-// (session lost — must destroy and recreate). See the design doc for the
-// full OpenXR-state-to-VizSession-state mapping.
-enum class SessionState
-{
-    kUninitialized, // Before create()
-    kReady, // Vulkan + display initialized; layers can be added
-    kRunning, // Frame loop active
-    kStopping, // XR only: session is stopping; end_frame submits empty
-    kLost, // XR only: session lost; must destroy and recreate
-    kDestroyed, // After destroy(); no operations valid
-};
-
 // Per-frame state surfaced to the caller of render() / begin_frame().
 // Layers should not depend on this directly — it's plumbing for the
 // application's frame loop (logging, stale-content detection, XR pose

--- a/src/viz/session/cpp/inc/viz/session/viz_compositor.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_compositor.hpp
@@ -73,6 +73,16 @@ private:
 
     void create_command_pool();
     void create_command_buffer();
+    void create_readback_staging();
+
+    // vkQueueSubmit wrapper that recovers the fence if submit fails.
+    // After frame_sync_->reset(), the fence is unsignaled; if the real
+    // submit then fails, the next frame_sync_->wait() would deadlock
+    // forever on UINT64_MAX. On submit failure we attempt an empty
+    // no-op submit so the fence gets signaled, converting "silent
+    // hang" into "throw on next call" — the caller can then destroy +
+    // recreate the session.
+    void submit_or_signal_fence(const VkSubmitInfo& info, const char* what);
 
     const VkContext* ctx_ = nullptr;
     Config config_{};
@@ -82,6 +92,14 @@ private:
 
     VkCommandPool command_pool_ = VK_NULL_HANDLE;
     VkCommandBuffer command_buffer_ = VK_NULL_HANDLE;
+
+    // Pre-allocated host-visible staging buffer for readback_to_host.
+    // Created once at init() (sized to the configured resolution),
+    // reused on every readback, freed in destroy(). Avoids per-call
+    // allocation churn and removes the leak-on-throw concern entirely.
+    VkBuffer readback_buffer_ = VK_NULL_HANDLE;
+    VkDeviceMemory readback_memory_ = VK_NULL_HANDLE;
+    VkDeviceSize readback_byte_size_ = 0;
 };
 
 } // namespace viz

--- a/src/viz/session/cpp/inc/viz/session/viz_compositor.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_compositor.hpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <viz/core/frame_sync.hpp>
+#include <viz/core/render_target.hpp>
+#include <viz/core/viz_types.hpp>
+#include <vulkan/vulkan.h>
+
+#include <memory>
+#include <vector>
+
+namespace viz
+{
+
+class LayerBase;
+class VkContext;
+
+// VizCompositor: the per-session GPU pipeline that runs one render pass
+// per frame. Owns the intermediate RenderTarget, command pool / buffer,
+// and FrameSync. Iterates a layer registry (held by VizSession) calling
+// each visible layer's record() inside the active render pass, then
+// submits to the queue.
+//
+// Lifetime: owned by VizSession. Created when the session moves from
+// kUninitialized to kReady; destroyed when the session is destroyed.
+class VizCompositor
+{
+public:
+    struct Config
+    {
+        Resolution resolution{};
+        VkClearColorValue clear_color{ { 0.0f, 0.0f, 0.0f, 1.0f } };
+    };
+
+    static std::unique_ptr<VizCompositor> create(const VkContext& ctx, const Config& config);
+
+    ~VizCompositor();
+    void destroy();
+
+    VizCompositor(const VizCompositor&) = delete;
+    VizCompositor& operator=(const VizCompositor&) = delete;
+    VizCompositor(VizCompositor&&) = delete;
+    VizCompositor& operator=(VizCompositor&&) = delete;
+
+    // Records and submits one frame. Iterates `layers` (insertion order),
+    // skipping invisible ones, calling layer->record() inside the active
+    // render pass. Blocks on the previous frame's fence before recording
+    // and on the new fence before returning (1-frame-in-flight today).
+    //
+    // Throws std::runtime_error on Vulkan failure.
+    void render(const std::vector<LayerBase*>& layers, const std::vector<ViewInfo>& views);
+
+    // Read the most recent frame's color attachment back to a host buffer.
+    // Returns tightly-packed RGBA8 bytes (width * height * 4). The session
+    // is expected to have called render() at least once; pixels are
+    // undefined otherwise. Used by tests / debug tooling — production
+    // (CUDA-pointer) readback lands with CUDA-Vulkan interop.
+    std::vector<uint8_t> readback_to_host();
+
+    // Accessors for layers / external code that needs to build pipelines
+    // against the compositor's render pass.
+    VkRenderPass render_pass() const noexcept;
+    Resolution resolution() const noexcept;
+
+private:
+    VizCompositor(const VkContext& ctx, const Config& config);
+    void init();
+
+    void create_command_pool();
+    void create_command_buffer();
+
+    const VkContext* ctx_ = nullptr;
+    Config config_{};
+
+    std::unique_ptr<RenderTarget> render_target_;
+    std::unique_ptr<FrameSync> frame_sync_;
+
+    VkCommandPool command_pool_ = VK_NULL_HANDLE;
+    VkCommandBuffer command_buffer_ = VK_NULL_HANDLE;
+};
+
+} // namespace viz

--- a/src/viz/session/cpp/inc/viz/session/viz_compositor.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_compositor.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <viz/core/frame_sync.hpp>
+#include <viz/core/host_image.hpp>
 #include <viz/core/render_target.hpp>
 #include <viz/core/viz_types.hpp>
 #include <vulkan/vulkan.h>
@@ -52,12 +53,14 @@ public:
     // Throws std::runtime_error on Vulkan failure.
     void render(const std::vector<LayerBase*>& layers, const std::vector<ViewInfo>& views);
 
-    // Read the most recent frame's color attachment back to a host buffer.
-    // Returns tightly-packed RGBA8 bytes (width * height * 4). The session
-    // is expected to have called render() at least once; pixels are
-    // undefined otherwise. Used by tests / debug tooling — production
-    // (CUDA-pointer) readback lands with CUDA-Vulkan interop.
-    std::vector<uint8_t> readback_to_host();
+    // Read the most recent frame's color attachment back to a host
+    // buffer. Returns a HostImage owning tightly-packed RGBA8 bytes;
+    // call HostImage::view() to obtain a VizBuffer view suitable for
+    // image helpers. The caller must have called render() at least
+    // once; pixels are undefined otherwise. Used by tests / debug
+    // tooling — production (CUDA-pointer) readback ships with
+    // CUDA-Vulkan interop.
+    HostImage readback_to_host();
 
     // Accessors for layers / external code that needs to build pipelines
     // against the compositor's render pass.

--- a/src/viz/session/cpp/inc/viz/session/viz_session.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_session.hpp
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <viz/core/host_image.hpp>
 #include <viz/core/viz_types.hpp>
 #include <viz/core/vk_context.hpp>
 #include <viz/layers/layer_base.hpp>
@@ -132,12 +133,14 @@ public:
         return timing_stats_;
     }
 
-    // Read the most recent composited frame as host-side RGBA8 bytes
-    // (width * height * 4). Defined in kOffscreen; throws in kWindow /
-    // kXr (use the swapchain present path there). Test / debug grade —
-    // the production CUDA-pointer readback returning a VizBuffer ships
-    // with CUDA-Vulkan interop.
-    std::vector<uint8_t> readback_to_host();
+    // Read the most recent composited frame as a host-side image.
+    // Returns a HostImage owning RGBA8 pixels; call HostImage::view()
+    // to get a VizBuffer (MemorySpace::kHost) for image helpers, or
+    // HostImage::data() for raw byte access. Defined in kOffscreen;
+    // throws in kWindow / kXr (use the swapchain present path there).
+    // Test / debug grade — the production CUDA-pointer readback
+    // returning a device-space VizBuffer ships with CUDA-Vulkan interop.
+    HostImage readback_to_host();
 
     // Vulkan handle accessors for external renderers and custom layers
     // that need to build pipelines against the compositor's render pass.

--- a/src/viz/session/cpp/inc/viz/session/viz_session.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_session.hpp
@@ -1,0 +1,156 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <viz/core/viz_types.hpp>
+#include <viz/core/vk_context.hpp>
+#include <viz/layers/layer_base.hpp>
+#include <viz/session/frame_info.hpp>
+#include <viz/session/viz_compositor.hpp>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace viz
+{
+
+// Display backend selection at session creation time.
+//
+// kOffscreen is the only mode implemented today; readback_to_host() is
+// the primary output. kWindow (GLFW) and kXr (OpenXR + CloudXR) ship
+// with the window-mode and XR-mode milestones respectively.
+enum class DisplayMode
+{
+    kOffscreen,
+    kWindow,
+    kXr,
+};
+
+// VizSession: the central object. Owns the Vulkan context, the
+// compositor, and the layer registry. One VizSession per display
+// surface (one window, one XR session, or one offscreen target).
+//
+// Frame loop, two API levels:
+//   - render() — convenience for "wait + composite + present" in one
+//     call. Returns the FrameInfo for the just-rendered frame.
+//   - begin_frame() / end_frame() — explicit pair for callers that need
+//     FrameInfo before submitting (e.g. to make per-frame decisions
+//     about what to render).
+//
+// State machine: kUninitialized -> kReady (after create) -> kRunning
+// (after first render/begin_frame) -> kDestroyed (after destroy).
+// XR-only states (kStopping, kLost) ship with the XR backend.
+class VizSession
+{
+public:
+    struct Config
+    {
+        DisplayMode mode = DisplayMode::kOffscreen;
+        uint32_t window_width = 1024;
+        uint32_t window_height = 1024;
+        std::string app_name = "televiz";
+
+        // Initial clear color for the framebuffer (RGBA, [0..1] each).
+        // Layers render on top of this. Defaults to opaque black.
+        float clear_color[4] = { 0.0f, 0.0f, 0.0f, 1.0f };
+
+        // Optional pre-built Vulkan context. If null, the session creates
+        // its own VkContext. Pass an externally-owned ctx (heap or static)
+        // when sharing the device with another component.
+        VkContext* external_context = nullptr;
+
+        // OpenXR instance extensions to enable beyond Televiz's required
+        // set. Used in kXr mode by the XR backend (no effect in
+        // kOffscreen / kWindow today).
+        std::vector<std::string> required_extensions;
+    };
+
+    static std::unique_ptr<VizSession> create(const Config& config);
+
+    ~VizSession();
+    void destroy();
+
+    VizSession(const VizSession&) = delete;
+    VizSession& operator=(const VizSession&) = delete;
+    VizSession(VizSession&&) = delete;
+    VizSession& operator=(VizSession&&) = delete;
+
+    // Layer management. Insertion order is render order. Returns a raw
+    // pointer to the layer for content updates / set_visible(). The
+    // session owns the layer's lifetime.
+    template <typename L, typename... Args>
+    L* add_layer(Args&&... args)
+    {
+        auto layer = std::make_unique<L>(std::forward<Args>(args)...);
+        L* raw = layer.get();
+        layers_.push_back(std::move(layer));
+        return raw;
+    }
+
+    // Removes a layer by pointer. No-op if `layer` is not registered.
+    void remove_layer(LayerBase* layer);
+
+    // Convenience frame loop: wait + composite + (in window/XR) present.
+    // Returns the FrameInfo for the just-rendered frame.
+    FrameInfo render();
+
+    // Explicit frame-loop pair. begin_frame returns FrameInfo for the
+    // upcoming frame; end_frame composites + presents. Application code
+    // can inspect FrameInfo (e.g. `should_render`, `views`) between
+    // begin_frame and end_frame to decide what to draw.
+    FrameInfo begin_frame();
+    void end_frame();
+
+    SessionState get_state() const noexcept
+    {
+        return state_;
+    }
+    Resolution get_recommended_resolution() const noexcept;
+    FrameTimingStats get_frame_timing_stats() const noexcept
+    {
+        return timing_stats_;
+    }
+
+    // Read the most recent composited frame as host-side RGBA8 bytes
+    // (width * height * 4). Defined in kOffscreen; throws in kWindow /
+    // kXr (use the swapchain present path there). Test / debug grade —
+    // the production CUDA-pointer readback returning a VizBuffer ships
+    // with CUDA-Vulkan interop.
+    std::vector<uint8_t> readback_to_host();
+
+    // Vulkan handle accessors for external renderers and custom layers
+    // that need to build pipelines against the compositor's render pass.
+    VkDevice get_vk_device() const noexcept;
+    VkPhysicalDevice get_vk_physical_device() const noexcept;
+    uint32_t get_vk_queue_family_index() const noexcept;
+    VkRenderPass get_render_pass() const noexcept;
+
+private:
+    explicit VizSession(const Config& config);
+    void init();
+
+    const VkContext& ctx() const noexcept;
+    void update_timing_stats(float frame_time_seconds);
+
+    Config config_{};
+
+    // Either we own a VkContext or we hold a borrowed pointer.
+    std::unique_ptr<VkContext> owned_ctx_;
+    VkContext* ctx_ptr_ = nullptr;
+
+    std::unique_ptr<VizCompositor> compositor_;
+    std::vector<std::unique_ptr<LayerBase>> layers_;
+
+    SessionState state_ = SessionState::kUninitialized;
+    uint64_t frame_index_ = 0;
+    std::chrono::steady_clock::time_point last_frame_time_{};
+    bool first_frame_ = true;
+    FrameInfo current_frame_info_{};
+    FrameTimingStats timing_stats_{};
+};
+
+} // namespace viz

--- a/src/viz/session/cpp/inc/viz/session/viz_session.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_session.hpp
@@ -30,6 +30,23 @@ enum class DisplayMode
     kXr,
 };
 
+// Lifecycle states for a VizSession. The full set covers XR; window /
+// offscreen modes only transition through:
+//   kUninitialized -> kReady -> kRunning -> kDestroyed
+//
+// XR adds kStopping (session stopping per OpenXR runtime) and kLost
+// (session lost — must destroy and recreate). See the design doc for
+// the full OpenXR-state-to-VizSession-state mapping.
+enum class SessionState
+{
+    kUninitialized, // Before create()
+    kReady, // Vulkan + display initialized; layers can be added
+    kRunning, // Frame loop active
+    kStopping, // XR only: session is stopping; end_frame submits empty
+    kLost, // XR only: session lost; must destroy and recreate
+    kDestroyed, // After destroy(); no operations valid
+};
+
 // VizSession: the central object. Owns the Vulkan context, the
 // compositor, and the layer registry. One VizSession per display
 // surface (one window, one XR session, or one offscreen target).

--- a/src/viz/session/cpp/inc/viz/session/viz_session.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_session.hpp
@@ -100,6 +100,13 @@ public:
     // Layer management. Insertion order is render order. Returns a raw
     // pointer to the layer for content updates / set_visible(). The
     // session owns the layer's lifetime.
+    //
+    // Threading: add_layer / remove_layer must be called from the same
+    // thread that drives the frame loop (render() / begin_frame() /
+    // end_frame()). Concurrent or re-entrant mutation during a frame
+    // (including from inside a layer's record() callback) is undefined
+    // behavior. The only thread-safe layer mutation is
+    // LayerBase::set_visible(), which uses an atomic flag.
     template <typename L, typename... Args>
     L* add_layer(Args&&... args)
     {
@@ -110,6 +117,7 @@ public:
     }
 
     // Removes a layer by pointer. No-op if `layer` is not registered.
+    // See add_layer for threading contract.
     void remove_layer(LayerBase* layer);
 
     // Convenience frame loop: wait + composite + (in window/XR) present.
@@ -169,6 +177,7 @@ private:
     uint64_t frame_index_ = 0;
     std::chrono::steady_clock::time_point last_frame_time_{};
     bool first_frame_ = true;
+    bool frame_in_progress_ = false;
     FrameInfo current_frame_info_{};
     FrameTimingStats timing_stats_{};
 };

--- a/src/viz/session/cpp/viz_compositor.cpp
+++ b/src/viz/session/cpp/viz_compositor.cpp
@@ -126,7 +126,6 @@ void VizCompositor::render(const std::vector<LayerBase*>& layers, const std::vec
     // Wait for the previous frame's GPU work to complete before reusing
     // the command buffer / fence (1 frame in flight today).
     frame_sync_->wait();
-    frame_sync_->reset();
 
     check_vk(vkResetCommandBuffer(command_buffer_, 0), "vkResetCommandBuffer");
 
@@ -161,6 +160,12 @@ void VizCompositor::render(const std::vector<LayerBase*>& layers, const std::vec
 
     vkCmdEndRenderPass(command_buffer_);
     check_vk(vkEndCommandBuffer(command_buffer_), "vkEndCommandBuffer");
+
+    // Reset the fence immediately before submit. If anything between
+    // wait() and here threw (a layer's record(), a Vulkan API failure
+    // during recording), the fence stays signaled from the previous
+    // frame and the next render() doesn't deadlock on wait().
+    frame_sync_->reset();
 
     VkSubmitInfo submit{};
     submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;

--- a/src/viz/session/cpp/viz_compositor.cpp
+++ b/src/viz/session/cpp/viz_compositor.cpp
@@ -175,7 +175,7 @@ void VizCompositor::render(const std::vector<LayerBase*>& layers, const std::vec
     frame_sync_->wait();
 }
 
-std::vector<uint8_t> VizCompositor::readback_to_host()
+HostImage VizCompositor::readback_to_host()
 {
     const uint32_t w = config_.resolution.width;
     const uint32_t h = config_.resolution.height;
@@ -233,7 +233,7 @@ std::vector<uint8_t> VizCompositor::readback_to_host()
     check_vk(vkQueueSubmit(ctx_->queue(), 1, &submit, frame_sync_->in_flight_fence()), "vkQueueSubmit(readback)");
     frame_sync_->wait();
 
-    std::vector<uint8_t> result(byte_size);
+    HostImage result(config_.resolution, PixelFormat::kRGBA8);
     void* mapped = nullptr;
     check_vk(vkMapMemory(ctx_->device(), memory, 0, byte_size, 0, &mapped), "vkMapMemory(staging)");
     std::memcpy(result.data(), mapped, byte_size);

--- a/src/viz/session/cpp/viz_compositor.cpp
+++ b/src/viz/session/cpp/viz_compositor.cpp
@@ -72,6 +72,7 @@ void VizCompositor::init()
         frame_sync_ = FrameSync::create(*ctx_);
         create_command_pool();
         create_command_buffer();
+        create_readback_staging();
     }
     catch (...)
     {
@@ -91,6 +92,17 @@ void VizCompositor::destroy()
     {
         return;
     }
+    if (readback_buffer_ != VK_NULL_HANDLE)
+    {
+        vkDestroyBuffer(device, readback_buffer_, nullptr);
+        readback_buffer_ = VK_NULL_HANDLE;
+    }
+    if (readback_memory_ != VK_NULL_HANDLE)
+    {
+        vkFreeMemory(device, readback_memory_, nullptr);
+        readback_memory_ = VK_NULL_HANDLE;
+    }
+    readback_byte_size_ = 0;
     if (command_pool_ != VK_NULL_HANDLE)
     {
         // Pool destruction frees all command buffers allocated from it.
@@ -119,6 +131,52 @@ void VizCompositor::create_command_buffer()
     info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
     info.commandBufferCount = 1;
     check_vk(vkAllocateCommandBuffers(ctx_->device(), &info, &command_buffer_), "vkAllocateCommandBuffers");
+}
+
+void VizCompositor::create_readback_staging()
+{
+    // Sized to one tightly-packed RGBA8 frame at the configured
+    // resolution. destroy() owns cleanup; readback_to_host() never
+    // allocates per call.
+    readback_byte_size_ = static_cast<VkDeviceSize>(config_.resolution.width) * config_.resolution.height *
+                          bytes_per_pixel(PixelFormat::kRGBA8);
+
+    VkBufferCreateInfo bi{};
+    bi.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bi.size = readback_byte_size_;
+    bi.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    check_vk(vkCreateBuffer(ctx_->device(), &bi, nullptr, &readback_buffer_), "vkCreateBuffer(readback staging)");
+
+    VkMemoryRequirements reqs;
+    vkGetBufferMemoryRequirements(ctx_->device(), readback_buffer_, &reqs);
+
+    VkMemoryAllocateInfo ai{};
+    ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    ai.allocationSize = reqs.size;
+    ai.memoryTypeIndex = find_memory_type(ctx_->physical_device(), reqs.memoryTypeBits,
+                                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    check_vk(vkAllocateMemory(ctx_->device(), &ai, nullptr, &readback_memory_), "vkAllocateMemory(readback staging)");
+    check_vk(vkBindBufferMemory(ctx_->device(), readback_buffer_, readback_memory_, 0),
+             "vkBindBufferMemory(readback staging)");
+}
+
+void VizCompositor::submit_or_signal_fence(const VkSubmitInfo& info, const char* what)
+{
+    const VkResult r = vkQueueSubmit(ctx_->queue(), 1, &info, frame_sync_->in_flight_fence());
+    if (r == VK_SUCCESS)
+    {
+        return;
+    }
+    // Real submit failed; the fence is still unsignaled. Best-effort
+    // signal it via an empty no-op submit so the next wait() throws
+    // (or returns) instead of deadlocking on UINT64_MAX. If this also
+    // fails the original error still propagates and the caller should
+    // destroy + recreate the session.
+    VkSubmitInfo empty{};
+    empty.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    (void)vkQueueSubmit(ctx_->queue(), 1, &empty, frame_sync_->in_flight_fence());
+    throw std::runtime_error(std::string("VizCompositor: ") + what + " failed: VkResult=" + std::to_string(r));
 }
 
 void VizCompositor::render(const std::vector<LayerBase*>& layers, const std::vector<ViewInfo>& views)
@@ -171,7 +229,7 @@ void VizCompositor::render(const std::vector<LayerBase*>& layers, const std::vec
     submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submit.commandBufferCount = 1;
     submit.pCommandBuffers = &command_buffer_;
-    check_vk(vkQueueSubmit(ctx_->queue(), 1, &submit, frame_sync_->in_flight_fence()), "vkQueueSubmit");
+    submit_or_signal_fence(submit, "vkQueueSubmit");
 
     // Wait for completion before returning so readback / next frame sees
     // a consistent state. With 1 frame in flight this is the natural
@@ -182,32 +240,11 @@ void VizCompositor::render(const std::vector<LayerBase*>& layers, const std::vec
 
 HostImage VizCompositor::readback_to_host()
 {
+    // Reuses the staging buffer allocated at init() — no per-call alloc,
+    // no cleanup-on-throw concerns. Buffer lifetime tracks the
+    // compositor's; destroy() frees it.
     const uint32_t w = config_.resolution.width;
     const uint32_t h = config_.resolution.height;
-    const VkDeviceSize byte_size = static_cast<VkDeviceSize>(w) * h * 4;
-
-    // Host-visible staging buffer. Allocated each call — readback is a
-    // test-grade path; production (CUDA-pointer) readback lands with
-    // CUDA-Vulkan interop and avoids the host bounce entirely.
-    VkBufferCreateInfo bi{};
-    bi.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    bi.size = byte_size;
-    bi.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkBuffer buffer = VK_NULL_HANDLE;
-    check_vk(vkCreateBuffer(ctx_->device(), &bi, nullptr, &buffer), "vkCreateBuffer(staging)");
-
-    VkMemoryRequirements reqs;
-    vkGetBufferMemoryRequirements(ctx_->device(), buffer, &reqs);
-
-    VkMemoryAllocateInfo ai{};
-    ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
-    ai.allocationSize = reqs.size;
-    ai.memoryTypeIndex = find_memory_type(ctx_->physical_device(), reqs.memoryTypeBits,
-                                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDeviceMemory memory = VK_NULL_HANDLE;
-    check_vk(vkAllocateMemory(ctx_->device(), &ai, nullptr, &memory), "vkAllocateMemory(staging)");
-    check_vk(vkBindBufferMemory(ctx_->device(), buffer, memory, 0), "vkBindBufferMemory(staging)");
 
     // Record + submit a single copy. The render pass already transitioned
     // the color image to TRANSFER_SRC_OPTIMAL, so no barrier is needed.
@@ -225,8 +262,8 @@ HostImage VizCompositor::readback_to_host()
     region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     region.imageSubresource.layerCount = 1;
     region.imageExtent = { w, h, 1 };
-    vkCmdCopyImageToBuffer(
-        command_buffer_, render_target_->color_image(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buffer, 1, &region);
+    vkCmdCopyImageToBuffer(command_buffer_, render_target_->color_image(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                           readback_buffer_, 1, &region);
 
     check_vk(vkEndCommandBuffer(command_buffer_), "vkEndCommandBuffer(readback)");
 
@@ -235,17 +272,15 @@ HostImage VizCompositor::readback_to_host()
     submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
     submit.commandBufferCount = 1;
     submit.pCommandBuffers = &command_buffer_;
-    check_vk(vkQueueSubmit(ctx_->queue(), 1, &submit, frame_sync_->in_flight_fence()), "vkQueueSubmit(readback)");
+    submit_or_signal_fence(submit, "vkQueueSubmit(readback)");
     frame_sync_->wait();
 
     HostImage result(config_.resolution, PixelFormat::kRGBA8);
     void* mapped = nullptr;
-    check_vk(vkMapMemory(ctx_->device(), memory, 0, byte_size, 0, &mapped), "vkMapMemory(staging)");
-    std::memcpy(result.data(), mapped, byte_size);
-    vkUnmapMemory(ctx_->device(), memory);
+    check_vk(vkMapMemory(ctx_->device(), readback_memory_, 0, readback_byte_size_, 0, &mapped), "vkMapMemory(readback)");
+    std::memcpy(result.data(), mapped, readback_byte_size_);
+    vkUnmapMemory(ctx_->device(), readback_memory_);
 
-    vkDestroyBuffer(ctx_->device(), buffer, nullptr);
-    vkFreeMemory(ctx_->device(), memory, nullptr);
     return result;
 }
 

--- a/src/viz/session/cpp/viz_compositor.cpp
+++ b/src/viz/session/cpp/viz_compositor.cpp
@@ -1,0 +1,257 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <viz/core/vk_context.hpp>
+#include <viz/layers/layer_base.hpp>
+#include <viz/session/viz_compositor.hpp>
+
+#include <array>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+namespace viz
+{
+
+namespace
+{
+
+void check_vk(VkResult result, const char* what)
+{
+    if (result != VK_SUCCESS)
+    {
+        throw std::runtime_error(std::string("VizCompositor: ") + what + " failed: VkResult=" + std::to_string(result));
+    }
+}
+
+uint32_t find_memory_type(VkPhysicalDevice physical_device, uint32_t type_bits, VkMemoryPropertyFlags properties)
+{
+    VkPhysicalDeviceMemoryProperties mem_props;
+    vkGetPhysicalDeviceMemoryProperties(physical_device, &mem_props);
+    for (uint32_t i = 0; i < mem_props.memoryTypeCount; ++i)
+    {
+        if ((type_bits & (1u << i)) != 0 && (mem_props.memoryTypes[i].propertyFlags & properties) == properties)
+        {
+            return i;
+        }
+    }
+    throw std::runtime_error("VizCompositor: no memory type matches readback requirements");
+}
+
+} // namespace
+
+std::unique_ptr<VizCompositor> VizCompositor::create(const VkContext& ctx, const Config& config)
+{
+    if (!ctx.is_initialized())
+    {
+        throw std::invalid_argument("VizCompositor: VkContext is not initialized");
+    }
+    if (config.resolution.width == 0 || config.resolution.height == 0)
+    {
+        throw std::invalid_argument("VizCompositor: resolution must be non-zero");
+    }
+    std::unique_ptr<VizCompositor> c(new VizCompositor(ctx, config));
+    c->init();
+    return c;
+}
+
+VizCompositor::VizCompositor(const VkContext& ctx, const Config& config) : ctx_(&ctx), config_(config)
+{
+}
+
+VizCompositor::~VizCompositor()
+{
+    destroy();
+}
+
+void VizCompositor::init()
+{
+    try
+    {
+        render_target_ = RenderTarget::create(*ctx_, RenderTarget::Config{ config_.resolution });
+        frame_sync_ = FrameSync::create(*ctx_);
+        create_command_pool();
+        create_command_buffer();
+    }
+    catch (...)
+    {
+        destroy();
+        throw;
+    }
+}
+
+void VizCompositor::destroy()
+{
+    if (ctx_ == nullptr)
+    {
+        return;
+    }
+    const VkDevice device = ctx_->device();
+    if (device == VK_NULL_HANDLE)
+    {
+        return;
+    }
+    if (command_pool_ != VK_NULL_HANDLE)
+    {
+        // Pool destruction frees all command buffers allocated from it.
+        vkDestroyCommandPool(device, command_pool_, nullptr);
+        command_pool_ = VK_NULL_HANDLE;
+        command_buffer_ = VK_NULL_HANDLE;
+    }
+    frame_sync_.reset();
+    render_target_.reset();
+}
+
+void VizCompositor::create_command_pool()
+{
+    VkCommandPoolCreateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    info.queueFamilyIndex = ctx_->queue_family_index();
+    check_vk(vkCreateCommandPool(ctx_->device(), &info, nullptr, &command_pool_), "vkCreateCommandPool");
+}
+
+void VizCompositor::create_command_buffer()
+{
+    VkCommandBufferAllocateInfo info{};
+    info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    info.commandPool = command_pool_;
+    info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    info.commandBufferCount = 1;
+    check_vk(vkAllocateCommandBuffers(ctx_->device(), &info, &command_buffer_), "vkAllocateCommandBuffers");
+}
+
+void VizCompositor::render(const std::vector<LayerBase*>& layers, const std::vector<ViewInfo>& views)
+{
+    // Wait for the previous frame's GPU work to complete before reusing
+    // the command buffer / fence (1 frame in flight today).
+    frame_sync_->wait();
+    frame_sync_->reset();
+
+    check_vk(vkResetCommandBuffer(command_buffer_, 0), "vkResetCommandBuffer");
+
+    VkCommandBufferBeginInfo begin{};
+    begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    check_vk(vkBeginCommandBuffer(command_buffer_, &begin), "vkBeginCommandBuffer");
+
+    std::array<VkClearValue, 2> clears{};
+    clears[0].color = config_.clear_color;
+    clears[1].depthStencil = { 1.0f, 0 };
+
+    VkRenderPassBeginInfo rp{};
+    rp.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+    rp.renderPass = render_target_->render_pass();
+    rp.framebuffer = render_target_->framebuffer();
+    rp.renderArea.offset = { 0, 0 };
+    rp.renderArea.extent = { config_.resolution.width, config_.resolution.height };
+    rp.clearValueCount = static_cast<uint32_t>(clears.size());
+    rp.pClearValues = clears.data();
+
+    vkCmdBeginRenderPass(command_buffer_, &rp, VK_SUBPASS_CONTENTS_INLINE);
+
+    // Layer dispatch: insertion order; skip invisible.
+    for (LayerBase* layer : layers)
+    {
+        if (layer != nullptr && layer->is_visible())
+        {
+            layer->record(command_buffer_, views, *render_target_);
+        }
+    }
+
+    vkCmdEndRenderPass(command_buffer_);
+    check_vk(vkEndCommandBuffer(command_buffer_), "vkEndCommandBuffer");
+
+    VkSubmitInfo submit{};
+    submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &command_buffer_;
+    check_vk(vkQueueSubmit(ctx_->queue(), 1, &submit, frame_sync_->in_flight_fence()), "vkQueueSubmit");
+
+    // Wait for completion before returning so readback / next frame sees
+    // a consistent state. With 1 frame in flight this is the natural
+    // synchronization point; multi-buffered swapchain rendering moves
+    // this wait to the start of the next frame.
+    frame_sync_->wait();
+}
+
+std::vector<uint8_t> VizCompositor::readback_to_host()
+{
+    const uint32_t w = config_.resolution.width;
+    const uint32_t h = config_.resolution.height;
+    const VkDeviceSize byte_size = static_cast<VkDeviceSize>(w) * h * 4;
+
+    // Host-visible staging buffer. Allocated each call — readback is a
+    // test-grade path; production (CUDA-pointer) readback lands with
+    // CUDA-Vulkan interop and avoids the host bounce entirely.
+    VkBufferCreateInfo bi{};
+    bi.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    bi.size = byte_size;
+    bi.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    bi.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    VkBuffer buffer = VK_NULL_HANDLE;
+    check_vk(vkCreateBuffer(ctx_->device(), &bi, nullptr, &buffer), "vkCreateBuffer(staging)");
+
+    VkMemoryRequirements reqs;
+    vkGetBufferMemoryRequirements(ctx_->device(), buffer, &reqs);
+
+    VkMemoryAllocateInfo ai{};
+    ai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    ai.allocationSize = reqs.size;
+    ai.memoryTypeIndex = find_memory_type(ctx_->physical_device(), reqs.memoryTypeBits,
+                                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    VkDeviceMemory memory = VK_NULL_HANDLE;
+    check_vk(vkAllocateMemory(ctx_->device(), &ai, nullptr, &memory), "vkAllocateMemory(staging)");
+    check_vk(vkBindBufferMemory(ctx_->device(), buffer, memory, 0), "vkBindBufferMemory(staging)");
+
+    // Record + submit a single copy. The render pass already transitioned
+    // the color image to TRANSFER_SRC_OPTIMAL, so no barrier is needed.
+    check_vk(vkResetCommandBuffer(command_buffer_, 0), "vkResetCommandBuffer(readback)");
+
+    VkCommandBufferBeginInfo begin{};
+    begin.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+    begin.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
+    check_vk(vkBeginCommandBuffer(command_buffer_, &begin), "vkBeginCommandBuffer(readback)");
+
+    VkBufferImageCopy region{};
+    region.bufferOffset = 0;
+    region.bufferRowLength = 0;
+    region.bufferImageHeight = 0;
+    region.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    region.imageSubresource.layerCount = 1;
+    region.imageExtent = { w, h, 1 };
+    vkCmdCopyImageToBuffer(
+        command_buffer_, render_target_->color_image(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buffer, 1, &region);
+
+    check_vk(vkEndCommandBuffer(command_buffer_), "vkEndCommandBuffer(readback)");
+
+    frame_sync_->reset();
+    VkSubmitInfo submit{};
+    submit.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+    submit.commandBufferCount = 1;
+    submit.pCommandBuffers = &command_buffer_;
+    check_vk(vkQueueSubmit(ctx_->queue(), 1, &submit, frame_sync_->in_flight_fence()), "vkQueueSubmit(readback)");
+    frame_sync_->wait();
+
+    std::vector<uint8_t> result(byte_size);
+    void* mapped = nullptr;
+    check_vk(vkMapMemory(ctx_->device(), memory, 0, byte_size, 0, &mapped), "vkMapMemory(staging)");
+    std::memcpy(result.data(), mapped, byte_size);
+    vkUnmapMemory(ctx_->device(), memory);
+
+    vkDestroyBuffer(ctx_->device(), buffer, nullptr);
+    vkFreeMemory(ctx_->device(), memory, nullptr);
+    return result;
+}
+
+VkRenderPass VizCompositor::render_pass() const noexcept
+{
+    return render_target_ ? render_target_->render_pass() : VK_NULL_HANDLE;
+}
+
+Resolution VizCompositor::resolution() const noexcept
+{
+    return config_.resolution;
+}
+
+} // namespace viz

--- a/src/viz/session/cpp/viz_session.cpp
+++ b/src/viz/session/cpp/viz_session.cpp
@@ -193,7 +193,7 @@ Resolution VizSession::get_recommended_resolution() const noexcept
     return compositor_ ? compositor_->resolution() : Resolution{ config_.window_width, config_.window_height };
 }
 
-std::vector<uint8_t> VizSession::readback_to_host()
+HostImage VizSession::readback_to_host()
 {
     check_offscreen_only(config_.mode, "readback_to_host");
     if (!compositor_)

--- a/src/viz/session/cpp/viz_session.cpp
+++ b/src/viz/session/cpp/viz_session.cpp
@@ -1,0 +1,231 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <viz/session/viz_session.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace viz
+{
+
+namespace
+{
+
+void check_offscreen_only(DisplayMode mode, const char* what)
+{
+    if (mode != DisplayMode::kOffscreen)
+    {
+        throw std::runtime_error(std::string("VizSession: ") + what +
+                                 " is not implemented for the requested DisplayMode "
+                                 "(only kOffscreen ships in this milestone; "
+                                 "kWindow / kXr arrive with their respective backends)");
+    }
+}
+
+} // namespace
+
+std::unique_ptr<VizSession> VizSession::create(const Config& config)
+{
+    if (config.window_width == 0 || config.window_height == 0)
+    {
+        throw std::invalid_argument("VizSession: window dimensions must be non-zero");
+    }
+    std::unique_ptr<VizSession> s(new VizSession(config));
+    s->init();
+    return s;
+}
+
+VizSession::VizSession(const Config& config) : config_(config)
+{
+}
+
+VizSession::~VizSession()
+{
+    destroy();
+}
+
+void VizSession::init()
+{
+    try
+    {
+        // Acquire / create the Vulkan context.
+        if (config_.external_context != nullptr)
+        {
+            if (!config_.external_context->is_initialized())
+            {
+                throw std::invalid_argument("VizSession: external_context is not initialized");
+            }
+            ctx_ptr_ = config_.external_context;
+        }
+        else
+        {
+            owned_ctx_ = std::make_unique<VkContext>();
+            owned_ctx_->init(VkContext::Config{});
+            ctx_ptr_ = owned_ctx_.get();
+        }
+
+        // Compositor (kOffscreen only; window/XR backends add display targets).
+        check_offscreen_only(config_.mode, "create");
+
+        VizCompositor::Config c_cfg{};
+        c_cfg.resolution = { config_.window_width, config_.window_height };
+        c_cfg.clear_color = { { config_.clear_color[0], config_.clear_color[1], config_.clear_color[2],
+                                config_.clear_color[3] } };
+        compositor_ = VizCompositor::create(*ctx_ptr_, c_cfg);
+
+        state_ = SessionState::kReady;
+    }
+    catch (...)
+    {
+        destroy();
+        throw;
+    }
+}
+
+void VizSession::destroy()
+{
+    layers_.clear();
+    compositor_.reset();
+    if (owned_ctx_)
+    {
+        owned_ctx_.reset();
+    }
+    ctx_ptr_ = nullptr;
+    state_ = SessionState::kDestroyed;
+}
+
+void VizSession::remove_layer(LayerBase* layer)
+{
+    if (layer == nullptr)
+    {
+        return;
+    }
+    auto it = std::remove_if(
+        layers_.begin(), layers_.end(), [layer](const std::unique_ptr<LayerBase>& p) { return p.get() == layer; });
+    layers_.erase(it, layers_.end());
+}
+
+FrameInfo VizSession::begin_frame()
+{
+    if (state_ == SessionState::kDestroyed || state_ == SessionState::kLost)
+    {
+        throw std::runtime_error("VizSession: begin_frame called on destroyed/lost session");
+    }
+    if (state_ == SessionState::kReady)
+    {
+        state_ = SessionState::kRunning;
+    }
+
+    const auto now = std::chrono::steady_clock::now();
+    if (first_frame_)
+    {
+        current_frame_info_.delta_time = 0.0f;
+        first_frame_ = false;
+    }
+    else
+    {
+        current_frame_info_.delta_time = std::chrono::duration<float>(now - last_frame_time_).count();
+    }
+    last_frame_time_ = now;
+
+    current_frame_info_.frame_index = frame_index_;
+    current_frame_info_.predicted_display_time = 0; // XR-only; 0 in offscreen
+    current_frame_info_.should_render = (state_ == SessionState::kRunning);
+    current_frame_info_.resolution = compositor_->resolution();
+    // Single identity view in window/offscreen; XR backend extends to per-eye.
+    current_frame_info_.views.assign(1, ViewInfo{});
+
+    return current_frame_info_;
+}
+
+void VizSession::end_frame()
+{
+    if (state_ != SessionState::kRunning)
+    {
+        // No-op in non-running states (matches the design: kStopping
+        // submits an empty frame; kReady never enters end_frame).
+        return;
+    }
+
+    // Build a raw-pointer view of the layer registry for the compositor —
+    // avoids forcing the compositor to know about std::unique_ptr.
+    std::vector<LayerBase*> raw_layers;
+    raw_layers.reserve(layers_.size());
+    for (const auto& l : layers_)
+    {
+        raw_layers.push_back(l.get());
+    }
+
+    if (current_frame_info_.should_render)
+    {
+        compositor_->render(raw_layers, current_frame_info_.views);
+    }
+
+    update_timing_stats(current_frame_info_.delta_time);
+    ++frame_index_;
+}
+
+FrameInfo VizSession::render()
+{
+    auto info = begin_frame();
+    end_frame();
+    return info;
+}
+
+void VizSession::update_timing_stats(float frame_time_seconds)
+{
+    if (frame_time_seconds <= 0.0f)
+    {
+        return;
+    }
+    // Simple exponential moving average; full FPS smoothing arrives with
+    // the window/XR backends' real frame pacing.
+    constexpr float kSmoothing = 0.1f;
+    const float frame_ms = frame_time_seconds * 1000.0f;
+    timing_stats_.avg_frame_time_ms = kSmoothing * frame_ms + (1.0f - kSmoothing) * timing_stats_.avg_frame_time_ms;
+    timing_stats_.render_fps =
+        (timing_stats_.avg_frame_time_ms > 0.0f) ? 1000.0f / timing_stats_.avg_frame_time_ms : 0.0f;
+}
+
+Resolution VizSession::get_recommended_resolution() const noexcept
+{
+    return compositor_ ? compositor_->resolution() : Resolution{ config_.window_width, config_.window_height };
+}
+
+std::vector<uint8_t> VizSession::readback_to_host()
+{
+    check_offscreen_only(config_.mode, "readback_to_host");
+    if (!compositor_)
+    {
+        throw std::runtime_error("VizSession: readback_to_host called before init");
+    }
+    return compositor_->readback_to_host();
+}
+
+const VkContext& VizSession::ctx() const noexcept
+{
+    return *ctx_ptr_;
+}
+
+VkDevice VizSession::get_vk_device() const noexcept
+{
+    return ctx_ptr_ ? ctx_ptr_->device() : VK_NULL_HANDLE;
+}
+
+VkPhysicalDevice VizSession::get_vk_physical_device() const noexcept
+{
+    return ctx_ptr_ ? ctx_ptr_->physical_device() : VK_NULL_HANDLE;
+}
+
+uint32_t VizSession::get_vk_queue_family_index() const noexcept
+{
+    return ctx_ptr_ ? ctx_ptr_->queue_family_index() : UINT32_MAX;
+}
+
+VkRenderPass VizSession::get_render_pass() const noexcept
+{
+    return compositor_ ? compositor_->render_pass() : VK_NULL_HANDLE;
+}
+
+} // namespace viz

--- a/src/viz/session/cpp/viz_session.cpp
+++ b/src/viz/session/cpp/viz_session.cpp
@@ -47,6 +47,11 @@ VizSession::~VizSession()
 
 void VizSession::init()
 {
+    // Reject unsupported display modes before allocating any Vulkan
+    // state — saves a wasted vkCreateInstance + device on a config we
+    // know we can't support yet.
+    check_offscreen_only(config_.mode, "create");
+
     try
     {
         // Acquire / create the Vulkan context.
@@ -65,8 +70,6 @@ void VizSession::init()
             ctx_ptr_ = owned_ctx_.get();
         }
 
-        // Compositor (kOffscreen only; window/XR backends add display targets).
-        check_offscreen_only(config_.mode, "create");
 
         VizCompositor::Config c_cfg{};
         c_cfg.resolution = { config_.window_width, config_.window_height };
@@ -112,6 +115,12 @@ FrameInfo VizSession::begin_frame()
     {
         throw std::runtime_error("VizSession: begin_frame called on destroyed/lost session");
     }
+    if (frame_in_progress_)
+    {
+        throw std::logic_error(
+            "VizSession: begin_frame called while a frame is already in "
+            "progress (missing end_frame for previous begin_frame)");
+    }
     if (state_ == SessionState::kReady)
     {
         state_ = SessionState::kRunning;
@@ -136,17 +145,39 @@ FrameInfo VizSession::begin_frame()
     // Single identity view in window/offscreen; XR backend extends to per-eye.
     current_frame_info_.views.assign(1, ViewInfo{});
 
+    // Set last so any earlier throw leaves the flag false and the next
+    // begin_frame() can proceed normally.
+    frame_in_progress_ = true;
+
     return current_frame_info_;
 }
 
 void VizSession::end_frame()
 {
+    if (!frame_in_progress_)
+    {
+        throw std::logic_error("VizSession: end_frame called without a matching begin_frame");
+    }
     if (state_ != SessionState::kRunning)
     {
         // No-op in non-running states (matches the design: kStopping
         // submits an empty frame; kReady never enters end_frame).
+        // Still clear the in-progress flag so the pairing contract holds.
+        frame_in_progress_ = false;
         return;
     }
+
+    // Always clear the in-progress flag, even if the render call below
+    // throws — leaving it true would lock out all subsequent begin_frame()
+    // calls for the rest of the session.
+    struct ClearGuard
+    {
+        bool* flag;
+        ~ClearGuard()
+        {
+            *flag = false;
+        }
+    } guard{ &frame_in_progress_ };
 
     // Build a raw-pointer view of the layer registry for the compositor —
     // avoids forcing the compositor to know about std::unique_ptr.

--- a/src/viz/session_tests/CMakeLists.txt
+++ b/src/viz/session_tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+# Build C++ tests
+add_subdirectory(cpp)

--- a/src/viz/session_tests/cpp/CMakeLists.txt
+++ b/src/viz/session_tests/cpp/CMakeLists.txt
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+add_executable(viz_session_tests
+    test_offscreen_render.cpp
+    test_viz_session.cpp
+)
+
+target_link_libraries(viz_session_tests PRIVATE
+    viz::session
+    viz::layers_testing
+    Catch2::Catch2WithMain
+)
+
+message(STATUS "viz_session_tests target enabled with Catch2")
+
+catch_discover_tests(viz_session_tests ADD_TAGS_AS_LABELS)

--- a/src/viz/session_tests/cpp/test_offscreen_render.cpp
+++ b/src/viz/session_tests/cpp/test_offscreen_render.cpp
@@ -15,14 +15,17 @@
 #include <viz/core/host_image.hpp>
 #include <viz/core/vk_context.hpp>
 #include <viz/layers/testing/clear_rect_layer.hpp>
+#include <viz/layers/testing/throwing_layer.hpp>
 #include <viz/session/viz_session.hpp>
 
 #include <cstdint>
+#include <stdexcept>
 
 using viz::DisplayMode;
 using viz::HostImage;
 using viz::VizSession;
 using viz::testing::ClearRectLayer;
+using viz::testing::ThrowingLayer;
 
 namespace
 {
@@ -195,6 +198,79 @@ TEST_CASE("Multiple frames advance frame_index and avoid leaking sync state", "[
         const auto info = session->render();
         CHECK(info.frame_index == i);
     }
+}
+
+TEST_CASE("Session recovers from a layer that throws and renders the next frame", "[gpu][viz_session]")
+{
+    if (!gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    constexpr uint32_t kSide = 32;
+
+    VizSession::Config cfg{};
+    cfg.window_width = kSide;
+    cfg.window_height = kSide;
+    cfg.clear_color[0] = 0.0f;
+    cfg.clear_color[1] = 0.0f;
+    cfg.clear_color[2] = 1.0f; // blue
+    cfg.clear_color[3] = 1.0f;
+
+    auto session = VizSession::create(cfg);
+    auto* thrower = session->add_layer<ThrowingLayer>(ThrowingLayer::Config{ 0, "boom" });
+
+    // First render: layer throws, render() should propagate but leave
+    // the session usable. If the fence reset happens before this throw
+    // (the bug we fixed), the next render() would deadlock on wait().
+    CHECK_THROWS_AS(session->render(), std::runtime_error);
+    CHECK(thrower->call_count() == 1);
+
+    // Disable the throwing layer and render again. Must NOT deadlock
+    // and must produce the configured clear color.
+    thrower->set_visible(false);
+    CHECK_NOTHROW(session->render());
+
+    auto image = session->readback_to_host();
+    const uint8_t* center = image.data() + (kSide * (kSide / 2) + kSide / 2) * 4;
+    CHECK(center[0] == 0); // R
+    CHECK(center[1] == 0); // G
+    CHECK(center[2] == 255); // B (blue)
+    CHECK(center[3] == 255); // A
+}
+
+TEST_CASE("Layer that throws does not corrupt the layer registry", "[gpu][viz_session]")
+{
+    if (!gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    VizSession::Config cfg{};
+    cfg.window_width = 32;
+    cfg.window_height = 32;
+    auto session = VizSession::create(cfg);
+
+    // Three layers; the middle one throws on the 2nd record() call.
+    auto* a = session->add_layer<ClearRectLayer>(ClearRectLayer::Config{ 0, 0, 32, 32, { 1, 0, 0, 1 }, "A" });
+    auto* mid = session->add_layer<ThrowingLayer>(ThrowingLayer::Config{ 1, "mid-boom", "M" });
+    auto* c = session->add_layer<ClearRectLayer>(ClearRectLayer::Config{ 0, 0, 32, 32, { 0, 1, 0, 1 }, "C" });
+    REQUIRE(a != nullptr);
+    REQUIRE(mid != nullptr);
+    REQUIRE(c != nullptr);
+
+    // First frame: all three layers run successfully (M's throw_after = 1).
+    CHECK_NOTHROW(session->render());
+    CHECK(mid->call_count() == 1);
+
+    // Second frame: M throws. Session is still usable; remove M.
+    CHECK_THROWS_AS(session->render(), std::runtime_error);
+    CHECK(mid->call_count() == 2);
+
+    session->remove_layer(mid);
+
+    // Third frame: A and C remain, no throw, no deadlock.
+    CHECK_NOTHROW(session->render());
 }
 
 TEST_CASE("begin_frame / end_frame must be paired", "[gpu][viz_session]")

--- a/src/viz/session_tests/cpp/test_offscreen_render.cpp
+++ b/src/viz/session_tests/cpp/test_offscreen_render.cpp
@@ -12,14 +12,15 @@
 // in this milestone, exercised in one test.
 
 #include <catch2/catch_test_macros.hpp>
+#include <viz/core/host_image.hpp>
 #include <viz/core/vk_context.hpp>
 #include <viz/layers/testing/clear_rect_layer.hpp>
 #include <viz/session/viz_session.hpp>
 
 #include <cstdint>
-#include <vector>
 
 using viz::DisplayMode;
+using viz::HostImage;
 using viz::VizSession;
 using viz::testing::ClearRectLayer;
 
@@ -54,10 +55,11 @@ struct Rgba
     uint8_t a;
 };
 
-Rgba pixel_at(const std::vector<uint8_t>& fb, uint32_t width, uint32_t x, uint32_t y)
+Rgba pixel_at(const HostImage& img, uint32_t x, uint32_t y)
 {
-    const size_t i = (static_cast<size_t>(y) * width + x) * 4;
-    return Rgba{ fb[i], fb[i + 1], fb[i + 2], fb[i + 3] };
+    const size_t i = (static_cast<size_t>(y) * img.resolution().width + x) * 4;
+    const uint8_t* p = img.data() + i;
+    return Rgba{ p[0], p[1], p[2], p[3] };
 }
 
 } // namespace
@@ -104,18 +106,28 @@ TEST_CASE("Offscreen session renders layer pixels through to readback", "[gpu][v
     CHECK(info.views.size() == 1);
     CHECK(session->get_state() == viz::SessionState::kRunning);
 
-    auto pixels = session->readback_to_host();
-    REQUIRE(pixels.size() == static_cast<size_t>(kSide) * kSide * 4);
+    auto image = session->readback_to_host();
+    REQUIRE(image.resolution().width == kSide);
+    REQUIRE(image.resolution().height == kSide);
+    REQUIRE(image.format() == viz::PixelFormat::kRGBA8);
+    REQUIRE(image.size_bytes() == static_cast<size_t>(kSide) * kSide * 4);
+
+    // The view exposes the same bytes as a VizBuffer (kHost).
+    const viz::VizBuffer view = image.view();
+    CHECK(view.space == viz::MemorySpace::kHost);
+    CHECK(view.data == image.data());
+    CHECK(view.width == kSide);
+    CHECK(view.height == kSide);
 
     // Top half: session clear color (blue).
-    const Rgba top = pixel_at(pixels, kSide, kSide / 2, kHalfHeight / 2);
+    const Rgba top = pixel_at(image, kSide / 2, kHalfHeight / 2);
     CHECK(top.r == 0);
     CHECK(top.g == 0);
     CHECK(top.b == 255);
     CHECK(top.a == 255);
 
     // Bottom half: layer color (red).
-    const Rgba bot = pixel_at(pixels, kSide, kSide / 2, kHalfHeight + kHalfHeight / 2);
+    const Rgba bot = pixel_at(image, kSide / 2, kHalfHeight + kHalfHeight / 2);
     CHECK(bot.r == 255);
     CHECK(bot.g == 0);
     CHECK(bot.b == 0);
@@ -153,9 +165,9 @@ TEST_CASE("Hidden layer does not contribute to the framebuffer", "[gpu][viz_sess
     layer->set_visible(false);
 
     session->render();
-    auto pixels = session->readback_to_host();
+    auto image = session->readback_to_host();
 
-    const Rgba center = pixel_at(pixels, kSide, kSide / 2, kSide / 2);
+    const Rgba center = pixel_at(image, kSide / 2, kSide / 2);
     // Compositor's clear color (green) survives because the only layer
     // is hidden — confirms the dispatch loop honors is_visible().
     CHECK(center.r == 0);

--- a/src/viz/session_tests/cpp/test_offscreen_render.cpp
+++ b/src/viz/session_tests/cpp/test_offscreen_render.cpp
@@ -196,3 +196,31 @@ TEST_CASE("Multiple frames advance frame_index and avoid leaking sync state", "[
         CHECK(info.frame_index == i);
     }
 }
+
+TEST_CASE("begin_frame / end_frame must be paired", "[gpu][viz_session]")
+{
+    if (!gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    VizSession::Config cfg{};
+    cfg.window_width = 32;
+    cfg.window_height = 32;
+    auto session = VizSession::create(cfg);
+
+    // end_frame without begin_frame: error.
+    CHECK_THROWS_AS(session->end_frame(), std::logic_error);
+
+    // begin -> begin: the second begin throws because a frame is still
+    // in progress.
+    (void)session->begin_frame();
+    CHECK_THROWS_AS(session->begin_frame(), std::logic_error);
+
+    // The first begin is still in progress; close it cleanly.
+    session->end_frame();
+
+    // After a clean pair, a new begin/end cycle should succeed.
+    CHECK_NOTHROW(session->begin_frame());
+    CHECK_NOTHROW(session->end_frame());
+}

--- a/src/viz/session_tests/cpp/test_offscreen_render.cpp
+++ b/src/viz/session_tests/cpp/test_offscreen_render.cpp
@@ -1,0 +1,186 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Milestone test: end-to-end offscreen render through the full VizSession
+// pipeline. Creates a session in kOffscreen mode, registers a
+// ClearRectLayer that paints the bottom half red over a blue session
+// clear, renders one frame, and reads back the framebuffer to assert
+// the layer's pixels actually made it through.
+//
+// Validates: VkContext + RenderTarget + FrameSync + VizCompositor +
+// VizSession + LayerBase dispatch + readback path. Everything that ships
+// in this milestone, exercised in one test.
+
+#include <catch2/catch_test_macros.hpp>
+#include <viz/core/vk_context.hpp>
+#include <viz/layers/testing/clear_rect_layer.hpp>
+#include <viz/session/viz_session.hpp>
+
+#include <cstdint>
+#include <vector>
+
+using viz::DisplayMode;
+using viz::VizSession;
+using viz::testing::ClearRectLayer;
+
+namespace
+{
+
+// Same NVIDIA-driver-leak workaround as viz_core_tests: any [gpu] test
+// that creates a VkContext should check this first and SKIP if the
+// runner has no suitable GPU.
+bool gpu_available()
+{
+    static const bool cached = []()
+    {
+        for (const auto& info : viz::VkContext::enumerate_physical_devices())
+        {
+            if (info.meets_requirements)
+            {
+                return true;
+            }
+        }
+        return false;
+    }();
+    return cached;
+}
+
+// RGBA8 byte at (x, y) in a tightly-packed row-major framebuffer.
+struct Rgba
+{
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+    uint8_t a;
+};
+
+Rgba pixel_at(const std::vector<uint8_t>& fb, uint32_t width, uint32_t x, uint32_t y)
+{
+    const size_t i = (static_cast<size_t>(y) * width + x) * 4;
+    return Rgba{ fb[i], fb[i + 1], fb[i + 2], fb[i + 3] };
+}
+
+} // namespace
+
+TEST_CASE("Offscreen session renders layer pixels through to readback", "[gpu][viz_session]")
+{
+    if (!gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    constexpr uint32_t kSide = 256;
+    constexpr uint32_t kHalfHeight = kSide / 2;
+
+    VizSession::Config cfg{};
+    cfg.mode = DisplayMode::kOffscreen;
+    cfg.window_width = kSide;
+    cfg.window_height = kSide;
+    // Linear blue clear; sRGB encoding of 0/0/1/1 stays at 0/0/255/255.
+    cfg.clear_color[0] = 0.0f;
+    cfg.clear_color[1] = 0.0f;
+    cfg.clear_color[2] = 1.0f;
+    cfg.clear_color[3] = 1.0f;
+
+    auto session = VizSession::create(cfg);
+    REQUIRE(session != nullptr);
+    REQUIRE(session->get_state() == viz::SessionState::kReady);
+
+    // Bottom half of the framebuffer painted opaque red.
+    auto* layer = session->add_layer<ClearRectLayer>(ClearRectLayer::Config{
+        /*x=*/0,
+        /*y=*/static_cast<int32_t>(kHalfHeight),
+        /*w=*/kSide,
+        /*h=*/kHalfHeight,
+        /*rgba=*/{ 1.0f, 0.0f, 0.0f, 1.0f },
+        /*name=*/"bottom_half_red",
+    });
+    REQUIRE(layer != nullptr);
+
+    auto info = session->render();
+    CHECK(info.frame_index == 0);
+    CHECK(info.resolution.width == kSide);
+    CHECK(info.resolution.height == kSide);
+    CHECK(info.views.size() == 1);
+    CHECK(session->get_state() == viz::SessionState::kRunning);
+
+    auto pixels = session->readback_to_host();
+    REQUIRE(pixels.size() == static_cast<size_t>(kSide) * kSide * 4);
+
+    // Top half: session clear color (blue).
+    const Rgba top = pixel_at(pixels, kSide, kSide / 2, kHalfHeight / 2);
+    CHECK(top.r == 0);
+    CHECK(top.g == 0);
+    CHECK(top.b == 255);
+    CHECK(top.a == 255);
+
+    // Bottom half: layer color (red).
+    const Rgba bot = pixel_at(pixels, kSide, kSide / 2, kHalfHeight + kHalfHeight / 2);
+    CHECK(bot.r == 255);
+    CHECK(bot.g == 0);
+    CHECK(bot.b == 0);
+    CHECK(bot.a == 255);
+}
+
+TEST_CASE("Hidden layer does not contribute to the framebuffer", "[gpu][viz_session]")
+{
+    if (!gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    constexpr uint32_t kSide = 64;
+
+    VizSession::Config cfg{};
+    cfg.mode = DisplayMode::kOffscreen;
+    cfg.window_width = kSide;
+    cfg.window_height = kSide;
+    cfg.clear_color[0] = 0.0f;
+    cfg.clear_color[1] = 1.0f; // green
+    cfg.clear_color[2] = 0.0f;
+    cfg.clear_color[3] = 1.0f;
+
+    auto session = VizSession::create(cfg);
+
+    auto* layer = session->add_layer<ClearRectLayer>(ClearRectLayer::Config{
+        /*x=*/0,
+        /*y=*/0,
+        /*w=*/kSide,
+        /*h=*/kSide,
+        /*rgba=*/{ 1.0f, 0.0f, 0.0f, 1.0f }, // would paint full red
+        /*name=*/"hidden_red",
+    });
+    layer->set_visible(false);
+
+    session->render();
+    auto pixels = session->readback_to_host();
+
+    const Rgba center = pixel_at(pixels, kSide, kSide / 2, kSide / 2);
+    // Compositor's clear color (green) survives because the only layer
+    // is hidden — confirms the dispatch loop honors is_visible().
+    CHECK(center.r == 0);
+    CHECK(center.g == 255);
+    CHECK(center.b == 0);
+}
+
+TEST_CASE("Multiple frames advance frame_index and avoid leaking sync state", "[gpu][viz_session]")
+{
+    if (!gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    VizSession::Config cfg{};
+    cfg.mode = DisplayMode::kOffscreen;
+    cfg.window_width = 64;
+    cfg.window_height = 64;
+
+    auto session = VizSession::create(cfg);
+    session->add_layer<ClearRectLayer>(ClearRectLayer::Config{ 0, 0, 64, 64, { 0.5f, 0.5f, 0.5f, 1.0f } });
+
+    for (uint64_t i = 0; i < 5; ++i)
+    {
+        const auto info = session->render();
+        CHECK(info.frame_index == i);
+    }
+}

--- a/src/viz/session_tests/cpp/test_viz_session.cpp
+++ b/src/viz/session_tests/cpp/test_viz_session.cpp
@@ -32,7 +32,7 @@ TEST_CASE("VizSession::Config defaults are sensible", "[unit][viz_session]")
 
 TEST_CASE("SessionState enum exposes the full lifecycle set", "[unit][viz_session]")
 {
-    // Sanity that the values defined in frame_info.hpp don't accidentally
+    // Sanity that the values defined in viz_session.hpp don't accidentally
     // shrink — XR backends will rely on them.
     CHECK(static_cast<int>(SessionState::kUninitialized) == 0);
     CHECK(static_cast<int>(SessionState::kReady) == 1);
@@ -40,4 +40,18 @@ TEST_CASE("SessionState enum exposes the full lifecycle set", "[unit][viz_sessio
     CHECK(static_cast<int>(SessionState::kStopping) == 3);
     CHECK(static_cast<int>(SessionState::kLost) == 4);
     CHECK(static_cast<int>(SessionState::kDestroyed) == 5);
+}
+
+TEST_CASE("VizSession::create rejects unsupported display modes early", "[unit][viz_session]")
+{
+    // Mode validation must happen before any Vulkan work — verified by
+    // not requiring a GPU here. Both kWindow and kXr should throw
+    // before VkContext creation.
+    VizSession::Config cfg_window{};
+    cfg_window.mode = DisplayMode::kWindow;
+    CHECK_THROWS_AS(VizSession::create(cfg_window), std::runtime_error);
+
+    VizSession::Config cfg_xr{};
+    cfg_xr.mode = DisplayMode::kXr;
+    CHECK_THROWS_AS(VizSession::create(cfg_xr), std::runtime_error);
 }

--- a/src/viz/session_tests/cpp/test_viz_session.cpp
+++ b/src/viz/session_tests/cpp/test_viz_session.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for VizSession lifecycle that don't require a GPU.
+
+#include <catch2/catch_test_macros.hpp>
+#include <viz/session/viz_session.hpp>
+
+#include <stdexcept>
+
+using viz::DisplayMode;
+using viz::SessionState;
+using viz::VizSession;
+
+TEST_CASE("VizSession::create rejects zero window dimensions", "[unit][viz_session]")
+{
+    VizSession::Config cfg{};
+    cfg.window_width = 0;
+    CHECK_THROWS_AS(VizSession::create(cfg), std::invalid_argument);
+}
+
+TEST_CASE("VizSession::Config defaults are sensible", "[unit][viz_session]")
+{
+    VizSession::Config cfg{};
+    CHECK(cfg.mode == DisplayMode::kOffscreen);
+    CHECK(cfg.window_width == 1024);
+    CHECK(cfg.window_height == 1024);
+    CHECK(cfg.app_name == "televiz");
+    CHECK(cfg.external_context == nullptr);
+    CHECK(cfg.required_extensions.empty());
+}
+
+TEST_CASE("SessionState enum exposes the full lifecycle set", "[unit][viz_session]")
+{
+    // Sanity that the values defined in frame_info.hpp don't accidentally
+    // shrink — XR backends will rely on them.
+    CHECK(static_cast<int>(SessionState::kUninitialized) == 0);
+    CHECK(static_cast<int>(SessionState::kReady) == 1);
+    CHECK(static_cast<int>(SessionState::kRunning) == 2);
+    CHECK(static_cast<int>(SessionState::kStopping) == 3);
+    CHECK(static_cast<int>(SessionState::kLost) == 4);
+    CHECK(static_cast<int>(SessionState::kDestroyed) == 5);
+}


### PR DESCRIPTION
Adds the orchestration layer that turns the M2.1 primitives (VkContext, RenderTarget, FrameSync, LayerBase) into a working render pipeline. After this MR you can: create a VizSession in kOffscreen mode → register layers → call render() → read back the framebuffer → verify pixels. End-to-end Vulkan render through our code, no XR / no GLFW / no CUDA interop yet.

New sub-module viz/session/:
- frame_info.hpp: FrameInfo, FrameTimingStats, SessionState. Full six-state lifecycle enum (kUninitialized → kReady → kRunning → kStopping → kLost → kDestroyed) defined now; window/offscreen modes use the kReady-kRunning-kDestroyed subset, XR backends extend.
- viz_compositor.{hpp,cpp}: owns the intermediate RenderTarget + command pool/buffer + FrameSync. Records one render pass per frame, iterates the layer registry calling layer->record() inside the active pass, submits, waits. Exposes readback_to_host() that does vkCmdCopyImageToBuffer to a host-visible staging buffer.
- viz_session.{hpp,cpp}: public API. Config selects DisplayMode (kOffscreen today; kWindow/kXr throw with a "not implemented in this milestone" error). Supports add_layer<L>(args...) templated registration, render() convenience, begin_frame()/end_frame() explicit pair, get_state(), readback_to_host(), Vulkan handle accessors for external renderers / custom layers, and external_context to share a VkContext with another component.

New test-fixture sub-module viz/layers_tests/:
- ClearRectLayer: concrete LayerBase subclass that uses vkCmdClearAttachments to paint a configurable rectangular region of the active framebuffer. ~30 lines, no shaders / pipeline / vertex buffers — exercises the same in-pass command-recording surface real layers will use. Test-only; lives in viz::layers_testing static lib alongside its own [unit] smoke test.

New viz/session_tests/cpp/test_offscreen_render.cpp — milestone test:
- "Offscreen session renders layer pixels through to readback": creates a 256×256 kOffscreen session with a blue clear, registers a ClearRectLayer painting the bottom half red, renders one frame, reads back, asserts the top-half center is blue and bottom-half center is red. Validates the entire M2 pipeline end-to-end.
- "Hidden layer does not contribute": confirms set_visible(false) is honored by the compositor's dispatch loop.
- "Multiple frames advance frame_index": confirms repeated render() calls don't leak fence / sync state.

Why ClearRectLayer instead of a shader-based ColoredQuadLayer: the milestone goal is "verify the compositor's render-pass + layer- dispatch + readback paths work". vkCmdClearAttachments lets a layer write real pixels to the framebuffer with zero pipeline / shader machinery, exercising every path the compositor cares about. The shader-pipeline + first real graphics layer (QuadLayer) cluster naturally with CUDA-Vulkan interop in the next milestone — same machinery, same concern.

Build: 18 new files, +1268 lines. Three new test binaries (viz_layers_tests + viz_session_tests via the existing viz_*_tests glob in build-ubuntu.yml — no CI changes needed).

Verified locally on RTX 6000 Ada:
- 27 [unit] + 20 [gpu] tests pass (was 21 + 17 pre-MR)
- 10/10 stress runs of viz_session_tests "[gpu]" clean exit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `VizSession` API for managing rendering sessions with offscreen support
  * Added session state tracking (lifecycle states: uninitialized, ready, running, stopping, lost, destroyed)
  * Added per-frame timing diagnostics including FPS, frame time, and missed frame counts
  * Enabled layer management with visibility control and dynamic registration
  * Added host readback capability for rendered frames in offscreen mode

* **Tests**
  * Added comprehensive test fixtures and test layers for rendering validation
  * Extended test suite with GPU-based and unit tests for session functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->