### PR TITLE
ROS: Add Sharpa URDFs for dex-retargeting and make it default for hand teleop

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -505,7 +505,7 @@ jobs:
         fi
 
         # Run tests
-        for mode in controller_teleop controller_raw full_body; do
+        for mode in controller_teleop hand_teleop controller_raw full_body; do
           echo "Testing mode: $mode"
           LOG_FILE="${LOG_FILE_BASE}_${mode}.log"
           RUN_NAME="teleop-ros2-${PROJECT_NAME}-${mode//_/-}"

--- a/examples/teleop_ros2/AGENTS.md
+++ b/examples/teleop_ros2/AGENTS.md
@@ -1,0 +1,10 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Teleop ROS 2 Agent Notes
+
+## Docker Validation
+
+- When creating temporary Docker images for `examples/teleop_ros2` validation, remove them before finishing the task unless the user explicitly asks to keep them.

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -79,7 +79,19 @@ RUN mkdir -p /opt/nlopt-wheels && \
     fi
 
 # -----------------------------------------------------------------------------
-# Stage 2: build and install
+# Stage 2: fetch Sharpa Wave URDF assets
+# -----------------------------------------------------------------------------
+FROM base AS sharpa_urdfs
+
+WORKDIR /tmp/teleop_ros2
+COPY examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py scripts/
+COPY examples/teleop_ros2/configs/sharpa_wave_left_dexpilot.yml \
+     examples/teleop_ros2/configs/sharpa_wave_right_dexpilot.yml \
+     configs/
+RUN python3 scripts/fetch_sharpa_wave_urdfs.py --output-dir /opt/sharpa-wave-urdfs
+
+# -----------------------------------------------------------------------------
+# Stage 3: build and install
 # -----------------------------------------------------------------------------
 FROM base AS builder
 ARG ROS_DISTRO
@@ -124,7 +136,7 @@ exec "$@"
 EOF
 
 # -----------------------------------------------------------------------------
-# Stage 3: runtime image (install tree only)
+# Stage 4: runtime image (install tree only)
 # -----------------------------------------------------------------------------
 FROM base
 ARG PYTHON_VERSION
@@ -151,6 +163,7 @@ RUN uv venv --python=${PYTHON_VERSION} && \
        /tmp/requirements-grounding.txt
 
 COPY --from=builder /opt/isaacteleop/install /opt/isaacteleop/install
+COPY --from=sharpa_urdfs /opt/sharpa-wave-urdfs/ /opt/isaacteleop/install/examples/teleop_ros2/assets/urdf/sharpa_standalone/
 COPY --from=builder /usr/local/bin/teleop-env-setup /usr/local/bin/teleop-env-setup
 COPY --from=builder /usr/local/bin/teleop-entrypoint /usr/local/bin/teleop-entrypoint
 

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -44,14 +44,20 @@ the `hand_retargeter` parameter:
   `robotic_grounding` package data that provides the Sharpa MJCF assets.
 - `hand_retargeter:=dexpilot`: uses `DexHandRetargeter` with DexPilot configs from
   `examples/teleop_ros2/configs/`. It requires `isaacteleop[retargeters]` and
-  manually supplied or generated standalone Sharpa Wave URDFs at:
+  official standalone Sharpa Wave URDFs at:
   `examples/teleop_ros2/assets/urdf/sharpa_standalone/left_sharpa_wave.urdf`
   and
   `examples/teleop_ros2/assets/urdf/sharpa_standalone/right_sharpa_wave.urdf`.
 
-When running from the Docker image, that asset directory is installed at
-`/opt/isaacteleop/install/examples/teleop_ros2/assets/urdf/sharpa_standalone/`.
-These URDF assets are not fetched at runtime.
+The Docker build fetches the pinned official Sharpa Wave URDFs and installs them
+at `/opt/isaacteleop/install/examples/teleop_ros2/assets/urdf/sharpa_standalone/`.
+Source-tree users can populate the same local asset directory from the repo root:
+
+```bash
+python3 examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py
+```
+
+Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
 
 ## Published Topics
 

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -39,15 +39,15 @@ publisher uses a different ID.
 `hand_teleop` retargets OpenXR hand tracking to Sharpa hand joint commands via
 the `hand_retargeter` parameter:
 
