### PR TITLE
🍒(1.2) [ROS2 Ref]: Skip implicit uv sync at container start to fix aarch64 nlopt

### DIFF
--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -127,4 +127,6 @@ RUN echo "source /usr/local/bin/teleop-env-setup" >> /etc/bash.bashrc
 # Pre-install Python dependencies so uv run doesn't download at every launch.
 RUN uv sync --no-dev
 
-ENTRYPOINT ["/usr/local/bin/teleop-entrypoint", "uv", "run", "teleop_ros2_node.py"]
+# Use --no-sync because the venv is already provisioned above, and the implicit
+# resync runs without --find-links and fails on aarch64 (no nlopt wheel on PyPI).
+ENTRYPOINT ["/usr/local/bin/teleop-entrypoint", "uv", "run", "--no-sync", "teleop_ros2_node.py"]


### PR DESCRIPTION
(cherry picked from commit 64c2baab107f6f2d892cc744683056d100170a48)