### PR TITLE
feat(teleop): add latest-result pipelined retargeting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ Optional context index: [`src/core/AGENTS.md`](src/core/AGENTS.md) (also on the 
 
 - **High-level** expectations: boundaries between layers, what to avoid, naming or structural conventions, CMake/include policy at a glance, “always / never” rules that stay true across refactors.
 - **Style of work**: how minimal to keep diffs, when to ask for clarification, how this subsystem should relate to OpenXR/schema/deviceio, etc.
+- For build-only requests, use the documented CMake flags and environment first (for example `-DISAAC_TELEOP_PYTHON_VERSION=...`) rather than patching build files to select options.
 
 **What does *not* belong in `AGENTS.md`**
 

--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -330,8 +330,9 @@ Methods
   ``graph_time`` can be provided explicitly; when omitted, monotonic time is used
   for both sim/real time. If ``execution_events`` is provided, it is injected into
   ``ComputeContext`` and ``teleop_control_pipeline`` is skipped for that step.
-  Raises ``ValueError`` if required external inputs are missing or collide with
-  DeviceIO source names.
+  Extra top-level external inputs and extra per-leaf keys are ignored. Raises
+  ``ValueError`` if required external inputs are missing or collide with DeviceIO
+  source names.
 - ``get_external_input_specs() -> Dict[str, RetargeterIOType]`` -- Return the
   input specifications for all external (non-DeviceIO) leaf nodes that require
   caller-provided inputs in ``step()``.

--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -86,6 +86,7 @@ The main configuration object:
        verbose: bool = True                     # Print progress info
        oxr_handles: Optional[...] = None        # External OpenXR handles (optional)
        mcap_config: Optional[...] = None        # Required for REPLAY, optional for LIVE
+       retargeting_execution: RetargetingExecutionConfig = ...
 
 When ``mode`` is ``SessionMode.REPLAY``, ``TeleopSession`` skips OpenXR
 session creation and reads tracking data from the MCAP file specified in
@@ -113,6 +114,182 @@ argument is a ``uint64`` handle value.
        pipeline=pipeline,
        oxr_handles=handles,  # Skip internal OpenXR session creation
    )
+
+Retargeting execution
+"""""""""""""""""""""
+
+``TeleopSession.step()`` runs retargeting synchronously by default: each call
+updates DeviceIO, polls trackers, merges caller-provided inputs, runs optional
+control logic, runs the main retarget pipeline, and returns the current frame's
+``RetargeterIO`` before ``step()`` completes.
+
+Set ``retargeting_execution=RetargetingExecutionConfig(mode="pipelined")`` to
+opt into background retargeting. In pipelined mode, the application still calls
+``step()`` once per simulation frame and supplies any external inputs, graph
+time, or explicit execution events. IsaacTeleop owns one retarget worker thread.
+After the first seed frame, that worker runs the normal synchronous step body
+end-to-end.
+
+Per application frame in pipelined mode, ``step()`` submits the current request
+and returns the latest completed ``RetargeterIO``. On a normal hit this is often
+the previous application frame's output. If that returned output came from
+request N-1, then ``session.last_context`` also comes from N-1: tracker data,
+control messages, execution events, outputs, and context stay self-consistent
+for the completed frame that is returned. Use ``mode="sync"`` when the
+application needs exact current-frame sample/compute/return behavior.
+
+The return type is unchanged; inspect ``session.last_step_info`` for age and
+timing metadata such as ``returned_frame_id``, ``submitted_frame_id``,
+``returned_age_frames``, ``compute_duration_s``, ``ran_synchronously``, and
+``dropped_submissions``. ``dropped_submissions`` is per-step; accumulate it in
+the application when you need a run-wide total. ``frame_deadline_miss`` is a
+per-step flag for outputs more than one submitted frame old, meaning the worker
+missed the normal pipelined target of having a result ready for the next
+application frame. Consumers that want totals should accumulate it.
+
+``last_step_info`` fields:
+
+- ``returned_frame_id`` / ``submitted_frame_id``: frame identifiers for the
+  output returned and the request submitted by this call.
+- ``returned_age_frames`` / ``returned_age_s``: how old the returned output is.
+- ``compute_duration_s``: worker compute time for the returned output.
+- ``ran_synchronously``: the returned output was computed on the application
+  thread during this ``step()`` call. This is true in ``mode="sync"`` and for
+  the pipelined seed frame.
+- ``dropped_submissions``: unstarted pending requests replaced by this call;
+  accumulate this field for a run-wide total.
+- ``frame_deadline_miss``: returned output is more than one submitted frame old.
+- ``worker_exception``: worker failure surfaced on this step, when present.
+
+Because pipelined mode reuses completed frames, caller-provided external inputs
+and returned outputs must be snapshot-copyable. ``TensorGroup.create_snapshot()``
+handles standard scalar, array, and common DLPack-backed tensor cases; custom
+opaque values should provide an equivalent ``create_snapshot()`` hook or run
+with ``mode="sync"``. Pipelined mode returns a new snapshot of the cached
+output on each ``step()`` call. Sync mode returns the pipeline result directly,
+matching the historical ownership behavior.
+
+.. code-block:: python
+
+   from isaacteleop.teleop_session_manager import RetargetingExecutionConfig
+
+   config = TeleopSessionConfig(
+       app_name="MyApp",
+       pipeline=pipeline,
+       retargeting_execution=RetargetingExecutionConfig(mode="pipelined"),
+   )
+
+Key pipelined options:
+
+These options affect pipelined mode only. In ``mode="sync"``, ``step()`` always
+runs and returns the current frame directly.
+
+- ``pacing=ImmediatePacingConfig()`` starts retarget work as soon as the worker
+  receives a request. This is the default pacing when pipelined mode is enabled.
+- ``pacing=DeadlinePacingConfig(safety_margin_s=0.015)`` delays worker
+  requests toward the predicted next application frame using recent cadence and
+  compute-spike estimates. This prepares results just in time for simulation
+  consumption while preserving the pipelined submit-current/return-latest
+  contract. The safety margin is the main tuning knob.
+
+Pacing changes when the worker begins a submitted step request. It does not
+change the one-worker/one-pending-request correctness model. Unstarted paced
+work is coalesced so newer submissions replace older delayed requests.
+
+``TeleopSession.step()`` is intended to be called by one application loop
+thread. IsaacTeleop runs the retarget work on one background worker in
+pipelined mode, but public session state such as ``frame_count``,
+``last_context``, and ``last_step_info`` belongs to the application thread.
+
+.. code-block:: python
+
+   from isaacteleop.teleop_session_manager import (
+       DeadlinePacingConfig,
+       RetargetingExecutionConfig,
+   )
+
+   config = TeleopSessionConfig(
+       app_name="MyApp",
+       pipeline=pipeline,
+       retargeting_execution=RetargetingExecutionConfig(
+           mode="pipelined",
+           pacing=DeadlinePacingConfig(safety_margin_s=0.015),
+       ),
+   )
+
+Deadline pacing tuning
+""""""""""""""""""""""
+
+``DeadlinePacingConfig`` predicts the next application-frame deadline
+from recent ``step()`` submissions, estimates retarget compute cost, and starts
+the worker at roughly:
+
+``predicted_next_step_time - estimated_retarget_cost - safety_margin_s``.
+
+The goal is to avoid starting too early, which uses older inputs, while still
+finishing before the application asks for the next action. If accumulated
+``session.last_step_info.frame_deadline_miss`` counts rise, make the schedule
+more conservative. If misses stay low but outputs use unnecessarily old inputs,
+make the schedule less conservative.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Field
+     - Default
+     - What it changes
+     - When to tune it
+   * - ``safety_margin_s``
+     - ``0.015``
+     - Starts work this much earlier than the predicted deadline.
+     - Tune this first. Increase it when ``frame_deadline_miss`` counts rise;
+       decrease it when misses are near zero and you want more recent inputs.
+   * - ``spike_guard_percentile``
+     - ``0.90``
+     - Chooses how conservative the compute-spike estimate is.
+     - Raise it for rare slow retarget spikes; lower it for more recent inputs
+       on stable workloads.
+   * - ``spike_guard_window``
+     - ``60``
+     - Controls how many recent retarget durations feed the spike estimate.
+     - Increase it when spikes repeat in bursts; decrease it when old spikes
+       make the worker start early for too long.
+   * - ``frame_period_adaptation``
+     - ``0.2``
+     - Controls how quickly the predicted application cadence follows changes.
+     - Raise it when app frame rate changes quickly; lower it when cadence is
+       stable but jittery.
+   * - ``compute_cost_adaptation``
+     - ``0.25``
+     - Controls how quickly the estimated retarget cost follows recent compute
+       time.
+     - Raise it when retarget cost changes by mode/task; lower it when single
+       slow frames cause overreaction.
+   * - ``startup_frame_period_s``
+     - ``0.022``
+     - Initial frame-period guess before enough samples exist.
+     - Rarely tune. Match it to expected app cadence only if startup behavior
+       matters.
+   * - ``startup_compute_cost_s``
+     - ``0.005``
+     - Initial retarget-cost guess before enough samples exist.
+     - Rarely tune. Increase it only if the first few retargets are heavy.
+
+Practical tuning:
+
+- Light, stable load with near-zero misses: try
+  ``DeadlinePacingConfig(safety_margin_s=0.005)`` to ``0.010``. This
+  starts retargeting later so inputs are more recent.
+- Typical interactive XR load: keep ``safety_margin_s=0.015``. This is the
+  default balance between input recency and spike tolerance.
+- Heavy retargeting or occasional compute spikes: try
+  ``safety_margin_s=0.025`` to ``0.040``. If misses still come in bursts, also
+  try ``spike_guard_percentile=0.95`` or ``spike_guard_window=120``.
+- Variable app frame rate: try ``frame_period_adaptation=0.35`` to ``0.50`` so
+  the predicted deadline catches up faster.
+- Task modes that change retarget cost abruptly: try
+  ``compute_cost_adaptation=0.40`` to ``0.60`` so the compute estimate catches
+  up faster.
 
 PluginConfig
 ^^^^^^^^^^^^
@@ -144,8 +321,12 @@ Methods
 """""""
 
 - ``step(*, external_inputs=None, graph_time=None, execution_events=None) -> Dict[str, TensorGroup]``
-  -- Execute one step: updates the DeviceIO session, polls tracker data, merges
-  any caller-provided ``external_inputs``, and executes the retargeting pipeline.
+  -- Execute one step. In default sync mode, all work completes before
+  ``step()`` returns. In pipelined mode, the first call seeds an initial output,
+  then later calls submit DeviceIO update, tracker polling, ``external_inputs``
+  merge, and retargeting work to the worker before returning the latest
+  completed output; unstarted pending work may be replaced by a newer
+  submission.
   ``graph_time`` can be provided explicitly; when omitted, monotonic time is used
   for both sim/real time. If ``execution_events`` is provided, it is injected into
   ``ComputeContext`` and ``teleop_control_pipeline`` is skipped for that step.
@@ -187,6 +368,10 @@ Properties
 - ``config: TeleopSessionConfig`` -- The configuration object
 - ``oxr_session: Optional[OpenXRSession]`` -- The internal OpenXR session, or
   ``None`` when using external handles (read-only)
+- ``last_context: Optional[ComputeContext]`` -- Context corresponding to the
+  most recent returned output
+- ``last_step_info: RetargetingStepInfo`` -- Age and timing metadata for
+  the most recent returned output
 
 Helper Functions
 ^^^^^^^^^^^^^^^^

--- a/src/core/AGENTS.md
+++ b/src/core/AGENTS.md
@@ -10,3 +10,11 @@ SPDX-License-Identifier: Apache-2.0
 To see **all** `AGENTS.md` files in the IsaacTeleop repo, use the **`find` command (or `**/AGENTS.md` glob) documented in the repo root [`AGENTS.md`](../../AGENTS.md)**—do not rely on a hand-maintained list in this file.
 
 If work under **`src/core/`** went wrong—**user** correction, **pre-commit/CI** failure, or **repeated** same-class mistakes—you **must** follow the repo root **[`AGENTS.md`](../../AGENTS.md)** **Mandatory learning loop**: distill a short rule and **update** the **nearest** relevant `AGENTS.md` (this file or a package file) or **source comments** in the same session (including **delta vs `main`** scope).
+
+- Async retargeting pacing behavior belongs on the pacing config objects; keep the worker focused on scheduling mechanics and avoid adding concrete pacing-mode or subclass branches there.
+- Prefer coarse-grained async boundaries around an existing synchronous step before splitting DeviceIO/source polling away from graph execution; split internals only when a measured correctness or performance need justifies the extra thread-safety surface.
+- In pipelined `TeleopSession`, `last_context` follows the returned completed frame; reset/control-transition events travel with that frame and must not force exact-current-frame waits. Use sync mode for exact current-frame behavior.
+- Keep async retargeting comments short and local to invariants; user-facing pacing tuning guidance belongs in docs rather than long code docstrings.
+- When changing `TeleopSession` retargeting execution defaults, update config, docs, and default-behavior tests together so opt-in vs. default semantics stay aligned.
+- Preserve existing `TeleopSession` lifecycle flag semantics unless changing the public/context-manager contract intentionally; use tests to lock down cleanup details before altering them.
+- After Python test or session-manager edits, let `ruff format`/pre-commit own wrapping and rerun the hook when it modifies files.

