### PR TITLE
[TeleViz] camera_viz example scaffolding

### DIFF
--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -1,0 +1,76 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# camera_viz
+
+Holoscan-free camera-feed visualizer for Isaac Teleop, built on
+[Televiz](../../src/viz/). The teleop-side replacement for
+[`examples/camera_streamer/`](../camera_streamer/)'s display path
+(`HolovizOp` + `XrPlaneRenderer`), with the source / transport plumbing
+deliberately scoped down to what the operator's HMD needs.
+
+## Design points
+
+- **Zero D2H/H2D in the hot path.** Sources produce GPU-resident frames
+  (CuPy / PyTorch / NVDEC arrays) and feed them straight to QuadLayers
+  via `__cuda_array_interface__`. The only mandatory upload is at a
+  camera's hardware boundary (USB / network).
+- **Render on its own thread.** `VizRunner` owns one render thread
+  that pulls latest frames from each source and drives
+  `session.render()`. VizSession's blocking calls release the GIL, so
+  source producers run truly concurrently. Pairs cleanly with a
+  `TeleopSession` on the main thread.
+- **Light framework, not a DAG.** Linear source → display; no fan-out
+  / fan-in. Plug in a new source by subclassing `FrameSource` and
+  registering one factory case.
+- **Placement is app policy.** Lock modes live here, not in viz_layers.
+
+## Layout
+
+```
+camera_viz/
+├── camera_viz.py        # main: parse YAML, build, run
+├── pipeline/            # framework: source ABC + threaded runner
+├── placements/          # world / head / lazy locks (camera_plane.cpp port)
+├── sources/             # GPU-resident frame producers
+└── configs/             # example YAMLs
+```
+
+## Lock modes
+
+Ported 1:1 from `camera_streamer/operators/xr_plane_renderer/camera_plane.cpp`.
+Parameter names and defaults match `CameraPlaneConfig`.
+
+| Mode    | Behavior                                                              |
+|---------|-----------------------------------------------------------------------|
+| `world` | Snap in front of the user on first frame; never move again            |
+| `head`  | 6-DoF follow — plane glued to the head every frame                    |
+| `lazy`  | World-locked, but smoothly re-snaps when the user looks away or drifts |
+
+Lazy-mode tuning knobs (XR placement YAML block):
+
+| YAML key                  | Default | Meaning                                            |
+|---------------------------|---------|----------------------------------------------------|
+| `distance`                | `1.5`   | Meters in front of head when (re)placed            |
+| `offset_x`                | `0.0`   | Lateral offset (right = +)                         |
+| `offset_y`                | `0.0`   | Vertical offset (up = +)                           |
+| `look_away_angle_deg`     | `45.0`  | Degrees off-axis that counts as "looking away"     |
+| `reposition_distance`     | `0.5`   | Meters of drift before triggering reposition       |
+| `reposition_delay_s`      | `0.5`   | How long the user must stay disengaged before move |
+| `transition_duration_s`   | `0.3`   | Smoothstep duration for the re-snap                |
+
+## Running
+
+```bash
+# From the IsaacTeleop checkout, with a wheel already in build/wheels/:
+uv run --with ./build/wheels/isaacteleop-*.whl --with cupy-cuda12x --with pyyaml \
+       python examples/camera_viz/camera_viz.py examples/camera_viz/configs/synthetic_window.yaml
+
+# XR 3-up comparison (world / lazy / head side-by-side):
+uv run --with ./build/wheels/isaacteleop-*.whl --with cupy-cuda12x --with pyyaml \
+       python examples/camera_viz/camera_viz.py examples/camera_viz/configs/synthetic_xr_3up.yaml
+```
+
+Press Ctrl-C (window mode) or close the headset session (XR mode) to exit.

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""camera_viz — Holoscan-free camera-feed visualizer for Isaac Teleop.
+
+YAML-driven app that wires sources → VizSession + QuadLayers via the
+pipeline framework. World / head / lazy locks ported 1:1 from
+``examples/camera_streamer/operators/xr_plane_renderer/camera_plane.cpp``.
+
+Usage:
+    python -m camera_viz configs/synthetic_window.yaml
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import sys
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+import isaacteleop.viz as viz
+
+from pipeline import VizRunner
+from placements import PlacementConfig, build as build_placement
+from sources import SyntheticSource
+
+
+def _build_source(spec: dict):
+    """Construct a source from one entry of the YAML ``sources:`` list."""
+    kind = spec.get("type")
+    name = spec["name"]
+    width = int(spec["width"])
+    height = int(spec["height"])
+    if kind == "synthetic":
+        fps = float(spec.get("fps", 60.0))
+        hue_speed_hz = float(spec.get("hue_speed_hz", 0.25))
+        return SyntheticSource(
+            name=name, width=width, height=height, fps=fps, hue_speed_hz=hue_speed_hz
+        )
+    raise ValueError(f"camera_viz: unknown source type {kind!r} (known: synthetic)")
+
+
+def _build_placement(spec: Optional[dict], is_xr: bool):
+    if not is_xr or spec is None:
+        return None
+    cfg_kwargs = {}
+    if "size" in spec:
+        cfg_kwargs["size_meters"] = tuple(spec["size"])
+    for key in (
+        "distance",
+        "offset_x",
+        "offset_y",
+        "look_away_angle_deg",
+        "reposition_distance",
+        "reposition_delay_s",
+        "transition_duration_s",
+    ):
+        if key in spec:
+            cfg_kwargs[key] = spec[key]
+    cfg = PlacementConfig(**cfg_kwargs)
+    return build_placement(spec.get("lock_mode", "lazy"), cfg)
+
+
+def _make_session(cfg: dict) -> viz.VizSession:
+    mode_str = cfg.get("mode", "window").lower()
+    session_cfg = viz.VizSessionConfig()
+    if mode_str == "window":
+        session_cfg.mode = viz.DisplayMode.kWindow
+        w = cfg.get("window", {})
+        session_cfg.window_width = int(w.get("width", 1280))
+        session_cfg.window_height = int(w.get("height", 720))
+    elif mode_str == "xr":
+        session_cfg.mode = viz.DisplayMode.kXr
+        x = cfg.get("xr", {})
+        session_cfg.xr_near_z = float(x.get("near_z", 0.05))
+        session_cfg.xr_far_z = float(x.get("far_z", 100.0))
+    else:
+        raise ValueError(f"camera_viz: unknown mode {mode_str!r} (expected window|xr)")
+    if "clear_color" in cfg:
+        session_cfg.clear_color = tuple(cfg["clear_color"])
+    session_cfg.app_name = cfg.get("app_name", "camera_viz")
+    return viz.VizSession.create(session_cfg)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Televiz camera_viz example")
+    parser.add_argument("config", type=Path, help="YAML config file")
+    args = parser.parse_args(argv)
+
+    with open(args.config) as f:
+        cfg = yaml.safe_load(f)
+
+    session = _make_session(cfg)
+    is_xr = session.is_xr_mode()
+
+    # Build sources, layers, and placement strategies in parallel arrays.
+    sources = []
+    layers = []
+    strategies = []
+    for s_spec in cfg.get("sources", []):
+        source = _build_source(s_spec)
+        sources.append(source)
+
+        layer_cfg = viz.QuadLayerConfig()
+        layer_cfg.name = source.spec.name
+        layer_cfg.resolution = viz.Resolution(source.spec.width, source.spec.height)
+        layer_cfg.format = viz.PixelFormat.kRGBA8
+        layer = session.add_quad_layer(layer_cfg)
+        layers.append(layer)
+
+        strategies.append(_build_placement(s_spec.get("placement"), is_xr))
+
+    print(
+        f"camera_viz: {len(sources)} source(s), mode={cfg.get('mode')}, xr={is_xr}",
+        flush=True,
+    )
+
+    # Ctrl-C cleanly stops the render thread + source threads.
+    runner = VizRunner(session, sources, layers, strategies)
+
+    def _on_sigint(signum, frame):
+        print("camera_viz: stopping...", flush=True)
+        runner.stop()
+
+    signal.signal(signal.SIGINT, _on_sigint)
+
+    runner.start()
+    try:
+        runner.wait()
+    finally:
+        runner.stop()
+        session.destroy()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/camera_viz/configs/synthetic_window.yaml
+++ b/examples/camera_viz/configs/synthetic_window.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Single GPU-resident synthetic source displayed in a desktop window.
+# No GPU camera hardware required — useful for verifying the framework
+# and validating zero-copy throughput on a dev box.
+
+mode: window
+window:
+  width: 1280
+  height: 720
+clear_color: [0.05, 0.05, 0.08, 1.0]
+
+sources:
+  - name: synth
+    type: synthetic
+    width: 1280
+    height: 720
+    fps: 60.0

