### PR TITLE
feat(oob): Configurable ports for OOB

### DIFF
--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -22,13 +22,13 @@ from isaacteleop.cloudxr.oob_teleop_adb import (
     require_headset_non_loopback_network,
 )
 from isaacteleop.cloudxr.oob_teleop_env import (
-    USB_BACKEND_PORT,
     USB_HOST,
-    USB_TURN_PORT,
-    USB_UI_PORT,
     WSS_PROXY_DEFAULT_PORT,
     print_oob_hub_startup_banner,
     resolve_lan_host_for_oob,
+    usb_backend_port,
+    usb_turn_port,
+    usb_ui_port,
 )
 
 
@@ -74,8 +74,10 @@ def _parse_args() -> argparse.Namespace:
             "(127.0.0.1) via adb reverse.  Requires --setup-oob.  Orchestrates "
             "adb reverse for WSS proxy "
             f"({WSS_PROXY_DEFAULT_PORT}/tcp), CloudXR backend "
-            f"({USB_BACKEND_PORT}/tcp), coturn ({USB_TURN_PORT}/tcp), and "
-            f"HTTPS static WebXR UI on port {USB_UI_PORT}.  Files live under "
+            f"({usb_backend_port()}/tcp; override via USB_BACKEND_PORT env), "
+            f"coturn ({usb_turn_port()}/tcp; override via USB_TURN_PORT env), "
+            f"and HTTPS static WebXR UI on port {usb_ui_port()} "
+            "(override via USB_UI_PORT env).  Files live under "
             "TELEOP_WEB_CLIENT_STATIC_DIR or ~/.cloudxr/static-client; missing "
             "index.html / bundle.js are downloaded from nvidia.github.io/IsaacTeleop/client/.  "
             "The launcher serves them with the same PEM as the WSS proxy.  "

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -93,14 +93,13 @@ class CloudXRLauncher:
                 does not exist, the user is prompted on stdin.
             setup_oob: Enable the OOB teleop control hub and USB
                 adb automation in the WSS proxy.
-            usb_local: Route teleop traffic over USB on headset loopback
-                via ``adb reverse`` (requires *setup_oob*).  Sets up
-                ``adb reverse`` for WSS proxy, CloudXR backend, and
-                coturn TURN ports, and starts coturn locally for WebRTC
-                ICE relay.  WebXR static files use ``TELEOP_WEB_CLIENT_STATIC_DIR`` or
-                ``~/.cloudxr/static-client``; missing ``index.html`` / ``bundle.js`` are
-                fetched from GitHub Pages.  Python serves them over HTTPS on port 8080
-                with the same PEM as the WSS proxy.
+            usb_local: Route teleop traffic over USB headset loopback via
+                ``adb reverse`` (requires *setup_oob*); also starts coturn
+                for WebRTC ICE relay and serves WebXR static files
+                (``TELEOP_WEB_CLIENT_STATIC_DIR`` or ``~/.cloudxr/static-client``,
+                fetched from GitHub Pages if missing) over HTTPS.  Ports
+                are overridable via ``USB_UI_PORT`` / ``USB_BACKEND_PORT``
+                / ``USB_TURN_PORT``.
 
         Raises:
             RuntimeError: If the EULA is not accepted or the runtime

--- a/src/core/cloudxr/python/oob_teleop_adb.py
+++ b/src/core/cloudxr/python/oob_teleop_adb.py
@@ -314,10 +314,10 @@ def build_teleop_url(*, resolved_port: int, usb_local: bool = False) -> str:
     if usb_local:
         from .oob_teleop_env import (  # noqa: PLC0415
             USB_HOST,
-            USB_UI_PORT,
-            USB_TURN_PORT,
             USB_TURN_USER,
             USB_TURN_CREDENTIAL,
+            usb_turn_port,
+            usb_ui_port,
         )
 
         stream_cfg: dict = {
@@ -326,14 +326,14 @@ def build_teleop_url(*, resolved_port: int, usb_local: bool = False) -> str:
             # No mediaAddress: it's a NAT-override that bypasses ICE and would
             # short-circuit the TURN-relayed media path. Let the SDK discover
             # the media endpoint through ICE via coturn.
-            "turnServer": f"turn:{USB_HOST}:{USB_TURN_PORT}?transport=tcp",
+            "turnServer": f"turn:{USB_HOST}:{usb_turn_port()}?transport=tcp",
             "turnUsername": USB_TURN_USER,
             "turnCredential": USB_TURN_CREDENTIAL,
             "iceRelayOnly": True,
             **client_ui_fields_from_env(),
         }
         ovr = web_client_base_override_from_env()