--- a/src/core/retargeting_engine/python/interface/tensor_group.py
+++ b/src/core/retargeting_engine/python/interface/tensor_group.py
@@ -15,9 +15,66 @@ the required (non-optional) variant.
 """
 
 import copy as _copy
+import importlib
 from typing import List, Any
 from .tensor_group_type import TensorGroupType
 from .tensor import Tensor, UNSET_VALUE
+
+
+_SNAPSHOT_NOT_HANDLED = object()
+
+
+def _value_snapshot(value: Any) -> Any:
+    """Copy one tensor value for a TensorGroup snapshot.
+
+    Normal Python values still use ``deepcopy``. DLPack tensor providers are a
+    little different: some runtime arrays, notably simulation/GPU arrays, do
+    not support ``deepcopy`` but do provide framework copy/clone operations
+    that preserve device placement. Use those hooks before falling back to the
+    generic Python copier.
+    """
+
+    create_snapshot = getattr(value, "create_snapshot", None)
+    if callable(create_snapshot):
+        return create_snapshot()
+
+    if _supports_dlpack(value):
+        copied = _dlpack_value_snapshot(value)
+        if copied is not _SNAPSHOT_NOT_HANDLED:
+            return copied
+
+    return _copy.deepcopy(value)
+
+
+def _supports_dlpack(value: Any) -> bool:
+    """Return whether ``value`` looks like a DLPack tensor provider."""
+
+    return hasattr(value, "__dlpack__") and hasattr(value, "__dlpack_device__")
+
+
+def _dlpack_value_snapshot(value: Any) -> Any:
+    """Best-effort owned copy for common DLPack providers."""
+
+    # Warp arrays expose a module-level clone function rather than an array
+    # method. Import lazily so the retargeting engine does not require Warp just
+    # to construct scalar TensorGroups. Keep this behind importlib so mypy does
+    # not require optional framework stubs.
+    if type(value).__module__.split(".")[0] == "warp":
+        try:
+            wp = importlib.import_module("warp")
+            return wp.clone(value)
+        except Exception:
+            pass
+
+    for method_name in ("clone", "copy"):
+        method = getattr(value, method_name, None)
+        if callable(method):
+            try:
+                return method()
+            except TypeError:
+                continue
+
+    return _SNAPSHOT_NOT_HANDLED
 
 
 class OptionalTensorGroup:
@@ -130,16 +187,17 @@ class OptionalTensorGroup:
         """
         Return a new independent copy of this group.
 