--- a/examples/camera_viz/configs/synthetic_xr_3up.yaml
+++ b/examples/camera_viz/configs/synthetic_xr_3up.yaml
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Three synthetic sources in XR, one per lock mode — a comparison rig
+# for the placement strategies ported from camera_streamer.
+#
+# Layout, looking from above (user at origin facing -Z):
+#                   world (-0.6 m)   lazy (0.0 m)   head (+0.6 m)
+#                          |              |              |
+#                          +--------------+--------------+
+#                                         |
+#                                         O  user
+
+mode: xr
+xr:
+  near_z: 0.05
+  far_z: 100.0
+clear_color: [0.0, 0.0, 0.0, 1.0]
+
+sources:
+  - name: world_locked
+    type: synthetic
+    width: 1280
+    height: 720
+    fps: 60.0
+    placement:
+      lock_mode: world
+      size: [1.0, 0.5625]
+      distance: 1.5
+      offset_x: -0.6
+
+  - name: lazy_locked
+    type: synthetic
+    width: 1280
+    height: 720
+    fps: 60.0
+    placement:
+      lock_mode: lazy
+      size: [1.0, 0.5625]
+      distance: 1.5
+      offset_x: 0.0
+      # Defaults from camera_streamer's CameraPlaneConfig:
+      look_away_angle_deg: 45.0
+      reposition_distance: 0.5
+      reposition_delay_s: 0.5
+      transition_duration_s: 0.3
+
+  - name: head_locked
+    type: synthetic
+    width: 1280
+    height: 720
+    fps: 60.0
+    placement:
+      lock_mode: head
+      size: [1.0, 0.5625]
+      distance: 1.5
+      offset_x: 0.6

