### PR TITLE
Drop viser dependency

### DIFF
--- a/deps/v2d/version.txt
+++ b/deps/v2d/version.txt
@@ -7,4 +7,4 @@
 #
 # See docs/source/references/grounding_extra.rst for the end-to-end flow.
 
-27657fbbc85af946eaf58484aaf0bf6fead215e3
+3ae3de92f02954100b4eab8d76e5327709aafdd1

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -13,4 +13,7 @@ dependencies = [
     # The ROS node installs pink_ik and dexpilot together. Require nlopt>=2.8 so
     # dex-retargeting resolves to 0.5.x, keeping the env on NumPy 2 / Pinocchio 3.
     "nlopt>=2.8.0",
+    # robotic_grounding imports viser; pin the pre-yourdfpy version so Linux arm64 does not pull
+    # trimesh[easy] -> embreex, which has no aarch64 wheel.
+    "viser==0.1.0",
 ]

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -13,7 +13,4 @@ dependencies = [
     # The ROS node installs pink_ik and dexpilot together. Require nlopt>=2.8 so
     # dex-retargeting resolves to 0.5.x, keeping the env on NumPy 2 / Pinocchio 3.
     "nlopt>=2.8.0",
-    # robotic_grounding imports viser; pin the pre-yourdfpy version so Linux arm64 does not pull
-    # trimesh[easy] -> embreex, which has no aarch64 wheel.
-    "viser==0.1.0",
 ]

--- a/src/core/python/requirements-grounding.txt
+++ b/src/core/python/requirements-grounding.txt
@@ -18,4 +18,3 @@ pin>=2.7.0
 pin-pink>=4.0.0
 loop-rate-limiters>=1.0.0
 daqp>=0.5.0
-viser>=1.0.0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated viser dependency requirement to version 1.0.0 or higher.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/501)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->