### PR TITLE
fix(dex-hand): release temp YAML config after optimizer build

### DIFF
--- a/src/retargeters/dex_hand_retargeter.py
+++ b/src/retargeters/dex_hand_retargeter.py
@@ -135,6 +135,9 @@ class DexHandRetargeter(BaseRetargeter):
             config.hand_retargeting_config
         ).build()
 
+        # The optimizer has parsed the YAML; the temp file is no longer needed.
+        self._cleanup_temp_config()
+
         # Cache joint names from optimizer
         self._dof_names = self._dex_hand.optimizer.robot.dof_joint_names
 
@@ -176,6 +179,14 @@ class DexHandRetargeter(BaseRetargeter):
             HandJointIndex.LITTLE_DISTAL,
             HandJointIndex.LITTLE_TIP,
         ]
+
+    def __del__(self) -> None:
+        # Safety net for callers that construct a retargeter and abandon it
+        # before the optimizer build completes (e.g. a config-load exception).
+        try:
+            self._cleanup_temp_config()
+        except Exception:
+            pass
 
     def input_spec(self) -> RetargeterIOType:
         """Define input collections for hand tracking (Optional)."""
@@ -302,6 +313,24 @@ class DexHandRetargeter(BaseRetargeter):
 
         if temp_config:
             self._config.hand_retargeting_config = temp_config
+            # Track for cleanup once the optimizer has consumed the file.
+            self._temp_config_path: Optional[str] = temp_config
+        else:
+            self._temp_config_path = None
+
+    def _cleanup_temp_config(self) -> None:
+        """Remove the temp YAML written by ``_update_yaml`` once the optimizer
+        has been built from it. Safe to call repeatedly."""
+        path = getattr(self, "_temp_config_path", None)
+        if not path:
+            return
+        try:
+            os.unlink(path)
+        except FileNotFoundError:
+            pass
+        except OSError as e:
+            logger.warning(f"Failed to remove temp dex_retargeting config {path}: {e}")
+        self._temp_config_path = None
 
     def _update_yaml(self, yaml_path: str, urdf_path: str) -> Optional[str]:
         """

--- a/src/retargeters/dex_hand_retargeter.py
+++ b/src/retargeters/dex_hand_retargeter.py
@@ -130,9 +130,10 @@ class DexHandRetargeter(BaseRetargeter):
         # Setup paths and configs
         self._prepare_configs()
 
-        # Initialize dex retargeting optimizer
+        # Initialize dex retargeting optimizer (use the internal load path so
+        # the user's config object is not mutated to point at our temp file).
         self._dex_hand = RetargetingConfig.load_from_file(
-            config.hand_retargeting_config
+            self._retargeting_config_path
         ).build()
 
         # The optimizer has parsed the YAML; the temp file is no longer needed.
@@ -311,12 +312,14 @@ class DexHandRetargeter(BaseRetargeter):
             self._config.hand_retargeting_config, local_urdf
         )
 
-        if temp_config:
-            self._config.hand_retargeting_config = temp_config
-            # Track for cleanup once the optimizer has consumed the file.
-            self._temp_config_path: Optional[str] = temp_config
-        else:
-            self._temp_config_path = None
+        # Resolve the load path internally rather than mutating the user's
+        # ``DexHandRetargeterConfig``: that object may be reused or inspected
+        # by the caller, and overwriting it with a path we are about to
+        # delete in ``_cleanup_temp_config`` would leave it dangling.
+        self._retargeting_config_path: str = (
+            temp_config or self._config.hand_retargeting_config
+        )
+        self._temp_config_path: Optional[str] = temp_config
 
     def _cleanup_temp_config(self) -> None:
         """Remove the temp YAML written by ``_update_yaml`` once the optimizer


### PR DESCRIPTION
## Summary
- `DexHandRetargeter._update_yaml` writes a temp file (`tempfile.mkstemp(suffix=".yml", prefix="dex_retarget_")`) per construction so the URDF path can be patched without mutating the original config. The fd was closed but the file was never unlinked.
- Track the temp path on the instance and unlink it right after `RetargetingConfig.load_from_file(...).build()` returns — the optimizer has parsed the YAML by then and no longer needs the file.
- Add `__del__` as a safety net for the construction path where the optimizer build raises after the temp file was written.
- `_cleanup_temp_config` is idempotent (safe to call from both the explicit cleanup and `__del__`).

## Why this matters
Long-running sessions, test suites, and pytest runs that instantiate many `DexHandRetargeter`s leak a `/tmp/dex_retarget_*.yml` file each, slowly filling `/tmp`. No functional impact, but it's the kind of leak that surfaces as an outage on a long-running production deployment.

## Test plan
- [ ] Run any existing dex hand example/test; confirm `/tmp/dex_retarget_*` count is unchanged after the run vs. before.
- [ ] CI retargeting suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file cleanup to ensure all temporary configuration files are properly removed after optimizer initialization.
  * Added additional safety measures to guarantee cleanup completion even in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->