--- a/examples/camera_viz/pipeline/__init__.py
+++ b/examples/camera_viz/pipeline/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Lightweight source → display orchestration for camera_viz.
+
+Not a DAG framework — cameras feed Televiz directly. The renderer is the
+only sink; sources are pull-based via ``latest()`` returning the freshest
+GPU-resident frame (mailbox semantics matching QuadLayer's own 3-slot
+internal mailbox).
+"""
+
+from .interface import Frame, FrameSource, SourceSpec
+from .runner import VizRunner
+
+__all__ = ["Frame", "FrameSource", "SourceSpec", "VizRunner"]

--- a/examples/camera_viz/pipeline/interface.py
+++ b/examples/camera_viz/pipeline/interface.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Source contract for camera_viz.
+
+Sources own their own producer thread (or rely on the vendor SDK's
+callback thread) and expose ``latest()`` as a non-blocking mailbox.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class SourceSpec:
+    """Static description of what a source produces.
+
+    Layers are sized to ``(width, height)`` at construction; the source
+    contract is that every ``Frame.image`` it later emits matches this
+    shape + format exactly.
+    """
+
+    name: str
+    width: int
+    height: int
+    pixel_format: str = "rgba8"  # Phase 1: only RGBA8
+
+
+@dataclass
+class Frame:
+    """One produced frame, GPU-resident.
+
+    ``image`` is anything that exposes ``__cuda_array_interface__`` —
+    CuPy / PyTorch / Numba arrays all work. ``stream`` is the producer's
+    CUDA stream so the consumer can synchronize when it's not 0/default.
+    """
+
+    image: Any
+    timestamp_ns: int
+    source_id: str
+    stream: int = 0
+
+
+class FrameSource(ABC):
+    """Pull-based GPU-resident frame source."""
+
+    @property
+    @abstractmethod
+    def spec(self) -> SourceSpec: ...
+
+    @abstractmethod
+    def start(self) -> None: ...
+
+    @abstractmethod
+    def latest(self) -> Optional[Frame]:
+        """Return the freshest frame, or None if no new frame since the
+        last call. Must be non-blocking — the render loop polls this
+        every frame and skips submission on None."""
+
+    @abstractmethod
+    def stop(self) -> None: ...
+
+    # Convenience context manager so app code can `with source:`.
+    def __enter__(self) -> "FrameSource":
+        self.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.stop()

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Threaded render loop for camera_viz.
+
+The VizSession primitive is single-threaded by design; threading is app
+policy. VizRunner owns one render thread that:
+  1. updates each layer's placement from the current head pose (XR only),
+  2. polls each source's ``latest()`` and submits new frames,
+  3. drives ``session.render()`` (which blocks on present / xrWaitFrame).
+
+All blocking pybind11 calls release the GIL, so source producer threads
+can run concurrently.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional, Sequence
+
+import isaacteleop.viz as viz
+
+from .interface import FrameSource
+
+
+class VizRunner:
+    """Wires sources → layers and runs the render loop on a worker thread.
+
+    Caller owns the ``VizSession`` and the layers. ``placement_strategies``
+    is a parallel list; ``None`` entries are valid for layers whose
+    placement is fixed at construction (window mode, or a kCustom XR
+    placement set externally).
+    """
+
+    def __init__(
+        self,
+        session: viz.VizSession,
+        sources: Sequence[FrameSource],
+        layers: Sequence[viz.QuadLayer],
+        placement_strategies: Optional[Sequence[Optional[object]]] = None,
+    ) -> None:
+        if len(sources) != len(layers):
+            raise ValueError(
+                f"sources / layers length mismatch: {len(sources)} vs {len(layers)}"
+            )
+        if placement_strategies is not None and len(placement_strategies) != len(
+            layers
+        ):
+            raise ValueError(
+                f"placement_strategies / layers length mismatch: {len(placement_strategies)} vs {len(layers)}"
+            )
+
+        self._session = session
+        self._sources = list(sources)
+        self._layers = list(layers)
+        self._strategies = (
+            list(placement_strategies)
+            if placement_strategies is not None
+            else [None] * len(layers)
+        )
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        if self._thread is not None:
+            raise RuntimeError("VizRunner already started")
+        # Clear the stop event so ``start() → stop() → start()`` works —
+        # without this, a recycled runner's new render thread sees the
+        # previous stop signal and exits immediately.
+        self._stop.clear()
+        # Defensive startup: if a source's start() raises (e.g. SDK init
+        # failure) we'd otherwise leave the earlier sources' producer
+        # threads running with no one to stop them. Roll them back on
+        # failure and re-raise.
+        started: list[FrameSource] = []
+        try:
+            for s in self._sources:
+                s.start()
+                started.append(s)
+        except Exception:
+            for s in reversed(started):
+                try:
+                    s.stop()
+                except Exception:
+                    pass
+            raise
+        self._thread = threading.Thread(
+            target=self._render_loop, name="camera_viz_render", daemon=False
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+        for s in self._sources:
+            s.stop()
+
+    def wait(self) -> None:
+        """Block until the render thread exits — either via ``stop()`` from
+        another thread or via the session reporting ``should_close()``."""
+        if self._thread is not None:
+            self._thread.join()
+
+    def __enter__(self) -> "VizRunner":
+        self.start()
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.stop()
+
+    def _render_loop(self) -> None:
+        is_xr = self._session.is_xr_mode()
+        while not self._stop.is_set():
+            # 1. Update placements from current head pose (XR only).
+            if is_xr and any(s is not None for s in self._strategies):
+                head = self._session.head_pose_now()
+                if head is not None:
+                    for layer, strategy in zip(self._layers, self._strategies):
+                        if strategy is None:
+                            continue
+                        placement = strategy.update(head.position, head.orientation)
+                        layer.set_placement(
+                            viz.QuadLayerPlacement(
+                                viz.Pose3D(placement.position, placement.orientation),
+                                placement.size_meters,
+                            )
+                        )
+
+            # 2. Pull freshest frames and submit (mailbox: stale = no submit).
+            for layer, source in zip(self._layers, self._sources):
+                frame = source.latest()
+                if frame is not None:
+                    layer.submit_cuda_array(frame.image, stream=frame.stream)
+
+            # 3. Block until next frame is presented.
+            self._session.render()
+
+            if self._session.should_close():
+                self._stop.set()

--- a/examples/camera_viz/placements/__init__.py
+++ b/examples/camera_viz/placements/__init__.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Placement strategies for camera_viz, ported from
+examples/camera_streamer/operators/xr_plane_renderer/camera_plane.cpp.
+
+Parameter names, defaults, and semantics match the original
+``CameraPlaneConfig``. Strategies are app policy (per the viz design):
+they live in the example, not in viz_layers.
+"""
+
+from .lock_modes import (
+    HeadLocked,
+    LazyLocked,
+    Placement,
+    PlacementConfig,
+    WorldLocked,
+    build,
+)
+
+__all__ = [
+    "HeadLocked",
+    "LazyLocked",
+    "Placement",
+    "PlacementConfig",
+    "WorldLocked",
+    "build",
+]

