### PR TITLE
Force VR in headless

### DIFF
--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -366,10 +366,13 @@ function App() {
         ui.updateConnectButtonState();
         return;
       }
-      // Start XR session
-      if (config.immersiveMode === 'ar') {
+      // CloudXR2DUI.updateConfiguration already sets immersiveMode to 'vr' when headless is on.
+      // Repeat the rule here so session entry stays correct even if config were stale or built
+      // elsewhere; immersive-ar is wrong for headless (no passthrough blit path).
+      const immersiveMode: 'ar' | 'vr' = config.headless ? 'vr' : config.immersiveMode;
+      if (immersiveMode === 'ar') {
         await store.enterAR();
-      } else if (config.immersiveMode === 'vr') {
+      } else if (immersiveMode === 'vr') {
         await store.enterVR();
       } else {
         setErrorMessage('Unrecognized immersive mode');

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -729,8 +729,13 @@ export class CloudXR2DUI {
         this.getDefaultConfiguration().maxStreamingBitrateMbps,
       codec:
         (this.codecSelect.value as 'h264' | 'h265' | 'av1') || this.getDefaultConfiguration().codec,
-      immersiveMode:
-        (this.immersiveSelect.value as 'ar' | 'vr') || this.getDefaultConfiguration().immersiveMode,
+      // Headless mode turns off the client's CloudXR frame blit but keeps tracking; the WebXR
+      // session must be immersive-vr. immersive-ar uses passthrough semantics that do not match
+      // that pipeline, so we ignore the AR/VR dropdown whenever headless is checked.
+      immersiveMode: this.headlessInput.checked
+        ? 'vr'
+        : (this.immersiveSelect.value as 'ar' | 'vr') ||
+          this.getDefaultConfiguration().immersiveMode,
       deviceProfileId: resolveDeviceProfileId(this.deviceProfileSelect.value),
       serverType: this.serverTypeSelect.value || this.getDefaultConfiguration().serverType,
       proxyUrl: this.proxyUrlInput.value || this.getDefaultConfiguration().proxyUrl,
@@ -765,6 +770,7 @@ export class CloudXR2DUI {
         return !isNaN(v) ? v : undefined;
       })(),
       hideControllerModel: this.controllerModelVisibilitySelect.value === 'hide',
+      // See immersiveMode above: when true, callers must start an immersive-vr WebXR session.
       headless: this.headlessInput.checked,
       panelHiddenAtStart: this.panelHiddenAtStartSelect.value === 'true',
       teleopPath: this.teleopPath,


### PR DESCRIPTION
Forces WebXR to use VR not AR in headless mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed XR connection startup logic to enforce VR mode when headless mode is enabled, overriding AR/VR dropdown selection.
  * Enhanced configuration generation to properly respect headless mode settings throughout the session initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->