### PR TITLE
add required-environments platform constraints

### DIFF
--- a/cmake/InstallPythonExample.cmake
+++ b/cmake/InstallPythonExample.cmake
@@ -22,6 +22,14 @@ macro(install_python_example)
         message(FATAL_ERROR "install_python_example: DESTINATION is required")
     endif()
 
+    # Installed example is intended to run against a locally built wheel, so
+    # required-environments must list only the current build arch.
+    if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "^(aarch64|arm64)$")
+        set(_IPE_PLATFORM_MACHINE "aarch64")
+    else()
+        set(_IPE_PLATFORM_MACHINE "x86_64")
+    endif()
+
     # Read the bare pyproject.toml and append uv configuration for the
     # installed environment.
     file(READ "${CMAKE_CURRENT_SOURCE_DIR}/python/pyproject.toml" _PYPROJECT_BASE)
@@ -29,6 +37,7 @@ macro(install_python_example)
 find-links = [\"../../../wheels\"]
 python-preference = \"only-managed\"
 environments = [\"python_version == '${ISAAC_TELEOP_PYTHON_VERSION}'\"]
+required-environments = [\"sys_platform == 'linux' and platform_machine == '${_IPE_PLATFORM_MACHINE}'\"]
 ")
     if(_IPE_EXTRA_UV_EXTRA_BUILD_DEPS)
         string(APPEND _TOOL_UV_BLOCK "

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -109,8 +109,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /opt/isaacteleop
 COPY . /opt/isaacteleop
 
+# Wipe any stale wheels before building:
+#   - `install/` may arrive via `COPY . /opt/isaacteleop` when the host context
+#     contains an extracted build-ubuntu artifact tarball.
+#   - `build/wheels/` lives inside the persistent cmake build cache mount and
+#     accumulates one wheel per VERSION the cache has ever seen; `cmake
+#     --install` copies the entire directory.
+# Either source can pollute find-links with an isaacteleop wheel that is not
+# the one this build just produced.
 RUN --mount=type=cache,target=/opt/isaacteleop/build,id=isaacteleop-teleop-ros2-build-${ROS_DISTRO} \
-    cmake -B build -S . \
+    rm -rf /opt/isaacteleop/install /opt/isaacteleop/build/wheels \
+    && cmake -B build -S . \
         -DCMAKE_BUILD_TYPE=Release \
         -DCMAKE_INSTALL_PREFIX=/opt/isaacteleop/install \
         -DBUILD_EXAMPLES=OFF \

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -178,8 +178,18 @@ RUN echo "source /usr/local/bin/teleop-env-setup" >> /etc/bash.bashrc
 # diverge from what this image was actually built with). Extract the version
 # from the wheel filename rather than hard-coding it.
 RUN set -eu; \
-    wheel=$(ls /opt/isaacteleop/install/wheels/isaacteleop-*.whl | head -n1); \
+    echo "== isaacteleop wheels found in find-links =="; \
+    ls -la /opt/isaacteleop/install/wheels/ || true; \
+    wheels=$(ls /opt/isaacteleop/install/wheels/isaacteleop-*.whl 2>/dev/null); \
+    count=$(printf '%s\n' "$wheels" | grep -c .); \
+    if [ "$count" -ne 1 ]; then \
+        echo "ERROR: expected exactly 1 isaacteleop wheel in find-links, found $count:"; \
+        printf '  %s\n' $wheels; \
+        exit 1; \
+    fi; \
+    wheel=$wheels; \
     version=$(basename "$wheel" | sed -E 's/^isaacteleop-([^-]+)-.*$/\1/'); \
+    echo "== pinning isaacteleop==${version} =="; \
     uv sync --no-dev --find-links=/opt/nlopt-wheels --upgrade-package "isaacteleop==${version}"
 
 # Use --no-sync because the venv is already provisioned above, and the implicit

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -173,7 +173,14 @@ ENV BASH_ENV=/usr/local/bin/teleop-env-setup
 RUN echo "source /usr/local/bin/teleop-env-setup" >> /etc/bash.bashrc
 
 # Pre-install Python dependencies so uv run doesn't download at every launch.
-RUN uv sync --no-dev --find-links=/opt/nlopt-wheels
+# Pin isaacteleop to the exact version of the locally-built wheel so the
+# resolver cannot prefer a published PyPI release (whose dep metadata may
+# diverge from what this image was actually built with). Extract the version
+# from the wheel filename rather than hard-coding it.
+RUN set -eu; \
+    wheel=$(ls /opt/isaacteleop/install/wheels/isaacteleop-*.whl | head -n1); \
+    version=$(basename "$wheel" | sed -E 's/^isaacteleop-([^-]+)-.*$/\1/'); \
+    uv sync --no-dev --find-links=/opt/nlopt-wheels --upgrade-package "isaacteleop==${version}"
 
 # Use --no-sync because the venv is already provisioned above, and the implicit
 # resync runs without --find-links and fails on aarch64 (no nlopt wheel on PyPI).


### PR DESCRIPTION
Enforces that a valid resolution must exist for every environment listed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python example installation configuration to explicitly support Linux aarch64 and x86_64 architectures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/516)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->