--- a/examples/camera_viz/placements/_math.py
+++ b/examples/camera_viz/placements/_math.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Thin scipy.spatial.transform.Rotation adapters + a couple of stdlib helpers.
+
+Quaternion convention matches OpenXR / GLM: ``(w, x, y, z)``. scipy's
+``Rotation`` uses ``(x, y, z, w)``, so the adapters here convert at the
+boundary and the rest of the code stays on the wxyz tuple it already
+hands to ``viz.Pose3D``.
+
+The non-rotation helpers (``angle_between_xz_deg``, ``normalize_angle``,
+``smoothstep``) are stdlib one-liners — no point pulling a lib just for
+those.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Tuple
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+Vec3 = Tuple[float, float, float]
+Quat = Tuple[float, float, float, float]  # (w, x, y, z)
+
+
+def _rot_from_wxyz(q: Quat) -> Rotation:
+    """Build a scipy Rotation from a wxyz quaternion (our convention)."""
+    w, x, y, z = q
+    return Rotation.from_quat([x, y, z, w])
+
+
+def _rot_to_wxyz(r: Rotation) -> Quat:
+    """Convert a scipy Rotation back to a wxyz quaternion tuple."""
+    x, y, z, w = r.as_quat()
+    return (float(w), float(x), float(y), float(z))
+
+
+def rotate_vec(q: Quat, v: Vec3) -> Vec3:
+    """Rotate vector ``v`` by unit quaternion ``q``."""
+    rotated = _rot_from_wxyz(q).apply(np.asarray(v, dtype=np.float64))
+    return (float(rotated[0]), float(rotated[1]), float(rotated[2]))
+
+
+def quat_mul(a: Quat, b: Quat) -> Quat:
+    """Hamilton product ``a * b``."""
+    return _rot_to_wxyz(_rot_from_wxyz(a) * _rot_from_wxyz(b))
+
+
+def yaw_quat(yaw: float) -> Quat:
+    """Quaternion for a rotation of ``yaw`` radians about +Y."""
+    return _rot_to_wxyz(Rotation.from_euler("y", yaw))
+
+
+def project_forward_xz(q: Quat) -> Vec3:
+    """OpenXR head forward (-Z in head local) projected onto XZ, normalized.
+
+    Falls back to ``(0, 0, -1)`` if the head is looking near-vertical."""
+    fx, _fy, fz = rotate_vec(q, (0.0, 0.0, -1.0))
+    length = math.hypot(fx, fz)
+    if length < 1e-3:
+        return (0.0, 0.0, -1.0)
+    return (fx / length, 0.0, fz / length)
+
+
+def angle_between_xz_deg(a: Vec3, b: Vec3) -> float:
+    """Angle between two XZ-plane vectors, in degrees. 0 if either is ~0."""
+    la = math.hypot(a[0], a[2])
+    lb = math.hypot(b[0], b[2])
+    if la < 1e-6 or lb < 1e-6:
+        return 0.0
+    d = max(-1.0, min(1.0, (a[0] * b[0] + a[2] * b[2]) / (la * lb)))
+    return math.degrees(math.acos(d))
+
+
+def normalize_angle(angle: float) -> float:
+    """Wrap ``angle`` into (-pi, pi]."""
+    two_pi = 2.0 * math.pi
+    return ((angle + math.pi) % two_pi) - math.pi
+
+
+def smoothstep(t: float) -> float:
+    """C¹-continuous interpolation curve, t clamped to [0, 1]."""
+    if t <= 0.0:
+        return 0.0
+    if t >= 1.0:
+        return 1.0
+    return t * t * (3.0 - 2.0 * t)

