### PR TITLE
Manus plugin: HMD hand tracking, installer, docs, and visualizer

### DIFF
--- a/docs/source/device/index.rst
+++ b/docs/source/device/index.rst
@@ -20,3 +20,4 @@ See the `Plugins directory <https://github.com/NVIDIA/IsaacTeleop/tree/main/src/
    trackers
    add_device
    body_tracking
+   manus

--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -1,0 +1,183 @@
+..
+   SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+   SPDX-License-Identifier: Apache-2.0
+
+Manus Gloves
+============
+
+A Linux-only plugin for integrating `Manus <https://www.manus-meta.com/>`_ gloves
+into the Isaac Teleop framework. It provides full hand-joint tracking via the
+Manus SDK and injects the resulting poses into the OpenXR hand-tracking layer so
+any downstream retargeter can consume them transparently.
+
+Components
+----------
+
+- **Core library** (``manus_plugin_core``) — wraps the Manus SDK
+  (``libIsaacTeleopPluginsManus.so``) and exposes per-joint tracking data.
+- **Plugin executable** (``manus_hand_plugin``) — the main plugin binary that
+  integrates with the Teleop system via CloudXR / OpenXR.
+- **CLI tool** (``manus_hand_tracker_printer``) — a standalone diagnostic tool
+  that prints tracked joint data to the terminal and opens a real-time
+  **MANUS Data Visualizer** window showing the hand skeleton from two orthographic
+  views per hand.
+
+Prerequisites
+-------------
+
+- **Linux** — x86_64 (tested on Ubuntu 22.04 / 24.04).
+- **Manus SDK** for Linux — downloaded automatically by the install script.
+- **System dependencies** — the install script installs required packages automatically.
+
+Installation
+------------
+
+Automated (recommended)
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The install script handles SDK download, dependency installation, and building:
+
+.. code-block:: bash
+
+   cd src/plugins/manus
+   ./install_manus.sh
+
+The script will:
+
+1. Install the required system packages for MANUS Core Integrated.
+2. Download MANUS SDK v3.1.1.
+3. Extract and place the SDK in the correct location.
+4. Build the plugin and the diagnostic tool
+
+Manual
+~~~~~~
+
+If you prefer to install manually:
+
+1. Download the MANUS Core SDK from
+   `MANUS Downloads <https://docs.manus-meta.com/3.1.1/Resources/>`_.
+2. Extract and place the ``ManusSDK`` folder inside ``src/plugins/manus/``, or
+   point CMake at a different path by setting ``MANUS_SDK_ROOT``.
+3. Follow the
+   `MANUS Getting Started guide for Linux <https://docs.manus-meta.com/3.1.1/Plugins/SDK/Linux/>`_
+   to install the dependencies and configure device permissions.
+
+Expected directory layout after placing the SDK:
+
+.. code-block:: text
+
+   src/plugins/manus/
+     app/
+       main.cpp
+     core/
+       manus_hand_tracking_plugin.cpp
+     inc/
+       core/
+         manus_hand_tracking_plugin.hpp
+     tools/
+       manus_hand_tracker_printer.cpp
+     ManusSDK/        <-- placed here
+       include/
+       lib/
+
+Then build from the root:
+
+.. code-block:: bash
+
+   cd ../../..  # navigate to root
+   cmake -S . -B build
+   cmake --build build --target manus_hand_plugin manus_hand_tracker_printer -j
+   cmake --install build --component manus
+
+Running the Plugin
+------------------
+
+1. Set up the CloudXR environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Source the CloudXR environment and start the runtime before running the plugin:
+
+.. code-block:: bash
+
+   export NV_CXR_RUNTIME_DIR=~/.cloudxr/run
+   export XR_RUNTIME_JSON=~/.cloudxr/openxr_cloudxr.json
+
+2. Verify with the CLI tool
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verify that the gloves are working using the CLI tool:
+
+.. code-block:: bash
+
+   ./build/bin/manus_hand_tracker_printer
+
+The tool prints joint positions to the terminal and opens a **MANUS Data
+Visualizer** window showing a top-down and side view of each hand.
+
+3. Run the plugin
+~~~~~~~~~~~~~~~~~~
+
+The plugin is installed to the `install` directory, please ensure the CLI tool is not running when running the plugin.
+
+.. code-block:: bash
+
+   ./install/plugins/manus/manus_hand_plugin
+
+Wrist Positioning — Controllers vs Optical Hand Tracking
+---------------------------------------------------------
+
+Two sources are available for positioning the Manus gloves in 3D space:
+
+- **Controller adapters** — attach Quest 3 controllers to the Manus Universal
+  Mount on the back of the glove. The controller pose drives wrist placement.
+- **Optical hand tracking** — use the HMD's built-in optical hand tracking to
+  position the hands. No physical controller adapter required.
+
+The plugin selects the source automatically at runtime: optical hand tracking is
+preferred when ``XR_MNDX_xdev_space`` is supported and the runtime reports an
+actively tracked wrist pose; otherwise it falls back to the controller pose.
+
+.. note::
+
+   When using controller adapters it is advisable to disable the HMD's automatic
+   hand-tracking–to–controller switching to avoid unexpected source changes
+   mid-session.
+
+Troubleshooting
+---------------
+
+.. list-table::
+   :widths: 40 60
+   :header-rows: 1
+
+   * - Symptom
+     - Resolution
+   * - SDK download fails
+     - Check your internet connection and re-run the install script.
+   * - Manus SDK not found at build time
+     - With manual installation, ensure ``ManusSDK`` is inside
+       ``src/plugins/manus/`` or set ``MANUS_SDK_ROOT`` to your installation path.
+   * - Manus SDK not found at runtime
+     - The build configures RPATH automatically. If you moved the SDK after
+       building, set ``LD_LIBRARY_PATH`` to its ``lib/`` directory.
+   * - No data received
+     - Ensure Manus Core is running and the gloves are connected and calibrated.
+   * - CloudXR runtime errors
+     - Make sure ``scripts/setup_cloudxr_env.sh`` has been sourced before running.
+   * - Permission denied for USB devices
+     - The install script configures udev rules. If the rules were not reloaded,
+       run:
+
+       .. code-block:: bash
+
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger
+
+       Then reconnect your Manus devices.
+
+License
+-------
+
+Source files are covered by their stated licenses (Apache-2.0). The Manus SDK is
+proprietary to Manus and is subject to its own license; it is **not** redistributed
+by this project.

--- a/examples/native_openxr/xdev_list/main.cpp
+++ b/examples/native_openxr/xdev_list/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include "common/main_helpers.hpp"

--- a/examples/oxr/cpp/oxr_session_sharing.cpp
+++ b/examples/oxr/cpp/oxr_session_sharing.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <deviceio_session/deviceio_session.hpp>

--- a/src/core/oxr_utils/cpp/inc/oxr_utils/oxr_funcs.hpp
+++ b/src/core/oxr_utils/cpp/inc/oxr_utils/oxr_funcs.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
@@ -24,6 +24,10 @@ extern "C"
     XRAPI_ATTR XrResult XRAPI_CALL xrGetInstanceProcAddr(XrInstance instance,
                                                          const char* name,
                                                          PFN_xrVoidFunction* function);
+    XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateInstanceExtensionProperties(const char* layerName,
+                                                                          uint32_t propertyCapacityInput,
+                                                                          uint32_t* propertyCountOutput,
+                                                                          XrExtensionProperties* properties);
 }
 
 namespace core

--- a/src/core/schema/python/pedals_bindings.h
+++ b/src/core/schema/python/pedals_bindings.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Python bindings for the Pedals FlatBuffer schema.

--- a/src/plugins/manus/70-manus-hid.rules
+++ b/src/plugins/manus/70-manus-hid.rules
@@ -1,0 +1,5 @@
+# HIDAPI/libusb
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="3325", MODE:="0666"
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="83fd", MODE:="0666"
+# HIDAPI/hidraw
+KERNEL=="hidraw*", ATTRS{idVendor}=="3325", MODE:="0666"

--- a/src/plugins/manus/CMakeLists.txt
+++ b/src/plugins/manus/CMakeLists.txt
@@ -107,4 +107,5 @@ add_subdirectory(tools)
 # Install Manus SDK shared library
 install(FILES "${_MANUS_LIB}"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT manus
 )

--- a/src/plugins/manus/README.md
+++ b/src/plugins/manus/README.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -11,20 +11,38 @@ This folder provides a Linux-only example of using the Manus SDK for hand tracki
 
 - **Core Library** (`manus_plugin_core`): Interfaces with the Manus SDK (`libIsaacTeleopPluginsManus.so`).
 - **Plugin Executable** (`manus_hand_plugin`): The main plugin executable that integrates with the Teleop system.
-- **CLI Tool** (`manus_hand_tracker_printer`): A standalone tool to print tracked joint data for verification.
+- **CLI Tool** (`manus_hand_tracker_printer`): A standalone tool that prints tracked joint data to the terminal **and** opens a real-time Vulkan visualizer window ("MANUS Data Visualizer") showing the hand skeleton from two orthographic views.
 
 ## Prerequisites
 
-- **Linux** (x86_64, tested on Ubuntu 22.04)
-- **Manus SDK** for Linux x86_64
+- **Linux** (x86_64 tested on Ubuntu 22.04/24.04)
+- **Manus SDK** for Linux (automatically downloaded by install script)
+- **System dependencies**: The install script installs required packages automatically
 
-## Getting the Manus SDK
+## Installation
 
-The Manus SDK must be downloaded separately due to licensing.
+### Automated Installation (Recommended)
 