-        Each tensor value is deep-copied (``copy.deepcopy``), producing a
-        fully independent snapshot regardless of the value type.  The
-        returned instance has the same concrete type as ``self``
-        (``TensorGroup`` or ``OptionalTensorGroup``).
+        Each tensor value is copied into an owned value. DLPack providers use
+        framework copy/clone hooks where available so device-backed arrays do
+        not have to support ``copy.deepcopy``. The returned instance has the
+        same concrete type as ``self`` (``TensorGroup`` or
+        ``OptionalTensorGroup``).
         """
         new_group = type(self)(self._group_type)
         if not self.is_none:
             for i, tensor in enumerate(self._tensors):
                 if tensor._value is not UNSET_VALUE:
-                    new_group[i] = _copy.deepcopy(tensor._value)
+                    new_group[i] = _value_snapshot(tensor._value)
         return new_group
 
 

--- a/src/core/retargeting_engine_tests/python/test_tensor_group.py
+++ b/src/core/retargeting_engine_tests/python/test_tensor_group.py
@@ -11,6 +11,7 @@ from isaacteleop.retargeting_engine.interface import (
     TensorGroup,
     Tensor,
     TensorGroupType,
+    TensorType,
     UNSET_VALUE,
 )
 from isaacteleop.retargeting_engine.tensor_types import (
@@ -562,6 +563,43 @@ class TestTensorGroupCopy:
         tg = self._array_group()
         cp = tg.create_snapshot()
         assert not np.shares_memory(cp[0], tg[0])
+
+    def test_copy_dlpack_provider_uses_provider_copy_before_deepcopy(self):
+        """DLPack providers may not support deepcopy but can expose copy/clone hooks."""
+
+        class AnyValueType(TensorType):
+            def _check_instance_compatibility(self, other):
+                return True
+
+            def validate_value(self, value):
+                pass
+
+        class CopyOnlyDlpackValue:
+            def __init__(self, values):
+                self.values = list(values)
+
+            def __dlpack__(self):
+                raise RuntimeError("not needed by snapshot")
+
+            def __dlpack_device__(self):
+                return (1, 0)
+
+            def copy(self):
+                return CopyOnlyDlpackValue(self.values)
+
+            def __deepcopy__(self, memo):
+                raise TypeError("deepcopy is intentionally unsupported")
+
+        gt = TensorGroupType("dlpack_like", [AnyValueType("value")])
+        tg = TensorGroup(gt)
+        original = CopyOnlyDlpackValue([1.0, 2.0, 3.0])
+        tg[0] = original
+
+        cp = tg.create_snapshot()
+        cp[0].values[0] = 99.0
+
+        assert tg[0].values == [1.0, 2.0, 3.0]
+        assert cp[0].values == [99.0, 2.0, 3.0]
 
 
 class TestOptionalTensorGroupCopy:

--- a/src/core/teleop_session_manager/CMakeLists.txt
+++ b/src/core/teleop_session_manager/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TELEOP_SESSION_MANAGER_OUTPUT_DIR "${CMAKE_BINARY_DIR}/python_package/$<CONF
 # List of Python files to copy
 set(TELEOP_SESSION_MANAGER_PYTHON_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/python/__init__.py"
+    "${CMAKE_CURRENT_SOURCE_DIR}/python/async_retarget_runner.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/python/config.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/python/teleop_session.py"
     "${CMAKE_CURRENT_SOURCE_DIR}/python/helpers.py"

--- a/src/core/teleop_session_manager/python/__init__.py
+++ b/src/core/teleop_session_manager/python/__init__.py
@@ -1,11 +1,20 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from .teleop_session import TeleopSession
+from .teleop_session import RetargetingStepInfo, TeleopSession
 from .config import (
+    DeadlinePacingConfig,
+    ImmediatePacingConfig,
+    PluginConfig,
+    RetargetingExecutionConfig,
+    RetargetingExecutionMode,
+    RetargetingPacingMode,
     SessionMode,
     TeleopSessionConfig,
-    PluginConfig,
+)
+from .async_retarget_runner import (
+    AsyncRetargetRunnerStopped,
+    AsyncRetargetWorkerError,
 )
 from .helpers import (
     create_standard_inputs,
@@ -29,6 +38,14 @@ __all__ = [
     "TeleopSessionConfig",
     "SessionMode",
     "PluginConfig",
+    "ImmediatePacingConfig",
+    "DeadlinePacingConfig",
+    "RetargetingExecutionConfig",
+    "RetargetingExecutionMode",
+    "RetargetingPacingMode",
+    "AsyncRetargetRunnerStopped",
+    "AsyncRetargetWorkerError",
+    "RetargetingStepInfo",
     "create_standard_inputs",
     "get_required_oxr_extensions_from_pipeline",
     "TeleopStateManager",

--- a/src/core/teleop_session_manager/python/async_retarget_runner.py
+++ b/src/core/teleop_session_manager/python/async_retarget_runner.py
@@ -1,0 +1,448 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Single-worker pipelined TeleopSession step runner."""
+
+from __future__ import annotations
+
+import copy
+from collections import deque
+from dataclasses import dataclass
+import threading
+import time
+from collections.abc import Callable
+from typing import Any, Dict
+
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
+    ComputeContext,
+    GraphTime,
+    RetargeterIO,
+)
+from isaacteleop.retargeting_engine.interface.execution_events import (
+    ExecutionEvents,
+    ExecutionState,
+)
+
+from .config import RetargetingExecutionConfig
+
+
+StepExecutor = Callable[["StepRequest"], tuple[RetargeterIO, ComputeContext]]
+
+
+@dataclass(frozen=True)
+class StepRequest:
+    """One application-frame request for the sync path or worker."""
+
+    frame_id: int
+    external_inputs: Dict[str, RetargeterIO] | None
+    graph_time: GraphTime | None
+    execution_events: ExecutionEvents | None
+    submitted_time_s: float
+
+
+@dataclass(frozen=True)
+class RetargetFrame:
+    """Completed retarget result stored as the latest reusable frame."""
+
+    frame_id: int
+    outputs: RetargeterIO
+    context: ComputeContext
+    submitted_time_s: float
+    started_time_s: float
+    completed_time_s: float
+    compute_duration_s: float
+
+
+class AsyncRetargetWorkerError(RuntimeError):
+    """Raised on the application thread after the worker fails a step request."""
+
+
+class AsyncRetargetRunnerStopped(RuntimeError):
+    """Raised when the retarget runner cannot accept or run more work."""
+
+
+def snapshot_retargeter_io(io: RetargeterIO) -> RetargeterIO:
+    """Return an owned copy of a returned retargeter I/O dictionary.
+
+    Pipelined mode can return the same completed frame on more than one
+    application step when the worker has not published a newer result. Copying
+    the returned value prevents caller mutation from corrupting the cached
+    frame. If a value cannot be copied, pipelined mode fails with a clear error
+    instead of silently aliasing mutable state across frames; such values
+    should implement ``create_snapshot()`` or run in sync mode.
+    """
+
+    return {name: _snapshot_value(group) for name, group in io.items()}
+
+
+def snapshot_compute_context(context: ComputeContext) -> ComputeContext:
+    """Return an owned copy of a compute context crossing an async boundary.
+
+    ``last_context`` is public mutable state. Copying keeps user edits to the
+    public object from corrupting the cached frame that pipelined mode may
+    return again as the latest completed result.
+    """
+
+    return ComputeContext(
+        graph_time=GraphTime(
+            sim_time_ns=context.graph_time.sim_time_ns,
+            real_time_ns=context.graph_time.real_time_ns,
+        ),
+        execution_events=ExecutionEvents(
+            reset=bool(context.execution_events.reset),
+            execution_state=ExecutionState(context.execution_events.execution_state),
+        ),
+    )
+
+
+def _snapshot_value(value: Any) -> Any:
+    """Copy one value using TensorGroup hooks first, then deepcopy.
+
+    External inputs cross the application/worker thread boundary and returned
+    outputs may be reused when the same completed frame is returned again. Both
+    paths need owned data; a failed copy is a correctness problem, not an
+    optimization miss.
+    """
+    create_snapshot = getattr(value, "create_snapshot", None)
+    try:
+        if create_snapshot is not None:
+            return create_snapshot()
+        return copy.deepcopy(value)
+    except (TypeError, copy.Error) as exc:
+        raise TypeError(
+            "Pipelined retargeting requires external inputs and returned outputs "
+            "to be snapshot-copyable. Implement create_snapshot() for this value "
+            "or use RetargetingExecutionConfig(mode='sync')."
+        ) from exc
+
+
+def snapshot_pipeline_inputs(
+    inputs: Dict[str, RetargeterIO],
+) -> Dict[str, RetargeterIO]:
+    """Return strict owned copies of caller-provided external inputs.
+
+    Only explicit ``external_inputs`` cross into the worker. DeviceIO polling
+    happens inside the worker, which is why async mode does not need broad
+    schema/message-channel snapshotting. If an external value cannot be copied,
+    fail early rather than racing caller-owned state.
+    """
+
+    return {
+        name: {
+            input_name: _snapshot_value(group) for input_name, group in values.items()
+        }
+        for name, values in inputs.items()
+    }
+
+
+class AsyncRetargetRunner:
+    """Run whole TeleopSession steps on one background worker.
+
+    The runner accepts prepared ``StepRequest`` objects from the application
+    thread and executes the session's normal sync step serially on the worker.
+    It intentionally has only one running request and one pending request so
+    stateful retargeters are never called concurrently and backlog cannot grow
+    without bound.
+    """
+
+    def __init__(self, step_fn: StepExecutor, cfg: RetargetingExecutionConfig):
+        self._cfg = cfg
+        pacing = cfg.pacing
+        self._step_fn = step_fn
+        self._cond = threading.Condition()
+        self._pending: StepRequest | None = None
+        self._published: RetargetFrame | None = None
+        self._dropped_submissions = 0
+        self._last_submission_time_s: float | None = None
+        self._submission_count = 0
+        startup = pacing.startup_state()
+        self._submit_period_s = startup.submit_period_s
+        self._compute_duration_s = startup.compute_duration_s
+        self._compute_duration_samples = deque(maxlen=startup.compute_sample_window)
+        self._stop = False
+        self._closed = False
+        self._exception: BaseException | None = None
+        self._exception_reported = False
+        self._thread: threading.Thread | None = None
+
+    @property
+    def dropped_submissions(self) -> int:
+        """Total number of unstarted requests replaced by newer requests."""
+
+        with self._cond:
+            return self._dropped_submissions
+
+    def start(self) -> None:
+        """Start the worker if it is not already running.
+
+        Runners are intentionally one-shot. ``TeleopSession`` creates a new
+        runner for each context-manager entry, which avoids reusing cached
+        frames or pacing estimates across independent DeviceIO/OpenXR sessions.
+        """
+
+        with self._cond:
+            if self._thread is not None:
+                return
+            if self._closed:
+                raise AsyncRetargetRunnerStopped(
+                    "Async retarget runner cannot be restarted after stop"
+                )
+            self._stop = False
+            self._exception = None
+            self._exception_reported = False
+            self._thread = threading.Thread(
+                target=self._run,
+                name="IsaacTeleopAsyncRetarget",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def stop(self, timeout_s: float | None = None) -> bool:
+        """Stop accepting pending work and wait for the active step to finish.
+
+        ``TeleopSession.__exit__`` calls this before releasing DeviceIO/OpenXR
+        resources. The running request is not interrupted because retargeters
+        and DeviceIO updates generally are not cancellation-safe. Stopping
+        rejects new submissions, clears unstarted pending work, wakes
+        ``wait_for_frame()`` observers, and lets any running worker step leave
+        cleanly.
+
+        Returns:
+            ``True`` when no worker thread remains alive. ``False`` means the
+            caller supplied a timeout and the active step is still finishing;
+            call ``stop()`` again after the step can complete.
+        """
+
+        with self._cond:
+            self._stop = True
+            self._closed = True
+            self._pending = None
+            self._cond.notify_all()
+            thread = self._thread
+
+        if thread is not None:
+            thread.join(timeout=timeout_s)
+
+        with self._cond:
+            stopped = thread is None or not thread.is_alive()
+            if self._thread is thread and stopped:
+                self._thread = None
+            return stopped
+
+    def raise_if_failed(self, *, only_unreported: bool = False) -> None:
+        """Re-raise a captured worker failure on the application thread.
+
+        Worker exceptions cannot be raised directly where they occur, so
+        ``TeleopSession.step()`` and ``__exit__`` call this to surface failures
+        at deterministic public API boundaries.
+        """
+
+        with self._cond:
+            self._raise_if_failed_locked(only_unreported=only_unreported)
+
+    def publish_seed(self, frame: RetargetFrame) -> None:
+        """Publish the synchronous first frame before background work starts.
+
+        The first pipelined ``step()`` has no completed output to return, so
+        ``TeleopSession`` runs it synchronously, starts the worker, then seeds
+        the runner's latest-result slot with that frame. The seed also anchors
+        pacing estimates so the first background request can be scheduled
+        toward the next application frame.
+        """
+
+        with self._cond:
+            self._published = frame
+            self._record_submission_locked(frame.submitted_time_s)
+            self._record_compute_duration_locked(frame.compute_duration_s)
+            self._cond.notify_all()
+
+    def submit(self, request: StepRequest) -> int:
+        """Submit an ordinary step request.
+
+        If a previous request is pending but has not started, it is replaced by
+        this newer request. That keeps latency bounded: the worker either
+        finishes the currently running step or executes the most recent pending
+        step, but it never drains a superseded backlog.
+
+        Returns:
+            Number of unstarted pending requests dropped by this submission.
+        """
+
+        with self._cond:
+            self._raise_if_failed_locked()
+            self._raise_if_stopped_locked(
+                "Async retarget runner stopped before submission was accepted"
+            )
+            dropped = 0
+            if self._pending is not None:
+                dropped = 1
+                self._dropped_submissions += 1
+            self._pending = request
+            self._record_submission_locked(request.submitted_time_s)
+            self._cond.notify_all()
+            return dropped
+
+    def latest(self) -> RetargetFrame | None:
+        """Return the latest published frame without waiting.
+
+        This raises any worker failure instead of returning an older frame.
+        """
+
+        with self._cond:
+            self._raise_if_failed_locked()
+            return self._published
+
+    def wait_for_frame(
+        self,
+        frame_id: int,
+        timeout_s: float | None = None,
+    ) -> RetargetFrame | None:
+        """Wait until at least ``frame_id`` has been published.
+
+        Tests and internal observers use this to detect worker progress.
+        Returning a newer frame is acceptable because it still proves the worker
+        reached the requested frame id.
+        """
+
+        deadline = None if timeout_s is None else time.monotonic() + timeout_s
+        with self._cond:
+            while True:
+                self._raise_if_failed_locked()
+                if self._published is not None and self._published.frame_id >= frame_id:
+                    return self._published
+                if self._stop:
+                    return None
+                if deadline is None:
+                    self._cond.wait()
+                else:
+                    wait_s = deadline - time.monotonic()
+                    if wait_s <= 0:
+                        return None
+                    self._cond.wait(timeout=wait_s)
+
+    def _run(self) -> None:
+        """Worker loop: execute one ready request at a time and publish results.
+
+        This is the only place the step executor runs. That invariant is what
+        keeps stateful retargeters and DeviceIO polling serialized even though
+        the application thread keeps calling ``TeleopSession.step()``.
+        """
+        while True:
+            with self._cond:
+                request = self._take_ready_request_locked()
+            if request is None:
+                return
+
+            try:
+                started = time.monotonic()
+                outputs, context = self._step_fn(request)
+                completed = time.monotonic()
+                frame = RetargetFrame(
+                    frame_id=request.frame_id,
+                    outputs=snapshot_retargeter_io(outputs),
+                    context=snapshot_compute_context(context),
+                    submitted_time_s=request.submitted_time_s,
+                    started_time_s=started,
+                    completed_time_s=completed,
+                    compute_duration_s=completed - started,
+                )
+            except BaseException as exc:
+                with self._cond:
+                    self._exception = exc
+                    self._exception_reported = False
+                    self._cond.notify_all()
+                return
+
+            with self._cond:
+                self._record_compute_duration_locked(frame.compute_duration_s)
+                self._published = frame
+                self._cond.notify_all()
+
+    def _take_ready_request_locked(self) -> StepRequest | None:
+        """Return the latest unstarted request once its pacing delay has elapsed.
+
+        Pacing waits keep the request in ``_pending`` until it is ready to run.
+        That lets a newer application frame replace delayed work instead of
+        spending time on a superseded full step.
+        """
+        while True:
+            while self._pending is None and not self._stop:
+                self._cond.wait()
+            if self._stop:
+                return None
+
+            request = self._pending
+            assert request is not None
+            if not self._wait_until_ready_locked(request):
+                continue
+            if self._pending is not request:
+                continue
+            self._pending = None
+            self._cond.notify_all()
+            return request
+
+    def _raise_if_failed_locked(self, *, only_unreported: bool = False) -> None:
+        """Raise the stored worker exception while the condition lock is held."""
+        if self._exception is not None:
+            if only_unreported and self._exception_reported:
+                return
+            self._exception_reported = True
+            raise AsyncRetargetWorkerError(
+                "Async retarget worker failed"
+            ) from self._exception
+
+    def _raise_if_stopped_locked(self, message: str) -> None:
+        """Reject new or still-blocked submissions after teardown starts."""
+        if self._stop:
+            raise AsyncRetargetRunnerStopped(message)
+
+    def _record_submission_locked(self, submitted_time_s: float) -> None:
+        """Update the application step-period estimate from submit cadence."""
+        if self._last_submission_time_s is not None:
+            period_s = submitted_time_s - self._last_submission_time_s
+            pacing = self._cfg.pacing
+            self._submit_period_s = pacing.update_submit_period_s(
+                self._submit_period_s,
+                period_s,
+            )
+        self._last_submission_time_s = submitted_time_s
+        self._submission_count += 1
+
+    def _record_compute_duration_locked(self, duration_s: float) -> None:
+        """Update the retarget compute-duration estimate."""
+        pacing = self._cfg.pacing
+        self._compute_duration_s = pacing.update_compute_duration_s(
+            self._compute_duration_s,
+            duration_s,
+        )
+        self._compute_duration_samples.append(duration_s)
+
+    def _wait_until_ready_locked(self, request: StepRequest) -> bool:
+        """Wait for ``request`` pacing while letting newer submissions replace it.
+
+        Returns:
+            ``True`` when this request is still pending and ready to execute.
+        """
+        sleep_s = self._compute_pacing_sleep_s(request, time.monotonic())
+        if sleep_s <= 0.0:
+            return True
+
+        deadline = time.monotonic() + sleep_s
+        while not self._stop and self._pending is request:
+            remaining_s = deadline - time.monotonic()
+            if remaining_s <= 0.0:
+                return self._pending is request
+            self._cond.wait(timeout=remaining_s)
+        return False
+
+    def _compute_pacing_sleep_s(self, request: StepRequest, now_s: float) -> float:
+        """Return how long the worker should wait before executing ``request``."""
+        pacing = self._cfg.pacing
+        return pacing.compute_delay_s(
+            submitted_time_s=request.submitted_time_s,
+            now_s=now_s,
+            submission_count=self._submission_count,
+            submit_period_s=self._submit_period_s,
+            compute_duration_s=self._compute_duration_s,
+            compute_duration_samples=self._compute_duration_samples,
+        )

--- a/src/core/teleop_session_manager/python/config.py
+++ b/src/core/teleop_session_manager/python/config.py
@@ -9,6 +9,8 @@ These classes provide a clean, declarative way to configure teleop sessions.
 
 from __future__ import annotations
 
+import math
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -31,6 +33,234 @@ class SessionMode(Enum):
 
     LIVE = "live"
     REPLAY = "replay"
+
+
+class RetargetingExecutionMode(str, Enum):
+    """How :class:`TeleopSession` executes the main retargeting graph."""
+
+    SYNC = "sync"
+    PIPELINED = "pipelined"
+
+
+class RetargetingPacingMode(str, Enum):
+    """How the retarget worker schedules pipelined requests."""
+
+    IMMEDIATE = "immediate"
+    DEADLINE = "deadline"
+
+
+@dataclass(frozen=True)
+class PacingStartupState:
+    """Initial estimates the worker keeps for paced scheduling."""
+
+    submit_period_s: float = 0.0
+    compute_duration_s: float = 0.0
+    compute_sample_window: int = 1
+
+
+class _PacingBehavior:
+    """Default no-delay behavior shared by pacing configs."""
+
+    def startup_state(self) -> PacingStartupState:
+        return PacingStartupState()
+
+    def update_submit_period_s(
+        self,
+        current_estimate_s: float,
+        observed_period_s: float,
+    ) -> float:
+        return current_estimate_s
+
+    def update_compute_duration_s(
+        self,
+        current_estimate_s: float,
+        observed_duration_s: float,
+    ) -> float:
+        return current_estimate_s
+
+    def compute_delay_s(
+        self,
+        *,
+        submitted_time_s: float,
+        now_s: float,
+        submission_count: int,
+        submit_period_s: float,
+        compute_duration_s: float,
+        compute_duration_samples: Sequence[float],
+    ) -> float:
+        return 0.0
+
+
+@dataclass
+class ImmediatePacingConfig(_PacingBehavior):
+    """Start retarget work as soon as the worker receives a request."""
+
+    mode: RetargetingPacingMode | str = RetargetingPacingMode.IMMEDIATE
+
+    def __post_init__(self) -> None:
+        self.mode = RetargetingPacingMode(self.mode)
+        if self.mode != RetargetingPacingMode.IMMEDIATE:
+            raise ValueError("ImmediatePacingConfig mode must be 'immediate'")
+
+
+@dataclass
+class DeadlinePacingConfig(_PacingBehavior):
+    """Delay retarget work toward the predicted next application frame.
+
+    Tune :attr:`safety_margin_s` first. The adaptation and spike estimate fields
+    are for workloads whose frame cadence or retarget cost changes noticeably.
+    """
+
+    mode: RetargetingPacingMode | str = RetargetingPacingMode.DEADLINE
+    safety_margin_s: float = 0.015
+    frame_period_adaptation: float = 0.2
+    compute_cost_adaptation: float = 0.25
+    spike_guard_window: int = 60
+    spike_guard_percentile: float = 0.90
+    startup_frame_period_s: float = 0.022
+    startup_compute_cost_s: float = 0.005
+
+    def __post_init__(self) -> None:
+        self.mode = RetargetingPacingMode(self.mode)
+        self._validate()
+
+    def startup_state(self) -> PacingStartupState:
+        """Seed worker-side pacing estimates before runtime samples exist."""
+        return PacingStartupState(
+            submit_period_s=self.startup_frame_period_s,
+            compute_duration_s=self.startup_compute_cost_s,
+            compute_sample_window=self.spike_guard_window,
+        )
+
+    def update_submit_period_s(
+        self,
+        current_estimate_s: float,
+        observed_period_s: float,
+    ) -> float:
+        """Fold one observed app-frame period into the deadline estimate."""
+        if observed_period_s <= 0.0:
+            return current_estimate_s
+        return (
+            self.frame_period_adaptation * observed_period_s
+            + (1.0 - self.frame_period_adaptation) * current_estimate_s
+        )
+
+    def update_compute_duration_s(
+        self,
+        current_estimate_s: float,
+        observed_duration_s: float,
+    ) -> float:
+        """Fold one retarget duration into the cost estimate."""
+        return (
+            self.compute_cost_adaptation * observed_duration_s
+            + (1.0 - self.compute_cost_adaptation) * current_estimate_s
+        )
+
+    def compute_delay_s(
+        self,
+        *,
+        submitted_time_s: float,
+        now_s: float,
+        submission_count: int,
+        submit_period_s: float,
+        compute_duration_s: float,
+        compute_duration_samples: Sequence[float],
+    ) -> float:
+        """Delay work so DeviceIO polling happens near next use.
+
+        Deadline pacing is optional; the immediate default returns zero. This
+        mode starts later than immediate pacing to use more recent inputs, but
+        still reserves estimated compute time plus ``safety_margin_s`` so the
+        next application frame is less likely to miss the finished result.
+        """
+        if submission_count < 2:
+            return 0.0
+
+        target_start_s = (
+            submitted_time_s
+            + submit_period_s
+            - self._estimated_compute_duration_s(
+                compute_duration_s,
+                compute_duration_samples,
+            )
+            - self.safety_margin_s
+        )
+        return max(0.0, target_start_s - now_s)
+
+    def _estimated_compute_duration_s(
+        self,
+        compute_duration_s: float,
+        compute_duration_samples: Sequence[float],
+    ) -> float:
+        """Return the cost estimate used for spike-aware scheduling."""
+        if not compute_duration_samples:
+            return compute_duration_s
+
+        samples = sorted(compute_duration_samples)
+        index = min(
+            len(samples) - 1,
+            max(0, math.ceil(self.spike_guard_percentile * len(samples)) - 1),
+        )
+        return max(compute_duration_s, samples[index])
+
+    def _validate(self) -> None:
+        if self.mode != RetargetingPacingMode.DEADLINE:
+            raise ValueError("DeadlinePacingConfig mode must be 'deadline'")
+        if not (0.0 < self.frame_period_adaptation <= 1.0):
+            raise ValueError("frame_period_adaptation must be in (0, 1]")
+        if not (0.0 < self.compute_cost_adaptation <= 1.0):
+            raise ValueError("compute_cost_adaptation must be in (0, 1]")
+        if self.spike_guard_window <= 0:
+            raise ValueError("spike_guard_window must be positive")
+        if not (0.0 < self.spike_guard_percentile <= 1.0):
+            raise ValueError("spike_guard_percentile must be in (0, 1]")
+        if self.safety_margin_s < 0:
+            raise ValueError("safety_margin_s must be non-negative")
+        if self.startup_frame_period_s <= 0:
+            raise ValueError("startup_frame_period_s must be positive")
+        if self.startup_compute_cost_s < 0:
+            raise ValueError("startup_compute_cost_s must be non-negative")
+
+
+_RetargetingPacingConfig = ImmediatePacingConfig | DeadlinePacingConfig
+
+
+def _coerce_pacing_config(
+    pacing: _RetargetingPacingConfig | RetargetingPacingMode | str,
+) -> _RetargetingPacingConfig:
+    """Return a concrete pacing config from a config object or mode string."""
+    if isinstance(
+        pacing,
+        (ImmediatePacingConfig, DeadlinePacingConfig),
+    ):
+        return pacing
+
+    mode = RetargetingPacingMode(pacing)
+    if mode == RetargetingPacingMode.IMMEDIATE:
+        return ImmediatePacingConfig()
+    if mode == RetargetingPacingMode.DEADLINE:
+        return DeadlinePacingConfig()
+
+    raise ValueError(f"Unsupported pacing mode: {pacing}")
+
+
+@dataclass
+class RetargetingExecutionConfig:
+    """Configuration for synchronous vs. pipelined retarget step execution.
+
+    Pipelined mode keeps the public ``TeleopSession.step()`` return type as a
+    normal ``RetargeterIO`` dict, but returns the latest completed retarget
+    frame while submitting the current step request to a background worker.
+    """
+
+    mode: RetargetingExecutionMode | str = RetargetingExecutionMode.SYNC
+    pacing: _RetargetingPacingConfig | RetargetingPacingMode | str = field(
+        default_factory=ImmediatePacingConfig
+    )
+
+    def __post_init__(self) -> None:
+        self.mode = RetargetingExecutionMode(self.mode)
+        self.pacing = _coerce_pacing_config(self.pacing)
 
 
 @dataclass
@@ -93,6 +323,9 @@ class TeleopSessionConfig:
             ``name`` as the MCAP channel name).  Any ``tracker_names``
             explicitly provided in the config are **appended** after the
             auto-discovered sources.