--- a/examples/camera_viz/placements/lock_modes.py
+++ b/examples/camera_viz/placements/lock_modes.py
@@ -1,0 +1,223 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""World / head / lazy locked placements, ported from
+``examples/camera_streamer/operators/xr_plane_renderer/camera_plane.cpp``.
+
+Parameter names, defaults, and state-machine semantics are identical to
+the original ``CameraPlaneConfig`` so existing tuning carries over.
+"""
+
+from __future__ import annotations
+
+import math
+import time
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from ._math import (
+    Quat,
+    Vec3,
+    angle_between_xz_deg,
+    normalize_angle,
+    project_forward_xz,
+    quat_mul,
+    rotate_vec,
+    smoothstep,
+    yaw_quat,
+)
+
+
+@dataclass(frozen=True)
+class PlacementConfig:
+    """Mirrors ``CameraPlaneConfig`` (camera_plane.hpp:29).
+
+    ``size_meters`` is plane width/height in world units. The lazy-mode
+    fields are no-ops for World / Head locks.
+    """
+
+    size_meters: Tuple[float, float] = (1.0, 0.5625)
+    distance: float = 1.5
+    offset_x: float = 0.0
+    offset_y: float = 0.0
+    look_away_angle_deg: float = 45.0
+    reposition_distance: float = 0.5
+    reposition_delay_s: float = 0.5
+    transition_duration_s: float = 0.3
+
+
+@dataclass
+class Placement:
+    """Output of a strategy: feeds straight into ``viz.QuadLayerPlacement``."""
+
+    position: Vec3
+    orientation: Quat  # (w, x, y, z)
+    size_meters: Tuple[float, float]
+
+
+class PlacementStrategy(ABC):
+    """Per-layer placement policy. ``update`` is called from the render
+    thread each frame; implementations must be cheap and pure-CPU."""
+
+    @abstractmethod
+    def update(self, head_pos: Vec3, head_orientation: Quat) -> Placement: ...
+
+
+def _target_position(head_pos: Vec3, forward_xz: Vec3, cfg: PlacementConfig) -> Vec3:
+    """Place the quad ``distance`` ahead, with right-vector / up-vector offsets.
+    Mirrors ``CameraPlane::compute_target_position``."""
+    right_x = -forward_xz[2]
+    right_z = forward_xz[0]
+    return (
+        head_pos[0] + forward_xz[0] * cfg.distance + right_x * cfg.offset_x,
+        head_pos[1] + cfg.offset_y,
+        head_pos[2] + forward_xz[2] * cfg.distance + right_z * cfg.offset_x,
+    )
+
+
+def _yaw_to_face(target: Vec3, plane_pos: Vec3) -> float:
+    """Yaw rotation that aims the plane's front at ``target``.
+    Mirrors ``CameraPlane::compute_yaw_to_face``."""
+    return math.atan2(target[0] - plane_pos[0], target[2] - plane_pos[2])
+
+
+class WorldLocked(PlacementStrategy):
+    """Place once in front of the user; never move thereafter.
+    Mirrors ``CameraPlane::update_world``."""
+
+    def __init__(self, config: PlacementConfig) -> None:
+        self._config = config
+        self._cached: Optional[Placement] = None
+
+    def update(self, head_pos: Vec3, head_orientation: Quat) -> Placement:
+        if self._cached is None:
+            forward_xz = project_forward_xz(head_orientation)
+            position = _target_position(head_pos, forward_xz, self._config)
+            yaw = _yaw_to_face(head_pos, position)
+            self._cached = Placement(position, yaw_quat(yaw), self._config.size_meters)
+        return self._cached
+
+
+# 180° about +Y: rotates the quad to face back at the user.
+_ROT_Y_180: Quat = (0.0, 0.0, 1.0, 0.0)
+
+
+class HeadLocked(PlacementStrategy):
+    """Follow the head every frame, full 6-DoF.
+    Mirrors ``CameraPlane::update_head`` + the ``head_rotation * rotY(π)``
+    in ``CameraPlane::rotation``."""
+
+    def __init__(self, config: PlacementConfig) -> None:
+        self._config = config
+
+    def update(self, head_pos: Vec3, head_orientation: Quat) -> Placement:
+        forward = rotate_vec(head_orientation, (0.0, 0.0, -1.0))
+        right = rotate_vec(head_orientation, (1.0, 0.0, 0.0))
+        up = rotate_vec(head_orientation, (0.0, 1.0, 0.0))
+        d, ox, oy = self._config.distance, self._config.offset_x, self._config.offset_y
+        position = (
+            head_pos[0] + forward[0] * d + right[0] * ox + up[0] * oy,
+            head_pos[1] + forward[1] * d + right[1] * ox + up[1] * oy,
+            head_pos[2] + forward[2] * d + right[2] * ox + up[2] * oy,
+        )
+        orientation = quat_mul(head_orientation, _ROT_Y_180)
+        return Placement(position, orientation, self._config.size_meters)
+
+
+class LazyLocked(PlacementStrategy):
+    """World-locked, but smoothly re-snaps in front of the user when they
+    look away (or drift) past a threshold for ``reposition_delay_s``.
+
+    Mirrors ``CameraPlane::update_lazy`` + ``::update_transition``.
+    """
+
+    def __init__(self, config: PlacementConfig) -> None:
+        self._config = config
+        self._initialized = False
+        self._position: Vec3 = (0.0, 0.0, 0.0)
+        self._yaw: float = 0.0
+        self._is_looking_away = False
+        self._look_away_start_t = 0.0
+        self._is_transitioning = False
+        self._transition_start_t = 0.0
+        self._transition_start_position: Vec3 = (0.0, 0.0, 0.0)
+        self._transition_start_yaw = 0.0
+        self._target_position: Vec3 = (0.0, 0.0, 0.0)
+        self._target_yaw = 0.0
+
+    def update(self, head_pos: Vec3, head_orientation: Quat) -> Placement:
+        now = time.monotonic()
+        forward_xz = project_forward_xz(head_orientation)
+
+        if not self._initialized:
+            self._position = _target_position(head_pos, forward_xz, self._config)
+            self._target_position = self._position
+            self._yaw = _yaw_to_face(head_pos, self._position)
+            self._target_yaw = self._yaw
+            self._initialized = True
+            return Placement(
+                self._position, yaw_quat(self._yaw), self._config.size_meters
+            )
+
+        # Look-away check: angle between head forward and head→plane vector.
+        head_to_plane = (
+            self._position[0] - head_pos[0],
+            0.0,
+            self._position[2] - head_pos[2],
+        )
+        angle = angle_between_xz_deg(forward_xz, head_to_plane)
+        angle_triggered = angle > self._config.look_away_angle_deg
+
+        # Position drift check: user has moved far from the ideal placement.
+        ideal = _target_position(head_pos, forward_xz, self._config)
+        drift = math.sqrt(sum((self._position[i] - ideal[i]) ** 2 for i in range(3)))
+        position_triggered = (
+            self._config.reposition_distance > 0.0
+            and drift > self._config.reposition_distance
+        )
+
+        if angle_triggered or position_triggered:
+            if not self._is_looking_away:
+                self._is_looking_away = True
+                self._look_away_start_t = now
+            elif not self._is_transitioning:
+                if (now - self._look_away_start_t) >= self._config.reposition_delay_s:
+                    self._target_position = ideal
+                    self._target_yaw = _yaw_to_face(head_pos, self._target_position)
+                    self._transition_start_position = self._position
+                    self._transition_start_yaw = self._yaw
+                    self._transition_start_t = now
+                    self._is_transitioning = True
+        else:
+            self._is_looking_away = False
+
+        if self._is_transitioning:
+            dur = self._config.transition_duration_s
+            t = min((now - self._transition_start_t) / dur, 1.0) if dur > 0.0 else 1.0
+            s = smoothstep(t)
+            self._position = tuple(
+                self._transition_start_position[i]
+                + (self._target_position[i] - self._transition_start_position[i]) * s
+                for i in range(3)
+            )  # type: ignore[assignment]
+            yaw_diff = normalize_angle(self._target_yaw - self._transition_start_yaw)
+            self._yaw = self._transition_start_yaw + yaw_diff * s
+            if t >= 1.0:
+                self._is_transitioning = False
+                self._is_looking_away = False
+
+        return Placement(self._position, yaw_quat(self._yaw), self._config.size_meters)
+
+
+def build(lock_mode: str, config: PlacementConfig) -> PlacementStrategy:
+    """Factory used by the YAML loader.
+
+    Mode strings match camera_streamer's ``parse_lock_mode``:
+    ``"world"`` → WorldLocked, ``"head"`` → HeadLocked, anything else
+    (including ``"lazy"``) → LazyLocked.
+    """
+    if lock_mode == "world":
+        return WorldLocked(config)
+    if lock_mode == "head":
+        return HeadLocked(config)
+    return LazyLocked(config)

--- a/examples/camera_viz/pyproject.toml
+++ b/examples/camera_viz/pyproject.toml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Standalone pyproject for camera_viz so `uv run` resolves the example's
+# deps without polluting the IsaacTeleop wheel's runtime requirements.
+# isaacteleop is consumed from the locally built wheel (./build/wheels/)
+# or from PyPI — point uv at it via --find-links / --with as needed.
+
+[project]
+name = "camera-viz"
+version = "0.0.0"
+description = "Televiz camera-feed visualizer"
+requires-python = ">=3.10,<3.14"
+dependencies = [
+    "pyyaml>=6.0",
+    "cupy-cuda12x",
+    # numpy + scipy power the placement-strategy math (quaternion ops via
+    # scipy.spatial.transform.Rotation). Already in IsaacTeleop's
+    # retargeters extra, so deploy boxes already have them.
+    "numpy>=1.23",
+    "scipy>=1.15",
+]
+
+[tool.uv]
+python-preference = "only-managed"

--- a/examples/camera_viz/sources/__init__.py
+++ b/examples/camera_viz/sources/__init__.py
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Camera / video sources for camera_viz.
+
+Each source emits GPU-resident RGBA8 frames via the ``FrameSource``
+contract. The first batch (M7a) lands sources that stay GPU-resident
+end-to-end so the teleop hot path never round-trips through host memory.
+"""
+
+from .synthetic import SyntheticSource
+
+__all__ = ["SyntheticSource"]