-1. Obtain a Manus account and credentials.
-2. Download the MANUS Core SDK from [Manus Downloads](https://my.manus-meta.com/resources/downloads).
-3. Extract and place the `ManusSDK` folder inside `src/plugins/manus/`, or set the `MANUS_SDK_ROOT` environment variable to your installation path.
+Use the provided installation script which handles SDK download, dependency installation, and building:
+
+```bash
+cd src/plugins/manus
+./install_manus.sh
+```
+
+The script will:
+1. Install required system packages for MANUS Core Integrated
+2. Automatically download the MANUS SDK v3.1.1
+3. Extract and configure the SDK in the correct location
+4. Build the plugin
+
+### Manual Installation
+
+If you prefer to install manually:
+
+1. Download the MANUS Core SDK from [MANUS Downloads](https://docs.manus-meta.com/3.1.1/Resources/)
+2. Extract and place the `ManusSDK` folder inside `src/plugins/manus/`, or set the `MANUS_SDK_ROOT` environment variable to your installation path
+3. Follow the [MANUS Getting Started guide for Linux](https://docs.manus-meta.com/3.1.1/Plugins/SDK/Linux/) to install the dependencies and setup device permissions.
 
 Expected layout:
 ```text
@@ -43,41 +61,64 @@ src/plugins/manus/
     lib/
 ```
 
-## Build
-
-This plugin is built as part of the Isaac Teleop project. It will be automatically included if the Manus SDK is found.
-
-Run the project build from the repository root:
+4. Build from the TeleopCore root:
 
 ```bash
+cd ../../..  # Navigate to TeleopCore root
 cmake -S . -B build
-cmake --build build -j
+cmake --build build --target manus_hand_plugin manus_hand_tracker_printer -j
+cmake --install build --component manus
 ```
 
-If the SDK is not found, the build will skip the Manus plugin with a warning.
+## Running the Plugin
 
-## Running the Example
+### 1. Setup CloudXR Environment
+Before running the plugin, ensure CloudXR environment is configured:
 
-### 1. Verify with CLI Tool
-Ensure Manus Core is running and gloves are connected.
-Run the printer tool to verify data reception:
+The following environment variables must be set before running either the CLI tool or the plugin (adjust paths if your CloudXR installation differs from the defaults):
+
+```bash
+export NV_CXR_RUNTIME_DIR=~/.cloudxr/run
+export XR_RUNTIME_JSON=~/.cloudxr/openxr_cloudxr.json
+```
+
+### 2. Verify with CLI Tool
+Verify that the gloves are working using the CLI tool:
 
 ```bash
 ./build/bin/manus_hand_tracker_printer
 ```
 
-### 2. Run the Plugin
-The plugin is installed to the `install` directory.
+The tool prints joint positions to the terminal and opens a **MANUS Data Visualizer** window with a top-down and side view of each hand.
+
+### 3. Run the Plugin
+The plugin is installed to the `install` directory, please ensure the CLI tool is not running when running the plugin.
 
 ```bash
 ./install/plugins/manus/manus_hand_plugin
 ```
 
+## Controller positioning vs Optical hand tracking positioning
+To position the MANUS gloves in 3D space two avenues are available:
+
+- Use the MANUS Quest 3 controller adapters to attach the Quest 3 controllers to the MANUS Universal Mount on the back of the glove.
+- Use the HMD's optical hand tracking to position the hands.
+
+The system will switch dynamically based on the available tracking source. When using controllers it's advised to turn off hand tracking entirely or turn off automatic switching.
+
 ## Troubleshooting
 
-- **Manus SDK not found at build time**: Ensure `ManusSDK` is in `src/plugins/manus/` or `MANUS_SDK_ROOT` is set correctly.
-- **Manus SDK not found at runtime**: The build configures RPATH to find the SDK libraries. If you moved the SDK or built without RPATH support, you may need to set `LD_LIBRARY_PATH`.
-- **No data available**: Ensure Manus Core is running and gloves are properly connected and calibrated.
+- **SDK download fails**: Check your internet connection and try running the install script again
+- **Manus SDK not found at build time**: If using manual installation, ensure `ManusSDK` is in `src/plugins/manus/` or `MANUS_SDK_ROOT` is set correctly
+- **Manus SDK not found at runtime**: The CMake build configures RPATH to find the SDK libraries. If you moved the SDK, you may need to set `LD_LIBRARY_PATH`
+- **No data available**: Ensure Manus Core is running and gloves are properly connected and calibrated
+- **CloudXR runtime errors**: Make sure you've sourced `scripts/setup_cloudxr_env.sh` before running the plugin
+- **Permission denied for USB devices**: The install script configures udev rules. You may need to run:
+  ```bash
+  sudo udevadm control --reload-rules
+  sudo udevadm trigger
+  ```
+  Then reconnect your Manus devices.
 
 ## License
 

--- a/src/plugins/manus/app/CMakeLists.txt
+++ b/src/plugins/manus/app/CMakeLists.txt
@@ -26,8 +26,10 @@ set_target_properties(manus_hand_plugin PROPERTIES
 
 install(TARGETS manus_hand_plugin
     RUNTIME DESTINATION plugins/manus
+    COMPONENT manus
 )
 
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../plugin.yaml" "${CMAKE_CURRENT_SOURCE_DIR}/../README.md"
     DESTINATION plugins/manus
+    COMPONENT manus
 )

--- a/src/plugins/manus/core/CMakeLists.txt
+++ b/src/plugins/manus/core/CMakeLists.txt
@@ -38,4 +38,5 @@ set_target_properties(manus_plugin_core PROPERTIES
 install(TARGETS manus_plugin_core
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT manus
 )

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <core/manus_hand_tracking_plugin.hpp>
@@ -24,6 +24,30 @@ namespace plugins
 namespace manus
 {
 
+namespace
+{
+
+// Returns true if the OpenXR loader/runtime advertises the given extension.
+// xrEnumerateInstanceExtensionProperties is a loader-level function that can be
+// called before any XrInstance exists, so this is safe to use at init time.
+bool is_openxr_extension_supported(const char* ext_name)
+{
+    uint32_t count = 0;
+    if (XR_FAILED(xrEnumerateInstanceExtensionProperties(nullptr, 0, &count, nullptr)))
+    {
+        return false;
+    }
+    std::vector<XrExtensionProperties> props(count, XrExtensionProperties{ XR_TYPE_EXTENSION_PROPERTIES });
+    if (XR_FAILED(xrEnumerateInstanceExtensionProperties(nullptr, count, &count, props.data())))
+    {
+        return false;
+    }
+    return std::any_of(props.begin(), props.end(),
+                       [ext_name](const XrExtensionProperties& p) { return std::string(p.extensionName) == ext_name; });
+}
+
+} // anonymous namespace
+
 static constexpr XrPosef kLeftHandOffset = { { -0.70710678f, -0.5f, 0.0f, 0.5f }, { -0.1f, 0.02f, -0.02f } };
 static constexpr XrPosef kRightHandOffset = { { -0.70710678f, 0.5f, 0.0f, 0.5f }, { 0.1f, 0.02f, -0.02f } };
 
@@ -35,6 +59,12 @@ ManusTracker& ManusTracker::instance(const std::string& app_name) noexcept(false
 
 void ManusTracker::update()
 {
+    if (!m_deviceio_session)
+    {
+        // OpenXR unavailable — nothing to update for positioning/injection
+        return;
+    }
+
     // Update DeviceIOSession which handles time conversion and tracker updates internally
     m_deviceio_session->update();
 
@@ -51,6 +81,18 @@ std::vector<SkeletonNode> ManusTracker::get_right_hand_nodes() const
 {
     std::lock_guard<std::mutex> lock(m_skeleton_mutex);
     return m_right_hand_nodes;
+}
+
+std::vector<NodeInfo> ManusTracker::get_left_node_info() const
+{
+    std::lock_guard<std::mutex> lock(m_skeleton_mutex);
+    return m_left_node_info;
+}
+
+std::vector<NodeInfo> ManusTracker::get_right_node_info() const
+{
+    std::lock_guard<std::mutex> lock(m_skeleton_mutex);
+    return m_right_node_info;
 }
 
 ManusTracker::ManusTracker(const std::string& app_name) noexcept(false)
@@ -74,14 +116,14 @@ ManusTracker::~ManusTracker()
 
 void ManusTracker::initialize(const std::string& app_name) noexcept(false)
 {
-    std::cout << "Initializing Manus SDK..." << std::endl;
+    std::cout << "[Manus] Initializing SDK..." << std::endl;
     const SDKReturnCode t_InitializeResult = CoreSdk_InitializeIntegrated();
     if (t_InitializeResult != SDKReturnCode::SDKReturnCode_Success)
     {
         throw std::runtime_error("Failed to initialize Manus SDK, error code: " +
                                  std::to_string(static_cast<int>(t_InitializeResult)));
     }
-    std::cout << "Manus SDK initialized successfully" << std::endl;
+    std::cout << "[Manus] SDK initialized successfully" << std::endl;
 
     RegisterCallbacks();
 
@@ -92,7 +134,7 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
     t_VUH.view = AxisView::AxisView_ZToViewer;
     t_VUH.unitScale = 1.0f;
 
-    std::cout << "Setting up coordinate system (Z-up, right-handed, meters)..." << std::endl;
+    std::cout << "[Manus] Setting up coordinate system (Y-up, right-handed, meters)..." << std::endl;
     const SDKReturnCode t_CoordinateResult = CoreSdk_InitializeCoordinateSystemWithVUH(t_VUH, true);
 
     if (t_CoordinateResult != SDKReturnCode::SDKReturnCode_Success)
@@ -100,7 +142,7 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
         throw std::runtime_error("Failed to initialize Manus SDK coordinate system, error code: " +
                                  std::to_string(static_cast<int>(t_CoordinateResult)));
     }
-    std::cout << "Coordinate system initialized successfully" << std::endl;
+    std::cout << "[Manus] Coordinate system initialized successfully" << std::endl;
 
     ConnectToGloves();
 
@@ -109,28 +151,70 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
 
     try
     {
-        // Create ControllerTracker and DeviceIOSession
+        // Create ControllerTracker unconditionally; HandTracker requires
+        // XR_EXT_hand_tracking which is optional — only add it when the runtime
+        // advertises support so xrCreateInstance does not fail with
+        // XR_ERROR_EXTENSION_NOT_PRESENT on runtimes that lack the extension.
         m_controller_tracker = std::make_shared<core::ControllerTracker>();
         std::vector<std::shared_ptr<core::ITracker>> trackers = { m_controller_tracker };
+
+        const bool hand_tracking_supported = is_openxr_extension_supported(XR_EXT_HAND_TRACKING_EXTENSION_NAME);
+        if (hand_tracking_supported)
+        {
+            m_hand_tracker = std::make_shared<core::HandTracker>();
+            trackers.push_back(m_hand_tracker);
+        }
+        else
+        {
+            std::cout << "[Manus] " << XR_EXT_HAND_TRACKING_EXTENSION_NAME
+                      << " is not supported by the current runtime; HandTracker will not be created." << std::endl;
+        }
 
         // Get required extensions from trackers
         auto extensions = core::DeviceIOSession::get_required_extensions(trackers);
         extensions.push_back(XR_NVX1_DEVICE_INTERFACE_BASE_EXTENSION_NAME);
 
+        // XR_MNDX_XDEV_SPACE_EXTENSION_NAME is optional: it enables optical (HMD) hand
+        // tracking as a higher-quality wrist source. If the runtime does not advertise
+        // it we fall back to controller-based tracking instead of crashing.
+        const bool xdev_extension_supported = is_openxr_extension_supported(XR_MNDX_XDEV_SPACE_EXTENSION_NAME);
+        if (xdev_extension_supported)
+        {
+            extensions.push_back(XR_MNDX_XDEV_SPACE_EXTENSION_NAME);
+        }
+        else
+        {
+            std::cout << "[Manus] " << XR_MNDX_XDEV_SPACE_EXTENSION_NAME
+                      << " is not supported by the current runtime; optical hand tracking"
+                      << " will not be available and controller fallback will be used." << std::endl;
+        }
+
         // Create session with required extensions - constructor automatically begins the session
         m_session = std::make_shared<core::OpenXRSession>(app_name, extensions);
-        auto handles = m_session->get_handles();
+        m_handles = m_session->get_handles();
 
-        // Initialize hand injectors (one per hand) and time converter
+        // Initialize time converter now that handles are ready
+        m_time_converter.emplace(m_handles);
+
+        // Initialize hand injectors (one per hand)
         m_left_injector = std::make_unique<plugin_utils::HandInjector>(
-            handles.instance, handles.session, XR_HAND_LEFT_EXT, handles.space);
+            m_handles.instance, m_handles.session, XR_HAND_LEFT_EXT, m_handles.space);
         m_right_injector = std::make_unique<plugin_utils::HandInjector>(
-            handles.instance, handles.session, XR_HAND_RIGHT_EXT, handles.space);
-        m_time_converter.emplace(handles);
+            m_handles.instance, m_handles.session, XR_HAND_RIGHT_EXT, m_handles.space);
 
-        m_deviceio_session = core::DeviceIOSession::run(trackers, handles);
+        m_deviceio_session = core::DeviceIOSession::run(trackers, m_handles);
 
-        std::cout << "OpenXR session, HandInjector and DeviceIOSession initialized" << std::endl;
+        // Only attempt XDev hand tracker setup when the extension was actually enabled.
+        // Skipping here avoids calling xrGetInstanceProcAddr for MNDX entry points that
+        // the runtime would not have loaded.
+        if (xdev_extension_supported)
+        {
+            initialize_xdev_hand_trackers();
+        }
+
+        std::cout << "[Manus] Initialized with wrist source: " << (m_xdev_available ? "HandTracking" : "Controllers")
+                  << std::endl;
+
         success = true;
     }
     catch (const std::exception& e)
@@ -140,12 +224,8 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
 
     if (!success)
     {
-        std::cerr << "Failed to initialize OpenXR: " << error_msg << std::endl;
-
-        // Clean up Manus SDK
-        shutdown_sdk();
-
-        throw std::runtime_error(error_msg);
+        std::cerr << "[Manus] Warning: OpenXR initialization failed: " << error_msg << std::endl;
+        std::cerr << "[Manus] Continuing in Manus-only mode (no hand injection or OpenXR positioning)." << std::endl;
     }
 
     std::lock_guard<std::mutex> lock(m_lifecycle_mutex);
@@ -155,6 +235,9 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
 
 void ManusTracker::shutdown_sdk()
 {
+    // Cleanup XDev hand trackers first
+    cleanup_xdev_hand_trackers();
+
     CoreSdk_RegisterCallbackForRawSkeletonStream(nullptr);
     CoreSdk_RegisterCallbackForLandscapeStream(nullptr);
     CoreSdk_RegisterCallbackForErgonomicsStream(nullptr);
@@ -316,10 +399,9 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         return;
     }
 
-    // Determine which sides are present in this landscape update.
+    // Extract glove IDs from landscape data
     bool left_present = false;
     bool right_present = false;
-
     for (uint32_t i = 0; i < gloves.gloveCount; i++)
     {
         const GloveLandscapeData& glove = gloves.gloves[i];
@@ -327,30 +409,279 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         {
             tracker.left_glove_id = glove.id;
             left_present = true;
+            // Fetch bone topology once on connect
+            uint32_t nc = 0;
+            if (CoreSdk_GetRawSkeletonNodeCount(glove.id, nc) == SDKReturnCode::SDKReturnCode_Success && nc > 0)
+            {
+                std::lock_guard<std::mutex> sk(tracker.m_skeleton_mutex);
+                tracker.m_left_node_info.resize(nc);
+                if (CoreSdk_GetRawSkeletonNodeInfoArray(glove.id, tracker.m_left_node_info.data(), nc) !=
+                    SDKReturnCode::SDKReturnCode_Success)
+                    tracker.m_left_node_info.clear();
+            }
         }
         else if (glove.side == Side::Side_Right)
         {
             tracker.right_glove_id = glove.id;
             right_present = true;
+            uint32_t nc = 0;
+            if (CoreSdk_GetRawSkeletonNodeCount(glove.id, nc) == SDKReturnCode::SDKReturnCode_Success && nc > 0)
+            {
+                std::lock_guard<std::mutex> sk(tracker.m_skeleton_mutex);
+                tracker.m_right_node_info.resize(nc);
+                if (CoreSdk_GetRawSkeletonNodeInfoArray(glove.id, tracker.m_right_node_info.data(), nc) !=
+                    SDKReturnCode::SDKReturnCode_Success)
+                    tracker.m_right_node_info.clear();
+            }
         }
     }
 
-    // If a glove that was previously known is no longer in the landscape, it has
-    // disconnected. Clear its cached nodes and reset its injector so readers see
-    // isActive=false rather than a stale pose.
-    if (!left_present && tracker.left_glove_id.has_value())
+    // Clear stale state for any glove that is no longer present in this landscape
+    // update (i.e., disconnected). Resetting the IDs prevents OnSkeletonStream from
+    // matching future packets to a dead glove, and clearing the node cache prevents
+    // inject_hand_data() from replaying the last known stale pose indefinitely.
     {
-        tracker.left_glove_id.reset();
         std::lock_guard<std::mutex> skeleton_lock(tracker.m_skeleton_mutex);
-        tracker.m_left_hand_nodes.clear();
+        if (!left_present && tracker.left_glove_id.has_value())
+        {
+            std::cout << "[Manus] Left glove disconnected (ID " << *tracker.left_glove_id << ")" << std::endl;
+            tracker.left_glove_id.reset();
+            tracker.m_left_hand_nodes.clear();
+            tracker.m_left_node_info.clear();
+        }
+        if (!right_present && tracker.right_glove_id.has_value())
+        {
+            std::cout << "[Manus] Right glove disconnected (ID " << *tracker.right_glove_id << ")" << std::endl;
+            tracker.right_glove_id.reset();
+            tracker.m_right_hand_nodes.clear();
+            tracker.m_right_node_info.clear();
+        }
+    }
+}
+
+void ManusTracker::initialize_xdev_hand_trackers()
+{
+    // Load XDev extension function pointers
+    auto load_func = [this](const char* name, PFN_xrVoidFunction* ptr) -> bool
+    {
+        XrResult result = m_handles.xrGetInstanceProcAddr(m_handles.instance, name, ptr);
+        return XR_SUCCEEDED(result) && *ptr != nullptr;
+    };
+
+    // Load XDev extension functions
+    if (!load_func("xrCreateXDevListMNDX", reinterpret_cast<PFN_xrVoidFunction*>(&m_pfn_create_xdev_list)) ||
+        !load_func("xrDestroyXDevListMNDX", reinterpret_cast<PFN_xrVoidFunction*>(&m_pfn_destroy_xdev_list)) ||
+        !load_func("xrEnumerateXDevsMNDX", reinterpret_cast<PFN_xrVoidFunction*>(&m_pfn_enumerate_xdevs)) ||
+        !load_func("xrGetXDevPropertiesMNDX", reinterpret_cast<PFN_xrVoidFunction*>(&m_pfn_get_xdev_properties)))
+    {
+        std::cerr << "[Manus] XR_MNDX_xdev_space extension not available, falling back to controllers" << std::endl;
+        return;
     }
 
-    if (!right_present && tracker.right_glove_id.has_value())
+    // Load hand tracking extension functions
+    if (!load_func("xrCreateHandTrackerEXT", reinterpret_cast<PFN_xrVoidFunction*>(&m_pfn_create_hand_tracker)) ||
+        !load_func("xrDestroyHandTrackerEXT", reinterpret_cast<PFN_xrVoidFunction*>(&m_pfn_destroy_hand_tracker)) ||
+        !load_func("xrLocateHandJointsEXT", reinterpret_cast<PFN_xrVoidFunction*>(&m_pfn_locate_hand_joints)))
     {
-        tracker.right_glove_id.reset();
-        std::lock_guard<std::mutex> skeleton_lock(tracker.m_skeleton_mutex);
-        tracker.m_right_hand_nodes.clear();
+        std::cerr << "[Manus] Hand tracking extension not available, falling back to controllers" << std::endl;
+        return;
     }
+
+    // Create XDev list
+    XrCreateXDevListInfoMNDX create_info{ XR_TYPE_CREATE_XDEV_LIST_INFO_MNDX };
+    XrResult result = m_pfn_create_xdev_list(m_handles.session, &create_info, &m_xdev_list);
+    if (XR_FAILED(result))
+    {
+        std::cerr << "[Manus] Failed to create XDevList, falling back to controllers" << std::endl;
+        return;
+    }
+
+    // Enumerate XDevs
+    uint32_t xdev_count = 0;
+    result = m_pfn_enumerate_xdevs(m_xdev_list, 0, &xdev_count, nullptr);
+    if (XR_FAILED(result) || xdev_count == 0)
+    {
+        std::cerr << "[Manus] No XDevs found, falling back to controllers" << std::endl;
+        return;
+    }
+
+    std::vector<XrXDevIdMNDX> xdev_ids(xdev_count);
+    result = m_pfn_enumerate_xdevs(m_xdev_list, xdev_count, &xdev_count, xdev_ids.data());
+    if (XR_FAILED(result))
+    {
+        return;
+    }
+
+    // Find native hand tracking devices by matching against their serial strings.
+    //
+    // NOTE: The serial values "Head Device (0)" (left) and "Head Device (1)" (right) are
+    // NOT defined by the XR_MNDX_xdev_space specification. They are an observed runtime-
+    // specific naming convention (e.g. Monado). If a runtime changes these display names
+    // across firmware or software updates the match below will silently fail.
+    // See: https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html (XR_MNDX_xdev_space)
+    XrXDevIdMNDX left_xdev_id = 0;
+    XrXDevIdMNDX right_xdev_id = 0;
+    std::vector<std::string> seen_serials;
+
+    for (const auto& xdev_id : xdev_ids)
+    {
+        XrGetXDevInfoMNDX get_info{ XR_TYPE_GET_XDEV_INFO_MNDX };
+        get_info.id = xdev_id;
+
+        XrXDevPropertiesMNDX properties{ XR_TYPE_XDEV_PROPERTIES_MNDX };
+        result = m_pfn_get_xdev_properties(m_xdev_list, &get_info, &properties);
+        if (XR_FAILED(result))
+        {
+            continue;
+        }
+
+        std::string serial_str = properties.serial ? properties.serial : "";
+        seen_serials.push_back(serial_str);
+
+        if (serial_str == "Head Device (0)")
+        {
+            left_xdev_id = xdev_id;
+        }
+        else if (serial_str == "Head Device (1)")
+        {
+            right_xdev_id = xdev_id;
+        }
+    }
+
+    if (left_xdev_id == 0 || right_xdev_id == 0)
+    {
+        std::string serials_list;
+        for (const auto& s : seen_serials)
+        {
+            if (!serials_list.empty())
+                serials_list += ", ";
+            serials_list += '"';
+            serials_list += s;
+            serials_list += '"';
+        }
+        std::cerr << "[Manus] Could not match optical hand-tracking XDevs by serial. "
+                  << "Expected \"Head Device (0)\" (left) and \"Head Device (1)\" (right), "
+                  << "but found: [" << serials_list << "]. "
+                  << "These serial strings are runtime-specific and may have changed." << std::endl;
+    }
+
+    // Create hand trackers from XDevs
+    auto create_tracker = [this](XrXDevIdMNDX xdev_id, XrHandEXT hand, XrHandTrackerEXT& out_tracker) -> bool
+    {
+        if (xdev_id == 0)
+        {
+            return false;
+        }
+
+        XrCreateHandTrackerXDevMNDX xdev_create_info{ XR_TYPE_CREATE_HAND_TRACKER_XDEV_MNDX };
+        xdev_create_info.xdevList = m_xdev_list;
+        xdev_create_info.id = xdev_id;
+
+        XrHandTrackerCreateInfoEXT create_info{ XR_TYPE_HAND_TRACKER_CREATE_INFO_EXT };
+        create_info.next = &xdev_create_info;
+        create_info.hand = hand;
+        create_info.handJointSet = XR_HAND_JOINT_SET_DEFAULT_EXT;
+
+        return XR_SUCCEEDED(m_pfn_create_hand_tracker(m_handles.session, &create_info, &out_tracker));
+    };
+
+    bool left_ok = create_tracker(left_xdev_id, XR_HAND_LEFT_EXT, m_native_left_hand_tracker);
+    bool right_ok = create_tracker(right_xdev_id, XR_HAND_RIGHT_EXT, m_native_right_hand_tracker);
+
+    if (left_ok && right_ok)
+    {
+        m_xdev_available = true;
+    }
+    else
+    {
+        std::cerr << "[Manus] Failed to create native hand trackers, falling back to controllers" << std::endl;
+        cleanup_xdev_hand_trackers();
+    }
+}
+
+void ManusTracker::cleanup_xdev_hand_trackers()
+{
+    if (m_native_left_hand_tracker != XR_NULL_HANDLE && m_pfn_destroy_hand_tracker)
+    {
+        m_pfn_destroy_hand_tracker(m_native_left_hand_tracker);
+        m_native_left_hand_tracker = XR_NULL_HANDLE;
+    }
+    if (m_native_right_hand_tracker != XR_NULL_HANDLE && m_pfn_destroy_hand_tracker)
+    {
+        m_pfn_destroy_hand_tracker(m_native_right_hand_tracker);
+        m_native_right_hand_tracker = XR_NULL_HANDLE;
+    }
+    if (m_xdev_list != XR_NULL_HANDLE && m_pfn_destroy_xdev_list)
+    {
+        m_pfn_destroy_xdev_list(m_xdev_list);
+        m_xdev_list = XR_NULL_HANDLE;
+    }
+    m_xdev_available = false;
+}
+
+bool ManusTracker::update_xdev_hand(XrHandTrackerEXT tracker, XrTime time, XrPosef& out_wrist_pose, bool& out_is_tracked)
+{
+    out_is_tracked = false;
+
+    if (tracker == XR_NULL_HANDLE || !m_pfn_locate_hand_joints || time == 0)
+    {
+        return false;
+    }
+
+    XrHandJointsLocateInfoEXT locate_info{ XR_TYPE_HAND_JOINTS_LOCATE_INFO_EXT };
+    locate_info.baseSpace = m_handles.space;
+    locate_info.time = time;
+
+    XrHandJointLocationEXT joint_locations[XR_HAND_JOINT_COUNT_EXT];
+
+    XrHandJointLocationsEXT locations{ XR_TYPE_HAND_JOINT_LOCATIONS_EXT };
+    locations.jointCount = XR_HAND_JOINT_COUNT_EXT;
+    locations.jointLocations = joint_locations;
+
+    XrResult result = m_pfn_locate_hand_joints(tracker, &locate_info, &locations);
+    if (XR_FAILED(result) || !locations.isActive)
+    {
+        return false;
+    }
+
+    const auto& wrist = joint_locations[XR_HAND_JOINT_WRIST_EXT];
+    const bool is_valid = (wrist.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) &&
+                          (wrist.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT);
+
+    if (is_valid)
+    {
+        out_wrist_pose = wrist.pose;
+        // Distinguish actively tracked from valid-but-predicted/stale poses so
+        // callers can advertise TRACKED bits only when the runtime confirms it.
+        out_is_tracked = (wrist.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT) &&
+                         (wrist.locationFlags & XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT);
+        return true;
+    }
+
+    return false;
+}
+
+bool ManusTracker::get_controller_wrist_pose(bool is_left, XrPosef& out_wrist_pose)
+{
+    const auto& tracked = is_left ? m_controller_tracker->get_left_controller(*m_deviceio_session) :
+                                    m_controller_tracker->get_right_controller(*m_deviceio_session);
+
+    if (!tracked.data)
+    {
+        return false;
+    }
+
+    bool aim_valid = false;
+    XrPosef raw_pose = oxr_utils::get_aim_pose(*tracked.data, aim_valid);
+
+    if (!aim_valid)
+    {
+        return false;
+    }
+
+    XrPosef offset_pose = is_left ? kLeftHandOffset : kRightHandOffset;
+    out_wrist_pose = oxr_utils::multiply_poses(raw_pose, offset_pose);
+    return true;
 }
 
 void ManusTracker::inject_hand_data()
@@ -364,65 +695,63 @@ void ManusTracker::inject_hand_data()
         right_nodes = m_right_hand_nodes;
     }
 
-    // Get controller data from DeviceIOSession
-    const auto& left_tracked = m_controller_tracker->get_left_controller(*m_deviceio_session);
-    const auto& right_tracked = m_controller_tracker->get_right_controller(*m_deviceio_session);
-
-    // Use the OpenXR runtime clock for injection time so it aligns with the
-    // runtime's own time domain (XrTime), rather than a raw steady_clock cast.
+    // Get current XrTime from the system monotonic clock
     XrTime time = m_time_converter->os_monotonic_now();
 
-    auto process_hand =
-        [&](const std::vector<SkeletonNode>& nodes, bool is_left, std::unique_ptr<plugin_utils::HandInjector>& injector)
+    auto process_hand = [&](const std::vector<SkeletonNode>& nodes, bool is_left)
     {
         if (nodes.empty())
         {
-            // Glove has disconnected — reset the injector so the runtime sees
-            // isActive=false. No-op if already null.
-            injector.reset();
             return;
-        }
-
-        if (!injector)
-        {
-            // Glove reconnected — lazily recreate the push device.
-            const auto handles = m_session->get_handles();
-            XrHandEXT hand = is_left ? XR_HAND_LEFT_EXT : XR_HAND_RIGHT_EXT;
-            injector =
-                std::make_unique<plugin_utils::HandInjector>(handles.instance, handles.session, hand, handles.space);
         }
 
         XrHandJointLocationEXT joints[XR_HAND_JOINT_COUNT_EXT];
         XrPosef root_pose = { { 0.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f } };
         bool is_root_tracked = false;
 
-        // Get controller snapshot for this hand
-        const auto& tracked = is_left ? left_tracked : right_tracked;
-
-        if (tracked.data)
+        // Get wrist pose - auto-select hand tracking or controllers
+        XrPosef wrist_pose;
+        bool xdev_pose_valid = false;
+        if (m_xdev_available)
         {
-            bool aim_valid = false;
-            XrPosef raw_pose = oxr_utils::get_aim_pose(*tracked.data, aim_valid);
-
-            if (aim_valid)
+            XrHandTrackerEXT tracker = is_left ? m_native_left_hand_tracker : m_native_right_hand_tracker;
+            bool xdev_tracked = false;
+            if (update_xdev_hand(tracker, time, wrist_pose, xdev_tracked))
             {
-                XrPosef offset_pose = is_left ? kLeftHandOffset : kRightHandOffset;
-                XrPosef new_root = oxr_utils::multiply_poses(raw_pose, offset_pose);
-
+                // Cache the pose (valid even when only predicted/stale) so the
+                // last good pose is available if tracking is briefly interrupted.
                 if (is_left)
                 {
-                    m_left_root_pose = new_root;
+                    m_left_root_pose = wrist_pose;
                 }
                 else
                 {
-                    m_right_root_pose = new_root;
+                    m_right_root_pose = wrist_pose;
                 }
-                is_root_tracked = true;
+                // Only mark as tracked when the runtime confirms active tracking;
+                // a valid-but-untracked pose must not have TRACKED bits set.
+                is_root_tracked = xdev_tracked;
+                xdev_pose_valid = true;
             }
         }
 
-        root_pose = is_left ? m_left_root_pose : m_right_root_pose;
+        // Fall back to controllers only when xdev provided no valid pose at all.
+        // If xdev gave a valid-but-untracked pose we keep it rather than
+        // overwriting it with a controller pose that would be falsely marked tracked.
+        if (!xdev_pose_valid && get_controller_wrist_pose(is_left, wrist_pose))
+        {
+            if (is_left)
+            {
+                m_left_root_pose = wrist_pose;
+            }
+            else
+            {
+                m_right_root_pose = wrist_pose;
+            }
+            is_root_tracked = true;
+        }
 
+        root_pose = is_left ? m_left_root_pose : m_right_root_pose;
         uint32_t nodes_count = static_cast<uint32_t>(nodes.size());
 
         for (uint32_t j = 0; j < XR_HAND_JOINT_COUNT_EXT; j++)
@@ -483,18 +812,16 @@ void ManusTracker::inject_hand_data()
 
         if (is_left)
         {
-            if (m_left_injector)
-                m_left_injector->push(joints, time);
+            m_left_injector->push(joints, time);
         }
         else
         {
-            if (m_right_injector)
-                m_right_injector->push(joints, time);
+            m_right_injector->push(joints, time);
         }
     };
 
-    process_hand(left_nodes, true, m_left_injector);
-    process_hand(right_nodes, false, m_right_injector);
+    process_hand(left_nodes, true);
+    process_hand(right_nodes, false);
 }
 
 } // namespace manus

--- a/src/plugins/manus/inc/core/manus_hand_tracking_plugin.hpp
+++ b/src/plugins/manus/inc/core/manus_hand_tracking_plugin.hpp
@@ -1,15 +1,18 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
 
 #include <deviceio_session/deviceio_session.hpp>
 #include <deviceio_trackers/controller_tracker.hpp>
-#include <openxr/openxr.h>
+#include <deviceio_trackers/hand_tracker.hpp>
+#include <openxr/openxr_platform.h>
+#include <oxr/oxr_session.hpp>
 #include <oxr_utils/oxr_time.hpp>
 #include <plugin_utils/hand_injector.hpp>
 
 #include <ManusSDK.h>
+#include <XR_MNDX_xdev_space.h>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -29,11 +32,14 @@ namespace manus
 class __attribute__((visibility("default"))) ManusTracker
 {
 public:
+    /// Get the singleton instance
     static ManusTracker& instance(const std::string& app_name = "ManusHandPlugin") noexcept(false);
 
     void update();
     std::vector<SkeletonNode> get_left_hand_nodes() const;
     std::vector<SkeletonNode> get_right_hand_nodes() const;
+    std::vector<NodeInfo> get_left_node_info() const;
+    std::vector<NodeInfo> get_right_node_info() const;
 
 private:
     // Lifecycle
@@ -56,6 +62,14 @@ private:
 
     // OpenXR specific methods
     void inject_hand_data();
+    void initialize_xdev_hand_trackers();
+    void cleanup_xdev_hand_trackers();
+    // Returns true if a valid (POSITION_VALID | ORIENTATION_VALID) wrist pose was
+    // obtained. out_is_tracked is set to true only when the runtime also reports
+    // POSITION_TRACKED | ORIENTATION_TRACKED, meaning the pose is actively tracked
+    // rather than predicted/stale.
+    bool update_xdev_hand(XrHandTrackerEXT tracker, XrTime time, XrPosef& out_wrist_pose, bool& out_is_tracked);
+    bool get_controller_wrist_pose(bool is_left, XrPosef& out_wrist_pose);
 
     // -- Member Variables --
 
@@ -71,11 +85,28 @@ private:
 
     // OpenXR State
     std::shared_ptr<core::OpenXRSession> m_session;
+    core::OpenXRSessionHandles m_handles;
     std::unique_ptr<plugin_utils::HandInjector> m_left_injector;
     std::unique_ptr<plugin_utils::HandInjector> m_right_injector;
-    std::optional<core::XrTimeConverter> m_time_converter;
     std::shared_ptr<core::ControllerTracker> m_controller_tracker;
+    std::shared_ptr<core::HandTracker> m_hand_tracker;
     std::unique_ptr<core::DeviceIOSession> m_deviceio_session;
+
+    // XDev native hand trackers (Quest 3 hand tracking via XR_MNDX_xdev_space)
+    XrXDevListMNDX m_xdev_list = XR_NULL_HANDLE;
+    XrHandTrackerEXT m_native_left_hand_tracker = XR_NULL_HANDLE;
+    XrHandTrackerEXT m_native_right_hand_tracker = XR_NULL_HANDLE;
+    bool m_xdev_available = false;
+
+    // XDev function pointers
+    PFN_xrCreateXDevListMNDX m_pfn_create_xdev_list = nullptr;
+    PFN_xrDestroyXDevListMNDX m_pfn_destroy_xdev_list = nullptr;
+    PFN_xrEnumerateXDevsMNDX m_pfn_enumerate_xdevs = nullptr;
+    PFN_xrGetXDevPropertiesMNDX m_pfn_get_xdev_properties = nullptr;
+    PFN_xrCreateHandTrackerEXT m_pfn_create_hand_tracker = nullptr;
+    PFN_xrDestroyHandTrackerEXT m_pfn_destroy_hand_tracker = nullptr;
+    PFN_xrLocateHandJointsEXT m_pfn_locate_hand_joints = nullptr;
+
     // Persistent root poses (initialized to identity)
     XrPosef m_left_root_pose = { { 0.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f } };
     XrPosef m_right_root_pose = { { 0.0f, 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, 0.0f } };
@@ -84,6 +115,12 @@ private:
     mutable std::mutex m_skeleton_mutex;
     std::vector<SkeletonNode> m_left_hand_nodes;
     std::vector<SkeletonNode> m_right_hand_nodes;
+    // Node topology (parent IDs) — populated once per glove connect
+    std::vector<NodeInfo> m_left_node_info;
+    std::vector<NodeInfo> m_right_node_info;
+
+    // Time converter for XR timestamps (initialized after handles are ready)
+    std::optional<core::XrTimeConverter> m_time_converter;
 };
 
 } // namespace manus