+        retargeting_execution: Synchronous vs. pipelined execution settings for
+            the main retargeting pipeline. Defaults to synchronous exact-current-frame
+            behavior; set ``mode="pipelined"`` to opt into background execution.
 
     Example (auto-discovery):
         # Source creates its own tracker automatically!
@@ -139,6 +372,9 @@ class TeleopSessionConfig:
     verbose: bool = True
     oxr_handles: Optional[OpenXRSessionHandles] = None
     mcap_config: Optional[Union[McapRecordingConfig, McapReplayConfig]] = None
+    retargeting_execution: RetargetingExecutionConfig = field(
+        default_factory=RetargetingExecutionConfig
+    )
 
     def __post_init__(self) -> None:
         """Validate configuration consistency."""

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -308,6 +308,8 @@ class TeleopSession:
                 leaf nodes that require caller-provided inputs. Use get_external_input_specs()
                 to discover what external inputs are expected. Keys that do not correspond
                 to an external leaf node or a DeviceIO source name are silently ignored.
+                Within each external leaf, keys not declared by that leaf's input_spec()
+                are silently ignored.
                 Keys that collide with a DeviceIO source name are invalid and cause
                 validation to raise.
             graph_time: Optional ``GraphTime`` for this step. When omitted,
@@ -366,14 +368,14 @@ class TeleopSession:
 
         The whole-step worker polls DeviceIO itself, so only explicit
         ``external_inputs`` cross the thread boundary. Those inputs, along with
-        optional graph time and explicit execution events, are copied here so
-        the application can safely reuse or mutate its objects after ``step()``
+        optional graph time and explicit execution events, are filtered to the
+        external leaf specs before optionally being copied here so the
+        application can safely reuse or mutate its objects after ``step()``
         returns. Sync mode disables the snapshot and uses this same request
         shape only to avoid duplicating the step execution path.
         """
         self._validate_external_inputs(external_inputs)
-        if snapshot_external_inputs:
-            external_inputs = self._filter_external_inputs(external_inputs)
+        external_inputs = self._filter_external_inputs(external_inputs)
         request_external_inputs = None
         if external_inputs:
             request_external_inputs = (
@@ -780,11 +782,9 @@ class TeleopSession:
     ) -> Optional[Dict[str, RetargeterIO]]:
         """Drop allowed-but-unused external leaf names and per-leaf input keys.
 
-        The public API has historically ignored extra external leaf names. In
-        pipelined mode this filtering matters because snapshotting an ignored
-        value could fail or waste work even though the pipeline will never read
-        it. The same rule applies inside a valid leaf dict: keep required input
-        names, ignore extras.
+        The public API has historically ignored extra external leaf names. This
+        filtering also keeps sync and pipelined mode aligned when callers pass
+        extra per-leaf values. Keep required input names, ignore extras.
         """
         if not external_inputs:
             return None

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -9,8 +9,10 @@ plugins, and retargeting engines, allowing users to focus on configuration
 rather than initialization code.
 """
 
+import logging
 import time
 from contextlib import ExitStack
+from dataclasses import dataclass
 from typing import Optional, Dict, Any, List, Set
 
 from isaacteleop.retargeting_engine.deviceio_source_nodes import IDeviceIOSource
@@ -32,10 +34,47 @@ import isaacteleop.oxr as oxr
 import isaacteleop.plugin_manager as pm
 
 from .config import (
+    RetargetingExecutionMode,
     SessionMode,
     TeleopSessionConfig,
 )
+from .async_retarget_runner import (
+    AsyncRetargetRunnerStopped,
+    AsyncRetargetWorkerError,
+    AsyncRetargetRunner,
+    RetargetFrame,
+    StepRequest,
+    snapshot_compute_context,
+    snapshot_retargeter_io,
+    snapshot_pipeline_inputs,
+)
 from .teleop_state_manager_types import teleop_control_states
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RetargetingStepInfo:
+    """Age and timing metadata for the most recent ``step()`` return.
+
+    ``returned_frame_id`` and ``submitted_frame_id`` identify which completed
+    frame was returned and which request this call submitted. Pipelined callers
+    can use ``returned_age_frames`` to observe result age without implying any
+    current-frame wait. Counts such as ``dropped_submissions`` and
+    ``frame_deadline_miss`` are per-step so apps can accumulate them for
+    run-wide debug summaries.
+    """
+
+    returned_frame_id: int | None = None
+    submitted_frame_id: int | None = None
+    returned_age_frames: int | None = None
+    returned_age_s: float | None = None
+    compute_duration_s: float | None = None
+    dropped_submissions: int = 0
+    ran_synchronously: bool = False
+    frame_deadline_miss: bool = False
+    worker_exception: BaseException | None = None
 
 
 class TeleopSession:
@@ -133,6 +172,12 @@ class TeleopSession:
         self.frame_count: int = 0
         self.start_time: float = 0.0
         self._last_context: Optional[ComputeContext] = None
+        self._last_step_info = RetargetingStepInfo()
+        self._last_execution_state: Optional[ExecutionState] = None
+        self._async_runner: Optional[AsyncRetargetRunner] = None
+        self._active_retargeting_execution_mode: Optional[RetargetingExecutionMode] = (
+            None
+        )
         self._setup_complete: bool = False
         # Discover sources and external leaves from pipeline
         self._discover_sources()
@@ -146,6 +191,11 @@ class TeleopSession:
     def last_context(self) -> Optional[ComputeContext]:
         """Most recent ComputeContext produced by ``step()``, or ``None`` before first step."""
         return self._last_context
+
+    @property
+    def last_step_info(self) -> RetargetingStepInfo:
+        """Age and timing metadata for the most recent ``step()`` return."""
+        return self._last_step_info
 
     def _discover_sources(self) -> None:
         """Discover DeviceIO source modules and external leaf nodes from the pipeline.
@@ -240,8 +290,17 @@ class TeleopSession:
     ):
         """Execute a single step of the teleop session.
 
-        Updates DeviceIO session, polls tracker data, merges any caller-provided
-        external inputs, and executes the retargeting pipeline.
+        In sync mode, updates DeviceIO session, polls tracker data, merges any
+        caller-provided external inputs, and executes the retargeting pipeline
+        before returning. In pipelined mode after the seed frame, this call
+        submits that work to the retarget worker and returns the latest
+        completed output; an unstarted pending request may be replaced by a
+        newer submission.
+
+        ``TeleopSession.step()`` is single-caller application-loop API. The
+        async runner serializes retarget work internally, but session fields
+        such as ``frame_count`` and ``last_step_info`` are intentionally owned
+        by the application thread that calls ``step()``.
 
         Args:
             external_inputs: Optional dict mapping external leaf node names to their
@@ -259,10 +318,10 @@ class TeleopSession:
 
         Returns:
             Dict[str, TensorGroup] - Output from the retargeting pipeline. The
-            returned reference points into the session's internal output buffers and
-            will be overwritten on the next call to step(). Consumers that need to
-            retain the result across steps must copy it themselves.
-            The per-step context is available via ``session.last_context``.
+            per-step context is available via ``session.last_context``. In
+            pipelined mode this is the latest completed retarget result, which
+            can be older than the current submitted frame; age/timing metadata is
+            available via ``session.last_step_info``.
 
         Raises:
             ValueError: If external leaves exist but external_inputs is missing or
