### PR TITLE
ROS: add dex retargeter for Sharpa hard teleop

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -514,6 +514,8 @@ jobs:
 
           rm -f "$LOG_FILE"
 
+          # This test overrides the image entrypoint, so keep uv's runtime
+          # resolver pointed at the locally built arm64 nlopt wheel.
           docker run -d \
             --name "$RUN_NAME" \
             --gpus all \
@@ -524,7 +526,7 @@ jobs:
             -e XR_RUNTIME_JSON="$CXR_HOST_VOLUME_PATH/.cloudxr/openxr_cloudxr.json" \
             -e PYTHONUNBUFFERED=1 \
             --entrypoint bash teleop_ros2_ref:${{ env.ROS_DISTRO }} -c \
-            "source /usr/local/bin/teleop-env-setup && exec uv run teleop_ros2_node.py --ros-args -p mode:=$mode -p use_mock_operators:=true" >/dev/null
+            "source /usr/local/bin/teleop-env-setup && exec uv run --find-links=/opt/nlopt-wheels teleop_ros2_node.py --ros-args -p mode:=$mode -p use_mock_operators:=true" >/dev/null
 
           deadline=$((SECONDS + READINESS_TIMEOUT_SEC))
           while [ "$SECONDS" -lt "$deadline" ]; do