--- a/examples/camera_viz/sources/synthetic.py
+++ b/examples/camera_viz/sources/synthetic.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""GPU-resident synthetic source for camera_viz.
+
+Generates an animated test pattern entirely on the GPU via CuPy — no
+H2D / D2H copies, so it doubles as a sanity check for the zero-copy
+hot path before real cameras (M7b) land.
+
+Uses double-buffering so the producer thread can update the next frame
+while the renderer's ``cudaMemcpy2D`` is still consuming the current
+one. The vendor-SDK sources will model the same pattern.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Optional
+
+from pipeline import Frame, FrameSource, SourceSpec
+
+
+class SyntheticSource(FrameSource):
+    """Two-buffer GPU source emitting an animated RGBA8 pattern."""
+
+    def __init__(
+        self,
+        name: str,
+        width: int,
+        height: int,
+        fps: float = 60.0,
+        hue_speed_hz: float = 0.25,
+    ) -> None:
+        # CuPy is required for GPU-resident sources. We import lazily so
+        # camera_viz can advertise this source's existence on a CuPy-less
+        # box without crashing module import.
+        try:
+            import cupy as cp
+        except ImportError as e:
+            raise RuntimeError(
+                "SyntheticSource requires CuPy (cupy-cuda12x). Install via "
+                "`uv pip install cupy-cuda12x` or skip this source."
+            ) from e
+
+        self._cp = cp
+        self._spec = SourceSpec(
+            name=name, width=width, height=height, pixel_format="rgba8"
+        )
+        self._frame_interval_s = 1.0 / fps if fps > 0.0 else 0.0
+        self._hue_speed_hz = hue_speed_hz
+
+        # Two GPU buffers — producer writes B while consumer reads A.
+        self._buffers = [
+            cp.zeros((height, width, 4), dtype=cp.uint8),
+            cp.zeros((height, width, 4), dtype=cp.uint8),
+        ]
+        self._write_idx = 0
+        self._publish_idx: int = -1  # -1 = nothing published yet
+        self._consumed_idx: int = -2  # track what `latest()` last returned
+        self._lock = threading.Lock()
+
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._t0_ns = 0
+
+    @property
+    def spec(self) -> SourceSpec:
+        return self._spec
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._t0_ns = time.monotonic_ns()
+        self._thread = threading.Thread(
+            target=self._produce_loop, name=f"synth_{self._spec.name}", daemon=False
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    def latest(self) -> Optional[Frame]:
+        with self._lock:
+            if self._publish_idx < 0 or self._publish_idx == self._consumed_idx:
+                return None
+            idx = self._publish_idx
+            self._consumed_idx = idx
+        return Frame(
+            image=self._buffers[idx],
+            timestamp_ns=time.monotonic_ns(),
+            source_id=self._spec.name,
+            stream=0,
+        )
+
+    def _produce_loop(self) -> None:
+        cp = self._cp
+        h, w = self._spec.height, self._spec.width
+        # Pin this producer thread to the GPU the pre-allocated buffers
+        # live on. On multi-GPU hosts VizSession picks the Vulkan adapter
+        # (potentially non-default), the buffers land on that device, and
+        # the producer thread otherwise defaults to GPU 0 — every kernel
+        # then fires CuPy's cross-device peer-access fallback and warns.
+        with cp.cuda.Device(int(self._buffers[0].device.id)):
+            # Precompute coordinate grids once; reused every frame for the pattern.
+            y_grid = cp.arange(h, dtype=cp.float32).reshape(h, 1)
+            x_grid = cp.arange(w, dtype=cp.float32).reshape(1, w)
+            diag = (x_grid + y_grid) / float(w + h)  # 0..1 sweep
+
+            while not self._stop.is_set():
+                t = (time.monotonic_ns() - self._t0_ns) * 1e-9
+                phase = (t * self._hue_speed_hz) % 1.0
+                # Three offset sinusoids over the diagonal — readable on any HMD.
+                r = (cp.sin((diag + phase) * 6.2831853) * 127.0 + 128.0).astype(
+                    cp.uint8
+                )
+                g = (
+                    cp.sin((diag + phase + 0.3333) * 6.2831853) * 127.0 + 128.0
+                ).astype(cp.uint8)
+                b = (
+                    cp.sin((diag + phase + 0.6667) * 6.2831853) * 127.0 + 128.0
+                ).astype(cp.uint8)
+
+                buf = self._buffers[self._write_idx]
+                buf[..., 0] = r
+                buf[..., 1] = g
+                buf[..., 2] = b
+                buf[..., 3] = 255
+                # Block until the kernel writes are visible to the renderer's
+                # consumer copy (which runs on stream 0). Without this the
+                # async kernel could still be in flight when submit() issues
+                # its cudaMemcpy2D and we'd see torn frames.
+                cp.cuda.Stream.null.synchronize()
+
+                with self._lock:
+                    self._publish_idx = self._write_idx
+                self._write_idx = 1 - self._write_idx
+
+                if self._frame_interval_s > 0.0:
+                    # Coarse pacing — CuPy fill kernels at 1080p are well under
+                    # the budget, so a simple sleep keeps us at target fps.
+                    time.sleep(self._frame_interval_s)


### PR DESCRIPTION
Pure-Python example that drives Televiz from YAML, replacing camera_streamer's HolovizOp + XrPlaneRenderer display path. Zero D2H/H2D in the hot path: sources produce GPU-resident frames and feed QuadLayers via __cuda_array_interface__.

- pipeline/: FrameSource ABC + threaded PipelineRunner. Linear source → layer wiring, not a DAG. Render thread polls latest() from each source and drives session.render().
- placements/: world / head / lazy lock modes ported 1:1 from examples/camera_streamer/operators/xr_plane_renderer/camera_plane.cpp. Parameter names, defaults, and state-machine semantics match CameraPlaneConfig — existing teleop tuning carries over.
- sources/synthetic.py: GPU-resident CuPy source with double- buffering. Validates the zero-copy path end to end without requiring camera hardware. Vendor-SDK sources (OAK-D, ZED, V4L2) follow the same shape in M7b.
- camera_viz.py: YAML loader + main. Builds layers + strategies per source spec; clean Ctrl-C teardown via signal handler.
- configs/synthetic_{window,xr_3up}.yaml: smoke + a 3-up XR layout exercising all three lock modes side-by-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `camera_viz` example application supporting window and XR visualization modes
  * YAML-driven configuration system for camera sources and display settings
  * Three placement lock modes (world, head, lazy) for flexible view control in XR
  * Synthetic camera source for testing and demonstration

* **Documentation**
  * Added comprehensive README with configuration examples and usage instructions

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/505)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->