### PR TITLE
docs: add nlopt system dependency prerequisite

### DIFF
--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -23,6 +23,8 @@ Prerequisites
 - **C++20** compatible compiler
 - **Python** 3.10, 3.11, 3.12, or 3.13 (default 3.11; see ``ISAAC_TELEOP_PYTHON_VERSION`` in root ``CMakeLists.txt``)
 - **uv** for Python dependency management and managed Python
+- **NLopt development headers** (``libnlopt-dev`` on Ubuntu) when Python installs ``nlopt``
+  from source
 - **Internet connection** for downloading dependencies via CMake FetchContent
 
 .. _one-time-setup:
@@ -36,7 +38,7 @@ the list of dependencies. On **Ubuntu**, install build tools and clang-format:
 .. code-block:: bash
 
    sudo apt-get update
-   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf
+   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf libnlopt-dev
 
 Runtime-only dependencies (needed to actually run teleop, not to build):
 

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -30,6 +30,14 @@ to clone the repository for a couple quick samples to run.
 
 In a new terminal, install the package from PyPI (or from a local wheel if you built from source):
 
+On Ubuntu systems, install the system package needed when the ``nlopt`` Python dependency builds
+from source (for example on Linux ``aarch64`` where a pre-built wheel may not be available):
+
+.. code-block:: bash
+
+   sudo apt-get update
+   sudo apt-get install -y libnlopt-dev
+
 .. code-block:: bash
 
    # From PyPI


### PR DESCRIPTION
## Summary
- document `libnlopt-dev` as an Ubuntu prerequisite when `nlopt` has to build from source
- add the same prerequisite to the Quick Start pip install path and Build from Source apt package list

Fixes #452.

## Verification
- `git diff --check`
- confirmed both updated getting-started docs mention `libnlopt-dev`

Note: `pre-commit` is not installed in my local environment, so I could not run the repository pre-commit hook set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated build-from-source documentation to explicitly require NLopt development headers when building Python bindings with NLopt support
  * Enhanced quick-start guide with Ubuntu system dependency installation step for the required libnlopt-dev package
  * Aligned prerequisite requirements across documentation for consistent setup instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->