-- `hand_retargeter:=pink_ik` (default): uses `SharpaHandRetargeter`. It requires the
-  `isaacteleop[grounding]` runtime dependencies and the bundled
-  `robotic_grounding` package data that provides the Sharpa MJCF assets.
-- `hand_retargeter:=dexpilot`: uses `DexHandRetargeter` with DexPilot configs from
+- `hand_retargeter:=dexpilot` (default): uses `DexHandRetargeter` with DexPilot configs from
   `examples/teleop_ros2/configs/`. It requires `isaacteleop[retargeters]` and
   official standalone Sharpa Wave URDFs at:
   `examples/teleop_ros2/assets/urdf/sharpa_standalone/left_sharpa_wave.urdf`
   and
   `examples/teleop_ros2/assets/urdf/sharpa_standalone/right_sharpa_wave.urdf`.
+- `hand_retargeter:=pink_ik`: uses `SharpaHandRetargeter`. It requires the
+  `isaacteleop[grounding]` runtime dependencies and the bundled
+  `robotic_grounding` package data that provides the Sharpa MJCF assets.
 
 The Docker build fetches the pinned official Sharpa Wave URDFs and installs them
 at `/opt/isaacteleop/install/examples/teleop_ros2/assets/urdf/sharpa_standalone/`.

--- a/examples/teleop_ros2/assets/urdf/sharpa_standalone/README.md
+++ b/examples/teleop_ros2/assets/urdf/sharpa_standalone/README.md
@@ -5,10 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 
 # Sharpa Wave Standalone URDFs
 
-Place manually supplied or generated Sharpa Wave standalone hand URDFs in this
-directory before running `hand_teleop` with `hand_retargeter:=dexpilot`:
+This directory stores the official Sharpa Wave standalone hand URDFs used by
+`hand_teleop` with `hand_retargeter:=dexpilot`:
 
 - `left_sharpa_wave.urdf`
 - `right_sharpa_wave.urdf`
 