--- a/examples/teleop_ros2/CMakeLists.txt
+++ b/examples/teleop_ros2/CMakeLists.txt
@@ -11,3 +11,7 @@ install_python_example(DESTINATION examples/teleop_ros2/python
 install(FILES README.md Dockerfile
     DESTINATION examples/teleop_ros2
 )
+
+install(DIRECTORY configs assets
+    DESTINATION examples/teleop_ros2
+)

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -111,18 +111,18 @@ WORKDIR /opt/isaacteleop/install/examples/teleop_ros2/python
 # Pre-install heavy Python dependencies so they are cached independently of C++ builds.
 # Copy requirements from the context, avoiding any files from the 'builder' stage.
 COPY src/core/python/requirements.txt \
-     src/core/python/requirements-retargeters-lite.txt \
+     src/core/python/requirements-retargeters.txt \
      src/core/python/requirements-grounding.txt \
      /tmp/
 RUN uv venv --python=${PYTHON_VERSION} && \
     uv pip install setuptools wheel && \
     uv pip install --no-build-isolation-package nlopt \
         -r /tmp/requirements.txt \
-        -r /tmp/requirements-retargeters-lite.txt \
+        -r /tmp/requirements-retargeters.txt \
         -r /tmp/requirements-grounding.txt \
-        msgpack msgpack-numpy pyyaml && \
+        msgpack msgpack-numpy && \
     rm /tmp/requirements.txt \
-       /tmp/requirements-retargeters-lite.txt \
+       /tmp/requirements-retargeters.txt \
        /tmp/requirements-grounding.txt
 
 COPY --from=builder /opt/isaacteleop/install /opt/isaacteleop/install

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -56,7 +56,30 @@ RUN uv python install ${PYTHON_VERSION} --quiet \
     && uv python find ${PYTHON_VERSION}
 
 # -----------------------------------------------------------------------------
-# Stage 1: build and install
+# Stage 1: build an nlopt wheel for platforms PyPI does not cover
+# -----------------------------------------------------------------------------
+FROM base AS nlopt_wheel
+ARG PYTHON_VERSION
+ARG TARGETARCH
+
+WORKDIR /tmp/nlopt-python
+RUN mkdir -p /opt/nlopt-wheels && \
+    if [ "${TARGETARCH}" = "arm64" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends \
+            build-essential \
+            cmake \
+            git \
+            pkg-config \
+        && rm -rf /var/lib/apt/lists/* \
+        && git clone --depth 1 --branch 2.10.0 https://github.com/DanielBok/nlopt-python.git . \
+        && git submodule update --init --recursive \
+        && uv venv --python=${PYTHON_VERSION} /tmp/nlopt-wheel-venv \
+        && VIRTUAL_ENV=/tmp/nlopt-wheel-venv uv pip install numpy setuptools wheel \
+        && /tmp/nlopt-wheel-venv/bin/python setup.py bdist_wheel -d /opt/nlopt-wheels; \
+    fi
+
+# -----------------------------------------------------------------------------
+# Stage 2: build and install
 # -----------------------------------------------------------------------------
 FROM base AS builder
 ARG ROS_DISTRO
@@ -101,12 +124,14 @@ exec "$@"
 EOF
 
 # -----------------------------------------------------------------------------
-# Stage 2: runtime image (install tree only)
+# Stage 3: runtime image (install tree only)
 # -----------------------------------------------------------------------------
 FROM base
 ARG PYTHON_VERSION
 
 WORKDIR /opt/isaacteleop/install/examples/teleop_ros2/python
+
+COPY --from=nlopt_wheel /opt/nlopt-wheels /opt/nlopt-wheels
 
 # Pre-install heavy Python dependencies so they are cached independently of C++ builds.
 # Copy requirements from the context, avoiding any files from the 'builder' stage.
@@ -116,7 +141,7 @@ COPY src/core/python/requirements.txt \
      /tmp/
 RUN uv venv --python=${PYTHON_VERSION} && \
     uv pip install setuptools wheel && \
-    uv pip install --no-build-isolation-package nlopt \
+    uv pip install --find-links=/opt/nlopt-wheels --no-build-isolation-package nlopt \
         -r /tmp/requirements.txt \
         -r /tmp/requirements-retargeters.txt \
         -r /tmp/requirements-grounding.txt \
@@ -135,6 +160,6 @@ ENV BASH_ENV=/usr/local/bin/teleop-env-setup
 RUN echo "source /usr/local/bin/teleop-env-setup" >> /etc/bash.bashrc
 
 # Pre-install Python dependencies so uv run doesn't download at every launch.
-RUN uv sync --no-dev
+RUN uv sync --no-dev --find-links=/opt/nlopt-wheels
 
 ENTRYPOINT ["/usr/local/bin/teleop-entrypoint", "uv", "run", "teleop_ros2_node.py"]

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -34,12 +34,24 @@ The default collection ID is `generic_3axis_pedal`. Override it with
 `--ros-args -p pedal_collection_id:=<your_collection_id>` when your pedal
 publisher uses a different ID.
 
-## Prerequisite: Sharpa Retargeting For `hand_teleop`
+## Prerequisite: Hand Retargeting For `hand_teleop`
 
 `hand_teleop` retargets OpenXR hand tracking to Sharpa hand joint commands via
-`SharpaHandRetargeter`. It requires the `isaacteleop[grounding]` runtime
-dependencies and the bundled `robotic_grounding` package data that provides the
-Sharpa MJCF assets.
+the `hand_retargeter` parameter:
+
+- `hand_retargeter:=pink_ik` (default): uses `SharpaHandRetargeter`. It requires the
+  `isaacteleop[grounding]` runtime dependencies and the bundled
+  `robotic_grounding` package data that provides the Sharpa MJCF assets.
+- `hand_retargeter:=dexpilot`: uses `DexHandRetargeter` with DexPilot configs from
+  `examples/teleop_ros2/configs/`. It requires `isaacteleop[retargeters]` and
+  manually supplied or generated standalone Sharpa Wave URDFs at:
+  `examples/teleop_ros2/assets/urdf/sharpa_standalone/left_sharpa_wave.urdf`
+  and
+  `examples/teleop_ros2/assets/urdf/sharpa_standalone/right_sharpa_wave.urdf`.
+
+When running from the Docker image, that asset directory is installed at
+`/opt/isaacteleop/install/examples/teleop_ros2/assets/urdf/sharpa_standalone/`.
+These URDF assets are not fetched at runtime.
 
 ## Published Topics
 
@@ -52,7 +64,7 @@ Sharpa MJCF assets.
 - `xr_teleop/root_pose` (`geometry_msgs/PoseStamped`)
 - `xr_teleop/controller_data` (`std_msgs/ByteMultiArray`, msgpack-encoded dictionary)
 - `xr_teleop/finger_joints` (`sensor_msgs/JointState`)
-  - Retargeted finger joint angles for the robot; contains joint names and position arrays corresponding to the robot finger joints (TriHand in `controller_teleop`, Sharpa in `hand_teleop`)
+  - Retargeted finger joint angles for the robot; contains joint names and position arrays corresponding to the robot finger joints (TriHand in `controller_teleop`, selected Sharpa retargeter in `hand_teleop`)
 - `/tf` (`tf2_msgs/TFMessage`)
   - `world_frame` → `right_wrist_frame`: Right wrist transform (published in `controller_teleop` and `hand_teleop` modes)
   - `world_frame` → `left_wrist_frame`: Left wrist transform (published in `controller_teleop` and `hand_teleop` modes)
@@ -104,7 +116,7 @@ docker run --rm --net=host --ipc=host \
   -r xr_teleop/hand:=my_robot/hand -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 

--- a/examples/teleop_ros2/assets/.gitignore
+++ b/examples/teleop_ros2/assets/.gitignore
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+*.urdf
+*.stl
+*.STL
+meshes/
+!README.md
+!.gitignore

--- a/examples/teleop_ros2/assets/urdf/sharpa_standalone/README.md
+++ b/examples/teleop_ros2/assets/urdf/sharpa_standalone/README.md
@@ -1,0 +1,14 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Sharpa Wave Standalone URDFs
+
+Place manually supplied or generated Sharpa Wave standalone hand URDFs in this
+directory before running `hand_teleop` with `hand_retargeter:=dexpilot`:
+
+- `left_sharpa_wave.urdf`
+- `right_sharpa_wave.urdf`
+
+These robot model assets are not fetched at runtime.

--- a/examples/teleop_ros2/configs/sharpa_wave_left_dexpilot.yml
+++ b/examples/teleop_ros2/configs/sharpa_wave_left_dexpilot.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Isaac Lab Project Developers.
+# SPDX-License-Identifier: Apache-2.0
+
+retargeting:
+  finger_tip_link_names:
+    - left_thumb_fingertip
+    - left_index_fingertip
+    - left_middle_fingertip
+    - left_ring_fingertip
+    - left_pinky_fingertip
+  low_pass_alpha: 0.2
+  scaling_factor: 1.2
+  target_joint_names:
+    - left_thumb_CMC_FE
+    - left_thumb_CMC_AA
+    - left_thumb_MCP_FE
+    - left_thumb_MCP_AA
+    - left_thumb_IP
+    - left_index_MCP_FE
+    - left_index_MCP_AA
+    - left_index_PIP
+    - left_index_DIP
+    - left_middle_MCP_FE
+    - left_middle_MCP_AA
+    - left_middle_PIP
+    - left_middle_DIP
+    - left_ring_MCP_FE
+    - left_ring_MCP_AA
+    - left_ring_PIP
+    - left_ring_DIP
+    - left_pinky_CMC
+    - left_pinky_MCP_FE
+    - left_pinky_MCP_AA
+    - left_pinky_PIP
+    - left_pinky_DIP
+  type: DexPilot
+  urdf_path: placeholder_overridden_at_runtime
+  wrist_link_name: left_hand_C_MC

--- a/examples/teleop_ros2/configs/sharpa_wave_right_dexpilot.yml
+++ b/examples/teleop_ros2/configs/sharpa_wave_right_dexpilot.yml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 The Isaac Lab Project Developers.
+# SPDX-License-Identifier: Apache-2.0
+
+retargeting:
+  finger_tip_link_names:
+    - right_thumb_fingertip
+    - right_index_fingertip
+    - right_middle_fingertip
+    - right_ring_fingertip
+    - right_pinky_fingertip
+  low_pass_alpha: 0.2
+  scaling_factor: 1.2
+  target_joint_names:
+    - right_thumb_CMC_FE
+    - right_thumb_CMC_AA
+    - right_thumb_MCP_FE
+    - right_thumb_MCP_AA
+    - right_thumb_IP
+    - right_index_MCP_FE
+    - right_index_MCP_AA
+    - right_index_PIP
+    - right_index_DIP
+    - right_middle_MCP_FE
+    - right_middle_MCP_AA
+    - right_middle_PIP
+    - right_middle_DIP
+    - right_ring_MCP_FE
+    - right_ring_MCP_AA
+    - right_ring_PIP
+    - right_ring_DIP
+    - right_pinky_CMC
+    - right_pinky_MCP_FE
+    - right_pinky_MCP_AA
+    - right_pinky_PIP
+    - right_pinky_DIP
+  type: DexPilot
+  urdf_path: placeholder_overridden_at_runtime
+  wrist_link_name: right_hand_C_MC

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -10,6 +10,9 @@ dependencies = [
     "isaacteleop[grounding,retargeters]",
     "msgpack",
     "msgpack-numpy",
+    # The ROS node installs pink_ik and dexpilot together. Require nlopt>=2.8 so
+    # dex-retargeting resolves to 0.5.x, keeping the env on NumPy 2 / Pinocchio 3.
+    "nlopt>=2.8.0",
     # robotic_grounding imports viser; pin the pre-yourdfpy version so Linux arm64 does not pull
     # trimesh[easy] -> embreex, which has no aarch64 wheel.
     "viser==0.1.0",

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -7,12 +7,9 @@ version = "0.1.0"
 description = "Isaac Teleop ROS2 Example"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "isaacteleop[grounding,retargeters-lite]",
+    "isaacteleop[grounding,retargeters]",
     "msgpack",
     "msgpack-numpy",
-    "pyyaml>=6.0.3",
-    # robotic_grounding imports torch at module import time.
-    "torch>=2.7.0",
     # robotic_grounding imports viser; pin the pre-yourdfpy version so Linux arm64 does not pull
     # trimesh[easy] -> embreex, which has no aarch64 wheel.
     "viser==0.1.0",

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -70,6 +70,8 @@ from isaacteleop.retargeting_engine.deviceio_source_nodes.pedals_source import (
 )
 from isaacteleop.retargeting_engine.interface import OptionalTensorGroup, OutputCombiner
 from isaacteleop.retargeters import (
+    DexHandRetargeter,
+    DexHandRetargeterConfig,
     FootPedalRootCmdRetargeter,
     FootPedalRootCmdRetargeterConfig,
     LocomotionRootCmdRetargeter,
@@ -93,7 +95,7 @@ from teleop_ros2_retargeters import JointNameAliasRetargeter
 
 
 _BODY_JOINT_NAMES = [e.name for e in BodyJointPicoIndex]
-_SHARPA_FINGER_JOINT_COUNT = 22
+_HAND_RETARGETERS = ("pink_ik", "dexpilot")
 _TELEOP_MODES = ("controller_teleop", "hand_teleop", "controller_raw", "full_body")
 
 _TRIHAND_JOINT_NAMES = [
@@ -107,6 +109,35 @@ _TRIHAND_JOINT_NAMES = [
 ]
 _LEFT_FINGER_JOINT_NAMES = [f"left_{n}" for n in _TRIHAND_JOINT_NAMES]
 _RIGHT_FINGER_JOINT_NAMES = [f"right_{n}" for n in _TRIHAND_JOINT_NAMES]
+
+_SHARPA_WAVE_JOINT_NAMES = [
+    "thumb_CMC_FE",
+    "thumb_CMC_AA",
+    "thumb_MCP_FE",
+    "thumb_MCP_AA",
+    "thumb_IP",
+    "index_MCP_FE",
+    "index_MCP_AA",
+    "index_PIP",
+    "index_DIP",
+    "middle_MCP_FE",
+    "middle_MCP_AA",
+    "middle_PIP",
+    "middle_DIP",
+    "ring_MCP_FE",
+    "ring_MCP_AA",
+    "ring_PIP",
+    "ring_DIP",
+    "pinky_CMC",
+    "pinky_MCP_FE",
+    "pinky_MCP_AA",
+    "pinky_PIP",
+    "pinky_DIP",
+]
+_SHARPA_FINGER_JOINT_COUNT = len(_SHARPA_WAVE_JOINT_NAMES)
+_LEFT_SHARPA_WAVE_JOINT_NAMES = [f"left_{n}" for n in _SHARPA_WAVE_JOINT_NAMES]
+_RIGHT_SHARPA_WAVE_JOINT_NAMES = [f"right_{n}" for n in _SHARPA_WAVE_JOINT_NAMES]
+_DEX_HANDTRACKING_TO_BASELINK_FRAME_TRANSFORM = (0, -1, 0, -1, 0, 0, 0, 0, -1)
 
 
 # Helper functions
@@ -285,6 +316,38 @@ def _resolve_sharpa_mjcf(filename: str) -> str:
         raise ModuleNotFoundError(
             "hand_teleop requires robotic_grounding assets for Sharpa retargeting. "
             "Install/use a build with isaacteleop[grounding] and bundled robotic_grounding."
+        ) from exc
+
+
+def _resolve_teleop_ros2_file(description: str, *parts: str) -> str:
+    path = Path(__file__).resolve().parents[1].joinpath(*parts)
+    if not path.is_file():
+        raise FileNotFoundError(f"{description} not found at: {path}")
+    return str(path)
+
+
+def _resolve_dex_sharpa_config(filename: str) -> str:
+    return _resolve_teleop_ros2_file(
+        "DexPilot Sharpa Wave retargeting config",
+        "configs",
+        filename,
+    )
+
+
+def _resolve_dex_sharpa_urdf(filename: str) -> str:
+    try:
+        return _resolve_teleop_ros2_file(
+            "Standalone Sharpa Wave URDF",
+            "assets",
+            "urdf",
+            "sharpa_standalone",
+            filename,
+        )
+    except FileNotFoundError as exc:
+        raise FileNotFoundError(
+            f"{exc}. Place manually supplied or generated Sharpa Wave URDFs under "
+            "examples/teleop_ros2/assets/urdf/sharpa_standalone/ before using "
+            "hand_retargeter:=dexpilot."
         ) from exc
 
 
@@ -545,6 +608,16 @@ class TeleopRos2Node(Node):
                 )
             ),
         )
+        self.declare_parameter(
+            "hand_retargeter",
+            "pink_ik",
+            ParameterDescriptor(
+                description=(
+                    "Hand retargeter backend used by hand_teleop. "
+                    "Valid values: 'pink_ik' or 'dexpilot'."
+                )
+            ),
+        )
 
         self.declare_parameter(
             "transform_translation",
@@ -639,6 +712,16 @@ class TeleopRos2Node(Node):
             )
         self.get_logger().info(f"Mode: {mode}")
         self._mode: str = mode
+        self._hand_retargeter: str = (
+            self.get_parameter("hand_retargeter").get_parameter_value().string_value
+        )
+        if self._hand_retargeter not in _HAND_RETARGETERS:
+            raise ValueError(
+                f"Parameter 'hand_retargeter' must be one of {_HAND_RETARGETERS}, "
+                f"got {self._hand_retargeter!r}"
+            )
+        if self._mode == "hand_teleop":
+            self.get_logger().info(f"Hand retargeter: {self._hand_retargeter}")
 
         self._pedal_collection_id: str = (
             self.get_parameter("pedal_collection_id").get_parameter_value().string_value
@@ -869,18 +952,6 @@ class TeleopRos2Node(Node):
             _SHARPA_FINGER_JOINT_COUNT,
         )
 
-        try:
-            from isaacteleop.retargeters import (
-                SharpaHandRetargeter,
-                SharpaHandRetargeterConfig,
-            )
-        except ModuleNotFoundError as exc:
-            raise ModuleNotFoundError(
-                "hand_teleop requires Sharpa retargeting dependencies. "
-                "Install/use a build with isaacteleop[grounding] and bundled "
-                "robotic_grounding."
-            ) from exc
-
         hands = HandsSource(name="hands")
         pedals = Generic3AxisPedalSource(
             name="pedals", collection_id=self._pedal_collection_id
@@ -891,20 +962,69 @@ class TeleopRos2Node(Node):
         )
         locomotion_connected = locomotion.connect({"pedals": pedals.output("pedals")})
 
-        left_hand_retargeter = SharpaHandRetargeter(
-            SharpaHandRetargeterConfig(
-                robot_asset_path=_resolve_sharpa_mjcf("left_sharpawave_nomesh.xml"),
-                hand_side="left",
-            ),
-            name="sharpa_left",
-        )
-        right_hand_retargeter = SharpaHandRetargeter(
-            SharpaHandRetargeterConfig(
-                robot_asset_path=_resolve_sharpa_mjcf("right_sharpawave_nomesh.xml"),
-                hand_side="right",
-            ),
-            name="sharpa_right",
-        )
+        if self._hand_retargeter == "pink_ik":
+            try:
+                from isaacteleop.retargeters import (
+                    SharpaHandRetargeter,
+                    SharpaHandRetargeterConfig,
+                )
+            except ModuleNotFoundError as exc:
+                raise ModuleNotFoundError(
+                    "hand_teleop with hand_retargeter:=pink_ik requires Sharpa "
+                    "retargeting dependencies. Install/use a build with "
+                    "isaacteleop[grounding] and bundled robotic_grounding."
+                ) from exc
+
+            left_hand_retargeter = SharpaHandRetargeter(
+                SharpaHandRetargeterConfig(
+                    robot_asset_path=_resolve_sharpa_mjcf("left_sharpawave_nomesh.xml"),
+                    hand_side="left",
+                ),
+                name="sharpa_left",
+            )
+            right_hand_retargeter = SharpaHandRetargeter(
+                SharpaHandRetargeterConfig(
+                    robot_asset_path=_resolve_sharpa_mjcf(
+                        "right_sharpawave_nomesh.xml"
+                    ),
+                    hand_side="right",
+                ),
+                name="sharpa_right",
+            )
+            left_alias_name = "sharpa_left_joint_aliases"
+            right_alias_name = "sharpa_right_joint_aliases"
+        else:
+            left_hand_retargeter = DexHandRetargeter(
+                DexHandRetargeterConfig(
+                    hand_retargeting_config=_resolve_dex_sharpa_config(
+                        "sharpa_wave_left_dexpilot.yml"
+                    ),
+                    hand_urdf=_resolve_dex_sharpa_urdf("left_sharpa_wave.urdf"),
+                    hand_joint_names=_LEFT_SHARPA_WAVE_JOINT_NAMES,
+                    handtracking_to_baselink_frame_transform=(
+                        _DEX_HANDTRACKING_TO_BASELINK_FRAME_TRANSFORM
+                    ),
+                    hand_side="left",
+                ),
+                name="dex_sharpa_left",
+            )
+            right_hand_retargeter = DexHandRetargeter(
+                DexHandRetargeterConfig(
+                    hand_retargeting_config=_resolve_dex_sharpa_config(
+                        "sharpa_wave_right_dexpilot.yml"
+                    ),
+                    hand_urdf=_resolve_dex_sharpa_urdf("right_sharpa_wave.urdf"),
+                    hand_joint_names=_RIGHT_SHARPA_WAVE_JOINT_NAMES,
+                    handtracking_to_baselink_frame_transform=(
+                        _DEX_HANDTRACKING_TO_BASELINK_FRAME_TRANSFORM
+                    ),
+                    hand_side="right",
+                ),
+                name="dex_sharpa_right",
+            )
+            left_alias_name = "dex_sharpa_left_joint_aliases"
+            right_alias_name = "dex_sharpa_right_joint_aliases"
+
         left_hand_connected = left_hand_retargeter.connect(
             {HandsSource.LEFT: hands.output(HandsSource.LEFT)}
         )
@@ -917,7 +1037,7 @@ class TeleopRos2Node(Node):
                 left_hand_retargeter.output_spec()["hand_joints"]
             ),
             self._left_finger_joint_name_aliases,
-            "sharpa_left_joint_aliases",
+            left_alias_name,
         )
         right_finger_joints = _maybe_alias_hand_joints(
             right_hand_connected,
@@ -925,7 +1045,7 @@ class TeleopRos2Node(Node):
                 right_hand_retargeter.output_spec()["hand_joints"]
             ),
             self._right_finger_joint_name_aliases,
-            "sharpa_right_joint_aliases",
+            right_alias_name,
         )
 
         pipeline = OutputCombiner(

--- a/src/core/python/requirements-retargeters.txt
+++ b/src/core/python/requirements-retargeters.txt
@@ -6,9 +6,9 @@ scipy>=1.15.0
 pyyaml>=6.0.3
 torch>=2.7.0
 
-# nlopt: architecture-specific so x86_64 can use pre-built wheels; arm builds from sdist
-nlopt==2.6.2; platform_machine == "aarch64" or platform_machine == "arm64"
-nlopt>=2.6.2; platform_machine != "aarch64" and platform_machine != "arm64"
+# Do not pin Linux arm64 to nlopt==2.6.2 here: that forces dex-retargeting 0.4.x
+# and NumPy 1.x, which cannot coexist with Pinocchio 3.x in combined environments.
+nlopt>=2.6.2
 
 # NOTE: The Sharpa retargeter's Pinocchio/Pink/daqp/loop-rate-limiters deps live
 # in `requirements-grounding.txt`, transitively via the `robotic_grounding`


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Selectable hand retargeting backend for hand_teleop (pink_ik or dexpilot).
  * DexPilot Sharpa Wave configs and runtime support for DexPilot retargeting.

* **Documentation**
  * Updated hand_teleop setup, published topics, parameter list, and asset placement guidance.
  * Added asset README for Sharpa Wave URDFs and .gitignore for asset files.

* **Chores**
  * Docker/runtime updates to use prebuilt nlopt wheels during install.
  * Updated Python dependency and installation rules to support retargeters and asset installation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/490)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->