### PR TITLE
docs-preview: stop publishing webxr client

### DIFF
--- a/.github/workflows/docs-preview-on-demand.yaml
+++ b/.github/workflows/docs-preview-on-demand.yaml
@@ -140,19 +140,6 @@ jobs:
           run-id: ${{ steps.find-build.outputs.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Download webapp artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: webapp
-          path: ./webapp
-          run-id: ${{ steps.find-build.outputs.run_id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Place webapp under /client/
-        run: |
-          mkdir -p ./docs/build/current/client
-          cp -r ./webapp/. ./docs/build/current/client/
-
       - name: Deploy preview to gh-pages
         uses: peaceiris/actions-gh-pages@v4
         with:


### PR DESCRIPTION
Currently the preview of WebXR client is broken:
https://github.com/NVIDIA/IsaacTeleop/actions/runs/25649510578/job/75284840878

Stop publishing the preview for it for now and unblock other mission critical docs works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified documentation preview deployment by optimizing artifact management in the deployment workflow.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/498)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->