@@ -272,29 +331,100 @@ class TeleopSession:
                 while updating the session. This is a fatal condition; the
                 application is expected to terminate rather than continue.
         """
-        # Validate external inputs required by main pipeline leaves.
-        self._validate_external_inputs(external_inputs)
-
-        # Check plugin health periodically
         if self.frame_count % 60 == 0:
             self._check_plugin_health()
 
-        # Update DeviceIO session (polls trackers)
-        self.deviceio_session.update()
+        execution_mode = (
+            self._active_retargeting_execution_mode
+            or self.config.retargeting_execution.mode
+        )
+        # Latch sync vs. pipelined for the active context-manager run. The
+        # config object is mutable, but switching modes while a worker is live
+        # could otherwise execute the same graph concurrently.
+        if execution_mode == RetargetingExecutionMode.PIPELINED:
+            return self._step_pipelined(
+                external_inputs=external_inputs,
+                graph_time=graph_time,
+                execution_events=execution_events,
+            )
 
-        # Build input dictionary from tracker data
+        return self._step_sync(
+            external_inputs=external_inputs,
+            graph_time=graph_time,
+            execution_events=execution_events,
+        )
+
+    def _build_step_request(
+        self,
+        *,
+        external_inputs: Optional[Dict[str, RetargeterIO]],
+        graph_time: Optional[GraphTime],
+        execution_events: Optional[ExecutionEvents],
+        snapshot_external_inputs: bool = True,
+    ) -> StepRequest:
+        """Snapshot caller-owned step arguments into a worker request.
+
+        The whole-step worker polls DeviceIO itself, so only explicit
+        ``external_inputs`` cross the thread boundary. Those inputs, along with
+        optional graph time and explicit execution events, are copied here so
+        the application can safely reuse or mutate its objects after ``step()``
+        returns. Sync mode disables the snapshot and uses this same request
+        shape only to avoid duplicating the step execution path.
+        """
+        self._validate_external_inputs(external_inputs)
+        if snapshot_external_inputs:
+            external_inputs = self._filter_external_inputs(external_inputs)
+        request_external_inputs = None
+        if external_inputs:
+            request_external_inputs = (
+                snapshot_pipeline_inputs(external_inputs)
+                if snapshot_external_inputs
+                else external_inputs
+            )
+
+        return StepRequest(
+            frame_id=self.frame_count,
+            external_inputs=request_external_inputs,
+            graph_time=GraphTime(
+                sim_time_ns=graph_time.sim_time_ns,
+                real_time_ns=graph_time.real_time_ns,
+            )
+            if graph_time is not None
+            else None,
+            execution_events=ExecutionEvents(
+                reset=bool(execution_events.reset),
+                execution_state=ExecutionState(execution_events.execution_state),
+            )
+            if execution_events is not None
+            else None,
+            submitted_time_s=time.monotonic(),
+        )
+
+    def _execute_step_request(
+        self,
+        request: StepRequest,
+    ) -> tuple[RetargeterIO, ComputeContext]:
+        """Execute one normal synchronous step for ``request``.
+
+        Pipelined mode deliberately moves this whole method to the worker
+        thread. Keeping DeviceIO polling, control decoding, and graph execution
+        together preserves the old synchronous ordering and avoids passing raw
+        DeviceIO source state across threads. Sync mode calls the same method
+        directly so the behavioral core stays in one place.
+        """
+        self.deviceio_session.update()
         pipeline_inputs = self._collect_tracker_data()
 
-        # Merge external inputs (for non-DeviceIO leaf nodes)
-        if external_inputs:
-            pipeline_inputs.update(external_inputs)
+        if request.external_inputs:
+            pipeline_inputs.update(request.external_inputs)
 
         now_ns = time.monotonic_ns()
+        graph_time = request.graph_time
         if graph_time is None:
             graph_time = GraphTime(sim_time_ns=now_ns, real_time_ns=now_ns)
 
+        execution_events = request.execution_events
         if execution_events is None and self.teleop_control_pipeline is not None:
-            # Filter pipeline_inputs to only control leaf inputs
             control_inputs = {
                 k: v
                 for k, v in pipeline_inputs.items()
@@ -311,19 +441,218 @@ class TeleopSession:
             )
 
         context = ComputeContext(
-            graph_time=graph_time,
-            execution_events=execution_events,
+            graph_time=GraphTime(
+                sim_time_ns=graph_time.sim_time_ns,
+                real_time_ns=graph_time.real_time_ns,
+            ),
+            execution_events=ExecutionEvents(
+                reset=bool(execution_events.reset),
+                execution_state=ExecutionState(execution_events.execution_state),
+            ),
         )
-        self._last_context = context
 
         # Filter pipeline_inputs to only main leaf inputs
         main_inputs = {
             k: v for k, v in pipeline_inputs.items() if k in self._main_leaf_names
         }
-        result = self.pipeline.execute_pipeline(main_inputs, context)
+        return self.pipeline.execute_pipeline(main_inputs, context), context
+
+    def _make_retarget_frame(
+        self,
+        request: StepRequest,
+        outputs: RetargeterIO,
+        context: ComputeContext,
+        *,
+        started_time_s: float,
+        completed_time_s: float,
+    ) -> RetargetFrame:
+        """Package one completed request as an owned cached frame.
+
+        The first pipelined call runs on the application thread as a seed frame
+        before the worker exists. It still enters the same latest-frame cache,
+        so it must follow the worker invariant: cached outputs/context are
+        owned by IsaacTeleop and can be returned later without aliasing
+        retargeter-owned reusable buffers.
+        """
+        return RetargetFrame(
+            frame_id=request.frame_id,
+            outputs=snapshot_retargeter_io(outputs),
+            context=snapshot_compute_context(context),
+            submitted_time_s=request.submitted_time_s,
+            started_time_s=started_time_s,
+            completed_time_s=completed_time_s,
+            compute_duration_s=completed_time_s - started_time_s,
+        )
+
+    def _step_sync(
+        self,
+        *,
+        external_inputs: Optional[Dict[str, RetargeterIO]],
+        graph_time: Optional[GraphTime],
+        execution_events: Optional[ExecutionEvents],
+    ) -> RetargeterIO:
+        """Execute retargeting synchronously for exact current-frame behavior.
+
+        This is both the escape hatch for users that cannot accept older-frame
+        actions and the reference behavior that pipelined mode overlaps with
+        the application loop.
+        """
+        request = self._build_step_request(
+            external_inputs=external_inputs,
+            graph_time=graph_time,
+            execution_events=execution_events,
+            snapshot_external_inputs=False,
+        )
+        started = time.monotonic()
+        result, context = self._execute_step_request(request)
+        completed = time.monotonic()
+
+        self._last_context = context
+        self._last_execution_state = context.execution_events.execution_state
+        self._last_step_info = RetargetingStepInfo(
+            returned_frame_id=request.frame_id,
+            submitted_frame_id=request.frame_id,
+            returned_age_frames=0,
+            returned_age_s=completed - request.submitted_time_s,
+            compute_duration_s=completed - started,
+            ran_synchronously=True,
+        )
 
         self.frame_count += 1
         return result
+
+    def _step_pipelined(
+        self,
+        *,
+        external_inputs: Optional[Dict[str, RetargeterIO]],
+        graph_time: Optional[GraphTime],
+        execution_events: Optional[ExecutionEvents],
+    ) -> RetargeterIO:
+        """Submit a full sync step and return the latest completed output.
+
+        Public ``step()`` remains a normal function returning ``RetargeterIO``.
+        In pipelined mode it acts as a small scheduler: submit the current
+        application-frame request, then return the latest completed frame.
+        """
+        if self._async_runner is None:
+            return self._step_pipelined_seed(
+                external_inputs=external_inputs,
+                graph_time=graph_time,
+                execution_events=execution_events,
+            )
+
+        runner = self._async_runner
+        try:
+            runner.raise_if_failed()
+            request = self._build_step_request(
+                external_inputs=external_inputs,
+                graph_time=graph_time,
+                execution_events=execution_events,
+            )
+
+            dropped = runner.submit(request)
+            frame = runner.latest()
+            if frame is None:
+                raise AsyncRetargetRunnerStopped(
+                    "Async retarget runner has no completed frame to return"
+                )
+            return self._return_pipelined_frame(
+                frame,
+                submitted_frame_id=request.frame_id,
+                dropped_submissions=dropped,
+                ran_synchronously=False,
+            )
+        except AsyncRetargetWorkerError as exc:
+            self._last_step_info = RetargetingStepInfo(worker_exception=exc)
+            raise
+
+    def _step_pipelined_seed(
+        self,
+        *,
+        external_inputs: Optional[Dict[str, RetargeterIO]],
+        graph_time: Optional[GraphTime],
+        execution_events: Optional[ExecutionEvents],
+    ) -> RetargeterIO:
+        """Run the first pipelined frame synchronously, then start the worker.
+
+        The first call has no previous action to return, so it runs exactly
+        once on the application thread. Publishing that seed frame lets later
+        calls use the latest-completed path without changing the public return
+        type.
+        """
+        request = self._build_step_request(
+            external_inputs=external_inputs,
+            graph_time=graph_time,
+            execution_events=execution_events,
+        )
+        started = time.monotonic()
+        outputs, context = self._execute_step_request(request)
+        completed = time.monotonic()
+        frame = self._make_retarget_frame(
+            request,
+            outputs,
+            context,
+            started_time_s=started,
+            completed_time_s=completed,
+        )
+
+        runner = self._ensure_async_runner()
+        runner.publish_seed(frame)
+        return self._return_pipelined_frame(
+            frame,
+            submitted_frame_id=request.frame_id,
+            dropped_submissions=0,
+            ran_synchronously=True,
+        )
+
+    def _ensure_async_runner(self) -> AsyncRetargetRunner:
+        """Create and start the pipelined retarget worker lazily.
+
+        The worker is session-scoped rather than construction-scoped because
+        DeviceIO/OpenXR resources only exist inside the context manager.
+        """
+        if self._async_runner is None:
+            self._async_runner = AsyncRetargetRunner(
+                self._execute_step_request,
+                self.config.retargeting_execution,
+            )
+            self._async_runner.start()
+        return self._async_runner
+
+    def _return_pipelined_frame(
+        self,
+        frame: RetargetFrame,
+        *,
+        submitted_frame_id: int,
+        dropped_submissions: int,
+        ran_synchronously: bool,
+    ) -> RetargeterIO:
+        """Publish metadata/context for a pipelined result and finish the step.
+
+        ``last_context`` must always describe the output returned from this
+        call, not the request just submitted. The returned output is copied so
+        user mutation cannot corrupt the cached latest frame; uncopyable
+        outputs should implement ``create_snapshot()`` or use sync mode.
+        """
+        returned_outputs = snapshot_retargeter_io(frame.outputs)
+        returned_context = snapshot_compute_context(frame.context)
+        now = time.monotonic()
+        returned_age_frames = submitted_frame_id - frame.frame_id
+        frame_deadline_miss = returned_age_frames > 1
+        self._last_context = returned_context
+        self._last_execution_state = returned_context.execution_events.execution_state
+        self._last_step_info = RetargetingStepInfo(
+            returned_frame_id=frame.frame_id,
+            submitted_frame_id=submitted_frame_id,
+            returned_age_frames=returned_age_frames,
+            returned_age_s=max(0.0, now - frame.submitted_time_s),
+            compute_duration_s=frame.compute_duration_s,
+            dropped_submissions=dropped_submissions,
+            ran_synchronously=ran_synchronously,
+            frame_deadline_miss=frame_deadline_miss,
+        )
+        self.frame_count += 1
+        return returned_outputs
 
     def _decode_teleop_control_events(
         self, control_outputs: RetargeterIO
@@ -444,6 +773,34 @@ class TeleopSession:
                     f"Expected keys: {expected_keys}. "
                     f"Use get_external_input_specs() to discover required inputs."
                 )
+
+    def _filter_external_inputs(
+        self,
+        external_inputs: Optional[Dict[str, RetargeterIO]],
+    ) -> Optional[Dict[str, RetargeterIO]]:
+        """Drop allowed-but-unused external leaf names and per-leaf input keys.
+
+        The public API has historically ignored extra external leaf names. In
+        pipelined mode this filtering matters because snapshotting an ignored
+        value could fail or waste work even though the pipeline will never read
+        it. The same rule applies inside a valid leaf dict: keep required input
+        names, ignore extras.
+        """
+        if not external_inputs:
+            return None
+        leaves_by_name = {leaf.name: leaf for leaf in self._external_leaves}
+        filtered_inputs: Dict[str, RetargeterIO] = {}
+        for name, values in external_inputs.items():
+            leaf = leaves_by_name.get(name)
+            if leaf is None:
+                continue
+            expected_keys = set(leaf.input_spec().keys())
+            filtered_inputs[name] = {
+                input_name: value
+                for input_name, value in values.items()
+                if input_name in expected_keys
+            }
+        return filtered_inputs or None
 
     def _collect_tracker_data(self) -> Dict[str, Any]:
         """Collect raw tracking data from all sources and map to module names.
@@ -573,6 +930,10 @@ class TeleopSession:
         self.frame_count = 0
         self.start_time = time.time()
         self._last_context = None
+        self._last_step_info = RetargetingStepInfo()
+        self._last_execution_state = None
+        self._async_runner = None
+        self._active_retargeting_execution_mode = self.config.retargeting_execution.mode
 
         self._setup_complete = True
         return self
@@ -582,7 +943,30 @@ class TeleopSession:
         if not self._setup_complete:
             return False
 
-        # ExitStack automatically cleans up all managed contexts in reverse order
-        self._exit_stack.__exit__(exc_type, exc_val, exc_tb)
+        runner_error = None
+        if self._async_runner is not None:
+            runner = self._async_runner
+            runner.stop()
+            try:
+                runner.raise_if_failed(only_unreported=True)
+            except BaseException as err:
+                if exc_type is None:
+                    runner_error = err
+                else:
+                    logger.error(
+                        "Async retarget worker failed during TeleopSession cleanup",
+                        exc_info=(type(err), err, err.__traceback__),
+                    )
+            self._async_runner = None
+        self._active_retargeting_execution_mode = None
 
-        return exc_type is None  # Suppress exception only if we didn't have one
+        # ExitStack automatically cleans up all managed contexts in reverse order.
+        # Preserve TeleopSession's historical behavior of not suppressing
+        # exceptions from the user body, even if a child context manager would.
+        self._exit_stack.__exit__(exc_type, exc_val, exc_tb)
+        self._exit_stack = ExitStack()
+
+        if runner_error is not None:
+            raise runner_error
+
+        return False

--- a/src/core/teleop_session_manager_tests/python/test_session_reset.py
+++ b/src/core/teleop_session_manager_tests/python/test_session_reset.py
@@ -28,7 +28,12 @@ from isaacteleop.retargeters import (
 )
 
 from isaacteleop.retargeting_engine.tensor_types import ControllerInput, HandInput
-from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
+from isaacteleop.teleop_session_manager import (
+    RetargetingExecutionConfig,
+    RetargetingExecutionMode,
+    TeleopSession,
+    TeleopSessionConfig,
+)
 
 
 # ============================================================================
@@ -79,6 +84,10 @@ def _running_events(*, reset: bool = False) -> ExecutionEvents:
     return ExecutionEvents(reset=reset, execution_state=ExecutionState.RUNNING)
 
 
+def _sync_retargeting() -> RetargetingExecutionConfig:
+    return RetargetingExecutionConfig(mode=RetargetingExecutionMode.SYNC)
+
+
 # ============================================================================
 # Tests
 # ============================================================================
@@ -99,6 +108,7 @@ class TestSessionResetLocomotion:
         config = TeleopSessionConfig(
             app_name="test_reset",
             pipeline=retargeter,
+            retargeting_execution=_sync_retargeting(),
         )
 
         with _mock_session_deps():
@@ -125,11 +135,37 @@ class TestSessionResetLocomotion:
                     "hip_height should be restored to initial after reset"
                 )
 
+    def test_default_sync_reset_returns_current_reset_state(self, retargeter):
+        """Default sync mode should return the reset frame's current state."""
+        config = TeleopSessionConfig(app_name="test_reset", pipeline=retargeter)
+
+        with _mock_session_deps():
+            with TeleopSession(config) as session:
+                ext = {"loco": _absent_controller_inputs()}
+
+                session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(),
+                )
+                retargeter._hip_height = 0.95
+
+                result = session.step(
+                    external_inputs=ext,
+                    execution_events=_running_events(reset=True),
+                )
+
+                cmd = np.from_dlpack(result["root_command"][0])
+                assert cmd[3] == pytest.approx(0.72)
+                assert session.last_step_info.returned_age_frames == 0
+                assert session.last_step_info.ran_synchronously is True
+                assert session.last_context.execution_events.reset is True
+
     def test_no_reset_preserves_state_via_session(self, retargeter):
         """Hip height stays mutated when reset is not signalled."""
         config = TeleopSessionConfig(
             app_name="test_no_reset",
             pipeline=retargeter,
+            retargeting_execution=_sync_retargeting(),
         )
 
         with _mock_session_deps():
@@ -169,6 +205,7 @@ class TestSessionResetGripper:
         config = TeleopSessionConfig(
             app_name="test_gripper_reset",
             pipeline=retargeter,
+            retargeting_execution=_sync_retargeting(),
         )
 
         with _mock_session_deps():
@@ -199,6 +236,7 @@ class TestSessionResetGripper:
         config = TeleopSessionConfig(
             app_name="test_gripper_no_reset",
             pipeline=retargeter,
+            retargeting_execution=_sync_retargeting(),
         )
 
         with _mock_session_deps():

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1351,6 +1351,35 @@ class TestStep:
                 # The pipeline should receive the external inputs
                 assert "sim_state" in pipeline.last_inputs
 
