### PR TITLE
[ROS2 Ref]: Skip implicit uv sync at container start to fix aarch64 nlopt

### DIFF
--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -175,4 +175,6 @@ RUN echo "source /usr/local/bin/teleop-env-setup" >> /etc/bash.bashrc
 # Pre-install Python dependencies so uv run doesn't download at every launch.
 RUN uv sync --no-dev --find-links=/opt/nlopt-wheels
 
-ENTRYPOINT ["/usr/local/bin/teleop-entrypoint", "uv", "run", "teleop_ros2_node.py"]
+# Use --no-sync because the venv is already provisioned above, and the implicit
+# resync runs without --find-links and fails on aarch64 (no nlopt wheel on PyPI).
+ENTRYPOINT ["/usr/local/bin/teleop-entrypoint", "uv", "run", "--no-sync", "teleop_ros2_node.py"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved teleop container startup reliability by preventing unnecessary environment resynchronization, which was causing failures on systems where certain package wheels are unavailable from upstream repositories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/506)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->