### PR TITLE
Do not fail fast on push

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-22.04-arm' || 'ubuntu-22.04' }}
 
     strategy:
+      fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
         build_type: ["Debug", "Release"]
         python_version: ['3.10', '3.11', '3.12', '3.13']
@@ -207,6 +208,7 @@ jobs:
     needs: build-ubuntu
 
     strategy:
+      fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
         arch: ['x64', 'arm64']
 
@@ -394,6 +396,7 @@ jobs:
     needs: build-ubuntu
 
     strategy:
+      fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
         python_version: ['3.10', '3.11', '3.12', '3.13']
         arch: ['x64', 'arm64']
@@ -436,6 +439,7 @@ jobs:
     needs: build-ubuntu
 
     strategy:
+      fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
         python_version: ['3.10', '3.12']
         arch: ['x64', 'arm64']


### PR DESCRIPTION
Pushes are supposedly verified in PR therefore failures on push are likely intermitent, so proceed to complete as many variants as possible for a quicker retry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow configuration to modify job execution behavior for different event types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/519)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->