### PR TITLE
docs(manus): clarify installation instructions and prerequisites

### DIFF
--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -30,7 +30,7 @@ Prerequisites
 - **System dependencies** — the install script installs required packages automatically.
 
 The Manus plugin cannot be installed via normal ``pip`` packaging; **build Isaac Teleop
-from source first** by following the :doc:`build_from_source/index` guide under Getting Started.
+from source first** by following the :doc:`../getting_started/build_from_source/index` guide under Getting Started.
 
 Automated (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -29,11 +29,11 @@ Prerequisites
 - **Manus SDK** for Linux — downloaded automatically by the install script.
 - **System dependencies** — the install script installs required packages automatically.
 
-Installation
-------------
+The Manus plugin cannot be installed via normal ``pip`` packaging; **build Isaac Teleop
+from source first** by following the :doc:`build_from_source/index` guide under Getting Started.
 
 Automated (recommended)
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~
 
 The install script handles SDK download, dependency installation, and building:
 
@@ -52,7 +52,7 @@ The script will:
 Manual
 ~~~~~~
 
-If you prefer to install manually:
+If you prefer to install manually, follow these steps after building the repository from source:
 
 1. Download the MANUS Core SDK from
    `MANUS Downloads <https://docs.manus-meta.com/3.1.1/Resources/>`_.

--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -29,8 +29,7 @@ Prerequisites
 - **Manus SDK** for Linux — downloaded automatically by the install script.
 - **System dependencies** — the install script installs required packages automatically.
 
-The Manus plugin cannot be installed via normal ``pip`` packaging; **build Isaac Teleop
-from source first** by following the :doc:`../getting_started/build_from_source/index` guide under Getting Started.
+The Manus plugin cannot be installed via normal ``pip`` packaging; **build Isaac Teleop from source first** by following the :doc:`../getting_started/build_from_source/index` guide under Getting Started.
 
 Automated (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Manus plugin requires building the Teleop repo from source. This has now been clarified in the docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Manus plugin installation guidance to clarify that it must be built from source rather than installed via standard package management.
  * Reorganized installation instructions section for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->