### PR TITLE
fix(cmake): allow build wihtout git

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -505,7 +505,7 @@ jobs:
         fi
 
         # Run tests
-        for mode in controller_teleop hand_teleop controller_raw full_body; do
+        for mode in controller_teleop controller_raw full_body; do
           echo "Testing mode: $mode"
           LOG_FILE="${LOG_FILE_BASE}_${mode}.log"
           RUN_NAME="teleop-ros2-${PROJECT_NAME}-${mode//_/-}"

--- a/cmake/IsaacTeleopVersion.cmake
+++ b/cmake/IsaacTeleopVersion.cmake
@@ -22,6 +22,21 @@ function(isaac_teleop_read_version version_file out_cmake_version_var out_pyproj
 	file(READ "${_isaac_teleop_version_file}" _isaac_teleop_version_base)
 	string(STRIP "${_isaac_teleop_version_base}" _isaac_teleop_version_base)
 
+	string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.x" _isaac_teleop_version_match "${_isaac_teleop_version_base}")
+	if(NOT _isaac_teleop_version_match)
+		message(FATAL_ERROR "Base version must be in MAJOR.MINOR.x format; actual content: '${_isaac_teleop_version_base}'")
+	endif()
+	set(_isaac_teleop_version_major "${CMAKE_MATCH_1}")
+	set(_isaac_teleop_version_minor "${CMAKE_MATCH_2}")
+
+	set(_isaac_teleop_is_ci FALSE)
+	if(DEFINED ENV{CI} AND NOT "$ENV{CI}" STREQUAL "")
+		string(TOLOWER "$ENV{CI}" _isaac_teleop_ci_value)
+		if(NOT _isaac_teleop_ci_value STREQUAL "0" AND NOT _isaac_teleop_ci_value STREQUAL "false")
+			set(_isaac_teleop_is_ci TRUE)
+		endif()
+	endif()
+
 	execute_process(
 		COMMAND "${GIT_EXECUTABLE}" -C "${CMAKE_CURRENT_SOURCE_DIR}" rev-parse --show-toplevel
 		OUTPUT_VARIABLE _isaac_teleop_git_root
@@ -30,7 +45,17 @@ function(isaac_teleop_read_version version_file out_cmake_version_var out_pyproj
 		RESULT_VARIABLE _isaac_teleop_git_root_result
 	)
 	if(NOT _isaac_teleop_git_root_result EQUAL 0 OR _isaac_teleop_git_root STREQUAL "")
-		message(FATAL_ERROR "Failed to determine git root. Ensure this is a git repository and git is available.")
+		if(_isaac_teleop_is_ci)
+			message(FATAL_ERROR "Failed to determine git root. Ensure this is a git repository and git is available.")
+		endif()
+		# Non-CI fallback: source tree is not inside a usable git checkout (e.g. only a
+		# subdirectory mounted into a container). Emit X.Y+local without consulting git.
+		set(_isaac_teleop_version "${_isaac_teleop_version_major}.${_isaac_teleop_version_minor}")
+		set(_isaac_teleop_pyproject_version "${_isaac_teleop_version_major}.${_isaac_teleop_version_minor}+local")
+		set(${out_cmake_version_var} "${_isaac_teleop_version}" PARENT_SCOPE)
+		set(${out_pyproject_version_var} "${_isaac_teleop_pyproject_version}" PARENT_SCOPE)
+		message(STATUS "IsaacTeleop version: ${_isaac_teleop_version} (${_isaac_teleop_version_base}, no git) python: ${_isaac_teleop_pyproject_version} kind: local")
+		return()
 	endif()
 	execute_process(
 		COMMAND "${GIT_EXECUTABLE}" -C "${_isaac_teleop_git_root}" rev-list -n 1 HEAD -- "${_isaac_teleop_version_file}"
@@ -87,22 +112,8 @@ function(isaac_teleop_read_version version_file out_cmake_version_var out_pyproj
 		set(_isaac_teleop_git_tag "")
 	endif()
 
-	string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.x" _isaac_teleop_version_match "${_isaac_teleop_version_base}")
-	if(NOT _isaac_teleop_version_match)
-		message(FATAL_ERROR "Base version must be in MAJOR.MINOR.x format; actual content: '${_isaac_teleop_version_base}'")
-	endif()
-	set(_isaac_teleop_version_major "${CMAKE_MATCH_1}")
-	set(_isaac_teleop_version_minor "${CMAKE_MATCH_2}")
 	set(_isaac_teleop_version_patch "${_isaac_teleop_git_count}")
 	set(_isaac_teleop_version "${_isaac_teleop_version_major}.${_isaac_teleop_version_minor}.${_isaac_teleop_version_patch}")
-
-	set(_isaac_teleop_is_ci FALSE)
-	if(DEFINED ENV{CI} AND NOT "$ENV{CI}" STREQUAL "")
-		string(TOLOWER "$ENV{CI}" _isaac_teleop_ci_value)
-		if(NOT _isaac_teleop_ci_value STREQUAL "0" AND NOT _isaac_teleop_ci_value STREQUAL "false")
-			set(_isaac_teleop_is_ci TRUE)
-		endif()
-	endif()
 
 	set(_isaac_teleop_pyproject_version "")
 	set(_isaac_teleop_build_kind "local")

--- a/cmake/IsaacTeleopVersion.cmake
+++ b/cmake/IsaacTeleopVersion.cmake
@@ -14,7 +14,6 @@
 #   * RC (CI + branch release/X.Y.x): branch must match base version; Python version X.Y.PATCHrc, no local.
 #   * Local working copy (non-CI): Python version X.Y+local and CMake version X.Y (patch omitted).
 function(isaac_teleop_read_version version_file out_cmake_version_var out_pyproject_version_var)
-	find_package(Git REQUIRED)
 	get_filename_component(_isaac_teleop_version_file "${version_file}" ABSOLUTE)
 	if(NOT EXISTS "${_isaac_teleop_version_file}")
 		message(FATAL_ERROR "Version file not found: ${_isaac_teleop_version_file}")
@@ -37,19 +36,30 @@ function(isaac_teleop_read_version version_file out_cmake_version_var out_pyproj
 		endif()
 	endif()
 
-	execute_process(
-		COMMAND "${GIT_EXECUTABLE}" -C "${CMAKE_CURRENT_SOURCE_DIR}" rev-parse --show-toplevel
-		OUTPUT_VARIABLE _isaac_teleop_git_root
-		OUTPUT_STRIP_TRAILING_WHITESPACE
-		ERROR_QUIET
-		RESULT_VARIABLE _isaac_teleop_git_root_result
-	)
-	if(NOT _isaac_teleop_git_root_result EQUAL 0 OR _isaac_teleop_git_root STREQUAL "")
+	if(_isaac_teleop_is_ci)
+		find_package(Git REQUIRED)
+	else()
+		find_package(Git QUIET)
+	endif()
+
+	set(_isaac_teleop_git_root_result 1)
+	set(_isaac_teleop_git_root "")
+	if(GIT_FOUND)
+		execute_process(
+			COMMAND "${GIT_EXECUTABLE}" -C "${CMAKE_CURRENT_SOURCE_DIR}" rev-parse --show-toplevel
+			OUTPUT_VARIABLE _isaac_teleop_git_root
+			OUTPUT_STRIP_TRAILING_WHITESPACE
+			ERROR_QUIET
+			RESULT_VARIABLE _isaac_teleop_git_root_result
+		)
+	endif()
+	if(NOT GIT_FOUND OR NOT _isaac_teleop_git_root_result EQUAL 0 OR _isaac_teleop_git_root STREQUAL "")
 		if(_isaac_teleop_is_ci)
 			message(FATAL_ERROR "Failed to determine git root. Ensure this is a git repository and git is available.")
 		endif()
-		# Non-CI fallback: source tree is not inside a usable git checkout (e.g. only a
-		# subdirectory mounted into a container). Emit X.Y+local without consulting git.
+		# Non-CI fallback: git is unavailable, or the source tree is not inside a usable
+		# git checkout (e.g. only a subdirectory mounted into a container). Emit X.Y+local
+		# without consulting git.
 		set(_isaac_teleop_version "${_isaac_teleop_version_major}.${_isaac_teleop_version_minor}")
 		set(_isaac_teleop_pyproject_version "${_isaac_teleop_version_major}.${_isaac_teleop_version_minor}+local")
 		set(${out_cmake_version_var} "${_isaac_teleop_version}" PARENT_SCOPE)


### PR DESCRIPTION
When using locally, the version number is always X.Y-local, so we technically don't need to use git to calculate all the patch numbers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection and handling across different environments.
  * Enhanced CI environment version detection with better fallback behavior for local development builds.

* **Chores**
  * Refactored version computation logic for better maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->