-These robot model assets are not fetched at runtime.
+Docker builds fetch the pinned official URDFs into the image at build time.
+Source-tree users can populate this directory from the repo root:
+
+```bash
+python3 examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py
+```
+
+These robot model assets are not fetched at runtime by `teleop_ros2_node.py`.

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -611,7 +611,7 @@ class TeleopRos2Node(Node):
         )
         self.declare_parameter(
             "hand_retargeter",
-            "pink_ik",
+            "dexpilot",
             ParameterDescriptor(
                 description=(
                     "Hand retargeter backend used by hand_teleop. "

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -345,9 +345,10 @@ def _resolve_dex_sharpa_urdf(filename: str) -> str:
         )
     except FileNotFoundError as exc:
         raise FileNotFoundError(
-            f"{exc}. Place manually supplied or generated Sharpa Wave URDFs under "
-            "examples/teleop_ros2/assets/urdf/sharpa_standalone/ before using "
-            "hand_retargeter:=dexpilot."
+            f"{exc}. Populate the official Sharpa Wave URDFs with "
+            "examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py before using "
+            "hand_retargeter:=dexpilot, or use a Docker image built from "
+            "examples/teleop_ros2/Dockerfile."
         ) from exc
 
 

--- a/examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py
+++ b/examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fetch official Sharpa Wave URDFs used by the teleop ROS 2 DexPilot configs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import sys
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+_SHARPA_URDF_REF = "3e953f588ba9954cebaa720aaa4cee06a43a068e"
+_SHARPA_URDF_BASE_URL = (
+    "https://raw.githubusercontent.com/"
+    f"sharpa-robotics/sharpa-urdf-usd-xml/{_SHARPA_URDF_REF}/wave_01"
+)
+_URDF_SHA256 = {
+    "left_sharpa_wave.urdf": (
+        "4cf9fcf07a4545b538995c6c17aaf1a5768e61541b11b1cc385026da3626bad8"
+    ),
+    "right_sharpa_wave.urdf": (
+        "7a9ab7f824482d23765b2da40b7e96fc605e7e70eda4615a5ca51fea88afb845"
+    ),
+}
+_URDF_SOURCES = {
+    "left": {
+        "url": f"{_SHARPA_URDF_BASE_URL}/left_sharpa_wave/left_sharpa_wave.urdf",
+        "filename": "left_sharpa_wave.urdf",
+        "config": "sharpa_wave_left_dexpilot.yml",
+    },
+    "right": {
+        "url": f"{_SHARPA_URDF_BASE_URL}/right_sharpa_wave/right_sharpa_wave.urdf",
+        "filename": "right_sharpa_wave.urdf",
+        "config": "sharpa_wave_right_dexpilot.yml",
+    },
+}
+
+
+def _example_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _default_output_dir() -> Path:
+    return _example_root() / "assets" / "urdf" / "sharpa_standalone"
+
+
+def _default_config_dir() -> Path:
+    return _example_root() / "configs"
+
+
+def _parse_retargeting_config(path: Path) -> tuple[set[str], set[str]]:
+    if not path.is_file():
+        raise FileNotFoundError(f"DexPilot config not found at: {path}")
+
+    links: set[str] = set()
+    joints: set[str] = set()
+    section: str | None = None
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line == "finger_tip_link_names:":
+            section = "links"
+            continue
+        if line == "target_joint_names:":
+            section = "joints"
+            continue
+        if line.startswith("wrist_link_name:"):
+            links.add(line.split(":", maxsplit=1)[1].strip())
+            section = None
+            continue
+        if line.startswith("- ") and section == "links":
+            links.add(line[2:].strip())
+            continue
+        if line.startswith("- ") and section == "joints":
+            joints.add(line[2:].strip())
+            continue
+        if not line.startswith("- "):
+            section = None
+
+    if not links or not joints:
+        raise ValueError(
+            f"DexPilot config at {path} does not contain fingertip links, "
+            "a wrist link, and target joints"
+        )
+    return links, joints
+
+
+def _parse_urdf_names(path: Path) -> tuple[set[str], set[str]]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Sharpa Wave URDF not found at: {path}")
+
+    root = ET.parse(path).getroot()
+    links = {
+        link.attrib["name"] for link in root.findall("link") if "name" in link.attrib
+    }
+    joints = {
+        joint.attrib["name"]
+        for joint in root.findall("joint")
+        if "name" in joint.attrib
+    }
+    return links, joints
+
+
+def _verify_urdf(config_path: Path, urdf_path: Path) -> None:
+    required_links, required_joints = _parse_retargeting_config(config_path)
+    urdf_links, urdf_joints = _parse_urdf_names(urdf_path)
+
+    missing_links = sorted(required_links - urdf_links)
+    missing_joints = sorted(required_joints - urdf_joints)
+    if missing_links or missing_joints:
+        details = []
+        if missing_links:
+            details.append(f"missing links: {', '.join(missing_links)}")
+        if missing_joints:
+            details.append(f"missing joints: {', '.join(missing_joints)}")
+        raise ValueError(
+            f"{urdf_path} does not match {config_path}: {'; '.join(details)}"
+        )
+
+
+def _download(url: str, destination: Path) -> None:
+    try:
+        with urllib.request.urlopen(url, timeout=30) as response:
+            content = response.read()
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Failed to download {url} to {destination}: {exc}") from exc
+
+    expected_sha256 = _URDF_SHA256[destination.name]
+    actual_sha256 = hashlib.sha256(content).hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise RuntimeError(
+            f"Downloaded {url} has SHA-256 {actual_sha256}, "
+            f"expected {expected_sha256}; not writing {destination}"
+        )
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_bytes(content)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Download pinned official Sharpa Wave URDFs and verify them against "
+            "the teleop ROS 2 DexPilot configs."
+        )
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=_default_output_dir(),
+        help="Directory to write left_sharpa_wave.urdf and right_sharpa_wave.urdf.",
+    )
+    parser.add_argument(
+        "--config-dir",
+        type=Path,
+        default=_default_config_dir(),
+        help="Directory containing sharpa_wave_{left,right}_dexpilot.yml.",
+    )
+    parser.add_argument(
+        "--skip-verification",
+        action="store_true",
+        help="Download URDFs without checking link and joint names against DexPilot YAMLs.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+
+    for side, source in _URDF_SOURCES.items():
+        urdf_path = args.output_dir / source["filename"]
+        config_path = args.config_dir / source["config"]
+        _download(source["url"], urdf_path)
+        if not args.skip_verification:
+            _verify_urdf(config_path, urdf_path)
+        print(f"Fetched {side} Sharpa Wave URDF: {urdf_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI-based URDF asset fetching and installation for the hand simulation.
  * Test validation expanded to include hand_teleop mode.

* **Documentation**
  * Clarified hand retargeter defaults and retargeting options.
  * Documented Docker and source-tree workflows for provisioning official URDF assets.

* **Improvements**
  * Improved error guidance directing users to the asset-provisioning options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/491)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->