### PR TITLE
Disable AR/VR dropdown on headless

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/webxrModeDebugText.ts
+++ b/deps/cloudxr/webxr_client/helpers/webxrModeDebugText.ts
@@ -1,0 +1,107 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Console diagnostics: WebXR at startup (no session) and when an immersive session starts.
+ */
+
+/** Lines describing the live XRSession (authoritative mode vs @react-three/xr store). */
+export function dumpXRSessionDetails(
+  session: XRSession | null | undefined,
+  xrStoreMode?: string
+): string[] {
+  if (session == null) {
+    return ['XRSession: null'];
+  }
+
+  const lines: string[] = [];
+  const extended = session as XRSession & {
+    mode?: XRSessionMode;
+    interactionMode?: string;
+  };
+
+  if (xrStoreMode != null) {
+    lines.push(`@react-three/xr store mode: ${xrStoreMode}`);
+  }
+
+  const apiMode = extended.mode;
+  if (apiMode != null) {
+    lines.push(`session.mode (WebXR): ${apiMode}`);
+    if (apiMode === 'immersive-vr') {
+      lines.push('  → WebXR reports immersive-vr (VR / opaque headset environment).');
+    } else if (apiMode === 'immersive-ar') {
+      lines.push('  → WebXR reports immersive-ar (passthrough / camera-backed).');
+    }
+    if (xrStoreMode != null && xrStoreMode !== apiMode) {
+      lines.push(
+        `  WARNING: store mode and session.mode differ — trust session.mode for what the browser is running.`
+      );
+    }
+  } else {
+    lines.push('session.mode (WebXR): — (missing on this UA; infer from store / blend mode)');
+  }
+
+  lines.push(`session.environmentBlendMode: ${session.environmentBlendMode}`);
+  if (extended.interactionMode != null) {
+    lines.push(`session.interactionMode: ${extended.interactionMode}`);
+  }
+
+  const feats = session.enabledFeatures ?? [];
+  lines.push(`session.enabledFeatures [${feats.length}]: ${feats.map(String).join(', ') || '(none)'}`);
+
+  const rs = session.renderState;
+  lines.push(`session.renderState.depthNear: ${rs.depthNear}`);
+  lines.push(`session.renderState.depthFar: ${rs.depthFar}`);
+  const iFoV = rs.inlineVerticalFieldOfView;
+  lines.push(
+    `session.renderState.inlineVerticalFieldOfView: ${iFoV != null ? String(iFoV) : '—'}`
+  );
+
+  const base = rs.baseLayer;
+  if (base == null) {
+    lines.push('session.renderState.baseLayer: null');
+  } else if ('framebufferWidth' in base && 'framebufferHeight' in base) {
+    const layer = base as XRWebGLLayer;
+    lines.push(
+      `session.renderState.baseLayer: XRWebGLLayer ${layer.framebufferWidth}x${layer.framebufferHeight}px`
+    );
+    lines.push(`  antialias: ${layer.antialias}`);
+    if ('ignoreDepthValues' in layer) {
+      lines.push(`  ignoreDepthValues: ${layer.ignoreDepthValues}`);
+    }
+  } else {
+    const tag =
+      base != null && typeof base === 'object' && 'constructor' in base
+        ? (base as { constructor?: { name?: string } }).constructor?.name
+        : undefined;
+    lines.push(`session.renderState.baseLayer: ${tag ?? typeof base}`);
+  }
+
+  lines.push(`session (object): ${session.constructor?.name ?? 'XRSession'}`);
+
+  return lines;
+}
+
+/** Call when an immersive session begins — confirms VR vs AR from the WebXR session object. */
+export function logImmersiveXRSessionToConsole(
+  session: XRSession | null | undefined,
+  xrStoreMode: string
+): void {
+  console.groupCollapsed(`[Isaac Teleop] WebXR session (entered immersive: ${xrStoreMode})`);
+  console.info(dumpXRSessionDetails(session, xrStoreMode).join('\n'));
+  console.groupEnd();
+}

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -38,6 +38,9 @@ import { kPerformanceOptions } from '@helpers/PerformanceProfiles';
 import CloudXRComponent from '@helpers/react/CloudXRComponent';
 import { SimpleEnvironment } from '@helpers/react/SimpleEnvironment';
 import { getControlPanelPositionVector } from '@helpers/react/utils';