-        web_base = ovr if ovr else f"https://localhost:{USB_UI_PORT}"
+        web_base = ovr if ovr else f"https://localhost:{usb_ui_port()}"
     else:
         stream_cfg = {
             "serverIP": resolve_lan_host_for_oob(),
@@ -502,18 +502,21 @@ def setup_adb_reverse_ports() -> None:
     Reverse-maps headset loopback ports to the PC so the headset can reach
     the WebXR static HTTPS server, WSS proxy, and CloudXR backend over USB.
 
-    Ports reversed: :data:`~.oob_teleop_env.USB_UI_PORT` (8080, the static
-    HTTPS server started by
-    :func:`~.oob_teleop_env.start_usb_local_https_server`), the WSS proxy
-    port (resolved via :func:`~.oob_teleop_env.wss_proxy_port`), and
-    :data:`~.oob_teleop_env.USB_BACKEND_PORT` (49100).
+    Ports reversed: the USB UI port (resolved via
+    :func:`~.oob_teleop_env.usb_ui_port`, default 8080; override via the
+    ``USB_UI_PORT`` env var) — the static HTTPS server started by
+    :func:`~.oob_teleop_env.start_usb_local_https_server` — the WSS proxy
+    port (resolved via :func:`~.oob_teleop_env.wss_proxy_port`), and the
+    CloudXR backend port (resolved via
+    :func:`~.oob_teleop_env.usb_backend_port`, default 49100; override via
+    the ``USB_BACKEND_PORT`` env var).
 
     Raises:
         subprocess.CalledProcessError: If any ``adb reverse`` call fails.
     """
-    from .oob_teleop_env import USB_UI_PORT, USB_BACKEND_PORT, wss_proxy_port  # noqa: PLC0415
+    from .oob_teleop_env import usb_backend_port, usb_ui_port, wss_proxy_port  # noqa: PLC0415
 
-    ports = [USB_UI_PORT, wss_proxy_port(), USB_BACKEND_PORT]
+    ports = [usb_ui_port(), wss_proxy_port(), usb_backend_port()]
     for port in ports:
         subprocess.run(
             ["adb", "reverse", f"tcp:{port}", f"tcp:{port}"],
@@ -527,9 +530,9 @@ def setup_adb_reverse_ports() -> None:
 
 def teardown_adb_reverse_ports() -> None:
     """Remove the ``adb reverse`` rules set by :func:`setup_adb_reverse_ports`."""
-    from .oob_teleop_env import USB_UI_PORT, USB_BACKEND_PORT, wss_proxy_port  # noqa: PLC0415
+    from .oob_teleop_env import usb_backend_port, usb_ui_port, wss_proxy_port  # noqa: PLC0415
 
-    ports = [USB_UI_PORT, wss_proxy_port(), USB_BACKEND_PORT]
+    ports = [usb_ui_port(), wss_proxy_port(), usb_backend_port()]
     for port in ports:
         subprocess.run(
             ["adb", "reverse", "--remove", f"tcp:{port}"],
@@ -610,7 +613,9 @@ def start_coturn(turn_port: int, user: str, credential: str) -> subprocess.Popen
     headset (via adb reverse) and the CloudXR backend (UDP on PC loopback).
 
     Args:
-        turn_port: TCP/UDP port for coturn (default :data:`~.oob_teleop_env.USB_TURN_PORT`).
+        turn_port: TCP/UDP port for coturn (resolved via
+            :func:`~.oob_teleop_env.usb_turn_port`, default 3478; override via
+            the ``USB_TURN_PORT`` env var).
         user: TURN username.
         credential: TURN credential (password).
 

--- a/src/core/cloudxr/python/oob_teleop_env.py
+++ b/src/core/cloudxr/python/oob_teleop_env.py
@@ -46,13 +46,15 @@ CHROME_INSPECT_DEVICES_URL = "chrome://inspect/#devices"
 # "USB-local" means: the headset reaches the PC over loopback (127.0.0.1) via
 # ``adb reverse``.  Static assets live under ``TELEOP_WEB_CLIENT_STATIC_DIR`` or
 # default ``~/.cloudxr/static-client`` (downloaded from NVIDIA GitHub Pages if missing).
-# Python serves them over HTTPS on :USB_UI_PORT with the same PEM as the WSS proxy.
+# Python serves them over HTTPS on the resolved USB UI port (:func:`usb_ui_port`,
+# default 8080; override via the ``USB_UI_PORT`` env var) with the same PEM as
+# the WSS proxy.
 # ---------------------------------------------------------------------------
 
 USB_HOST = "127.0.0.1"  # serverIP seen by the headset (its own localhost)
-USB_UI_PORT = 8080  # HTTPS static WebXR UI (loopback)
-USB_BACKEND_PORT = 49100  # CloudXR backend (native client direct connection)
-USB_TURN_PORT = 3478  # coturn TURN server port (adb reverse'd to headset)
+USB_UI_DEFAULT_PORT = 8080  # HTTPS static WebXR UI (loopback)
+USB_BACKEND_DEFAULT_PORT = 49100  # CloudXR backend (webrtc client direct connection)
+USB_TURN_DEFAULT_PORT = 3478  # coturn TURN server port (adb reverse'd to headset)
 USB_TURN_USER = "cloudxr"  # TURN username
 USB_TURN_CREDENTIAL = "cloudxrpass"  # TURN credential
 
@@ -200,10 +202,16 @@ def start_usb_local_https_server(
     *,
     cert_file: Path,
     key_file: Path,
-    port: int = USB_UI_PORT,
+    port: int | None = None,
     ready_timeout: float = 15.0,
 ) -> tuple[threading.Thread, http.server.ThreadingHTTPServer]:
-    """Serve *static_root* over HTTPS on loopback using the same PEM as the WSS proxy."""
+    """Serve *static_root* over HTTPS on loopback using the same PEM as the WSS proxy.
+
+    When *port* is ``None`` (the default) the bind port is resolved via
+    :func:`usb_ui_port` (env-overridable through ``USB_UI_PORT``).
+    """
+    if port is None:
+        port = usb_ui_port()
     handler_cls = _usb_local_static_handler_class(static_root)
     httpd = http.server.ThreadingHTTPServer(("127.0.0.1", port), handler_cls)
     httpd.daemon_threads = True
@@ -275,6 +283,48 @@ def wss_proxy_port() -> int:
     if raw:
         return parse_env_port("PROXY_PORT", raw)
     return WSS_PROXY_DEFAULT_PORT
+
+
+def usb_ui_port() -> int:
+    """TCP port for the USB-local WebXR static HTTPS server.
+
+    Reads the ``USB_UI_PORT`` environment variable if set, else falls back to
+    :data:`USB_UI_DEFAULT_PORT` (8080).  Override this when something else on
+    the host needs port 8080 (e.g. a Viser/Meshcat viewer running alongside).
+    """
+    raw = os.environ.get("USB_UI_PORT", "").strip()
+    if raw:
+        return parse_env_port("USB_UI_PORT", raw)
+    return USB_UI_DEFAULT_PORT
+
+
+def usb_backend_port() -> int:
+    """TCP port for the USB-local CloudXR backend (native client direct connection).
+
+    Reads the ``USB_BACKEND_PORT`` environment variable if set, else falls
+    back to :data:`USB_BACKEND_DEFAULT_PORT` (49100).  This port is exposed
+    to the headset via ``adb reverse``; override only when a host process
+    already owns 49100.
+    """
+    raw = os.environ.get("USB_BACKEND_PORT", "").strip()
+    if raw:
+        return parse_env_port("USB_BACKEND_PORT", raw)
+    return USB_BACKEND_DEFAULT_PORT
+
+
+def usb_turn_port() -> int:
+    """TCP/UDP port for the USB-local coturn TURN server.
+
+    Reads the ``USB_TURN_PORT`` environment variable if set, else falls back
+    to :data:`USB_TURN_DEFAULT_PORT` (3478).  coturn binds this on
+    127.0.0.1 and ``adb reverse`` exposes it to the headset for WebRTC
+    ICE relay.  Override only when 3478 is occupied (e.g. by a system
+    coturn that wasn't masked).
+    """
+    raw = os.environ.get("USB_TURN_PORT", "").strip()
+    if raw:
+        return parse_env_port("USB_TURN_PORT", raw)
+    return USB_TURN_DEFAULT_PORT
 
 
 def guess_lan_ipv4() -> str | None:
@@ -390,6 +440,9 @@ def print_oob_hub_startup_banner(
             on loopback; WebXR UI from ``TELEOP_WEB_CLIENT_STATIC_DIR`` (HTTPS, same PEM as WSS).
     """
     port = wss_proxy_port()
+    ui_port = usb_ui_port()
+    backend_port = usb_backend_port()
+    turn_port = usb_turn_port()
     token = os.environ.get("CONTROL_TOKEN") or None
 
     if not lan_host:
@@ -399,7 +452,7 @@ def print_oob_hub_startup_banner(
     if usb_local:
         web_base = (
             os.environ.get("TELEOP_WEB_CLIENT_BASE", "").strip()
-            or f"https://localhost:{USB_UI_PORT}"
+            or f"https://localhost:{ui_port}"
         )
     else:
         web_base = DEFAULT_WEB_CLIENT_ORIGIN
@@ -409,7 +462,7 @@ def print_oob_hub_startup_banner(
         # No mediaAddress: it's a NAT-override that bypasses ICE and would
         # short-circuit the TURN-relayed media path. Let the SDK discover
         # the media endpoint through ICE via coturn.
-        stream_cfg["turnServer"] = f"turn:{USB_HOST}:{USB_TURN_PORT}?transport=tcp"
+        stream_cfg["turnServer"] = f"turn:{USB_HOST}:{turn_port}?transport=tcp"
         stream_cfg["turnUsername"] = USB_TURN_USER
         stream_cfg["turnCredential"] = USB_TURN_CREDENTIAL
         stream_cfg["iceRelayOnly"] = True
@@ -447,10 +500,10 @@ def print_oob_hub_startup_banner(
     if usb_local:
         print(
             "  USB-local mode: adb reverse active for ports "
-            f"{USB_UI_PORT}/tcp (WebXR static UI — HTTPS), "
+            f"{ui_port}/tcp (WebXR static UI — HTTPS), "
             f"{port}/tcp (WSS), "
-            f"{USB_BACKEND_PORT}/tcp (backend), "
-            f"{USB_TURN_PORT}/tcp (TURN relay — coturn)."
+            f"{backend_port}/tcp (backend), "
+            f"{turn_port}/tcp (TURN relay — coturn)."
         )
         print(
             "  The launcher has started the WebXR static HTTPS server + coturn automatically "

--- a/src/core/cloudxr/python/wss.py
+++ b/src/core/cloudxr/python/wss.py
@@ -534,24 +534,32 @@ async def run(
             log.info("WSS proxy listening on port %d", resolved_port)
 
             # ------------------------------------------------------------------
-            # USB-local: HTTPS static client (:oob_teleop_env.USB_UI_PORT) +
-            # adb reverse (WSS / backend / TURN) + coturn. Assets are ensured in
+            # USB-local: HTTPS static client (:func:`oob_teleop_env.usb_ui_port`,
+            # default 8080; override via ``USB_UI_PORT`` env) + adb reverse
+            # (WSS / backend / TURN) + coturn. Assets are ensured in
             # require_usb_local_webxr_static_dir (also called from launcher).
             # ------------------------------------------------------------------
             _usb_coturn_proc = None
             _usb_https_thread = None
             _usb_https_httpd = None
+            _usb_turn_port_resolved: int | None = None
 
             if usb_local:
                 from .oob_teleop_env import (  # noqa: PLC0415
-                    USB_TURN_PORT,
                     USB_TURN_USER,
                     USB_TURN_CREDENTIAL,
-                    USB_UI_PORT,
                     require_usb_local_webxr_static_dir,
                     start_usb_local_https_server,
                     stop_usb_local_https_server,
+                    usb_turn_port,
+                    usb_ui_port,
                 )
+
+                # Resolve once so the coturn bind, adb reverse, and shutdown
+                # paths all agree (env vars are read at process start; pinning
+                # to a local also avoids re-reading on the cleanup path after
+                # the env may have been mutated).
+                _usb_turn_port_resolved = usb_turn_port()
                 from .oob_teleop_adb import (  # noqa: PLC0415
                     setup_adb_reverse_ports,
                     teardown_adb_reverse_ports,
@@ -566,7 +574,7 @@ async def run(
                     static_root,
                     cert_file=cert_paths.cert_file,
                     key_file=cert_paths.key_file,
-                    port=USB_UI_PORT,
+                    port=usb_ui_port(),
                 )
 
                 # 2. adb reverse for TCP ports (WebXR UI, WSS proxy, backend)
@@ -582,7 +590,7 @@ async def run(
 
                 # 3. coturn TURN server (ICE relay required for WebRTC)
                 _usb_coturn_proc = start_coturn(
-                    USB_TURN_PORT, USB_TURN_USER, USB_TURN_CREDENTIAL
+                    _usb_turn_port_resolved, USB_TURN_USER, USB_TURN_CREDENTIAL
                 )
                 if _usb_coturn_proc is None:
                     print(
@@ -593,9 +601,10 @@ async def run(
 
                 # 4. adb reverse for TURN port (headset → PC coturn)
                 try:
-                    setup_adb_reverse_turn(USB_TURN_PORT)
+                    setup_adb_reverse_turn(_usb_turn_port_resolved)
                     log.info(
-                        "USB-local: adb reverse TURN active (port %d)", USB_TURN_PORT
+                        "USB-local: adb reverse TURN active (port %d)",
+                        _usb_turn_port_resolved,
                     )
                 except subprocess.CalledProcessError as exc:
                     log.warning("USB-local: adb reverse TURN setup failed: %s", exc)
@@ -631,7 +640,8 @@ async def run(
                         pass
                 if usb_local:
                     stop_coturn(_usb_coturn_proc)
-                    teardown_adb_reverse_turn(USB_TURN_PORT)
+                    if _usb_turn_port_resolved is not None:
+                        teardown_adb_reverse_turn(_usb_turn_port_resolved)
                     teardown_adb_reverse_ports()
                     stop_usb_local_https_server(_usb_https_thread, _usb_https_httpd)
                     log.info("USB-local: cleanup complete")

--- a/src/core/cloudxr_tests/python/test_oob_teleop_env.py
+++ b/src/core/cloudxr_tests/python/test_oob_teleop_env.py
@@ -13,6 +13,9 @@ import pytest
 from cloudxr_py_test_ns.oob_teleop_env import (
     TELEOP_WEB_CLIENT_BASE_ENV,
     TELEOP_WEB_CLIENT_STATIC_DIR_ENV,
+    USB_BACKEND_DEFAULT_PORT,
+    USB_TURN_DEFAULT_PORT,
+    USB_UI_DEFAULT_PORT,
     WSS_PROXY_DEFAULT_PORT,
     build_headset_bookmark_url,
     client_ui_fields_from_env,
@@ -21,6 +24,9 @@ from cloudxr_py_test_ns.oob_teleop_env import (
     print_oob_hub_startup_banner,
     require_usb_local_webxr_static_dir,
     resolve_lan_host_for_oob,
+    usb_backend_port,
+    usb_turn_port,
+    usb_ui_port,
     web_client_base_override_from_env,
     wss_proxy_port,
 )
@@ -31,6 +37,9 @@ from cloudxr_py_test_ns.oob_teleop_hub import OOB_WS_PATH
 def clear_teleop_env(monkeypatch: pytest.MonkeyPatch) -> None:
     keys = (
         "PROXY_PORT",
+        "USB_UI_PORT",
+        "USB_BACKEND_PORT",
+        "USB_TURN_PORT",
         "TELEOP_STREAM_SERVER_IP",
         "TELEOP_STREAM_PORT",
         "TELEOP_CLIENT_CODEC",
@@ -53,6 +62,63 @@ def test_wss_proxy_port_from_env(
 ) -> None:
     monkeypatch.setenv("PROXY_PORT", "50000")
     assert wss_proxy_port() == 50000
+
+
+def test_usb_ui_port_default(clear_teleop_env: None) -> None:
+    assert usb_ui_port() == USB_UI_DEFAULT_PORT
+
+
+def test_usb_ui_port_from_env(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("USB_UI_PORT", "8081")
+    assert usb_ui_port() == 8081
+
+
+def test_usb_ui_port_invalid_env_raises(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("USB_UI_PORT", "not-a-port")
+    with pytest.raises(ValueError, match="USB_UI_PORT"):
+        usb_ui_port()
+
+
+def test_usb_backend_port_default(clear_teleop_env: None) -> None:
+    assert usb_backend_port() == USB_BACKEND_DEFAULT_PORT
+
+
+def test_usb_backend_port_from_env(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("USB_BACKEND_PORT", "49200")
+    assert usb_backend_port() == 49200
+
+
+def test_usb_backend_port_invalid_env_raises(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("USB_BACKEND_PORT", "not-a-port")
+    with pytest.raises(ValueError, match="USB_BACKEND_PORT"):
+        usb_backend_port()
+
+
+def test_usb_turn_port_default(clear_teleop_env: None) -> None:
+    assert usb_turn_port() == USB_TURN_DEFAULT_PORT
+
+
+def test_usb_turn_port_from_env(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("USB_TURN_PORT", "5349")
+    assert usb_turn_port() == 5349
+
+
+def test_usb_turn_port_invalid_env_raises(
+    clear_teleop_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("USB_TURN_PORT", "not-a-port")
+    with pytest.raises(ValueError, match="USB_TURN_PORT"):
+        usb_turn_port()
 
 
 def test_web_client_base_override_from_env(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * USB-local port configuration can now be overridden via environment variables (`USB_UI_PORT`, `USB_BACKEND_PORT`, `USB_TURN_PORT`) for flexible deployment scenarios.

* **Documentation**
  * Updated messaging and help text to clarify configurable port behavior for WebXR UI, backend, and TURN server components in USB-local mode.

* **Tests**
  * Added comprehensive test coverage for environment-based port configuration and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->