--- a/src/plugins/manus/install_manus.sh
+++ b/src/plugins/manus/install_manus.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e  # Exit on error
+set -u  # Exit on undefined variable
+
+echo "=== MANUS SDK Installation Script ==="
+echo ""
+
+# Define SDK download URL and version
+MANUS_SDK_VERSION="3.1.1"
+MANUS_SDK_URL="https://static.manus-meta.com/resources/manus_core_3/sdk/MANUS_Core_${MANUS_SDK_VERSION}_SDK.zip"
+MANUS_SDK_ZIP="MANUS_Core_${MANUS_SDK_VERSION}_SDK.zip"
+MANUS_SDK_SHA256="c5ccd3c42a501107ec79f70d8450a486fbc3925c5c1e18e606114d09f2d9d24a"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Detect architecture
+ARCH=$(uname -m)
+echo "Detected architecture: $ARCH"
+echo ""
+
+# Install MANUS Core Integrated dependencies
+echo "[1/4] Installing MANUS Core Integrated dependencies..."
+sudo apt-get update
+sudo apt-get install -y \
+    build-essential \
+    cmake \
+    curl \
+    git \
+    libssl-dev \
+    unzip \
+    zlib1g-dev \
+    libc-ares-dev \
+    libzmq3-dev \
+    libncurses-dev \
+    libudev-dev \
+    libusb-1.0-0-dev \
+    libvulkan-dev \
+    libx11-dev
+
+# Add read/write permissions for manus devices
+if [ ! -f "/etc/udev/rules.d/70-manus-hid.rules" ]; then
+    echo "Adding read/write permissions for manus devices..."
+    sudo mkdir -p /etc/udev/rules.d/
+    sudo cp "$SCRIPT_DIR/70-manus-hid.rules" /etc/udev/rules.d/70-manus-hid.rules
+    sudo udevadm control --reload-rules
+fi
+echo ""
+
+# Download MANUS SDK
+echo "[2/4] Downloading MANUS SDK v${MANUS_SDK_VERSION}..."
+cd "$SCRIPT_DIR"
+
+if [ -f "$MANUS_SDK_ZIP" ]; then
+    echo "SDK archive already exists. Skipping download."
+else
+    if command -v curl &> /dev/null; then
+        # -f: fail on HTTP errors (4xx/5xx), -L: follow redirects
+        curl -fL "$MANUS_SDK_URL" -o "$MANUS_SDK_ZIP"
+    elif command -v wget &> /dev/null; then
+        # --server-response prints HTTP status; wget already exits non-zero on errors
+        wget --server-response "$MANUS_SDK_URL" -O "$MANUS_SDK_ZIP"
+    else
+        echo "Error: Neither curl nor wget found. Please install curl (apt-get install curl)."
+        exit 1
+    fi
+fi
+
+# Verify archive integrity before extracting
+if [ -n "${MANUS_SDK_SHA256:-}" ]; then
+    echo "Verifying SDK archive checksum..."
+    ACTUAL_SHA256=$(sha256sum "$MANUS_SDK_ZIP" | awk '{print $1}')
+    if [ "$ACTUAL_SHA256" != "$MANUS_SDK_SHA256" ]; then
+        echo "Error: SHA-256 checksum mismatch for $MANUS_SDK_ZIP"
+        echo "  Expected: $MANUS_SDK_SHA256"
+        echo "  Actual:   $ACTUAL_SHA256"
+        echo "The archive may be corrupted or tampered with. Aborting."
+        rm -f "$MANUS_SDK_ZIP"
+        exit 1
+    fi
+    echo "Checksum verified."
+else
+    echo "Warning: MANUS_SDK_SHA256 is not set. Skipping checksum verification."
+    echo "         Set MANUS_SDK_SHA256 in install_manus.sh to enable integrity checking."
+fi
+echo ""
+
+# Extract SDK and copy ManusSDK folder
+echo "[3/4] Extracting MANUS SDK..."
+
+# Remove existing ManusSDK if present
+if [ -d "$SCRIPT_DIR/ManusSDK" ]; then
+    echo "Removing existing ManusSDK directory..."
+    rm -rf "$SCRIPT_DIR/ManusSDK"
+fi
+
+# Extract the archive
+if command -v unzip &> /dev/null; then
+    unzip -q "$MANUS_SDK_ZIP"
+else
+    echo "Error: unzip command not found. Please install unzip."
+    exit 1
+fi
+
+SDK_CLIENT_DIR="SDKClient_Linux"
+
+# Find and copy ManusSDK folder
+EXTRACTED_DIR=$(find . -maxdepth 1 -type d -name "ManusSDK_v*" | head -n 1)
+if [ -z "$EXTRACTED_DIR" ]; then
+    echo "Error: Could not find extracted SDK directory."
+    exit 1
+fi
+
+if [ -d "$EXTRACTED_DIR/$SDK_CLIENT_DIR/ManusSDK" ]; then
+    echo "Copying ManusSDK folder from $SDK_CLIENT_DIR..."
+    cp -r "$EXTRACTED_DIR/$SDK_CLIENT_DIR/ManusSDK" "$SCRIPT_DIR/"
+    echo "ManusSDK copied successfully to $SCRIPT_DIR/ManusSDK"
+    echo "Note: Using libManusSDK_Integrated.so (CMake auto-selects)."
+else
+    echo "Error: ManusSDK folder not found in $EXTRACTED_DIR/$SDK_CLIENT_DIR"
+    exit 1
+fi
+
+# Clean up extracted directory and zip file
+echo "Cleaning up temporary files..."
+rm -rf "$EXTRACTED_DIR"
+rm -f "$MANUS_SDK_ZIP"
+echo ""
+
+# Build the plugin
+echo "[4/4] Building Manus plugin from TeleopCore root..."
+
+# Find TeleopCore root (3 levels up from src/plugins/manus)
+TELEOP_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+cd "$TELEOP_ROOT"
+
+echo "TeleopCore root: $TELEOP_ROOT"
+
+echo "Configuring CMake..."
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+
+# Build the plugin and the diagnostic printer tool
+echo "Building..."
+cmake --build build --target manus_hand_plugin manus_hand_tracker_printer -j$(nproc)
+
+# Install only the manus component
+echo "Installing..."
+cmake --install build --component manus
+
+echo ""
+echo "=== Installation Complete ==="
+echo "MANUS SDK v${MANUS_SDK_VERSION} installed to: $SCRIPT_DIR/ManusSDK"
+echo "Plugin built and installed successfully"
+echo "Plugin executable:  $TELEOP_ROOT/install/plugins/manus/manus_hand_plugin"
+echo "Printer diagnostic: $TELEOP_ROOT/build/bin/manus_hand_tracker_printer"
+echo ""
+echo "To reload udev rules (if not already done), run:"
+echo "  sudo udevadm control --reload-rules"
+echo "  sudo udevadm trigger"
+echo ""