+import {
+  logImmersiveXRSessionToConsole
+} from '@helpers/webxrModeDebugText';
 import { SuppressWebGLRendererWhenHeadless } from './SuppressWebGLRendererWhenHeadless';
 import {
   DEFAULT_TELEOP_PATH,
@@ -157,6 +160,8 @@ function App() {
   const [countdownRemaining, setCountdownRemaining] = useState(0);
   const [isTeleopRunning, setIsTeleopRunning] = useState(false);
   const countdownTimerRef = useRef<number | null>(null);
+  /** Avoid repeating immersive session dumps on every XR store tick. */
+  const immersiveSessionDumpLoggedRef = useRef(false);
   const [countdownDuration, setCountdownDuration] = useState<number>(() => {
     try {
       const saved = localStorage.getItem(COUNTDOWN_STORAGE_KEY);
@@ -181,19 +186,19 @@ function App() {
   // Note: React Three Fiber's emulation is disabled (emulate: false) to avoid conflicts
   useEffect(() => {
     const loadIWER = async () => {
-      const { supportsImmersive, iwerLoaded: wasIwerLoaded } = await loadIWERIfNeeded();
-      if (!supportsImmersive) {
-        setErrorMessage('Immersive mode not supported');
-        setIwerLoaded(false);
-        setCapabilitiesValid(false);
-        capabilitiesCheckedRef.current = false; // Reset check flag on failure
-        return;
-      }
+        const { supportsImmersive, iwerLoaded: wasIwerLoaded } = await loadIWERIfNeeded();
+        if (!supportsImmersive) {
+          setErrorMessage('Immersive mode not supported');
+          setIwerLoaded(false);
+          setCapabilitiesValid(false);
+          capabilitiesCheckedRef.current = false; // Reset check flag on failure
+          return;
+        }
       // IWER loaded successfully, now we can proceed with capability checks
-      setIwerLoaded(true);
+        setIwerLoaded(true);
       // Store whether IWER was loaded for status message display later
-      if (wasIwerLoaded) {
-        sessionStorage.setItem('iwerWasLoaded', 'true');
+        if (wasIwerLoaded) {
+          sessionStorage.setItem('iwerWasLoaded', 'true');
       }
     };
 
@@ -448,10 +453,17 @@ function App() {
           console.warn(`[Body Tracking] Enabled features: ${enabledFeatures.join(', ')}`);
         }
 
+        // One dump per immersive session: session.mode is authoritative (immersive-vr vs immersive-ar).
+        if (session && !immersiveSessionDumpLoggedRef.current) {
+          immersiveSessionDumpLoggedRef.current = true;
+          logImmersiveXRSessionToConsole(session, xrState.mode);
+        }
+
         if (cloudXR2DUI) {
           cloudXR2DUI.setStartButtonState(true, 'CONNECT (XR session active)');
         }
       } else {
+        immersiveSessionDumpLoggedRef.current = false;
         // XR session ended
         setIsXRMode(false);
         if (cloudXR2DUI) {

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -259,6 +259,22 @@ export class CloudXR2DUI {
       settings.headless ?? false,
     );
     this.headlessInput.checked = headless;
+    this.applyHeadlessImmersiveDropdown();
+  }
+
+  /**
+   * Headless forces immersive-vr: grey out AR/VR and show VR only ({@link CloudXR2DUI.updateConfiguration} still coerces immersiveMode).
+   */
+  private applyHeadlessImmersiveDropdown(): void {
+    if (this.headlessInput.checked) {
+      this.immersiveSelect.value = 'vr';
+      this.immersiveSelect.disabled = true;
+      this.immersiveSelect.title =
+        'Headless requires VR (immersive-vr); AR passthrough is not available in this mode.';
+    } else {
+      this.immersiveSelect.disabled = false;
+      this.immersiveSelect.title = '';
+    }
   }
 
   /**
@@ -330,6 +346,7 @@ export class CloudXR2DUI {
     if (headlessSeed === 'true' || headlessSeed === 'false') {
       this.headlessInput.checked = headlessSeed === 'true';
       savePerProject('headless', this.teleopPath, headlessSeed);
+      this.applyHeadlessImmersiveDropdown();
     }
   }
 
@@ -589,6 +606,7 @@ export class CloudXR2DUI {
     addListener(this.controllerModelVisibilitySelect, 'change', updateConfig);
     addListener(this.headlessInput, 'change', () => {
       savePerProject('headless', this.teleopPath, this.headlessInput.checked ? 'true' : 'false');
+      this.applyHeadlessImmersiveDropdown();
       this.updateConfiguration();
     });
 


### PR DESCRIPTION
Disables the AR/VR dropdown on headless mode.  Also dumps WebXR info to the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebXR console diagnostics displaying comprehensive session information including mode, blend mode, enabled features, depth settings, and base layer properties.
  * Automatic immersive session logging now captures XR entry details once per session.

* **Bug Fixes**
  * Enhanced headless mode with improved AR/VR dropdown control, including explanatory tooltips and proper UI state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->