### PR TITLE
Fix manus plugin build

### DIFF
--- a/src/plugins/manus/app/CMakeLists.txt
+++ b/src/plugins/manus/app/CMakeLists.txt
@@ -29,7 +29,7 @@ install(TARGETS manus_hand_plugin
     COMPONENT manus
 )
 
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../plugin.yaml" "${CMAKE_CURRENT_SOURCE_DIR}/../README.md"
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/../plugin.yaml"
     DESTINATION plugins/manus
     COMPONENT manus
 )


### PR DESCRIPTION
README.md has been removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the manus hand plugin installation configuration to modify which files are packaged with the plugin.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/499)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->