--- a/src/plugins/manus/tools/CMakeLists.txt
+++ b/src/plugins/manus/tools/CMakeLists.txt
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+find_package(Vulkan REQUIRED)
+find_package(X11 REQUIRED)
+
 add_executable(manus_hand_tracker_printer
   manus_hand_tracker_printer.cpp
 )
@@ -8,6 +11,13 @@ add_executable(manus_hand_tracker_printer
 target_link_libraries(manus_hand_tracker_printer
   PRIVATE
     manus_plugin_core
+    Vulkan::Vulkan
+    X11::X11
+)
+
+target_include_directories(manus_hand_tracker_printer
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
 set_target_properties(manus_hand_tracker_printer PROPERTIES
@@ -16,5 +26,11 @@ set_target_properties(manus_hand_tracker_printer PROPERTIES
   BUILD_WITH_INSTALL_RPATH NO
   SKIP_BUILD_RPATH NO
   BUILD_RPATH "${_ISAAC_MANUS_EFFECTIVE_BUILD_RPATH_STR}"
+  INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}"
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+)
+
+install(TARGETS manus_hand_tracker_printer
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT manus
 )

--- a/src/plugins/manus/tools/manus_hand_tracker_printer.cpp
+++ b/src/plugins/manus/tools/manus_hand_tracker_printer.cpp
@@ -1,5 +1,7 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+#include "manus_hand_visualizer.hpp"
 
 #include <core/manus_hand_tracking_plugin.hpp>
 
@@ -16,14 +18,34 @@ try
     (void)argc;
     (void)argv;
 
-    std::cout << "Initializing Manus Tracker..." << std::endl;
+    std::cout << "[Manus] Initializing Manus Tracker..." << std::endl;
 
     // Initialize the Manus tracker
     auto& tracker = plugins::manus::ManusTracker::instance("ManusHandPrinter");
 
-    std::cout << "Press Ctrl+C to stop. Printing joint data..." << std::endl;
+    // Start Vulkan visualizer in a background thread.
+    // If X11 or Vulkan is unavailable the thread exits cleanly and printing
+    // continues without the window.
+    // std::jthread automatically requests stop and joins on destruction,
+    // preventing the thread from outliving the tracker singleton.
+    std::jthread vis_thread(
+        [&tracker](std::stop_token st)
+        {
+            try
+            {
+                plugins::manus::HandVisualizer vis;
+                vis.run(tracker, std::move(st));
+            }
+            catch (const std::exception& e)
+            {
+                std::cerr << "[Vis] " << e.what() << " — running without visualizer" << std::endl;
+            }
+        });
+
+    std::cout << "[Manus] Press Ctrl+C to stop. Printing joint data..." << std::endl;
 
     int frame = 0;
+    bool waiting_printed = false;
     while (true)
     {
         // Get glove data from Manus SDK
@@ -32,12 +54,17 @@ try
 
         if (left_nodes.empty() && right_nodes.empty())
         {
-            std::cout << "No data available yet..." << std::endl;
+            if (!waiting_printed)
+            {
+                std::cout << "[Manus] Waiting for gloves..." << std::endl;
+                waiting_printed = true;
+            }
             std::this_thread::sleep_for(std::chrono::milliseconds(200));
             continue;
         }
+        waiting_printed = false;
 
-        std::cout << "\n=== Frame " << frame << " ===" << std::endl;
+        std::cout << "\n[Manus] === Frame " << frame << " ===" << std::endl;
 
         // Helper lambda to print hand data
         auto print_hand = [](const std::string& side, const std::vector<SkeletonNode>& nodes)
@@ -47,14 +74,14 @@ try
                 return;
             }
 
-            std::cout << "\n" << side << " hand (" << nodes.size() << " joints):" << std::endl;
+            std::cout << "[Manus] " << side << " hand (" << nodes.size() << " joints):" << std::endl;
 
             for (size_t i = 0; i < std::min(nodes.size(), static_cast<size_t>(5)); ++i)
             {
                 const auto& pos = nodes[i].transform.position;
                 const auto& ori = nodes[i].transform.rotation;
 
-                std::cout << "  Joint " << i << ": "
+                std::cout << "[Manus]   Joint " << i << ": "
                           << "pos=[" << std::fixed << std::setprecision(3) << pos.x << ", " << pos.y << ", " << pos.z
                           << "] "
                           << "ori=[" << ori.x << ", " << ori.y << ", " << ori.z << ", " << ori.w << "]" << std::endl;
@@ -62,7 +89,7 @@ try
 
             if (nodes.size() > 5)
             {
-                std::cout << "  ... (" << (nodes.size() - 5) << " more joints)" << std::endl;
+                std::cout << "[Manus]   ... (" << (nodes.size() - 5) << " more joints)" << std::endl;
             }
         };
 

--- a/src/plugins/manus/tools/manus_hand_visualizer.hpp
+++ b/src/plugins/manus/tools/manus_hand_visualizer.hpp
@@ -1,0 +1,1360 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Xlib must be included before Vulkan xlib surface header.
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <core/manus_hand_tracking_plugin.hpp>
+#include <vulkan/vulkan.h>
+#include <vulkan/vulkan_xlib.h>
+
+#include <array>
+#include <cstring>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <stop_token>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace plugins
+{
+namespace manus
+{
+
+// ---------------------------------------------------------------------------
+// Hand visualizer — opens an Xlib window and renders Manus hand skeletons
+// using raw Vulkan (no external windowing library required).
+//
+// Usage (from a background thread):
+//   HandVisualizer vis;      // throws if Vulkan/X11 unavailable
+//   vis.run(tracker);        // blocks until window is closed
+// ---------------------------------------------------------------------------
+class HandVisualizer
+{
+public:
+    // Construct and initialise Xlib + Vulkan.  Throws std::runtime_error if
+    // either is unavailable so the caller can continue without the visualizer.
+    HandVisualizer();
+    ~HandVisualizer();
+
+    // Block until the window is closed.  Reads hand data from tracker each frame.
+    // Exits early when st.stop_requested() returns true, allowing the owning
+    // std::jthread to request a clean shutdown before its destructor joins.
+    void run(ManusTracker& tracker, std::stop_token st = {});
+
+    // Non-copyable / non-movable (owns raw Vulkan handles).
+    HandVisualizer(const HandVisualizer&) = delete;
+    HandVisualizer& operator=(const HandVisualizer&) = delete;
+
+private:
+    // -----------------------------------------------------------------------
+    // Pre-compiled SPIR-V for the vertex shader:
+    //   layout(location=0) in  vec2 inPos;
+    //   layout(location=1) in  vec3 inColor;
+    //   layout(location=0) out vec3 fragColor;
+    //   void main() { gl_Position = vec4(inPos, 0.0, 1.0); fragColor = inColor; }
+    // -----------------------------------------------------------------------
+    static constexpr uint32_t kVertSpv[] = {
+        /* Header: magic, ver 1.0, gen 0, bound 30, schema 0 */
+        0x07230203,
+        0x00010000,
+        0x00000000,
+        0x0000001E,
+        0x00000000,
+        /* OpCapability Shader              */ 0x00020011,
+        0x00000001,
+        /* %1 OpExtInstImport "GLSL.std.450"*/ 0x0006000B,
+        0x00000001,
+        0x4C534C47,
+        0x6474732E,
+        0x3035342E,
+        0x00000000,
+        /* OpMemoryModel Logical GLSL450    */ 0x0003000E,
+        0x00000000,
+        0x00000001,
+        /* OpEntryPoint Vertex %4 "main" %9 %12 %16 %23 */
+        0x0009000F,
+        0x00000000,
+        0x00000004,
+        0x6E69616D,
+        0x00000000,
+        0x00000009,
+        0x0000000C,
+        0x00000010,
+        0x00000017,
+        /* OpDecorate %9  Location 0        */ 0x00040047,
+        0x00000009,
+        0x0000001E,
+        0x00000000,
+        /* OpDecorate %12 Location 1        */ 0x00040047,
+        0x0000000C,
+        0x0000001E,
+        0x00000001,
+        /* OpDecorate %23 Location 0        */ 0x00040047,
+        0x00000017,
+        0x0000001E,
+        0x00000000,
+        /* OpMemberDecorate %14 0 BuiltIn Position */ 0x00050048,
+        0x0000000E,
+        0x00000000,
+        0x0000000B,
+        0x00000000,
+        /* OpDecorate %14 Block             */ 0x00030047,
+        0x0000000E,
+        0x00000002,
+        /* %2  OpTypeVoid                   */ 0x00020013,
+        0x00000002,
+        /* %3  OpTypeFunction %2            */ 0x00030021,
+        0x00000003,
+        0x00000002,
+        /* %6  OpTypeFloat 32               */ 0x00030016,
+        0x00000006,
+        0x00000020,
+        /* %7  OpTypeVector %6 2            */ 0x00040017,
+        0x00000007,
+        0x00000006,
+        0x00000002,
+        /* %8  OpTypePointer Input %7       */ 0x00040020,
+        0x00000008,
+        0x00000001,
+        0x00000007,
+        /* %9  OpVariable %8 Input          */ 0x0004003B,
+        0x00000008,
+        0x00000009,
+        0x00000001,
+        /* %10 OpTypeVector %6 3            */ 0x00040017,
+        0x0000000A,
+        0x00000006,
+        0x00000003,
+        /* %11 OpTypePointer Input %10      */ 0x00040020,
+        0x0000000B,
+        0x00000001,
+        0x0000000A,
+        /* %12 OpVariable %11 Input         */ 0x0004003B,
+        0x0000000B,
+        0x0000000C,
+        0x00000001,
+        /* %13 OpTypeVector %6 4            */ 0x00040017,
+        0x0000000D,
+        0x00000006,
+        0x00000004,
+        /* %14 OpTypeStruct %13 (gl_PerVertex: position only) */
+        0x0003001E,
+        0x0000000E,
+        0x0000000D,
+        /* %15 OpTypePointer Output %14     */ 0x00040020,
+        0x0000000F,
+        0x00000003,
+        0x0000000E,
+        /* %16 OpVariable %15 Output        */ 0x0004003B,
+        0x0000000F,
+        0x00000010,
+        0x00000003,
+        /* %17 OpTypeInt 32 signed          */ 0x00040015,
+        0x00000011,
+        0x00000020,
+        0x00000001,
+        /* %18 OpConstant int 0             */ 0x0004002B,
+        0x00000011,
+        0x00000012,
+        0x00000000,
+        /* %19 OpConstant float 0.0         */ 0x0004002B,
+        0x00000006,
+        0x00000013,
+        0x00000000,
+        /* %20 OpConstant float 1.0         */ 0x0004002B,
+        0x00000006,
+        0x00000014,
+        0x3F800000,
+        /* %21 OpTypePointer Output vec4    */ 0x00040020,
+        0x00000015,
+        0x00000003,
+        0x0000000D,
+        /* %22 OpTypePointer Output vec3    */ 0x00040020,
+        0x00000016,
+        0x00000003,
+        0x0000000A,
+        /* %23 OpVariable %22 Output        */ 0x0004003B,
+        0x00000016,
+        0x00000017,
+        0x00000003,
+        /* %4  OpFunction void None %3      */ 0x00050036,
+        0x00000002,
+        0x00000004,
+        0x00000000,
+        0x00000003,
+        /* %5  OpLabel                      */ 0x000200F8,
+        0x00000005,
+        /* %24 OpLoad vec2 %9               */ 0x0004003D,
+        0x00000007,
+        0x00000018,
+        0x00000009,
+        /* %25 OpCompositeExtract float %24[0] */ 0x00050051,
+        0x00000006,
+        0x00000019,
+        0x00000018,
+        0x00000000,
+        /* %26 OpCompositeExtract float %24[1] */ 0x00050051,
+        0x00000006,
+        0x0000001A,
+        0x00000018,
+        0x00000001,
+        /* %27 OpCompositeConstruct vec4 (x,y,0,1) */
+        0x00070050,
+        0x0000000D,
+        0x0000001B,
+        0x00000019,
+        0x0000001A,
+        0x00000013,
+        0x00000014,
+        /* %28 OpAccessChain %21 %16[0]     */ 0x00050041,
+        0x00000015,
+        0x0000001C,
+        0x00000010,
+        0x00000012,
+        /* OpStore gl_Position = %27        */ 0x0003003E,
+        0x0000001C,
+        0x0000001B,
+        /* %29 OpLoad vec3 %12              */ 0x0004003D,
+        0x0000000A,
+        0x0000001D,
+        0x0000000C,
+        /* OpStore fragColor = %29          */ 0x0003003E,
+        0x00000017,
+        0x0000001D,
+        /* OpReturn                         */ 0x000100FD,
+        /* OpFunctionEnd                    */ 0x00010038,
+    };
+
+    // -----------------------------------------------------------------------
+    // Pre-compiled SPIR-V for the fragment shader:
+    //   layout(location=0) in  vec3 fragColor;
+    //   layout(location=0) out vec4 outColor;
+    //   void main() { outColor = vec4(fragColor, 1.0); }
+    // -----------------------------------------------------------------------
+    static constexpr uint32_t kFragSpv[] = {
+        /* Header: magic, ver 1.0, gen 0, bound 19, schema 0 */
+        0x07230203,
+        0x00010000,
+        0x00000000,
+        0x00000013,
+        0x00000000,
+        /* OpCapability Shader              */ 0x00020011,
+        0x00000001,
+        /* %1 OpExtInstImport "GLSL.std.450"*/ 0x0006000B,
+        0x00000001,
+        0x4C534C47,
+        0x6474732E,
+        0x3035342E,
+        0x00000000,
+        /* OpMemoryModel Logical GLSL450    */ 0x0003000E,
+        0x00000000,
+        0x00000001,
+        /* OpEntryPoint Fragment %4 "main" %9 %12 */
+        0x0007000F,
+        0x00000004,
+        0x00000004,
+        0x6E69616D,
+        0x00000000,
+        0x00000009,
+        0x0000000C,
+        /* OpExecutionMode OriginUpperLeft  */ 0x00030010,
+        0x00000004,
+        0x00000007,
+        /* OpDecorate %9  Location 0        */ 0x00040047,
+        0x00000009,
+        0x0000001E,
+        0x00000000,
+        /* OpDecorate %12 Location 0        */ 0x00040047,
+        0x0000000C,
+        0x0000001E,
+        0x00000000,
+        /* %2  OpTypeVoid                   */ 0x00020013,
+        0x00000002,
+        /* %3  OpTypeFunction %2            */ 0x00030021,
+        0x00000003,
+        0x00000002,
+        /* %6  OpTypeFloat 32               */ 0x00030016,
+        0x00000006,
+        0x00000020,
+        /* %7  OpTypeVector %6 3            */ 0x00040017,
+        0x00000007,
+        0x00000006,
+        0x00000003,
+        /* %8  OpTypePointer Input %7       */ 0x00040020,
+        0x00000008,
+        0x00000001,
+        0x00000007,
+        /* %9  OpVariable %8 Input          */ 0x0004003B,
+        0x00000008,
+        0x00000009,
+        0x00000001,
+        /* %10 OpTypeVector %6 4            */ 0x00040017,
+        0x0000000A,
+        0x00000006,
+        0x00000004,
+        /* %11 OpTypePointer Output %10     */ 0x00040020,
+        0x0000000B,
+        0x00000003,
+        0x0000000A,
+        /* %12 OpVariable %11 Output        */ 0x0004003B,
+        0x0000000B,
+        0x0000000C,
+        0x00000003,
+        /* %13 OpConstant float 1.0         */ 0x0004002B,
+        0x00000006,
+        0x0000000D,
+        0x3F800000,
+        /* %4  OpFunction void None %3      */ 0x00050036,
+        0x00000002,
+        0x00000004,
+        0x00000000,
+        0x00000003,
+        /* %5  OpLabel                      */ 0x000200F8,
+        0x00000005,
+        /* %14 OpLoad vec3 %9               */ 0x0004003D,
+        0x00000007,
+        0x0000000E,
+        0x00000009,
+        /* %15 OpCompositeExtract float %14[0] */ 0x00050051,
+        0x00000006,
+        0x0000000F,
+        0x0000000E,
+        0x00000000,
+        /* %16 OpCompositeExtract float %14[1] */ 0x00050051,
+        0x00000006,
+        0x00000010,
+        0x0000000E,
+        0x00000001,
+        /* %17 OpCompositeExtract float %14[2] */ 0x00050051,
+        0x00000006,
+        0x00000011,
+        0x0000000E,
+        0x00000002,
+        /* %18 OpCompositeConstruct vec4    */ 0x00070050,
+        0x0000000A,
+        0x00000012,
+        0x0000000F,
+        0x00000010,
+        0x00000011,
+        0x0000000D,
+        /* OpStore outColor = %18           */ 0x0003003E,
+        0x0000000C,
+        0x00000012,
+        /* OpReturn                         */ 0x000100FD,
+        /* OpFunctionEnd                    */ 0x00010038,
+    };
+
+    // -----------------------------------------------------------------------
+    // Per-vertex data sent to the GPU.
+    // -----------------------------------------------------------------------
+    struct Vertex
+    {
+        float x, y; // NDC position
+        float r, g, b; // linear colour
+    };
+
+    static constexpr uint32_t kWindowW = 800;
+    static constexpr uint32_t kWindowH = 600;
+    static constexpr uint32_t kMaxVertices = 16384;
+    static constexpr float kCrossSize = 0.015f; // NDC half-length of joint marker
+
+    // Left-hand colour: cyan-blue; right-hand colour: orange
+    static constexpr std::array<float, 3> kLeftColor = { 0.20f, 0.65f, 1.00f };
+    static constexpr std::array<float, 3> kRightColor = { 1.00f, 0.50f, 0.10f };
+
+    // -----------------------------------------------------------------------
+    // Projection modes
+    // -----------------------------------------------------------------------
+    enum class ProjectionMode
+    {
+        Top,
+        Side
+    };
+
+    // -----------------------------------------------------------------------
+    // Per-hand cached scale/3-D center (locked on first data frame, reset on disconnect)
+    // -----------------------------------------------------------------------
+    struct HandState
+    {
+        float scale = 0.0f;
+        float cx = 0.0f, cy = 0.0f, cz = 0.0f;
+    };
+    HandState m_left_state, m_right_state;
+
+    // -----------------------------------------------------------------------
+    // Xlib state
+    // -----------------------------------------------------------------------
+    Display* m_dpy = nullptr;
+    Window m_win = 0;
+    Atom m_wm_del = 0;
+
+    // -----------------------------------------------------------------------
+    // Vulkan handles
+    // -----------------------------------------------------------------------
+    VkInstance m_instance = VK_NULL_HANDLE;
+    VkSurfaceKHR m_surface = VK_NULL_HANDLE;
+    VkPhysicalDevice m_pdev = VK_NULL_HANDLE;
+    VkDevice m_dev = VK_NULL_HANDLE;
+    VkQueue m_queue = VK_NULL_HANDLE;
+    uint32_t m_qfam = 0;
+
+    VkSwapchainKHR m_swapchain = VK_NULL_HANDLE;
+    VkFormat m_sc_format = VK_FORMAT_UNDEFINED;
+    VkExtent2D m_sc_extent = {};
+    std::vector<VkImage> m_sc_images;
+    std::vector<VkImageView> m_sc_views;
+
+    VkRenderPass m_render_pass = VK_NULL_HANDLE;
+    VkPipelineLayout m_pipe_layout = VK_NULL_HANDLE;
+    VkPipeline m_pipeline = VK_NULL_HANDLE;
+
+    std::vector<VkFramebuffer> m_framebuffers;
+    VkCommandPool m_cmd_pool = VK_NULL_HANDLE;
+    std::vector<VkCommandBuffer> m_cmd_bufs;
+
+    VkSemaphore m_sem_image_avail = VK_NULL_HANDLE;
+    VkSemaphore m_sem_render_done = VK_NULL_HANDLE;
+    VkFence m_fence_in_flight = VK_NULL_HANDLE;
+
+    VkBuffer m_vbuf = VK_NULL_HANDLE;
+    VkDeviceMemory m_vbuf_mem = VK_NULL_HANDLE;
+    void* m_vbuf_ptr = nullptr; // persistently mapped
+
+    // -----------------------------------------------------------------------
+    // Init helpers
+    // -----------------------------------------------------------------------
+    void initXlib();
+    void initVulkan();
+    void createSwapchain();
+    void createRenderPass();
+    void createPipeline();
+    void createFramebuffers();
+    void createCommandBuffers();
+    void createSyncObjects();
+    void createVertexBuffer();
+
+    void destroySwapchainResources();
+
+    // Releases all X11/Vulkan resources whose handles are non-null.
+    // Safe to call on a partially-constructed object because every handle is
+    // value-initialised to VK_NULL_HANDLE / nullptr / 0 and each branch is
+    // guarded.  Called from both ~HandVisualizer() and the constructor's
+    // catch block so that a mid-construction throw cannot leak handles.
+    void teardown() noexcept;
+
+    VkShaderModule createShaderModule(const uint32_t* spv, size_t bytes);
+
+    // -----------------------------------------------------------------------
+    // Per-frame helpers
+    // -----------------------------------------------------------------------
+
+    // Build geometry for one hand view panel.
+    // mode     : Top (XZ plane, top-down) or Side (ZY plane, thumb-axis).
+    // scale    : uniform scale shared between both views of this hand.
+    // cx/cy/cz : 3-D world center of the hand (bbox midpoint).
+    // ndc_cx/cy: NDC screen center of this quadrant.
+    static void buildHandGeometry(const std::vector<SkeletonNode>& nodes,
+                                  const std::vector<NodeInfo>& info,
+                                  const std::array<float, 3>& colour,
+                                  ProjectionMode mode,
+                                  float scale,
+                                  float cx,
+                                  float cy,
+                                  float cz,
+                                  float ndc_cx,
+                                  float ndc_cy,
+                                  std::vector<Vertex>& verts);
+
+    // Project one 3-D point: Top → (x, −z), Side → (−z, y).
+    static std::pair<float, float> project(const ManusVec3& p, ProjectionMode mode);
+
+    // Compute 3-D bounding box.  Returns false when nodes is empty.
+    static bool computeBbox3D(const std::vector<SkeletonNode>& nodes,
+                              float& xmin,
+                              float& xmax,
+                              float& ymin,
+                              float& ymax,
+                              float& zmin,
+                              float& zmax);
+};
+
+// ===========================================================================
+// Implementation (header-only)
+// ===========================================================================
+
+inline HandVisualizer::HandVisualizer()
+{
+    try
+    {
+        initXlib();
+        initVulkan();
+        createSwapchain();
+        createRenderPass();
+        createPipeline();
+        createFramebuffers();
+        createCommandBuffers();
+        createSyncObjects();
+        createVertexBuffer();
+    }
+    catch (...)
+    {
+        // The destructor is not invoked when a constructor throws, so we
+        // must explicitly release whatever handles were created before the
+        // failing call.
+        teardown();
+        throw;
+    }
+}
+
+inline HandVisualizer::~HandVisualizer()
+{
+    teardown();
+}
+
+inline void HandVisualizer::teardown() noexcept
+{
+    if (m_dev)
+        vkDeviceWaitIdle(m_dev);
+
+    if (m_vbuf_ptr && m_vbuf_mem)
+        vkUnmapMemory(m_dev, m_vbuf_mem);
+    if (m_vbuf)
+        vkDestroyBuffer(m_dev, m_vbuf, nullptr);
+    if (m_vbuf_mem)
+        vkFreeMemory(m_dev, m_vbuf_mem, nullptr);
+
+    if (m_sem_image_avail)
+        vkDestroySemaphore(m_dev, m_sem_image_avail, nullptr);
+    if (m_sem_render_done)
+        vkDestroySemaphore(m_dev, m_sem_render_done, nullptr);
+    if (m_fence_in_flight)
+        vkDestroyFence(m_dev, m_fence_in_flight, nullptr);
+
+    destroySwapchainResources();
+
+    if (m_render_pass)
+        vkDestroyRenderPass(m_dev, m_render_pass, nullptr);
+    if (m_pipe_layout)
+        vkDestroyPipelineLayout(m_dev, m_pipe_layout, nullptr);
+    if (m_pipeline)
+        vkDestroyPipeline(m_dev, m_pipeline, nullptr);
+    if (m_cmd_pool)
+        vkDestroyCommandPool(m_dev, m_cmd_pool, nullptr);
+    if (m_dev)
+        vkDestroyDevice(m_dev, nullptr);
+    if (m_surface)
+        vkDestroySurfaceKHR(m_instance, m_surface, nullptr);
+    if (m_instance)
+        vkDestroyInstance(m_instance, nullptr);
+
+    if (m_win && m_dpy)
+        XDestroyWindow(m_dpy, m_win);
+    if (m_dpy)
+        XCloseDisplay(m_dpy);
+
+    // Zero handles so repeated teardown() calls (e.g. via destructor after a
+    // catch-rethrow) are harmless.
+    m_vbuf_ptr = nullptr;
+    m_vbuf = VK_NULL_HANDLE;
+    m_vbuf_mem = VK_NULL_HANDLE;
+    m_sem_image_avail = VK_NULL_HANDLE;
+    m_sem_render_done = VK_NULL_HANDLE;
+    m_fence_in_flight = VK_NULL_HANDLE;
+    m_render_pass = VK_NULL_HANDLE;
+    m_pipe_layout = VK_NULL_HANDLE;
+    m_pipeline = VK_NULL_HANDLE;
+    m_cmd_pool = VK_NULL_HANDLE;
+    m_dev = VK_NULL_HANDLE;
+    m_surface = VK_NULL_HANDLE;
+    m_instance = VK_NULL_HANDLE;
+    m_win = 0;
+    m_dpy = nullptr;
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::initXlib()
+{
+    m_dpy = XOpenDisplay(nullptr);
+    if (!m_dpy)
+        throw std::runtime_error("[Vis] Cannot open X11 display. Is DISPLAY set?");
+
+    int screen = DefaultScreen(m_dpy);
+    m_win = XCreateSimpleWindow(m_dpy, RootWindow(m_dpy, screen), 0, 0, kWindowW, kWindowH, 0,
+                                BlackPixel(m_dpy, screen), BlackPixel(m_dpy, screen));
+
+    XStoreName(m_dpy, m_win, "MANUS Data Visualizer");
+    XSelectInput(m_dpy, m_win, StructureNotifyMask | KeyPressMask);
+    XMapWindow(m_dpy, m_win);
+
+    m_wm_del = XInternAtom(m_dpy, "WM_DELETE_WINDOW", False);
+    XSetWMProtocols(m_dpy, m_win, &m_wm_del, 1);
+
+    // Wait for the MapNotify event so the window is visible before we attach
+    // a Vulkan surface.
+    XEvent ev;
+    while (true)
+    {
+        XNextEvent(m_dpy, &ev);
+        if (ev.type == MapNotify)
+            break;
+    }
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::initVulkan()
+{
+    // --- Instance -----------------------------------------------------------
+    const char* inst_exts[] = { VK_KHR_SURFACE_EXTENSION_NAME, VK_KHR_XLIB_SURFACE_EXTENSION_NAME };
+    const char* dev_exts[] = { VK_KHR_SWAPCHAIN_EXTENSION_NAME };
+
+    VkApplicationInfo app_info{};
+    app_info.sType = VK_STRUCTURE_TYPE_APPLICATION_INFO;
+    app_info.pApplicationName = "ManusHandVisualizer";
+    app_info.apiVersion = VK_API_VERSION_1_0;
+
+    VkInstanceCreateInfo inst_ci{};
+    inst_ci.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO;
+    inst_ci.pApplicationInfo = &app_info;
+    inst_ci.enabledExtensionCount = 2;
+    inst_ci.ppEnabledExtensionNames = inst_exts;
+
+    if (vkCreateInstance(&inst_ci, nullptr, &m_instance) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateInstance failed");
+
+    // --- Surface ------------------------------------------------------------
+    VkXlibSurfaceCreateInfoKHR surf_ci{};
+    surf_ci.sType = VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR;
+    surf_ci.dpy = m_dpy;
+    surf_ci.window = m_win;
+    if (vkCreateXlibSurfaceKHR(m_instance, &surf_ci, nullptr, &m_surface) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateXlibSurfaceKHR failed");
+
+    // --- Physical device ----------------------------------------------------
+    uint32_t pdev_count = 0;
+    vkEnumeratePhysicalDevices(m_instance, &pdev_count, nullptr);
+    if (pdev_count == 0)
+        throw std::runtime_error("[Vis] No Vulkan physical devices found");
+
+    std::vector<VkPhysicalDevice> pdevs(pdev_count);
+    vkEnumeratePhysicalDevices(m_instance, &pdev_count, pdevs.data());
+
+    for (auto& pd : pdevs)
+    {
+        uint32_t qfam_count = 0;
+        vkGetPhysicalDeviceQueueFamilyProperties(pd, &qfam_count, nullptr);
+        std::vector<VkQueueFamilyProperties> qfams(qfam_count);
+        vkGetPhysicalDeviceQueueFamilyProperties(pd, &qfam_count, qfams.data());
+
+        for (uint32_t i = 0; i < qfam_count; ++i)
+        {
+            if (!(qfams[i].queueFlags & VK_QUEUE_GRAPHICS_BIT))
+                continue;
+
+            VkBool32 can_present = VK_FALSE;
+            vkGetPhysicalDeviceSurfaceSupportKHR(pd, i, m_surface, &can_present);
+            if (!can_present)
+                continue;
+
+            m_pdev = pd;
+            m_qfam = i;
+            break;
+        }
+        if (m_pdev)
+            break;
+    }
+    if (!m_pdev)
+        throw std::runtime_error("[Vis] No suitable Vulkan device/queue found");
+
+    // --- Logical device -----------------------------------------------------
+    float queue_prio = 1.0f;
+    VkDeviceQueueCreateInfo qci{};
+    qci.sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO;
+    qci.queueFamilyIndex = m_qfam;
+    qci.queueCount = 1;
+    qci.pQueuePriorities = &queue_prio;
+
+    VkDeviceCreateInfo dev_ci{};
+    dev_ci.sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO;
+    dev_ci.queueCreateInfoCount = 1;
+    dev_ci.pQueueCreateInfos = &qci;
+    dev_ci.enabledExtensionCount = 1;
+    dev_ci.ppEnabledExtensionNames = dev_exts;
+
+    if (vkCreateDevice(m_pdev, &dev_ci, nullptr, &m_dev) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateDevice failed");
+
+    vkGetDeviceQueue(m_dev, m_qfam, 0, &m_queue);
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::createSwapchain()
+{
+    // Query surface capabilities
+    VkSurfaceCapabilitiesKHR caps{};
+    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(m_pdev, m_surface, &caps);
+
+    // Choose extent
+    m_sc_extent = (caps.currentExtent.width != UINT32_MAX) ? caps.currentExtent : VkExtent2D{ kWindowW, kWindowH };
+
+    // Choose format: prefer B8G8R8A8_SRGB, fall back to first available
+    uint32_t fmt_count = 0;
+    vkGetPhysicalDeviceSurfaceFormatsKHR(m_pdev, m_surface, &fmt_count, nullptr);
+    std::vector<VkSurfaceFormatKHR> fmts(fmt_count);
+    vkGetPhysicalDeviceSurfaceFormatsKHR(m_pdev, m_surface, &fmt_count, fmts.data());
+
+    m_sc_format = fmts[0].format;
+    VkColorSpaceKHR color_space = fmts[0].colorSpace;
+    for (auto& f : fmts)
+    {
+        if (f.format == VK_FORMAT_B8G8R8A8_SRGB && f.colorSpace == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR)
+        {
+            m_sc_format = f.format;
+            color_space = f.colorSpace;
+            break;
+        }
+    }
+
+    uint32_t img_count = caps.minImageCount + 1;
+    if (caps.maxImageCount > 0 && img_count > caps.maxImageCount)
+        img_count = caps.maxImageCount;
+
+    VkSwapchainCreateInfoKHR sc_ci{};
+    sc_ci.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
+    sc_ci.surface = m_surface;
+    sc_ci.minImageCount = img_count;
+    sc_ci.imageFormat = m_sc_format;
+    sc_ci.imageColorSpace = color_space;
+    sc_ci.imageExtent = m_sc_extent;
+    sc_ci.imageArrayLayers = 1;
+    sc_ci.imageUsage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+    sc_ci.imageSharingMode = VK_SHARING_MODE_EXCLUSIVE;
+    sc_ci.preTransform = caps.currentTransform;
+    sc_ci.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
+    sc_ci.presentMode = VK_PRESENT_MODE_FIFO_KHR;
+    sc_ci.clipped = VK_TRUE;
+
+    if (vkCreateSwapchainKHR(m_dev, &sc_ci, nullptr, &m_swapchain) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateSwapchainKHR failed");
+
+    uint32_t sc_img_count = 0;
+    vkGetSwapchainImagesKHR(m_dev, m_swapchain, &sc_img_count, nullptr);
+    m_sc_images.resize(sc_img_count);
+    vkGetSwapchainImagesKHR(m_dev, m_swapchain, &sc_img_count, m_sc_images.data());
+
+    m_sc_views.resize(sc_img_count);
+    for (uint32_t i = 0; i < sc_img_count; ++i)
+    {
+        VkImageViewCreateInfo view_ci{};
+        view_ci.sType = VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO;
+        view_ci.image = m_sc_images[i];
+        view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        view_ci.format = m_sc_format;
+        view_ci.components.r = VK_COMPONENT_SWIZZLE_IDENTITY;
+        view_ci.components.g = VK_COMPONENT_SWIZZLE_IDENTITY;
+        view_ci.components.b = VK_COMPONENT_SWIZZLE_IDENTITY;
+        view_ci.components.a = VK_COMPONENT_SWIZZLE_IDENTITY;
+        view_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        view_ci.subresourceRange.baseMipLevel = 0;
+        view_ci.subresourceRange.levelCount = 1;
+        view_ci.subresourceRange.baseArrayLayer = 0;
+        view_ci.subresourceRange.layerCount = 1;
+
+        if (vkCreateImageView(m_dev, &view_ci, nullptr, &m_sc_views[i]) != VK_SUCCESS)
+            throw std::runtime_error("[Vis] vkCreateImageView failed");
+    }
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::createRenderPass()
+{
+    VkAttachmentDescription color_att{};
+    color_att.format = m_sc_format;
+    color_att.samples = VK_SAMPLE_COUNT_1_BIT;
+    color_att.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+    color_att.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+    color_att.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+    color_att.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+    color_att.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    color_att.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+    VkAttachmentReference color_ref{};
+    color_ref.attachment = 0;
+    color_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+    VkSubpassDescription subpass{};
+    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass.colorAttachmentCount = 1;
+    subpass.pColorAttachments = &color_ref;
+
+    VkSubpassDependency dep{};
+    dep.srcSubpass = VK_SUBPASS_EXTERNAL;
+    dep.dstSubpass = 0;
+    dep.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dep.srcAccessMask = 0;
+    dep.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+    dep.dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+
+    VkRenderPassCreateInfo rp_ci{};
+    rp_ci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
+    rp_ci.attachmentCount = 1;
+    rp_ci.pAttachments = &color_att;
+    rp_ci.subpassCount = 1;
+    rp_ci.pSubpasses = &subpass;
+    rp_ci.dependencyCount = 1;
+    rp_ci.pDependencies = &dep;
+
+    if (vkCreateRenderPass(m_dev, &rp_ci, nullptr, &m_render_pass) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateRenderPass failed");
+}
+
+// ---------------------------------------------------------------------------
+inline VkShaderModule HandVisualizer::createShaderModule(const uint32_t* spv, size_t bytes)
+{
+    VkShaderModuleCreateInfo sm_ci{};
+    sm_ci.sType = VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO;
+    sm_ci.codeSize = bytes;
+    sm_ci.pCode = spv;
+
+    VkShaderModule module = VK_NULL_HANDLE;
+    if (vkCreateShaderModule(m_dev, &sm_ci, nullptr, &module) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateShaderModule failed");
+    return module;
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::createPipeline()
+{
+    VkShaderModule vert = createShaderModule(kVertSpv, sizeof(kVertSpv));
+    VkShaderModule frag = createShaderModule(kFragSpv, sizeof(kFragSpv));
+
+    VkPipelineShaderStageCreateInfo stages[2]{};
+    stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
+    stages[0].module = vert;
+    stages[0].pName = "main";
+    stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
+    stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    stages[1].module = frag;
+    stages[1].pName = "main";
+
+    // Vertex input: binding 0, stride=sizeof(Vertex)=20
+    VkVertexInputBindingDescription binding{};
+    binding.binding = 0;
+    binding.stride = sizeof(Vertex);
+    binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
+
+    VkVertexInputAttributeDescription attrs[2]{};
+    // location 0: vec2 at offset 0
+    attrs[0].binding = 0;
+    attrs[0].location = 0;
+    attrs[0].format = VK_FORMAT_R32G32_SFLOAT;
+    attrs[0].offset = 0;
+    // location 1: vec3 at offset 8
+    attrs[1].binding = 0;
+    attrs[1].location = 1;
+    attrs[1].format = VK_FORMAT_R32G32B32_SFLOAT;
+    attrs[1].offset = 8;
+
+    VkPipelineVertexInputStateCreateInfo vert_input{};
+    vert_input.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
+    vert_input.vertexBindingDescriptionCount = 1;
+    vert_input.pVertexBindingDescriptions = &binding;
+    vert_input.vertexAttributeDescriptionCount = 2;
+    vert_input.pVertexAttributeDescriptions = attrs;
+
+    VkPipelineInputAssemblyStateCreateInfo ia{};
+    ia.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
+    ia.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
+    ia.primitiveRestartEnable = VK_FALSE;
+
+    // Dynamic viewport and scissor
+    VkDynamicState dyn_states[] = { VK_DYNAMIC_STATE_VIEWPORT, VK_DYNAMIC_STATE_SCISSOR };
+    VkPipelineDynamicStateCreateInfo dyn_state{};
+    dyn_state.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
+    dyn_state.dynamicStateCount = 2;
+    dyn_state.pDynamicStates = dyn_states;
+
+    VkPipelineViewportStateCreateInfo vp_state{};
+    vp_state.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
+    vp_state.viewportCount = 1;
+    vp_state.scissorCount = 1;
+
+    VkPipelineRasterizationStateCreateInfo rast{};
+    rast.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
+    rast.polygonMode = VK_POLYGON_MODE_FILL;
+    rast.cullMode = VK_CULL_MODE_NONE;
+    rast.frontFace = VK_FRONT_FACE_CLOCKWISE;
+    rast.lineWidth = 1.0f;
+
+    VkPipelineMultisampleStateCreateInfo ms{};
+    ms.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
+    ms.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+
+    VkPipelineColorBlendAttachmentState blend_att{};
+    blend_att.colorWriteMask =
+        VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    blend_att.blendEnable = VK_FALSE;
+
+    VkPipelineColorBlendStateCreateInfo blend{};
+    blend.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
+    blend.attachmentCount = 1;
+    blend.pAttachments = &blend_att;
+
+    VkPipelineLayoutCreateInfo layout_ci{};
+    layout_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
+    if (vkCreatePipelineLayout(m_dev, &layout_ci, nullptr, &m_pipe_layout) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreatePipelineLayout failed");
+
+    VkGraphicsPipelineCreateInfo pipe_ci{};
+    pipe_ci.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
+    pipe_ci.stageCount = 2;
+    pipe_ci.pStages = stages;
+    pipe_ci.pVertexInputState = &vert_input;
+    pipe_ci.pInputAssemblyState = &ia;
+    pipe_ci.pViewportState = &vp_state;
+    pipe_ci.pRasterizationState = &rast;
+    pipe_ci.pMultisampleState = &ms;
+    pipe_ci.pColorBlendState = &blend;
+    pipe_ci.pDynamicState = &dyn_state;
+    pipe_ci.layout = m_pipe_layout;
+    pipe_ci.renderPass = m_render_pass;
+    pipe_ci.subpass = 0;
+
+    if (vkCreateGraphicsPipelines(m_dev, VK_NULL_HANDLE, 1, &pipe_ci, nullptr, &m_pipeline) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateGraphicsPipelines failed");
+
+    vkDestroyShaderModule(m_dev, vert, nullptr);
+    vkDestroyShaderModule(m_dev, frag, nullptr);
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::createFramebuffers()
+{
+    m_framebuffers.resize(m_sc_views.size());
+    for (size_t i = 0; i < m_sc_views.size(); ++i)
+    {
+        VkFramebufferCreateInfo fb_ci{};
+        fb_ci.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
+        fb_ci.renderPass = m_render_pass;
+        fb_ci.attachmentCount = 1;
+        fb_ci.pAttachments = &m_sc_views[i];
+        fb_ci.width = m_sc_extent.width;
+        fb_ci.height = m_sc_extent.height;
+        fb_ci.layers = 1;
+
+        if (vkCreateFramebuffer(m_dev, &fb_ci, nullptr, &m_framebuffers[i]) != VK_SUCCESS)
+            throw std::runtime_error("[Vis] vkCreateFramebuffer failed");
+    }
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::createCommandBuffers()
+{
+    VkCommandPoolCreateInfo pool_ci{};
+    pool_ci.sType = VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO;
+    pool_ci.queueFamilyIndex = m_qfam;
+    pool_ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+
+    if (vkCreateCommandPool(m_dev, &pool_ci, nullptr, &m_cmd_pool) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateCommandPool failed");
+
+    m_cmd_bufs.resize(m_sc_images.size());
+    VkCommandBufferAllocateInfo alloc_info{};
+    alloc_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
+    alloc_info.commandPool = m_cmd_pool;
+    alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
+    alloc_info.commandBufferCount = static_cast<uint32_t>(m_cmd_bufs.size());
+
+    if (vkAllocateCommandBuffers(m_dev, &alloc_info, m_cmd_bufs.data()) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkAllocateCommandBuffers failed");
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::createSyncObjects()
+{
+    VkSemaphoreCreateInfo sem_ci{};
+    sem_ci.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
+
+    VkFenceCreateInfo fence_ci{};
+    fence_ci.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
+    fence_ci.flags = VK_FENCE_CREATE_SIGNALED_BIT;
+
+    if (vkCreateSemaphore(m_dev, &sem_ci, nullptr, &m_sem_image_avail) != VK_SUCCESS ||
+        vkCreateSemaphore(m_dev, &sem_ci, nullptr, &m_sem_render_done) != VK_SUCCESS ||
+        vkCreateFence(m_dev, &fence_ci, nullptr, &m_fence_in_flight) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] Failed to create sync objects");
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::createVertexBuffer()
+{
+    VkDeviceSize size = sizeof(Vertex) * kMaxVertices;
+
+    VkBufferCreateInfo buf_ci{};
+    buf_ci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
+    buf_ci.size = size;
+    buf_ci.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
+    buf_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+
+    if (vkCreateBuffer(m_dev, &buf_ci, nullptr, &m_vbuf) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkCreateBuffer failed");
+
+    VkMemoryRequirements mem_req{};
+    vkGetBufferMemoryRequirements(m_dev, m_vbuf, &mem_req);
+
+    VkPhysicalDeviceMemoryProperties mem_props{};
+    vkGetPhysicalDeviceMemoryProperties(m_pdev, &mem_props);
+
+    uint32_t mem_type = UINT32_MAX;
+    const uint32_t required = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    for (uint32_t i = 0; i < mem_props.memoryTypeCount; ++i)
+    {
+        if ((mem_req.memoryTypeBits & (1u << i)) && (mem_props.memoryTypes[i].propertyFlags & required) == required)
+        {
+            mem_type = i;
+            break;
+        }
+    }
+    if (mem_type == UINT32_MAX)
+        throw std::runtime_error("[Vis] No suitable host-visible memory type");
+
+    VkMemoryAllocateInfo alloc_info{};
+    alloc_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+    alloc_info.allocationSize = mem_req.size;
+    alloc_info.memoryTypeIndex = mem_type;
+
+    if (vkAllocateMemory(m_dev, &alloc_info, nullptr, &m_vbuf_mem) != VK_SUCCESS)
+        throw std::runtime_error("[Vis] vkAllocateMemory failed");
+
+    vkBindBufferMemory(m_dev, m_vbuf, m_vbuf_mem, 0);
+    vkMapMemory(m_dev, m_vbuf_mem, 0, size, 0, &m_vbuf_ptr);
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::destroySwapchainResources()
+{
+    for (auto fb : m_framebuffers)
+        if (fb)
+            vkDestroyFramebuffer(m_dev, fb, nullptr);
+    m_framebuffers.clear();
+    for (auto iv : m_sc_views)
+        if (iv)
+            vkDestroyImageView(m_dev, iv, nullptr);
+    m_sc_views.clear();
+    if (m_swapchain)
+    {
+        vkDestroySwapchainKHR(m_dev, m_swapchain, nullptr);
+        m_swapchain = VK_NULL_HANDLE;
+    }
+}
+
+// ---------------------------------------------------------------------------
+inline std::pair<float, float> HandVisualizer::project(const ManusVec3& p, ProjectionMode mode)
+{
+    if (mode == ProjectionMode::Top)
+        return { p.x, -p.z }; // top-down: X right, -Z up (fingers away from wrist)
+    else
+        return { -p.z, p.y }; // side (along thumb-axis +X): -Z right, Y up
+}
+
+// ---------------------------------------------------------------------------
+inline bool HandVisualizer::computeBbox3D(
+    const std::vector<SkeletonNode>& nodes, float& xmin, float& xmax, float& ymin, float& ymax, float& zmin, float& zmax)
+{
+    if (nodes.empty())
+        return false;
+    xmin = ymin = zmin = std::numeric_limits<float>::max();
+    xmax = ymax = zmax = -std::numeric_limits<float>::max();
+    for (auto& n : nodes)
+    {
+        const auto& p = n.transform.position;
+        xmin = std::min(xmin, p.x);
+        xmax = std::max(xmax, p.x);
+        ymin = std::min(ymin, p.y);
+        ymax = std::max(ymax, p.y);
+        zmin = std::min(zmin, p.z);
+        zmax = std::max(zmax, p.z);
+    }
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::buildHandGeometry(const std::vector<SkeletonNode>& nodes,
+                                              const std::vector<NodeInfo>& info,
+                                              const std::array<float, 3>& colour,
+                                              ProjectionMode mode,
+                                              float scale,
+                                              float cx,
+                                              float cy,
+                                              float cz,
+                                              float ndc_cx,
+                                              float ndc_cy,
+                                              std::vector<Vertex>& verts)
+{
+    if (nodes.empty())
+        return;
+
+    // Project the 3-D world center for this view
+    ManusVec3 center3d;
+    center3d.x = cx;
+    center3d.y = cy;
+    center3d.z = cz;
+    auto [world_cx, world_cy] = project(center3d, mode);
+
+    // Build fast id -> projected-position lookup
+    std::unordered_map<uint32_t, std::pair<float, float>> pos_map;
+    pos_map.reserve(nodes.size());
+    for (auto& n : nodes)
+        pos_map[n.id] = project(n.transform.position, mode);
+
+    // Map projected coords -> NDC in this quadrant
+    auto to_ndc = [&](const std::pair<float, float>& proj) -> std::pair<float, float>
+    {
+        float nx = (proj.first - world_cx) * scale + ndc_cx;
+        float ny = -(proj.second - world_cy) * scale + ndc_cy; // +Y up on screen
+        return { nx, ny };
+    };
+
+    float r = colour[0], g = colour[1], b = colour[2];
+
+    // Bones: line from parent to child
+    for (auto& ni : info)
+    {
+        // Skip only the true root (self-referencing: parentId == nodeId).
+        // Do NOT skip parentId==0 unconditionally — that would drop CMC-to-wrist edges
+        // when the wrist's nodeId happens to be 0.
+        if (ni.parentId == ni.nodeId)
+            continue;
+        auto it_child = pos_map.find(ni.nodeId);
+        auto it_parent = pos_map.find(ni.parentId);
+        if (it_child == pos_map.end() || it_parent == pos_map.end())
+            continue;
+
+        auto [cx2, cy2] = to_ndc(it_child->second);
+        auto [px2, py2] = to_ndc(it_parent->second);
+        verts.push_back({ cx2, cy2, r, g, b });
+        verts.push_back({ px2, py2, r, g, b });
+    }
+
+    // Joint markers: small "+" cross at each node
+    for (auto& n : nodes)
+    {
+        auto [nx2, ny2] = to_ndc(pos_map.at(n.id));
+        // Horizontal arm
+        verts.push_back({ nx2 - kCrossSize, ny2, r, g, b });
+        verts.push_back({ nx2 + kCrossSize, ny2, r, g, b });
+        // Vertical arm
+        verts.push_back({ nx2, ny2 - kCrossSize, r, g, b });
+        verts.push_back({ nx2, ny2 + kCrossSize, r, g, b });
+    }
+}
+
+// ---------------------------------------------------------------------------
+inline void HandVisualizer::run(ManusTracker& tracker, std::stop_token st)
+{
+    bool running = true;
+
+    while (running && !st.stop_requested())
+    {
+        // -- Poll X11 events -------------------------------------------------
+        while (XPending(m_dpy))
+        {
+            XEvent ev;
+            XNextEvent(m_dpy, &ev);
+            if (ev.type == ClientMessage && static_cast<Atom>(ev.xclient.data.l[0]) == m_wm_del)
+            {
+                running = false;
+            }
+            if (ev.type == KeyPress)
+                running = false;
+        }
+        if (!running)
+            break;
+
+        // -- Build geometry --------------------------------------------------
+        auto left_nodes = tracker.get_left_hand_nodes();
+        auto right_nodes = tracker.get_right_hand_nodes();
+        auto left_info = tracker.get_left_node_info();
+        auto right_info = tracker.get_right_node_info();
+
+        std::vector<Vertex> verts;
+        verts.reserve(1024);
+
+        // Separator lines between the 4 quadrants (dim grey)
+        constexpr float kG = 0.20f;
+        verts.push_back({ -1.0f, 0.0f, kG, kG, kG });
+        verts.push_back({ 1.0f, 0.0f, kG, kG, kG }); // horizontal
+        verts.push_back({ 0.0f, 1.0f, kG, kG, kG });
+        verts.push_back({ 0.0f, -1.0f, kG, kG, kG }); // vertical
+
+        // Per-hand scale locked on first data frame from 3-D bbox max extent,
+        // shared between Top and Side panels so both are at the same magnification.
+        // Reset when glove disconnects so it recalibrates on reconnect.
+        auto fit_scale3d = [](float xn, float xx, float yn, float yx, float zn, float zx) -> float {
+            return 0.85f / std::max({ xx - xn, yx - yn, zx - zn, 0.001f });
+        };
+
+        float lxmin, lxmax, lymin, lymax, lzmin, lzmax;
+        const bool has_left = computeBbox3D(left_nodes, lxmin, lxmax, lymin, lymax, lzmin, lzmax);
+        if (!has_left)
+            m_left_state = {};
+        else if (m_left_state.scale == 0.0f)
+        {
+            m_left_state.scale = fit_scale3d(lxmin, lxmax, lymin, lymax, lzmin, lzmax);
+            m_left_state.cx = (lxmin + lxmax) * 0.5f;
+            m_left_state.cy = (lymin + lymax) * 0.5f;
+            m_left_state.cz = (lzmin + lzmax) * 0.5f;
+        }
+
+        float rxmin, rxmax, rymin, rymax, rzmin, rzmax;
+        const bool has_right = computeBbox3D(right_nodes, rxmin, rxmax, rymin, rymax, rzmin, rzmax);
+        if (!has_right)
+            m_right_state = {};
+        else if (m_right_state.scale == 0.0f)
+        {
+            m_right_state.scale = fit_scale3d(rxmin, rxmax, rymin, rymax, rzmin, rzmax);
+            m_right_state.cx = (rxmin + rxmax) * 0.5f;
+            m_right_state.cy = (rymin + rymax) * 0.5f;
+            m_right_state.cz = (rzmin + rzmax) * 0.5f;
+        }
+
+        // 4-quadrant layout:
+        //   Top-left    (-0.5,+0.5): left  hand — top-down (XZ)
+        //   Bottom-left (-0.5,-0.5): left  hand — side (ZY, thumb axis)
+        //   Top-right   (+0.5,+0.5): right hand — top-down
+        //   Bottom-right(+0.5,-0.5): right hand — side
+        if (has_left)
+        {
+            buildHandGeometry(left_nodes, left_info, kLeftColor, ProjectionMode::Top, m_left_state.scale,
+                              m_left_state.cx, m_left_state.cy, m_left_state.cz, -0.5f, +0.5f, verts);
+            buildHandGeometry(left_nodes, left_info, kLeftColor, ProjectionMode::Side, m_left_state.scale,
+                              m_left_state.cx, m_left_state.cy, m_left_state.cz, -0.5f, -0.5f, verts);
+        }
+        if (has_right)
+        {
+            buildHandGeometry(right_nodes, right_info, kRightColor, ProjectionMode::Top, m_right_state.scale,
+                              m_right_state.cx, m_right_state.cy, m_right_state.cz, +0.5f, +0.5f, verts);
+            buildHandGeometry(right_nodes, right_info, kRightColor, ProjectionMode::Side, m_right_state.scale,
+                              m_right_state.cx, m_right_state.cy, m_right_state.cz, +0.5f, -0.5f, verts);
+        }
+
+        // -- Upload vertices -------------------------------------------------
+        uint32_t vert_count = static_cast<uint32_t>(std::min<size_t>(verts.size(), kMaxVertices));
+
+        if (vert_count > 0)
+            std::memcpy(m_vbuf_ptr, verts.data(), vert_count * sizeof(Vertex));
+
+        // -- Render frame ----------------------------------------------------
+        // Wait for the previous frame's fence before touching per-frame state.
+        // Do NOT reset the fence yet — if vkAcquireNextImageKHR fails we will
+        // continue without submitting, and the fence must stay signaled so the
+        // next iteration's vkWaitForFences returns immediately.
+        vkWaitForFences(m_dev, 1, &m_fence_in_flight, VK_TRUE, UINT64_MAX);
+
+        uint32_t img_idx = 0;
+        VkResult acquire_result =
+            vkAcquireNextImageKHR(m_dev, m_swapchain, UINT64_MAX, m_sem_image_avail, VK_NULL_HANDLE, &img_idx);
+
+        if (acquire_result == VK_ERROR_OUT_OF_DATE_KHR)
+        {
+            vkDeviceWaitIdle(m_dev);
+            destroySwapchainResources();
+            createSwapchain();
+            createFramebuffers();
+            createCommandBuffers();
+            // Fence is still signaled — leave it so the next vkWaitForFences
+            // returns immediately without us having submitted anything.
+            continue;
+        }
+
+        // Acquisition succeeded: safe to reset the fence now so we can use it
+        // as the submit signal for this frame.
+        vkResetFences(m_dev, 1, &m_fence_in_flight);
+
+        // Record command buffer
+        VkCommandBuffer cmd = m_cmd_bufs[img_idx];
+        vkResetCommandBuffer(cmd, 0);
+
+        VkCommandBufferBeginInfo begin_info{};
+        begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
+        vkBeginCommandBuffer(cmd, &begin_info);
+
+        VkClearValue clear_val{};
+        clear_val.color = { { 0.0f, 0.0f, 0.0f, 1.0f } }; // black background
+
+        VkRenderPassBeginInfo rp_begin{};
+        rp_begin.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
+        rp_begin.renderPass = m_render_pass;
+        rp_begin.framebuffer = m_framebuffers[img_idx];
+        rp_begin.renderArea.extent = m_sc_extent;
+        rp_begin.clearValueCount = 1;
+        rp_begin.pClearValues = &clear_val;
+
+        vkCmdBeginRenderPass(cmd, &rp_begin, VK_SUBPASS_CONTENTS_INLINE);
+        vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, m_pipeline);
+
+        VkViewport vp{};
+        vp.width = static_cast<float>(m_sc_extent.width);
+        vp.height = static_cast<float>(m_sc_extent.height);
+        vp.minDepth = 0.0f;
+        vp.maxDepth = 1.0f;
+        vkCmdSetViewport(cmd, 0, 1, &vp);
+
+        VkRect2D scissor{};
+        scissor.extent = m_sc_extent;
+        vkCmdSetScissor(cmd, 0, 1, &scissor);
+
+        if (vert_count > 0)
+        {
+            VkDeviceSize offset = 0;
+            vkCmdBindVertexBuffers(cmd, 0, 1, &m_vbuf, &offset);
+            vkCmdDraw(cmd, vert_count, 1, 0, 0);
+        }
+
+        vkCmdEndRenderPass(cmd);
+        vkEndCommandBuffer(cmd);
+
+        // Submit
+        VkPipelineStageFlags wait_stage = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+        VkSubmitInfo submit_info{};
+        submit_info.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+        submit_info.waitSemaphoreCount = 1;
+        submit_info.pWaitSemaphores = &m_sem_image_avail;
+        submit_info.pWaitDstStageMask = &wait_stage;
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &cmd;
+        submit_info.signalSemaphoreCount = 1;
+        submit_info.pSignalSemaphores = &m_sem_render_done;
+
+        vkQueueSubmit(m_queue, 1, &submit_info, m_fence_in_flight);
+
+        // Present
+        VkPresentInfoKHR present_info{};
+        present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
+        present_info.waitSemaphoreCount = 1;
+        present_info.pWaitSemaphores = &m_sem_render_done;
+        present_info.swapchainCount = 1;
+        present_info.pSwapchains = &m_swapchain;
+        present_info.pImageIndices = &img_idx;
+
+        VkResult present_result = vkQueuePresentKHR(m_queue, &present_info);
+        if (present_result == VK_ERROR_OUT_OF_DATE_KHR || present_result == VK_SUBOPTIMAL_KHR)
+        {
+            vkDeviceWaitIdle(m_dev);
+            destroySwapchainResources();
+            createSwapchain();
+            createFramebuffers();
+            createCommandBuffers();
+        }
+    }
+
+    vkDeviceWaitIdle(m_dev);
+}
+
+} // namespace manus
+} // namespace plugins

--- a/src/plugins/manus/tools/manus_hand_visualizer.hpp
+++ b/src/plugins/manus/tools/manus_hand_visualizer.hpp
@@ -543,8 +543,6 @@ inline void HandVisualizer::teardown() noexcept
         vkDestroyPipelineLayout(m_dev, m_pipe_layout, nullptr);
     if (m_pipeline)
         vkDestroyPipeline(m_dev, m_pipeline, nullptr);
-    if (m_cmd_pool)
-        vkDestroyCommandPool(m_dev, m_cmd_pool, nullptr);
     if (m_dev)
         vkDestroyDevice(m_dev, nullptr);
     if (m_surface)
@@ -1038,6 +1036,14 @@ inline void HandVisualizer::createVertexBuffer()
 // ---------------------------------------------------------------------------
 inline void HandVisualizer::destroySwapchainResources()
 {
+    // Command buffers are allocated from m_cmd_pool sized to the swapchain
+    // image count, so the pool's lifetime is tied to the swapchain.
+    if (m_cmd_pool)
+    {
+        vkDestroyCommandPool(m_dev, m_cmd_pool, nullptr);
+        m_cmd_pool = VK_NULL_HANDLE;
+        m_cmd_bufs.clear();
+    }
     for (auto fb : m_framebuffers)
         if (fb)
             vkDestroyFramebuffer(m_dev, fb, nullptr);


### PR DESCRIPTION
Use HMD hand tracking when available to position the hands, with the existing tracker-based pose as a fallback. The hand-tracking plugin is substantially reworked: detection of an OpenXR hand-tracking extension at init time, conditional pose composition, and updated public types.

Tooling:
- Add an install_manus.sh helper and a 70-manus-hid.rules udev rule. After review, the full installer was scaled back so the rule file is the abstracted, distributable artifact and the script focuses on bootstrapping the supported manual-setup path.
- Expand the tracker printer into a visualizer (manus_hand_visualizer.hpp) for inspecting tracker output, and clarify the CLI usage. Remove the obsolete Isaac Lab start script.

Documentation:
- Convert the Manus README to reStructuredText and add it to the device docs index (docs/source/device/manus.rst), with clarifications to the manual setup flow and updated log/installation guidance.

Core fix:
- Declare xrEnumerateInstanceExtensionProperties alongside xrGetInstanceProcAddr under XR_NO_PROTOTYPES in oxr_funcs, so the Manus plugin can enumerate supported OpenXR extensions at init time without a compile error when prototypes are suppressed.

Quality:
- clang-format and pre-commit linting passes across the touched files.
- Address CodeRabbit and GitHub Copilot review feedback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Manus gloves device integration with automated installation script
  * Added hand visualization tool featuring real-time skeleton rendering
  * Added optical hand tracking support for Quest 3

* **Documentation**
  * Added comprehensive Manus setup guide covering prerequisites, installation workflows, runtime configuration, and troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->