+    def test_default_sync_step_filters_unused_external_inputs(self):
+        """Default sync mode should ignore unused external leaves and per-leaf keys."""
+        ext = MockExternalRetargeter("sim_state")
+        pipeline = MockPipeline(leaf_nodes=[ext])
+
+        config = TeleopSessionConfig(
+            app_name="TestApp",
+            pipeline=pipeline,
+            verbose=False,
+        )
+        external_value = MagicMock()
+        external_data = {
+            "sim_state": {
+                "external_data": external_value,
+                "ignored_data": MagicMock(),
+            },
+            "bonus_data": {"external_data": MagicMock()},
+        }
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                session.step(external_inputs=external_data)
+
+                assert set(pipeline.last_inputs) == {"sim_state"}
+                assert set(pipeline.last_inputs["sim_state"]) == {"external_data"}
+                assert (
+                    pipeline.last_inputs["sim_state"]["external_data"] is external_value
+                )
+
     def test_step_with_mixed_sources(self):
         """step() with both DeviceIO sources and external inputs."""
         head = MockHeadSource()

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -10,6 +10,8 @@ discovery, external input validation, step execution, session lifecycle,
 and plugin management.
 """
 
+import logging
+import threading
 import time
 import pytest
 from pathlib import Path
@@ -18,8 +20,13 @@ from contextlib import contextmanager
 
 from isaacteleop.retargeting_engine.interface import (
     BaseRetargeter,
+    ComputeContext,
+    ExecutionEvents,
+    ExecutionState,
+    GraphTime,
     TensorGroupType,
     TensorGroup,
+    TensorType,
 )
 from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
     RetargeterIO,
@@ -28,12 +35,27 @@ from isaacteleop.retargeting_engine.interface.retargeter_core_types import (
 from isaacteleop.retargeting_engine.deviceio_source_nodes import IDeviceIOSource
 from isaacteleop.retargeting_engine.tensor_types import FloatType
 
+import isaacteleop.teleop_session_manager as teleop_session_manager
 from isaacteleop.teleop_session_manager.config import (
+    DeadlinePacingConfig,
+    ImmediatePacingConfig,
+    PluginConfig,
+    RetargetingExecutionConfig,
+    RetargetingExecutionMode,
     SessionMode,
     TeleopSessionConfig,
-    PluginConfig,
+)
+from isaacteleop.teleop_session_manager.async_retarget_runner import (
+    AsyncRetargetRunner,
+    AsyncRetargetRunnerStopped,
+    AsyncRetargetWorkerError,
+    RetargetFrame,
+    StepRequest,
 )
 from isaacteleop.teleop_session_manager.teleop_session import TeleopSession
+from isaacteleop.teleop_session_manager.teleop_state_manager_types import (
+    teleop_state_manager_output_spec,
+)
 
 
 # ============================================================================
@@ -258,6 +280,317 @@ class MockPipeline:
         return self.execute_pipeline(inputs, context)
 
 
+ASYNC_RESULT_TYPE = TensorGroupType("async_result", [FloatType("value")])
+
+
+class AnyValueType(TensorType):
+    """Tensor type for tests that need an opaque Python value."""
+
+    def _check_instance_compatibility(self, other: TensorType) -> bool:
+        return self.name == other.name
+
+    def validate_value(self, value) -> None:
+        pass
+
+
+OPAQUE_EXTERNAL_TYPE = TensorGroupType("opaque_external", [AnyValueType("value")])
+
+
+class UncopyableValue:
+    def __deepcopy__(self, memo):
+        raise TypeError("cannot pickle opaque value")
+
+
+def make_async_result(value: float) -> RetargeterIO:
+    tg = TensorGroup(ASYNC_RESULT_TYPE)
+    tg[0] = float(value)
+    return {"result": tg}
+
+
+def async_result_value(result: RetargeterIO) -> float:
+    return result["result"][0]
+
+
+class AnyExternalRetargeter(BaseRetargeter):
+    """External leaf that accepts an opaque test value."""
+
+    def __init__(self, name: str):
+        super().__init__(name)
+
+    def input_spec(self) -> RetargeterIOType:
+        return {"value": OPAQUE_EXTERNAL_TYPE}
+
+    def output_spec(self) -> RetargeterIOType:
+        return {"result": ASYNC_RESULT_TYPE}
+
+    def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
+        outputs["result"][0] = (
+            1.0 if isinstance(inputs["value"][0], UncopyableValue) else 0.0
+        )
+
+
+class CountingPipeline(MockPipeline):
+    """Pipeline that returns its call index and can sleep or fail per call."""
+
+    def __init__(self, *, sleep_s=0.0, fail_on_call=None):
+        super().__init__(leaf_nodes=[])
+        self.sleep_s = sleep_s
+        self.fail_on_call = fail_on_call
+        self.call_count = 0
+        self.max_active = 0
+        self.failed = threading.Event()
+        self._active = 0
+        self._lock = threading.Lock()
+
+    def execute_pipeline(self, inputs, context=None):
+        with self._lock:
+            call_idx = self.call_count
+            self.call_count += 1
+            self._active += 1
+            self.max_active = max(self.max_active, self._active)
+        try:
+            if self.sleep_s:
+                time.sleep(self.sleep_s)
+            if self.fail_on_call == call_idx:
+                self.failed.set()
+                raise RuntimeError("pipeline boom")
+            return make_async_result(call_idx)
+        finally:
+            with self._lock:
+                self._active -= 1
+
+
+class ExternalEchoPipeline(MockPipeline):
+    """Pipeline that echoes an external scalar after blocking its second call."""
+
+    def __init__(self):
+        self.leaf = MockExternalRetargeter("sim_state")
+        super().__init__(leaf_nodes=[self.leaf])
+        self.call_count = 0
+        self.second_started = threading.Event()
+        self.release_second = threading.Event()
+        self.second_done = threading.Event()
+
+    def execute_pipeline(self, inputs, context=None):
+        call_idx = self.call_count
+        self.call_count += 1
+        if call_idx == 1:
+            self.second_started.set()
+            self.release_second.wait(timeout=2.0)
+        value = inputs["sim_state"]["external_data"][0]
+        if call_idx == 1:
+            self.second_done.set()
+        return make_async_result(value)
+
+
+class ContextEchoPipeline(MockPipeline):
+    """Pipeline that blocks its second call, then echoes execution events."""
+
+    def __init__(self):
+        super().__init__(leaf_nodes=[])
+        self.call_count = 0
+        self.second_started = threading.Event()
+        self.release_second = threading.Event()
+        self.second_done = threading.Event()
+
+    def execute_pipeline(self, inputs, context=None):
+        call_idx = self.call_count
+        self.call_count += 1
+        if call_idx == 1:
+            self.second_started.set()
+            self.release_second.wait(timeout=2.0)
+        if context.execution_events.reset:
+            value = 1.0
+        elif context.execution_events.execution_state == ExecutionState.PAUSED:
+            value = 2.0
+        else:
+            value = 0.0
+        if call_idx == 1:
+            self.second_done.set()
+        return make_async_result(value)
+
+
+class FrameIdPipeline(MockPipeline):
+    """Pipeline that records and returns the frame id encoded in GraphTime."""
+
+    def __init__(self):
+        super().__init__(leaf_nodes=[])
+        self.executed_frame_ids: list[int] = []
+
+    def execute_pipeline(self, inputs, context=None):
+        frame_id = int(context.graph_time.sim_time_ns)
+        self.executed_frame_ids.append(frame_id)
+        return make_async_result(frame_id)
+
+
+class BlockingSecondCountingPipeline(CountingPipeline):
+    """Counting pipeline that holds its second call until released."""
+
+    def __init__(self):
+        super().__init__()
+        self.second_started = threading.Event()
+        self.release_second = threading.Event()
+
+    def execute_pipeline(self, inputs, context=None):
+        with self._lock:
+            call_idx = self.call_count
+            self.call_count += 1
+            self._active += 1
+            self.max_active = max(self.max_active, self._active)
+        try:
+            if call_idx == 1:
+                self.second_started.set()
+                self.release_second.wait(timeout=2.0)
+            return make_async_result(call_idx)
+        finally:
+            with self._lock:
+                self._active -= 1
+
+
+class ReusingOutputPipeline(MockPipeline):
+    """Pipeline that reuses one output object across calls.
+
+    This mirrors stateful retargeters that keep output buffers internally. The
+    async worker must snapshot before publishing, otherwise a later call can
+    mutate an older cached frame while the application is still returning it as
+    the latest completed output.
+    """
+
+    def __init__(self):
+        super().__init__(leaf_nodes=[])
+        self.outputs = make_async_result(-1.0)
+        self.second_started = threading.Event()
+        self.release_second = threading.Event()
+
+    def execute_pipeline(self, inputs, context=None):
+        frame_id = int(context.graph_time.sim_time_ns)
+        self.outputs["result"][0] = float(frame_id)
+        if frame_id == 2:
+            self.second_started.set()
+            self.release_second.wait(timeout=2.0)
+        return self.outputs
+
+
+class UncopyableOutputPipeline(MockPipeline):
+    """Pipeline whose output cannot be snapshot-copied."""
+
+    def __init__(self):
+        super().__init__(leaf_nodes=[])
+        self.group_type = TensorGroupType("opaque_result", [AnyValueType("value")])
+
+    def execute_pipeline(self, inputs, context=None):
+        group = TensorGroup(self.group_type)
+        group[0] = UncopyableValue()
+        return {"result": group}
+
+
+class BlockingControlPipeline(MockPipeline):
+    """Control pipeline that blocks its second automatic event decode."""
+
+    def __init__(
+        self,
+        *,
+        second_state: ExecutionState = ExecutionState.RUNNING,
+        second_reset: bool = False,
+    ):
+        super().__init__(leaf_nodes=[])
+        self.call_count = 0
+        self.second_started = threading.Event()
+        self.release_second = threading.Event()
+        self.second_state = second_state
+        self.second_reset = second_reset
+
+    def output_types(self) -> RetargeterIOType:
+        return teleop_state_manager_output_spec()
+
+    def execute_pipeline(self, inputs, context=None):
+        call_idx = self.call_count
+        self.call_count += 1
+        if call_idx == 1:
+            self.second_started.set()
+            self.release_second.wait(timeout=2.0)
+            return make_control_outputs(self.second_state, reset=self.second_reset)
+        return make_control_outputs(ExecutionState.RUNNING, reset=False)
+
+
+class ControlEventEchoPipeline(MockPipeline):
+    """Pipeline that encodes worker-decoded control events in its output."""
+
+    def execute_pipeline(self, inputs, context=None):
+        if context.execution_events.reset:
+            return make_async_result(1.0)
+        if context.execution_events.execution_state == ExecutionState.PAUSED:
+            return make_async_result(2.0)
+        return make_async_result(0.0)
+
+
+def make_external_scalar(value: float) -> RetargeterIO:
+    tg = TensorGroup(TensorGroupType("external_scalar", [FloatType("value")]))
+    tg[0] = float(value)
+    return {"external_data": tg}
+
+
+def make_opaque_external() -> RetargeterIO:
+    tg = TensorGroup(OPAQUE_EXTERNAL_TYPE)
+    tg[0] = UncopyableValue()
+    return {"value": tg}
+
+
+def make_control_outputs(state: ExecutionState, *, reset: bool) -> RetargeterIO:
+    outputs = {}
+    for name, group_type in teleop_state_manager_output_spec().items():
+        group = TensorGroup(group_type)
+        if name == "teleop_state":
+            for index, tensor_type in enumerate(group_type.types):
+                group[index] = tensor_type.name == state.value
+        else:
+            group[0] = reset
+        outputs[name] = group
+    return outputs
+
+
+def make_step_request(
+    frame_id: int,
+    *,
+    submitted_time_s: float | None = None,
+) -> StepRequest:
+    return StepRequest(
+        frame_id=frame_id,
+        external_inputs={},
+        graph_time=GraphTime(sim_time_ns=frame_id, real_time_ns=frame_id),
+        execution_events=ExecutionEvents(
+            reset=False,
+            execution_state=ExecutionState.RUNNING,
+        ),
+        submitted_time_s=(
+            time.monotonic() if submitted_time_s is None else submitted_time_s
+        ),
+    )
+
+
+def execute_pipeline_request(pipeline, request: StepRequest):
+    context = ComputeContext(
+        graph_time=request.graph_time
+        or GraphTime(sim_time_ns=request.frame_id, real_time_ns=request.frame_id),
+        execution_events=request.execution_events or ExecutionEvents(),
+    )
+    return pipeline.execute_pipeline(request.external_inputs or {}, context), context
+
+
+def make_async_runner(pipeline, config) -> AsyncRetargetRunner:
+    return AsyncRetargetRunner(
+        lambda request: execute_pipeline_request(pipeline, request),
+        config.retargeting_execution,
+    )
+
+
+class FailingPollSource(MockDeviceIOSource):
+    """Source whose first seed-frame poll fails before worker submission."""
+
+    def poll_tracker(self, deviceio_session):
+        raise RuntimeError("poll failed")
+
+
 # ============================================================================
 # Mock OpenXR Session
 # ============================================================================
@@ -420,14 +753,24 @@ def mock_session_dependencies(
 # ============================================================================
 
 
-def make_config(pipeline, plugins=None, trackers=None, app_name="TestApp"):
+def make_config(
+    pipeline,
+    plugins=None,
+    trackers=None,
+    app_name="TestApp",
+    teleop_control_pipeline=None,
+    retargeting_execution=None,
+):
     """Create a TeleopSessionConfig with sensible test defaults."""
     return TeleopSessionConfig(
         app_name=app_name,
         pipeline=pipeline,
+        teleop_control_pipeline=teleop_control_pipeline,
         trackers=trackers or [],
         plugins=plugins or [],
         verbose=False,
+        retargeting_execution=retargeting_execution
+        or RetargetingExecutionConfig(mode=RetargetingExecutionMode.SYNC),
     )
 
 
@@ -1075,6 +1418,681 @@ class TestStep:
                 assert session.frame_count == 1
 
 
+class TestPipelinedRetargeting:
+    """Tests for TeleopSession-owned pipelined async retarget execution."""
+
+    def _pipelined_config(self, pipeline, **execution_kwargs):
+        return make_config(
+            pipeline,
+            retargeting_execution=RetargetingExecutionConfig(
+                mode=RetargetingExecutionMode.PIPELINED,
+                **execution_kwargs,
+            ),
+        )
+
+    def test_first_frame_runs_synchronously_and_returns_seed(self):
+        pipeline = CountingPipeline()
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                result = session.step()
+
+                assert async_result_value(result) == 0.0
+                assert session.last_step_info.ran_synchronously is True
+                assert session.last_step_info.returned_frame_id == 0
+                assert session.last_step_info.submitted_frame_id == 0
+                assert session.last_step_info.returned_age_frames == 0
+
+    def test_default_pipelined_returns_latest_completed_result(self):
+        pipeline = BlockingSecondCountingPipeline()
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                first = session.step()
+                second = session.step()
+
+                assert async_result_value(first) == 0.0
+                assert async_result_value(second) == 0.0
+                assert session.last_step_info.ran_synchronously is False
+                assert session.last_step_info.returned_frame_id == 0
+                assert session.last_step_info.submitted_frame_id == 1
+                assert session.last_step_info.returned_age_frames == 1
+                pipeline.release_second.set()
+
+    def test_reset_frame_is_not_forced_current_but_returned_frame_is_consistent(self):
+        pipeline = ContextEchoPipeline()
+        config = self._pipelined_config(
+            pipeline,
+            pacing=DeadlinePacingConfig(
+                frame_period_adaptation=0.01,
+                safety_margin_s=0.0,
+                startup_frame_period_s=0.25,
+                startup_compute_cost_s=0.0,
+            ),
+        )
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert (
+                    async_result_value(
+                        session.step(
+                            execution_events=ExecutionEvents(
+                                reset=False,
+                                execution_state=ExecutionState.RUNNING,
+                            )
+                        )
+                    )
+                    == 0.0
+                )
+                result = session.step(
+                    execution_events=ExecutionEvents(
+                        reset=True,
+                        execution_state=ExecutionState.RUNNING,
+                    )
+                )
+
+                assert async_result_value(result) == 0.0
+                assert session.last_step_info.ran_synchronously is False
+                assert session.last_context.execution_events.reset is False
+
+                assert pipeline.second_started.wait(timeout=1.0)
+                pipeline.release_second.set()
+                assert pipeline.second_done.wait(timeout=1.0)
+                assert session._async_runner is not None
+                assert session._async_runner.wait_for_frame(1, timeout_s=1.0)
+
+                result = session.step(
+                    execution_events=ExecutionEvents(
+                        reset=False,
+                        execution_state=ExecutionState.RUNNING,
+                    )
+                )
+
+                assert async_result_value(result) == 1.0
+                assert session.last_step_info.ran_synchronously is False
+                assert session.last_step_info.returned_frame_id == 1
+                assert session.last_step_info.submitted_frame_id == 2
+                assert session.last_context.execution_events.reset is True
+
+    def test_control_transition_frame_is_returned_with_its_context(self):
+        pipeline = ContextEchoPipeline()
+        config = self._pipelined_config(
+            pipeline,
+            pacing=DeadlinePacingConfig(
+                frame_period_adaptation=0.01,
+                safety_margin_s=0.0,
+                startup_frame_period_s=0.25,
+                startup_compute_cost_s=0.0,
+            ),
+        )
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert (
+                    async_result_value(
+                        session.step(
+                            execution_events=ExecutionEvents(
+                                reset=False,
+                                execution_state=ExecutionState.RUNNING,
+                            )
+                        )
+                    )
+                    == 0.0
+                )
+                result = session.step(
+                    execution_events=ExecutionEvents(
+                        reset=False,
+                        execution_state=ExecutionState.PAUSED,
+                    )
+                )
+
+                assert async_result_value(result) == 0.0
+                assert session.last_step_info.ran_synchronously is False
+                assert pipeline.second_started.wait(timeout=1.0)
+                pipeline.release_second.set()
+                assert pipeline.second_done.wait(timeout=1.0)
+                assert session._async_runner is not None
+                assert session._async_runner.wait_for_frame(1, timeout_s=1.0)
+
+                result = session.step(
+                    execution_events=ExecutionEvents(
+                        reset=False,
+                        execution_state=ExecutionState.RUNNING,
+                    )
+                )
+
+                assert async_result_value(result) == 2.0
+                assert session.last_step_info.ran_synchronously is False
+                assert session.last_step_info.returned_frame_id == 1
+                assert session.last_step_info.submitted_frame_id == 2
+                assert (
+                    session.last_context.execution_events.execution_state
+                    == ExecutionState.PAUSED
+                )
+
+    def test_automatic_control_pipeline_frame_is_not_forced_current(self):
+        pipeline = ControlEventEchoPipeline()
+        control_pipeline = BlockingControlPipeline(second_reset=True)
+        config = make_config(
+            pipeline,
+            teleop_control_pipeline=control_pipeline,
+            retargeting_execution=RetargetingExecutionConfig(
+                mode=RetargetingExecutionMode.PIPELINED,
+                pacing=DeadlinePacingConfig(
+                    frame_period_adaptation=0.01,
+                    safety_margin_s=0.0,
+                    startup_frame_period_s=0.25,
+                    startup_compute_cost_s=0.0,
+                ),
+            ),
+        )
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert async_result_value(session.step()) == 0.0
+                result = session.step()
+
+                assert async_result_value(result) == 0.0
+                assert session.last_step_info.ran_synchronously is False
+                assert control_pipeline.second_started.wait(timeout=2.0)
+
+                control_pipeline.release_second.set()
+                assert session._async_runner is not None
+                assert session._async_runner.wait_for_frame(1, timeout_s=2.0)
+                result = session.step()
+
+                assert async_result_value(result) == 1.0
+                assert session.last_step_info.ran_synchronously is False
+                assert session.last_step_info.returned_frame_id == 1
+                assert session.last_step_info.submitted_frame_id == 2
+                assert session.last_context.execution_events.reset is True
+
+    def test_worker_inputs_are_snapshotted(self):
+        pipeline = ExternalEchoPipeline()
+        config = self._pipelined_config(pipeline)
+        first_external = {"sim_state": make_external_scalar(1.0)}
+        second_external = {"sim_state": make_external_scalar(2.0)}
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert (
+                    async_result_value(session.step(external_inputs=first_external))
+                    == 1.0
+                )
+                previous_frame = session.step(external_inputs=second_external)
+                assert async_result_value(previous_frame) == 1.0
+
+                assert pipeline.second_started.wait(timeout=2.0)
+                second_external["sim_state"]["external_data"][0] = 99.0
+                pipeline.release_second.set()
+                assert pipeline.second_done.wait(timeout=2.0)
+                assert session._async_runner is not None
+                assert session._async_runner.wait_for_frame(1, timeout_s=2.0)
+
+                result = session.step(external_inputs=second_external)
+                assert async_result_value(result) == 2.0
+
+    def test_worker_context_is_snapshotted(self):
+        pipeline = ContextEchoPipeline()
+        config = self._pipelined_config(pipeline)
+        reusable_events = ExecutionEvents(
+            reset=False,
+            execution_state=ExecutionState.RUNNING,
+        )
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert (
+                    async_result_value(session.step(execution_events=reusable_events))
+                    == 0.0
+                )
+                previous_frame = session.step(execution_events=reusable_events)
+                assert async_result_value(previous_frame) == 0.0
+
+                assert pipeline.second_started.wait(timeout=2.0)
+                reusable_events.reset = True
+                reusable_events.execution_state = ExecutionState.PAUSED
+                pipeline.release_second.set()
+                assert pipeline.second_done.wait(timeout=2.0)
+                assert session._async_runner is not None
+                assert session._async_runner.wait_for_frame(1, timeout_s=2.0)
+
+                result = session.step(
+                    execution_events=ExecutionEvents(
+                        reset=False,
+                        execution_state=ExecutionState.RUNNING,
+                    )
+                )
+                assert async_result_value(result) == 0.0
+                assert session.last_context.execution_events.reset is False
+                assert (
+                    session.last_context.execution_events.execution_state
+                    == ExecutionState.RUNNING
+                )
+
+    def test_repeated_completed_outputs_are_snapshots(self):
+        pipeline = CountingPipeline()
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                first = session.step()
+                first["result"][0] = 99.0
+
+                second = session.step()
+                assert async_result_value(second) == 0.0
+
+    def test_pipelined_uncopyable_outputs_fail_with_clear_error(self):
+        pipeline = UncopyableOutputPipeline()
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with pytest.raises(TypeError, match="snapshot-copyable"):
+                with TeleopSession(config) as session:
+                    session.step()
+
+    def test_sync_mode_allows_uncopyable_outputs(self):
+        pipeline = UncopyableOutputPipeline()
+        config = make_config(
+            pipeline,
+            retargeting_execution=RetargetingExecutionConfig(
+                mode=RetargetingExecutionMode.SYNC
+            ),
+        )
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                result = session.step()
+
+                assert isinstance(result["result"][0], UncopyableValue)
+
+    def test_sync_mode_allows_uncopyable_external_inputs(self):
+        pipeline = AnyExternalRetargeter("opaque")
+        config = make_config(
+            pipeline,
+            retargeting_execution=RetargetingExecutionConfig(
+                mode=RetargetingExecutionMode.SYNC
+            ),
+        )
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                result = session.step(
+                    external_inputs={"opaque": make_opaque_external()}
+                )
+
+                assert async_result_value(result) == 1.0
+
+    def test_pipelined_uncopyable_external_inputs_fail_before_worker(self):
+        pipeline = AnyExternalRetargeter("opaque")
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with pytest.raises(TypeError, match="snapshot-copyable"):
+                with TeleopSession(config) as session:
+                    session.step(external_inputs={"opaque": make_opaque_external()})
+
+    def test_pipelined_ignores_unused_per_leaf_external_inputs_before_snapshot(self):
+        pipeline = ExternalEchoPipeline()
+        config = self._pipelined_config(pipeline)
+        external = {"sim_state": make_external_scalar(3.0)}
+        external["sim_state"]["ignored_opaque"] = make_opaque_external()["value"]
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                result = session.step(external_inputs=external)
+
+                assert async_result_value(result) == 3.0
+
+    def test_worker_exception_surfaces_on_next_step(self):
+        pipeline = CountingPipeline(fail_on_call=1)
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert async_result_value(session.step()) == 0.0
+                assert async_result_value(session.step()) == 0.0
+                assert pipeline.failed.wait(timeout=2.0)
+
+                with pytest.raises(RuntimeError, match="Async retarget worker failed"):
+                    session.step()
+                assert session.last_step_info.worker_exception is not None
+
+    def test_worker_exception_surfaces_on_context_exit(self):
+        pipeline = CountingPipeline(fail_on_call=1)
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with pytest.raises(AsyncRetargetWorkerError):
+                with TeleopSession(config) as session:
+                    assert async_result_value(session.step()) == 0.0
+                    assert async_result_value(session.step()) == 0.0
+                    assert pipeline.failed.wait(timeout=2.0)
+
+    def test_worker_exception_during_user_exception_is_logged(self, caplog):
+        pipeline = CountingPipeline(fail_on_call=1)
+        config = self._pipelined_config(pipeline)
+        caplog.set_level(
+            logging.ERROR,
+            logger="isaacteleop.teleop_session_manager.teleop_session",
+        )
+
+        with mock_session_dependencies():
+            with pytest.raises(ValueError, match="user boom"):
+                with TeleopSession(config) as session:
+                    assert async_result_value(session.step()) == 0.0
+                    assert async_result_value(session.step()) == 0.0
+                    assert pipeline.failed.wait(timeout=2.0)
+                    raise ValueError("user boom")
+
+        assert (
+            "Async retarget worker failed during TeleopSession cleanup" in caplog.text
+        )
+
+    def test_first_frame_worker_exception_surfaces(self):
+        pipeline = CountingPipeline(fail_on_call=0)
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with pytest.raises(RuntimeError, match="pipeline boom"):
+                with TeleopSession(config) as session:
+                    session.step()
+
+    def test_app_thread_runtime_error_is_not_labeled_worker_exception(self):
+        source = FailingPollSource("failing", tracker=object())
+        pipeline = MockPipeline(leaf_nodes=[source])
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                with pytest.raises(RuntimeError, match="poll failed"):
+                    session.step()
+                assert session.last_step_info.worker_exception is None
+
+    def test_worker_never_executes_graph_concurrently(self):
+        pipeline = CountingPipeline(sleep_s=0.01)
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                for _ in range(8):
+                    session.step()
+
+        assert pipeline.max_active == 1
+
+    def test_frame_deadline_miss_marks_outputs_more_than_one_frame_old(self):
+        pipeline = BlockingSecondCountingPipeline()
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert async_result_value(session.step()) == 0.0
+                session.step()
+                assert pipeline.second_started.wait(timeout=1.0)
+
+                try:
+                    result = session.step()
+
+                    assert async_result_value(result) == 0.0
+                    assert session.last_step_info.returned_age_frames == 2
+                    assert session.last_step_info.frame_deadline_miss is True
+                finally:
+                    pipeline.release_second.set()
+
+    def test_deadline_pacing_uses_margin_and_cost_estimate(self):
+        pacing = DeadlinePacingConfig(
+            frame_period_adaptation=1.0,
+            compute_cost_adaptation=1.0,
+            spike_guard_window=4,
+            spike_guard_percentile=0.90,
+            safety_margin_s=0.015,
+            startup_frame_period_s=0.050,
+            startup_compute_cost_s=0.010,
+        )
+
+        sleep_s = pacing.compute_delay_s(
+            submitted_time_s=100.0,
+            now_s=100.020,
+            submission_count=2,
+            submit_period_s=0.050,
+            compute_duration_s=0.010,
+            compute_duration_samples=[0.004, 0.006, 0.012],
+        )
+
+        assert sleep_s == pytest.approx(0.003)
+
+    def test_deadline_pacing_uses_seed_for_first_worker_request(self):
+        pipeline = FrameIdPipeline()
+        config = self._pipelined_config(
+            pipeline,
+            pacing=DeadlinePacingConfig(
+                frame_period_adaptation=0.01,
+                safety_margin_s=0.0,
+                startup_frame_period_s=0.08,
+                startup_compute_cost_s=0.0,
+            ),
+        )
+        runner = make_async_runner(pipeline, config)
+        now_s = time.monotonic()
+        runner.publish_seed(
+            RetargetFrame(
+                frame_id=0,
+                outputs=make_async_result(0.0),
+                context=ComputeContext(
+                    graph_time=GraphTime(sim_time_ns=0, real_time_ns=0),
+                    execution_events=ExecutionEvents(
+                        reset=False,
+                        execution_state=ExecutionState.RUNNING,
+                    ),
+                ),
+                submitted_time_s=now_s,
+                started_time_s=now_s,
+                completed_time_s=now_s,
+                compute_duration_s=0.0,
+            )
+        )
+        runner.start()
+        try:
+            assert (
+                runner.submit(make_step_request(1, submitted_time_s=now_s + 0.001)) == 0
+            )
+            time.sleep(0.02)
+
+            assert pipeline.executed_frame_ids == []
+            latest = runner.latest()
+            assert latest is not None
+            assert latest.frame_id == 0
+
+            frame = runner.wait_for_frame(1, timeout_s=1.0)
+            assert frame is not None
+            assert frame.frame_id == 1
+        finally:
+            runner.stop(timeout_s=1.0)
+
+    def test_deadline_paced_unstarted_request_is_replaced_by_newer_submission(self):
+        pipeline = FrameIdPipeline()
+        config = self._pipelined_config(
+            pipeline,
+            pacing=DeadlinePacingConfig(
+                frame_period_adaptation=0.01,
+                safety_margin_s=0.0,
+                startup_frame_period_s=0.25,
+                startup_compute_cost_s=0.0,
+            ),
+        )
+        runner = make_async_runner(pipeline, config)
+        runner._submission_count = 1
+        runner.start()
+        try:
+            assert runner.submit(make_step_request(1)) == 0
+            time.sleep(0.05)
+            assert runner.submit(make_step_request(2)) == 1
+
+            frame = runner.wait_for_frame(2, timeout_s=1.0)
+
+            assert frame is not None
+            assert frame.frame_id == 2
+            assert pipeline.executed_frame_ids == [2]
+            assert runner.dropped_submissions == 1
+        finally:
+            runner.stop(timeout_s=1.0)
+
+    def test_deadline_pacing_submit_period_estimator_updates(self):
+        pipeline = CountingPipeline()
+        config = self._pipelined_config(
+            pipeline,
+            pacing=DeadlinePacingConfig(frame_period_adaptation=1.0),
+        )
+        runner = make_async_runner(pipeline, config)
+
+        with runner._cond:
+            runner._record_submission_locked(10.0)
+            runner._record_submission_locked(10.0005)
+            assert runner._submit_period_s == pytest.approx(0.0005)
+
+            runner._record_submission_locked(11.5005)
+            assert runner._submit_period_s == pytest.approx(1.5)
+
+    def test_published_frame_is_snapshotted_before_reused_output_mutates(self):
+        pipeline = ReusingOutputPipeline()
+        config = self._pipelined_config(pipeline)
+        runner = make_async_runner(pipeline, config)
+        runner.start()
+        try:
+            runner.submit(make_step_request(1))
+            first_frame = runner.wait_for_frame(1, timeout_s=1.0)
+            assert first_frame is not None
+            assert async_result_value(first_frame.outputs) == 1.0
+
+            runner.submit(make_step_request(2))
+            assert pipeline.second_started.wait(timeout=1.0)
+
+            latest = runner.latest()
+            assert latest is not None
+            assert latest.frame_id == 1
+            assert async_result_value(latest.outputs) == 1.0
+
+            pipeline.release_second.set()
+        finally:
+            pipeline.release_second.set()
+            runner.stop(timeout_s=1.0)
+
+    def test_submit_after_stop_raises(self):
+        pipeline = CountingPipeline()
+        config = self._pipelined_config(pipeline)
+        runner = make_async_runner(pipeline, config)
+        runner.start()
+        assert runner.stop(timeout_s=1.0) is True
+        assert runner.stop(timeout_s=1.0) is True
+
+        with pytest.raises(AsyncRetargetRunnerStopped, match="submission"):
+            runner.submit(make_step_request(1))
+
+    def test_runner_cannot_restart_after_stop(self):
+        pipeline = CountingPipeline()
+        config = self._pipelined_config(pipeline)
+        runner = make_async_runner(pipeline, config)
+        runner.start()
+        assert runner.stop(timeout_s=1.0) is True
+
+        with pytest.raises(AsyncRetargetRunnerStopped, match="restarted"):
+            runner.start()
+
+    def test_stop_timeout_reports_active_worker_and_later_stop_cleans_up(self):
+        pipeline = BlockingSecondCountingPipeline()
+        config = self._pipelined_config(pipeline)
+        runner = make_async_runner(pipeline, config)
+        runner.start()
+        try:
+            runner.submit(make_step_request(1))
+            assert runner.wait_for_frame(1, timeout_s=1.0) is not None
+            runner.submit(make_step_request(2))
+            assert pipeline.second_started.wait(timeout=1.0)
+
+            assert runner.stop(timeout_s=0.01) is False
+            assert runner._thread is not None
+
+            pipeline.release_second.set()
+            assert runner.stop(timeout_s=1.0) is True
+            assert runner._thread is None
+        finally:
+            pipeline.release_second.set()
+            runner.stop(timeout_s=1.0)
+
+    def test_wait_for_frame_returns_none_after_stop(self):
+        pipeline = CountingPipeline()
+        config = self._pipelined_config(pipeline)
+        runner = make_async_runner(pipeline, config)
+        runner.start()
+        try:
+            result = []
+
+            waiter = threading.Thread(
+                target=lambda: result.append(runner.wait_for_frame(10)),
+            )
+            waiter.start()
+            runner.stop(timeout_s=1.0)
+            waiter.join(timeout=1.0)
+
+            assert result == [None]
+        finally:
+            runner.stop(timeout_s=1.0)
+
+    def test_wait_for_frame_returns_already_published_frame_after_stop(self):
+        pipeline = CountingPipeline()
+        config = self._pipelined_config(pipeline)
+        runner = make_async_runner(pipeline, config)
+        runner.start()
+        try:
+            runner.submit(make_step_request(1))
+            frame = runner.wait_for_frame(1, timeout_s=1.0)
+            runner.stop(timeout_s=1.0)
+
+            assert frame is not None
+            assert runner.wait_for_frame(1, timeout_s=0.0) is frame
+        finally:
+            runner.stop(timeout_s=1.0)
+
+    def test_sync_mode_keeps_exact_current_frame_behavior(self):
+        pipeline = CountingPipeline()
+        config = make_config(
+            pipeline,
+            retargeting_execution=RetargetingExecutionConfig(
+                mode=RetargetingExecutionMode.SYNC
+            ),
+        )
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert async_result_value(session.step()) == 0.0
+                assert async_result_value(session.step()) == 1.0
+                assert session.last_step_info.returned_age_frames == 0
+                assert session.last_step_info.ran_synchronously is True
+
+    def test_execution_mode_is_latched_for_active_session_run(self):
+        pipeline = BlockingSecondCountingPipeline()
+        config = self._pipelined_config(pipeline)
+
+        with mock_session_dependencies():
+            with TeleopSession(config) as session:
+                assert async_result_value(session.step()) == 0.0
+                session.config.retargeting_execution.mode = (
+                    RetargetingExecutionMode.SYNC
+                )
+
+                try:
+                    result = session.step()
+
+                    assert async_result_value(result) == 0.0
+                    assert session.last_step_info.ran_synchronously is False
+                    assert session._async_runner is not None
+                    assert pipeline.second_started.wait(timeout=1.0)
+                finally:
+                    pipeline.release_second.set()
+
+
 class TestTrackerDataCollection:
     """Test _collect_tracker_data for different tracker types."""
 
@@ -1238,6 +2256,8 @@ class TestConfiguration:
         assert config.trackers == []
         assert config.plugins == []
         assert config.verbose is True
+        assert config.retargeting_execution.mode == RetargetingExecutionMode.SYNC
+        assert isinstance(config.retargeting_execution.pacing, ImmediatePacingConfig)
 
     def test_teleop_session_config_custom(self, tmp_path):
         """TeleopSessionConfig should accept custom values."""
@@ -1259,6 +2279,47 @@ class TestConfiguration:
         assert len(config.trackers) == 1
         assert len(config.plugins) == 1
         assert config.verbose is False
+
+    def test_retargeting_execution_config_accepts_pacing_config_objects(self):
+        """RetargetingExecutionConfig should preserve typed pacing configs."""
+        config = RetargetingExecutionConfig(
+            pacing=DeadlinePacingConfig(safety_margin_s=0.015),
+        )
+
+        assert isinstance(config.pacing, DeadlinePacingConfig)
+        assert config.pacing.safety_margin_s == 0.015
+
+    def test_retargeting_execution_config_default_pacing_is_immediate(self):
+        """RetargetingExecutionConfig should default to immediate pacing."""
+        config = RetargetingExecutionConfig()
+
+        assert isinstance(config.pacing, ImmediatePacingConfig)
+
+    def test_retargeting_execution_config_accepts_supported_pacing_mode_strings(self):
+        """Pacing mode strings should coerce to default pacing config objects."""
+        config = RetargetingExecutionConfig(pacing="deadline")
+
+        assert isinstance(config.pacing, DeadlinePacingConfig)
+
+    def test_retargeting_execution_config_rejects_removed_deadline_guarded_pacing(self):
+        """The old deadline_guarded spelling is no longer part of the public API."""
+        with pytest.raises(ValueError, match="deadline_guarded"):
+            RetargetingExecutionConfig(pacing="deadline_guarded")
+
+    def test_retargeting_execution_config_rejects_removed_fixed_delay_pacing(self):
+        """Fixed-delay pacing is no longer part of the public config surface."""
+        with pytest.raises(ValueError, match="fixed_delay"):
+            RetargetingExecutionConfig(pacing="fixed_delay")
+
+    def test_package_exports_concrete_pacing_configs_not_internal_union_alias(self):
+        """Users import concrete pacing configs; the union alias stays internal."""
+        assert hasattr(teleop_session_manager, "ImmediatePacingConfig")
+        assert hasattr(teleop_session_manager, "DeadlinePacingConfig")
+        assert hasattr(teleop_session_manager, "AsyncRetargetRunnerStopped")
+        assert not hasattr(teleop_session_manager, "DeadlineGuardedPacingConfig")
+        assert not hasattr(teleop_session_manager, "FixedDelayPacingConfig")
+        assert not hasattr(teleop_session_manager, "RetargetingMissPolicy")
+        assert not hasattr(teleop_session_manager, "RetargetingPacingConfig")
 
     def test_plugin_config_defaults(self, tmp_path):
         """PluginConfig should have enabled=True by default."""
@@ -1304,8 +2365,8 @@ class TestSessionReuse:
             with session:
                 assert session.frame_count == 0
 
-    def test_plugin_lists_accumulate(self, tmp_path):
-        """Plugin lists should accumulate if session is re-entered without reset."""
+    def test_plugin_lists_are_run_scoped(self, tmp_path):
+        """Plugin lists should contain only resources from the current session run."""
         pipeline = MockPipeline(leaf_nodes=[])
         mock_pm = MockPluginManager(plugin_names=["test_plugin"])
 
@@ -1322,8 +2383,6 @@ class TestSessionReuse:
             with session:
                 first_count = len(session.plugin_managers)
 
-        # Note: plugin_managers list is not cleared on re-entry
-        # This is expected behavior - users should create new sessions
         assert first_count == 1
 
 
@@ -1482,6 +2541,31 @@ class TestReplayModeSessionEnter:
                 assert session.deviceio_session is mocks.replay_session
             finally:
                 session.__exit__(None, None, None)
+
+    def test_replay_pipelined_mode_returns_latest_completed_result(self):
+        """Replay pipelined mode follows the same latest-completed contract."""
+        pipeline = BlockingSecondCountingPipeline()
+        config = TeleopSessionConfig(
+            app_name="test",
+            pipeline=pipeline,
+            mode=SessionMode.REPLAY,
+            mcap_config=MagicMock(),
+            retargeting_execution=RetargetingExecutionConfig(
+                mode=RetargetingExecutionMode.PIPELINED
+            ),
+        )
+
+        with mock_replay_dependencies():
+            with TeleopSession(config) as session:
+                assert async_result_value(session.step()) == 0.0
+                result = session.step()
+
+                assert async_result_value(result) == 0.0
+                assert session.last_step_info.ran_synchronously is False
+                assert session.last_step_info.returned_frame_id == 0
+                assert session.last_step_info.submitted_frame_id == 1
+                assert pipeline.second_started.wait(timeout=1.0)
+                pipeline.release_second.set()
 
 
 class TestReplayModePlugins:


### PR DESCRIPTION
This PR adds opt-in pipelined retargeting for TeleopSession, allowing applications to submit the current frame’s retarget request while returning the latest completed result after an initial seed frame. The default synchronous mode preserves exact current-frame sample/compute/return behavior, while pipelined mode runs the normal step body on a single background worker and keeps returned outputs, last_context, and step metadata self-consistent for the completed frame.

It also adds execution and pacing configuration, including immediate and deadline-based pacing, plus last_step_info timing/age diagnostics for observing result freshness, dropped submissions, deadline misses, and worker failures. Snapshot support for TensorGroup values was added so external inputs and cached outputs can safely cross the async boundary, with docs and tests covering the new contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Pipelined async retargeting execution mode with configurable pacing strategies (immediate and deadline-based)
  * New session properties for step execution metadata and compute context tracking

* **Bug Fixes**
  * Improved snapshot handling for device-backed arrays using framework-specific methods instead of deep copies

* **Documentation**
  * Comprehensive guide for retargeting execution configuration and pipelining semantics
  * Build guidance for CMake configuration options

* **Tests**
  * Extensive async retargeting execution coverage
  * Tensor group snapshot compatibility tests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->