### PR TITLE
Add frame-aligned MessageChannelTracker replay

### DIFF
--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -67,14 +67,42 @@ void LiveMessageChannelTrackerImpl::update(int64_t monotonic_time_ns)
     {
         // Runtime/client disconnected: rebuild the channel object so it can reconnect.
         try_reopen_channel();
-        return;
     }
-
-    if (status != MessageChannelStatus::CONNECTED)
+    else if (status == MessageChannelStatus::CONNECTED)
     {
-        return;
+        drain_messages();
     }
+    // For other statuses (CONNECTING / SHUTTING / UNKNOWN), no messages
+    // are drained but the sentinel write below still advances the
+    // replay frame clock.
 
+    if (mcap_channels_)
+    {
+        // The message channel is the replay impl's own frame clock:
+        // ReplayMessageChannelTrackerImpl consumes one timestamp-group
+        // per session.update() to stay aligned with the rest of the
+        // recorded data, so every live update must persist at least one
+        // record. When nothing was drained, write a data-null sentinel
+        // -- skipping the write would let a connection hiccup desync
+        // the replay from the per-frame trackers (head / hand / ...)
+        // by the duration of the gap.
+        DeviceDataTimestamp timestamp(last_update_time_, last_update_time_, xr_time);
+        if (messages_.data.empty())
+        {
+            mcap_channels_->write(0, timestamp, nullptr);
+        }
+        else
+        {
+            for (const auto& msg : messages_.data)
+            {
+                mcap_channels_->write(0, timestamp, msg);
+            }
+        }
+    }
+}
+
+void LiveMessageChannelTrackerImpl::drain_messages()
+{
     while (true)
     {
         // First call: query pending byte count without reading.
@@ -138,15 +166,6 @@ void LiveMessageChannelTrackerImpl::update(int64_t monotonic_time_ns)
         auto message = std::make_shared<MessageChannelMessagesT>();
         message->payload.assign(receive_buffer_.begin(), receive_buffer_.begin() + read_count);
         messages_.data.push_back(message);
-    }
-
-    if (mcap_channels_)
-    {
-        DeviceDataTimestamp timestamp(last_update_time_, last_update_time_, xr_time);
-        for (const auto& msg : messages_.data)
-        {
-            mcap_channels_->write(0, timestamp, msg);
-        }
     }
 }
 

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
@@ -55,6 +55,7 @@ private:
     void destroy_channel() noexcept;
     bool try_reopen_channel();
     XrUuidEXT make_uuid(const std::array<uint8_t, MessageChannelTracker::CHANNEL_UUID_SIZE>& channel_uuid) const;
+    void drain_messages();
 
     OpenXRSessionHandles handles_;
     const MessageChannelTracker* tracker_{ nullptr };

--- a/src/core/replay_deviceio_session_tests/cpp/test_replay_session.cpp
+++ b/src/core/replay_deviceio_session_tests/cpp/test_replay_session.cpp
@@ -110,6 +110,14 @@ void write_message_record(MessageChannelChannels& ch, int64_t time_ns, const std
     ch.write(0, core::DeviceDataTimestamp(time_ns, time_ns, time_ns), data);
 }
 
+// Mirror LiveMessageChannelTrackerImpl::update's data-null sentinel: a
+// record per session.update() with no payload, marking that frame on
+// the message channel's own frame clock.
+void write_message_sentinel(MessageChannelChannels& ch, int64_t time_ns)
+{
+    ch.write(0, core::DeviceDataTimestamp(time_ns, time_ns, time_ns), nullptr);
+}
+
 std::vector<std::string> to_string_vec(auto traits_channels)
 {
     return std::vector<std::string>(traits_channels.begin(), traits_channels.end());
@@ -292,50 +300,41 @@ TEST_CASE("ReplaySession: head and hand trackers in one session", "[replay][sess
 // Single tracker — MessageChannelTracker (frame-aligned replay)
 // =============================================================================
 //
-// The message-channel replay impl emits recorded payloads in lockstep with
-// the per-frame trackers' record stream, indexed by ``session.update()``
-// call count instead of wall-clock time. The per-frame replay impls emit
-// one record per update, so N updates == recording frame N regardless of
-// how fast the replay loop ticks. The impl derives an inter-frame
-// interval from the MCAP summary (densest non-self channel) and uses
-// ``frame_counter * dt`` as a virtual elapsed clock against each
-// pending record's offset from ``messageStartTime``.
+// LiveMessageChannelTrackerImpl writes ≥1 record per session.update():
+// one per drained payload, or a data-null sentinel when nothing was
+// drained that frame. ReplayMessageChannelTrackerImpl consumes one
+// timestamp-group per replay update, surfacing payload records and
+// silently dropping sentinels. These tests construct that record
+// stream directly (without going through the live impl) and assert
+// frame-aligned drain order under three scenarios: multiple payloads
+// in one frame, payloads spread across frames separated by sentinels,
+// and a tight replay loop that would have raced past every wall-clock
+// offset on the first tick under a wall-clock-based scheme.
 
 TEST_CASE("ReplaySession: message channel drains records on their recorded frame", "[replay][session][message_channel]")
 {
-    // Setup: 4 head records at 0 / 10ms / 20ms / 30ms establishes
-    // ``messageStartTime = 0`` and an inter-frame interval of 10ms (so
-    // ``recording_dt_ns_ = duration / (count - 1) = 30ms / 3 = 10ms``).
-    // Three message-channel records all at logTime 0 -> all map to
-    // recorded frame 0 -> all drain on the first session.update().
+    // Three payloads, all written by a single (recorded) session.update():
+    // they share one timestamp, so the first replay update drains all
+    // three at once.
     auto path = get_temp_mcap_path();
     TempFileCleanup cleanup(path);
-    const std::string head_base = "head";
     const std::string control_base = "_teleop_control";
 
     {
         auto writer = open_writer(path);
-        HeadChannels head_ch(*writer, head_base, core::HeadRecordingTraits::schema_name,
-                             to_string_vec(core::HeadRecordingTraits::recording_channels));
         MessageChannelChannels ctrl_ch(*writer, control_base, core::MessageChannelRecordingTraits::schema_name,
                                        to_string_vec(core::MessageChannelRecordingTraits::channels));
 
-        for (int i = 0; i < 4; ++i)
-        {
-            write_head_frame(head_ch, i * 10'000'000, 1.0f, 2.0f, 3.0f);
-        }
         write_message_record(ctrl_ch, 0, "start");
         write_message_record(ctrl_ch, 0, "stop");
         write_message_record(ctrl_ch, 0, "reset");
         writer->close();
     }
 
-    core::HeadTracker head_tracker;
     core::MessageChannelTracker ctrl_tracker(make_test_uuid(), "test_channel");
     core::McapReplayConfig config;
     config.filename = path;
     config.tracker_names = {
-        { &head_tracker, head_base },
         { &ctrl_tracker, control_base },
     };
 
@@ -358,47 +357,35 @@ TEST_CASE("ReplaySession: message channel drains records on their recorded frame
 
 TEST_CASE("ReplaySession: message channel fans recorded events across update ticks", "[replay][session][message_channel]")
 {
-    // Setup: 4 head records at 0 / 10ms / 20ms / 30ms (dt=10ms). Three
-    // message-channel records at logTimes 0 / 10ms / 20ms map to recorded
-    // frames 0 / 1 / 2 respectively -- exactly one drains per session
-    // update.
+    // Three frames, one payload each, with distinct timestamps. Each
+    // replay update drains exactly one record.
     auto path = get_temp_mcap_path();
     TempFileCleanup cleanup(path);
-    const std::string head_base = "head";
     const std::string control_base = "_teleop_control";
 
     constexpr int64_t dt_ns = 10'000'000;
 
     {
         auto writer = open_writer(path);
-        HeadChannels head_ch(*writer, head_base, core::HeadRecordingTraits::schema_name,
-                             to_string_vec(core::HeadRecordingTraits::recording_channels));
         MessageChannelChannels ctrl_ch(*writer, control_base, core::MessageChannelRecordingTraits::schema_name,
                                        to_string_vec(core::MessageChannelRecordingTraits::channels));
 
-        for (int i = 0; i < 4; ++i)
-        {
-            write_head_frame(head_ch, i * dt_ns, 1.0f, 2.0f, 3.0f);
-        }
         write_message_record(ctrl_ch, 0, "start");
         write_message_record(ctrl_ch, 1 * dt_ns, "stop");
         write_message_record(ctrl_ch, 2 * dt_ns, "reset");
         writer->close();
     }
 
-    core::HeadTracker head_tracker;
     core::MessageChannelTracker ctrl_tracker(make_test_uuid(), "test_channel");
     core::McapReplayConfig config;
     config.filename = path;
     config.tracker_names = {
-        { &head_tracker, head_base },
         { &ctrl_tracker, control_base },
     };
 
     auto session = core::ReplaySession::run(config);
     REQUIRE(session != nullptr);
 
-    // Frame 0: only the record at logTime 0 is due.
     session->update();
     {
         const auto& msgs = ctrl_tracker.get_messages(*session);
@@ -406,7 +393,6 @@ TEST_CASE("ReplaySession: message channel fans recorded events across update tic
         CHECK(payload_string(msgs.data[0]) == "start");
     }
 
-    // Frame 1: the record at logTime 10ms is due.
     session->update();
     {
         const auto& msgs = ctrl_tracker.get_messages(*session);
@@ -414,7 +400,6 @@ TEST_CASE("ReplaySession: message channel fans recorded events across update tic
         CHECK(payload_string(msgs.data[0]) == "stop");
     }
 
-    // Frame 2: the record at logTime 20ms is due.
     session->update();
     {
         const auto& msgs = ctrl_tracker.get_messages(*session);
@@ -422,7 +407,6 @@ TEST_CASE("ReplaySession: message channel fans recorded events across update tic
         CHECK(payload_string(msgs.data[0]) == "reset");
     }
 
-    // Frame 3+: nothing left.
     session->update();
     CHECK(ctrl_tracker.get_messages(*session).data.empty());
 }
@@ -435,12 +419,12 @@ TEST_CASE("ReplaySession: message channel emits at recorded frame regardless of 
     // 6th session.update() call, NOT on the first one and NOT at the
     // wall-clock offset between the START's logTime and the replay
     // loop's monotonic start. This test calls update() in a tight loop
-    // (no sleeps) so wall-clock would race past every logTime offset on
-    // tick 1 -- the only way the START surfaces on the right tick is by
-    // counting frames.
+    // (no sleeps) so any wall-clock-based scheme would race past every
+    // logTime offset on tick 1 -- the only way START surfaces on the
+    // right tick is by counting frames. Frames without payloads carry
+    // data-null sentinels, mirroring what the live impl records.
     auto path = get_temp_mcap_path();
     TempFileCleanup cleanup(path);
-    const std::string head_base = "head";
     const std::string control_base = "_teleop_control";
 
     constexpr int64_t t0_ns = 5'000'000'000;
@@ -451,26 +435,32 @@ TEST_CASE("ReplaySession: message channel emits at recorded frame regardless of 
 
     {
         auto writer = open_writer(path);
-        HeadChannels head_ch(*writer, head_base, core::HeadRecordingTraits::schema_name,
-                             to_string_vec(core::HeadRecordingTraits::recording_channels));
         MessageChannelChannels ctrl_ch(*writer, control_base, core::MessageChannelRecordingTraits::schema_name,
                                        to_string_vec(core::MessageChannelRecordingTraits::channels));
 
         for (int i = 0; i < kFrameCount; ++i)
         {
-            write_head_frame(head_ch, t0_ns + i * dt_ns, 1.0f, 2.0f, 3.0f);
+            const int64_t t = t0_ns + i * dt_ns;
+            if (i == kStartFrame)
+            {
+                write_message_record(ctrl_ch, t, "start");
+            }
+            else if (i == kStopFrame)
+            {
+                write_message_record(ctrl_ch, t, "stop");
+            }
+            else
+            {
+                write_message_sentinel(ctrl_ch, t);
+            }
         }
-        write_message_record(ctrl_ch, t0_ns + kStartFrame * dt_ns, "start");
-        write_message_record(ctrl_ch, t0_ns + kStopFrame * dt_ns, "stop");
         writer->close();
     }
 
-    core::HeadTracker head_tracker;
     core::MessageChannelTracker ctrl_tracker(make_test_uuid(), "test_channel");
     core::McapReplayConfig config;
     config.filename = path;
     config.tracker_names = {
-        { &head_tracker, head_base },
         { &ctrl_tracker, control_base },
     };
 
@@ -496,6 +486,60 @@ TEST_CASE("ReplaySession: message channel emits at recorded frame regardless of 
             CHECK(msgs.data.empty());
         }
     }
+}
+
+TEST_CASE("ReplaySession: message channel drains payloads alongside sentinels in the same frame", "[replay][session][message_channel]")
+{
+    // Mixed-fixture regression: when a frame contains both a sentinel
+    // and one or more payloads (which the live impl never emits, but
+    // is the limit case for the grouping logic), all records sharing
+    // the timestamp should drain on the same update and the sentinel
+    // should be silently dropped.
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+    const std::string control_base = "_teleop_control";
+
+    constexpr int64_t dt_ns = 10'000'000;
+
+    {
+        auto writer = open_writer(path);
+        MessageChannelChannels ctrl_ch(*writer, control_base, core::MessageChannelRecordingTraits::schema_name,
+                                       to_string_vec(core::MessageChannelRecordingTraits::channels));
+
+        write_message_sentinel(ctrl_ch, 0);
+        write_message_record(ctrl_ch, 1 * dt_ns, "hello");
+        write_message_sentinel(ctrl_ch, 1 * dt_ns);
+        write_message_record(ctrl_ch, 1 * dt_ns, "world");
+        write_message_sentinel(ctrl_ch, 2 * dt_ns);
+        writer->close();
+    }
+
+    core::MessageChannelTracker ctrl_tracker(make_test_uuid(), "test_channel");
+    core::McapReplayConfig config;
+    config.filename = path;
+    config.tracker_names = {
+        { &ctrl_tracker, control_base },
+    };
+
+    auto session = core::ReplaySession::run(config);
+    REQUIRE(session != nullptr);
+
+    session->update();
+    CHECK(ctrl_tracker.get_messages(*session).data.empty());
+
+    session->update();
+    {
+        const auto& msgs = ctrl_tracker.get_messages(*session);
+        REQUIRE(msgs.data.size() == 2);
+        CHECK(payload_string(msgs.data[0]) == "hello");
+        CHECK(payload_string(msgs.data[1]) == "world");
+    }
+
+    session->update();
+    CHECK(ctrl_tracker.get_messages(*session).data.empty());
+
+    session->update();
+    CHECK(ctrl_tracker.get_messages(*session).data.empty());
 }
 
 // =============================================================================

--- a/src/core/replay_deviceio_session_tests/cpp/test_replay_session.cpp
+++ b/src/core/replay_deviceio_session_tests/cpp/test_replay_session.cpp
@@ -9,11 +9,14 @@
 #include <deviceio_session/replay_session.hpp>
 #include <deviceio_trackers/hand_tracker.hpp>
 #include <deviceio_trackers/head_tracker.hpp>
+#include <deviceio_trackers/message_channel_tracker.hpp>
 #include <mcap/recording_traits.hpp>
 #include <mcap/tracker_channels.hpp>
 #include <schema/hand_generated.h>
 #include <schema/head_generated.h>
+#include <schema/message_channel_generated.h>
 
+#include <array>
 #include <atomic>
 #include <cstdint>
 #include <filesystem>
@@ -81,6 +84,7 @@ core::Pose make_pose(float x, float y, float z, float qw = 1.0f)
 
 using HeadChannels = core::McapTrackerChannels<core::HeadPoseRecord, core::HeadPose>;
 using HandChannels = core::McapTrackerChannels<core::HandPoseRecord, core::HandPose>;
+using MessageChannelChannels = core::McapTrackerChannels<core::MessageChannelMessagesRecord, core::MessageChannelMessages>;
 
 // ============================================================================
 // Write helpers
@@ -99,9 +103,27 @@ void write_hand_frame(HandChannels& ch, int64_t time_ns, size_t channel_index, s
     ch.write(channel_index, core::DeviceDataTimestamp(time_ns, time_ns, time_ns), data);
 }
 
+void write_message_record(MessageChannelChannels& ch, int64_t time_ns, const std::string& payload)
+{
+    auto data = std::make_shared<core::MessageChannelMessagesT>();
+    data->payload.assign(payload.begin(), payload.end());
+    ch.write(0, core::DeviceDataTimestamp(time_ns, time_ns, time_ns), data);
+}
+
 std::vector<std::string> to_string_vec(auto traits_channels)
 {
     return std::vector<std::string>(traits_channels.begin(), traits_channels.end());
+}
+
+std::string payload_string(const std::shared_ptr<core::MessageChannelMessagesT>& msg)
+{
+    return std::string(msg->payload.begin(), msg->payload.end());
+}
+
+std::array<uint8_t, core::MessageChannelTracker::CHANNEL_UUID_SIZE> make_test_uuid()
+{
+    return { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+             0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01 };
 }
 
 } // namespace
@@ -264,6 +286,216 @@ TEST_CASE("ReplaySession: head and hand trackers in one session", "[replay][sess
     CHECK_FALSE(head_tracker.get_head(*session).data);
     CHECK_FALSE(hand_tracker.get_left_hand(*session).data);
     CHECK_FALSE(hand_tracker.get_right_hand(*session).data);
+}
+
+// =============================================================================
+// Single tracker — MessageChannelTracker (frame-aligned replay)
+// =============================================================================
+//
+// The message-channel replay impl emits recorded payloads in lockstep with
+// the per-frame trackers' record stream, indexed by ``session.update()``
+// call count instead of wall-clock time. The per-frame replay impls emit
+// one record per update, so N updates == recording frame N regardless of
+// how fast the replay loop ticks. The impl derives an inter-frame
+// interval from the MCAP summary (densest non-self channel) and uses
+// ``frame_counter * dt`` as a virtual elapsed clock against each
+// pending record's offset from ``messageStartTime``.
+
+TEST_CASE("ReplaySession: message channel drains records on their recorded frame", "[replay][session][message_channel]")
+{
+    // Setup: 4 head records at 0 / 10ms / 20ms / 30ms establishes
+    // ``messageStartTime = 0`` and an inter-frame interval of 10ms (so
+    // ``recording_dt_ns_ = duration / (count - 1) = 30ms / 3 = 10ms``).
+    // Three message-channel records all at logTime 0 -> all map to
+    // recorded frame 0 -> all drain on the first session.update().
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+    const std::string head_base = "head";
+    const std::string control_base = "_teleop_control";
+
+    {
+        auto writer = open_writer(path);
+        HeadChannels head_ch(*writer, head_base, core::HeadRecordingTraits::schema_name,
+                             to_string_vec(core::HeadRecordingTraits::recording_channels));
+        MessageChannelChannels ctrl_ch(*writer, control_base, core::MessageChannelRecordingTraits::schema_name,
+                                       to_string_vec(core::MessageChannelRecordingTraits::channels));
+
+        for (int i = 0; i < 4; ++i)
+        {
+            write_head_frame(head_ch, i * 10'000'000, 1.0f, 2.0f, 3.0f);
+        }
+        write_message_record(ctrl_ch, 0, "start");
+        write_message_record(ctrl_ch, 0, "stop");
+        write_message_record(ctrl_ch, 0, "reset");
+        writer->close();
+    }
+
+    core::HeadTracker head_tracker;
+    core::MessageChannelTracker ctrl_tracker(make_test_uuid(), "test_channel");
+    core::McapReplayConfig config;
+    config.filename = path;
+    config.tracker_names = {
+        { &head_tracker, head_base },
+        { &ctrl_tracker, control_base },
+    };
+
+    auto session = core::ReplaySession::run(config);
+    REQUIRE(session != nullptr);
+
+    session->update();
+    {
+        const auto& msgs = ctrl_tracker.get_messages(*session);
+        REQUIRE(msgs.data.size() == 3);
+        CHECK(payload_string(msgs.data[0]) == "start");
+        CHECK(payload_string(msgs.data[1]) == "stop");
+        CHECK(payload_string(msgs.data[2]) == "reset");
+    }
+
+    // EOF: subsequent updates produce empty batches (no double-emission).
+    session->update();
+    CHECK(ctrl_tracker.get_messages(*session).data.empty());
+}
+
+TEST_CASE("ReplaySession: message channel fans recorded events across update ticks", "[replay][session][message_channel]")
+{
+    // Setup: 4 head records at 0 / 10ms / 20ms / 30ms (dt=10ms). Three
+    // message-channel records at logTimes 0 / 10ms / 20ms map to recorded
+    // frames 0 / 1 / 2 respectively -- exactly one drains per session
+    // update.
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+    const std::string head_base = "head";
+    const std::string control_base = "_teleop_control";
+
+    constexpr int64_t dt_ns = 10'000'000;
+
+    {
+        auto writer = open_writer(path);
+        HeadChannels head_ch(*writer, head_base, core::HeadRecordingTraits::schema_name,
+                             to_string_vec(core::HeadRecordingTraits::recording_channels));
+        MessageChannelChannels ctrl_ch(*writer, control_base, core::MessageChannelRecordingTraits::schema_name,
+                                       to_string_vec(core::MessageChannelRecordingTraits::channels));
+
+        for (int i = 0; i < 4; ++i)
+        {
+            write_head_frame(head_ch, i * dt_ns, 1.0f, 2.0f, 3.0f);
+        }
+        write_message_record(ctrl_ch, 0, "start");
+        write_message_record(ctrl_ch, 1 * dt_ns, "stop");
+        write_message_record(ctrl_ch, 2 * dt_ns, "reset");
+        writer->close();
+    }
+
+    core::HeadTracker head_tracker;
+    core::MessageChannelTracker ctrl_tracker(make_test_uuid(), "test_channel");
+    core::McapReplayConfig config;
+    config.filename = path;
+    config.tracker_names = {
+        { &head_tracker, head_base },
+        { &ctrl_tracker, control_base },
+    };
+
+    auto session = core::ReplaySession::run(config);
+    REQUIRE(session != nullptr);
+
+    // Frame 0: only the record at logTime 0 is due.
+    session->update();
+    {
+        const auto& msgs = ctrl_tracker.get_messages(*session);
+        REQUIRE(msgs.data.size() == 1);
+        CHECK(payload_string(msgs.data[0]) == "start");
+    }
+
+    // Frame 1: the record at logTime 10ms is due.
+    session->update();
+    {
+        const auto& msgs = ctrl_tracker.get_messages(*session);
+        REQUIRE(msgs.data.size() == 1);
+        CHECK(payload_string(msgs.data[0]) == "stop");
+    }
+
+    // Frame 2: the record at logTime 20ms is due.
+    session->update();
+    {
+        const auto& msgs = ctrl_tracker.get_messages(*session);
+        REQUIRE(msgs.data.size() == 1);
+        CHECK(payload_string(msgs.data[0]) == "reset");
+    }
+
+    // Frame 3+: nothing left.
+    session->update();
+    CHECK(ctrl_tracker.get_messages(*session).data.empty());
+}
+
+TEST_CASE("ReplaySession: message channel emits at recorded frame regardless of replay-loop speed", "[replay][session][message_channel]")
+{
+    // The user-visible regression that motivated frame-alignment: the
+    // operator presses START some way into the recording (e.g. on
+    // recorded frame 5 of 11). The control event must surface on the
+    // 6th session.update() call, NOT on the first one and NOT at the
+    // wall-clock offset between the START's logTime and the replay
+    // loop's monotonic start. This test calls update() in a tight loop
+    // (no sleeps) so wall-clock would race past every logTime offset on
+    // tick 1 -- the only way the START surfaces on the right tick is by
+    // counting frames.
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+    const std::string head_base = "head";
+    const std::string control_base = "_teleop_control";
+
+    constexpr int64_t t0_ns = 5'000'000'000;
+    constexpr int64_t dt_ns = 10'000'000;
+    constexpr int kFrameCount = 11;
+    constexpr int kStartFrame = 5;
+    constexpr int kStopFrame = 8;
+
+    {
+        auto writer = open_writer(path);
+        HeadChannels head_ch(*writer, head_base, core::HeadRecordingTraits::schema_name,
+                             to_string_vec(core::HeadRecordingTraits::recording_channels));
+        MessageChannelChannels ctrl_ch(*writer, control_base, core::MessageChannelRecordingTraits::schema_name,
+                                       to_string_vec(core::MessageChannelRecordingTraits::channels));
+
+        for (int i = 0; i < kFrameCount; ++i)
+        {
+            write_head_frame(head_ch, t0_ns + i * dt_ns, 1.0f, 2.0f, 3.0f);
+        }
+        write_message_record(ctrl_ch, t0_ns + kStartFrame * dt_ns, "start");
+        write_message_record(ctrl_ch, t0_ns + kStopFrame * dt_ns, "stop");
+        writer->close();
+    }
+
+    core::HeadTracker head_tracker;
+    core::MessageChannelTracker ctrl_tracker(make_test_uuid(), "test_channel");
+    core::McapReplayConfig config;
+    config.filename = path;
+    config.tracker_names = {
+        { &head_tracker, head_base },
+        { &ctrl_tracker, control_base },
+    };
+
+    auto session = core::ReplaySession::run(config);
+    REQUIRE(session != nullptr);
+
+    for (int frame = 0; frame < kFrameCount; ++frame)
+    {
+        session->update();
+        const auto& msgs = ctrl_tracker.get_messages(*session);
+        if (frame == kStartFrame)
+        {
+            REQUIRE(msgs.data.size() == 1);
+            CHECK(payload_string(msgs.data[0]) == "start");
+        }
+        else if (frame == kStopFrame)
+        {
+            REQUIRE(msgs.data.size() == 1);
+            CHECK(payload_string(msgs.data[0]) == "stop");
+        }
+        else
+        {
+            CHECK(msgs.data.empty());
+        }
+    }
 }
 
 // =============================================================================

--- a/src/core/replay_deviceio_session_tests/cpp/test_replay_session.cpp
+++ b/src/core/replay_deviceio_session_tests/cpp/test_replay_session.cpp
@@ -84,7 +84,8 @@ core::Pose make_pose(float x, float y, float z, float qw = 1.0f)
 
 using HeadChannels = core::McapTrackerChannels<core::HeadPoseRecord, core::HeadPose>;
 using HandChannels = core::McapTrackerChannels<core::HandPoseRecord, core::HandPose>;
-using MessageChannelChannels = core::McapTrackerChannels<core::MessageChannelMessagesRecord, core::MessageChannelMessages>;
+using MessageChannelChannels =
+    core::McapTrackerChannels<core::MessageChannelMessagesRecord, core::MessageChannelMessages>;
 
 // ============================================================================
 // Write helpers
@@ -130,8 +131,7 @@ std::string payload_string(const std::shared_ptr<core::MessageChannelMessagesT>&
 
 std::array<uint8_t, core::MessageChannelTracker::CHANNEL_UUID_SIZE> make_test_uuid()
 {
-    return { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
-             0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01 };
+    return { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x01 };
 }
 
 } // namespace
@@ -411,7 +411,8 @@ TEST_CASE("ReplaySession: message channel fans recorded events across update tic
     CHECK(ctrl_tracker.get_messages(*session).data.empty());
 }
 
-TEST_CASE("ReplaySession: message channel emits at recorded frame regardless of replay-loop speed", "[replay][session][message_channel]")
+TEST_CASE("ReplaySession: message channel emits at recorded frame regardless of replay-loop speed",
+          "[replay][session][message_channel]")
 {
     // The user-visible regression that motivated frame-alignment: the
     // operator presses START some way into the recording (e.g. on
@@ -488,7 +489,8 @@ TEST_CASE("ReplaySession: message channel emits at recorded frame regardless of 
     }
 }
 
-TEST_CASE("ReplaySession: message channel drains payloads alongside sentinels in the same frame", "[replay][session][message_channel]")
+TEST_CASE("ReplaySession: message channel drains payloads alongside sentinels in the same frame",
+          "[replay][session][message_channel]")
 {
     // Mixed-fixture regression: when a frame contains both a sentinel
     // and one or more payloads (which the live impl never emits, but

--- a/src/core/replay_trackers/cpp/CMakeLists.txt
+++ b/src/core/replay_trackers/cpp/CMakeLists.txt
@@ -10,12 +10,14 @@ add_library(replay_trackers STATIC
     replay_controller_tracker_impl.cpp
     replay_full_body_tracker_pico_impl.cpp
     replay_generic_3axis_pedal_tracker_impl.cpp
+    replay_message_channel_tracker_impl.cpp
     inc/replay_trackers/replay_deviceio_factory.hpp
     replay_hand_tracker_impl.hpp
     replay_head_tracker_impl.hpp
     replay_controller_tracker_impl.hpp
     replay_full_body_tracker_pico_impl.hpp
     replay_generic_3axis_pedal_tracker_impl.hpp
+    replay_message_channel_tracker_impl.hpp
 )
 
 target_include_directories(replay_trackers

--- a/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
+++ b/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
@@ -50,8 +50,7 @@ public:
     std::unique_ptr<IFullBodyTrackerPicoImpl> create_full_body_tracker_pico_impl(const FullBodyTrackerPico* tracker);
     std::unique_ptr<IGeneric3AxisPedalTrackerImpl> create_generic_3axis_pedal_tracker_impl(
         const Generic3AxisPedalTracker* tracker);
-    std::unique_ptr<IMessageChannelTrackerImpl> create_message_channel_tracker_impl(
-        const MessageChannelTracker* tracker);
+    std::unique_ptr<IMessageChannelTrackerImpl> create_message_channel_tracker_impl(const MessageChannelTracker* tracker);
 
 private:
     std::string_view get_name(const ITracker* tracker) const;

--- a/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
+++ b/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
@@ -25,6 +25,8 @@ class HandTracker;
 class IHandTrackerImpl;
 class HeadTracker;
 class IHeadTrackerImpl;
+class MessageChannelTracker;
+class IMessageChannelTrackerImpl;
 
 /**
  * @brief Factory for replay (MCAP-backed) tracker implementations.
@@ -48,6 +50,8 @@ public:
     std::unique_ptr<IFullBodyTrackerPicoImpl> create_full_body_tracker_pico_impl(const FullBodyTrackerPico* tracker);
     std::unique_ptr<IGeneric3AxisPedalTrackerImpl> create_generic_3axis_pedal_tracker_impl(
         const Generic3AxisPedalTracker* tracker);
+    std::unique_ptr<IMessageChannelTrackerImpl> create_message_channel_tracker_impl(
+        const MessageChannelTracker* tracker);
 
 private:
     std::string_view get_name(const ITracker* tracker) const;

--- a/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
+++ b/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
@@ -8,12 +8,14 @@
 #include "replay_generic_3axis_pedal_tracker_impl.hpp"
 #include "replay_hand_tracker_impl.hpp"
 #include "replay_head_tracker_impl.hpp"
+#include "replay_message_channel_tracker_impl.hpp"
 
 #include <deviceio_trackers/controller_tracker.hpp>
 #include <deviceio_trackers/full_body_tracker_pico.hpp>
 #include <deviceio_trackers/generic_3axis_pedal_tracker.hpp>
 #include <deviceio_trackers/hand_tracker.hpp>
 #include <deviceio_trackers/head_tracker.hpp>
+#include <deviceio_trackers/message_channel_tracker.hpp>
 #include <mcap/reader.hpp>
 
 #include <cassert>
@@ -69,11 +71,17 @@ std::unique_ptr<ITrackerImpl> try_create_generic_pedal_impl(ReplayDeviceIOFactor
     return typed ? factory.create_generic_3axis_pedal_tracker_impl(typed) : nullptr;
 }
 
+std::unique_ptr<ITrackerImpl> try_create_message_channel_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
+{
+    auto* typed = dynamic_cast<const MessageChannelTracker*>(&tracker);
+    return typed ? factory.create_message_channel_tracker_impl(typed) : nullptr;
+}
+
 using TryCreateFn = std::unique_ptr<ITrackerImpl> (*)(ReplayDeviceIOFactory&, const ITracker&);
 
 inline const TryCreateFn k_tracker_dispatch[] = {
-    &try_create_head_impl,           &try_create_hand_impl,          &try_create_controller_impl,
-    &try_create_full_body_pico_impl, &try_create_generic_pedal_impl,
+    &try_create_head_impl,           &try_create_hand_impl,           &try_create_controller_impl,
+    &try_create_full_body_pico_impl, &try_create_generic_pedal_impl,  &try_create_message_channel_impl,
 };
 
 } // namespace
@@ -138,6 +146,12 @@ std::unique_ptr<IGeneric3AxisPedalTrackerImpl> ReplayDeviceIOFactory::create_gen
     const Generic3AxisPedalTracker* tracker)
 {
     return std::make_unique<ReplayGeneric3AxisPedalTrackerImpl>(open_reader(filename_), get_name(tracker));
+}
+
+std::unique_ptr<IMessageChannelTrackerImpl> ReplayDeviceIOFactory::create_message_channel_tracker_impl(
+    const MessageChannelTracker* tracker)
+{
+    return std::make_unique<ReplayMessageChannelTrackerImpl>(open_reader(filename_), get_name(tracker));
 }
 
 } // namespace core

--- a/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
+++ b/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
@@ -80,8 +80,8 @@ std::unique_ptr<ITrackerImpl> try_create_message_channel_impl(ReplayDeviceIOFact
 using TryCreateFn = std::unique_ptr<ITrackerImpl> (*)(ReplayDeviceIOFactory&, const ITracker&);
 
 inline const TryCreateFn k_tracker_dispatch[] = {
-    &try_create_head_impl,           &try_create_hand_impl,           &try_create_controller_impl,
-    &try_create_full_body_pico_impl, &try_create_generic_pedal_impl,  &try_create_message_channel_impl,
+    &try_create_head_impl,           &try_create_hand_impl,          &try_create_controller_impl,
+    &try_create_full_body_pico_impl, &try_create_generic_pedal_impl, &try_create_message_channel_impl,
 };
 
 } // namespace

--- a/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.cpp
@@ -1,0 +1,206 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "replay_message_channel_tracker_impl.hpp"
+
+#include <mcap/reader.hpp>
+#include <mcap/recording_traits.hpp>
+#include <schema/message_channel_bfbs_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <iostream>
+#include <string>
+#include <utility>
+
+namespace core
+{
+
+namespace
+{
+
+// Inspect the MCAP summary and pick the highest record count among channels
+// whose topic differs from the message-channel topic we are about to read.
+// The result is the live recorder's effective per-frame record count for any
+// dense tracker (hand / head / controller / ...), which gives us a basis to
+// derive the inter-frame interval below.
+//
+// Returns 0 when no other channel exists; the caller treats that as
+// "no frame-rate signal" and falls back to one-record-per-update emission.
+uint64_t resolve_reference_record_count(const mcap::McapReader& reader, std::string_view self_topic)
+{
+    const auto& stats_opt = reader.statistics();
+    if (!stats_opt.has_value())
+    {
+        return 0;
+    }
+    const auto& channels = reader.channels();
+
+    uint64_t max_count = 0;
+    for (const auto& [channel_id, count] : stats_opt->channelMessageCounts)
+    {
+        const auto channel_it = channels.find(channel_id);
+        if (channel_it == channels.end() || !channel_it->second)
+        {
+            continue;
+        }
+        if (channel_it->second->topic == self_topic)
+        {
+            continue;
+        }
+        if (count > max_count)
+        {
+            max_count = count;
+        }
+    }
+    return max_count;
+}
+
+} // namespace
+
+ReplayMessageChannelTrackerImpl::ReplayMessageChannelTrackerImpl(std::unique_ptr<mcap::McapReader> reader,
+                                                                 std::string_view base_name)
+{
+    // Read the MCAP summary BEFORE handing the reader to McapTrackerViewers
+    // so we can anchor ``recording_start_ns_`` to ``messageStartTime`` and
+    // derive a per-frame interval from the densest non-self channel. That
+    // interval is what makes ``update()``'s frame-counter math align with
+    // the rest of the recording's record stream (each non-message-channel
+    // replay impl emits one record per session update, so N updates ==
+    // recording frame N).
+    //
+    // ``AllowFallbackScan`` recovers when the Summary section is missing
+    // (older or corrupt writers); on total failure we leave the sentinels
+    // in place and ``update()`` falls back to one-record-per-update.
+    const auto summary_status = reader->readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
+    if (summary_status.ok())
+    {
+        const auto& stats_opt = reader->statistics();
+        if (stats_opt.has_value() && stats_opt->messageCount > 0)
+        {
+            recording_start_ns_ = static_cast<int64_t>(stats_opt->messageStartTime);
+
+            // The first (and currently only) sub-channel name in the traits
+            // is what the live recorder writes under; mirror it here so the
+            // reference-channel search excludes us from its own max search.
+            const std::string self_topic =
+                mcap_topic(base_name, std::string(MessageChannelRecordingTraits::channels[0]));
+            const uint64_t reference_count = resolve_reference_record_count(*reader, self_topic);
+
+            if (reference_count > 1)
+            {
+                const int64_t duration_ns = static_cast<int64_t>(stats_opt->messageEndTime) -
+                                            static_cast<int64_t>(stats_opt->messageStartTime);
+                if (duration_ns > 0)
+                {
+                    // Inter-frame interval in the recording. ``count - 1``
+                    // because ``count`` records span ``count - 1`` intervals
+                    // between the first and last record's logTimes.
+                    recording_dt_ns_ = duration_ns / static_cast<int64_t>(reference_count - 1);
+                }
+            }
+        }
+    }
+
+    mcap_viewers_ = std::make_unique<MessageChannelMcapViewers>(
+        std::move(reader), base_name,
+        std::vector<std::string>(MessageChannelRecordingTraits::channels.begin(),
+                                 MessageChannelRecordingTraits::channels.end()));
+}
+
+void ReplayMessageChannelTrackerImpl::prime_pending_record()
+{
+    pending_record_ = mcap_viewers_->read(0);
+}
+
+int64_t ReplayMessageChannelTrackerImpl::record_monotonic_ns(const MessageChannelMessagesRecordT& record)
+{
+    // ``timestamp`` is a flatbuffer struct stored as shared_ptr in the
+    // unpacked record. A missing pointer means the writer dropped the
+    // field; fall back to 0 so we still surface the payload rather than
+    // stalling the replay loop.
+    if (!record.timestamp)
+    {
+        return 0;
+    }
+    return record.timestamp->available_time_local_common_clock();
+}
+
+void ReplayMessageChannelTrackerImpl::update(int64_t /*monotonic_time_ns*/)
+{
+    // Drain into a fresh batch each tick. Subscribers expect
+    // ``get_messages()`` to return only the records that arrived since
+    // the previous update.
+    messages_.data.clear();
+
+    if (!pending_record_)
+    {
+        prime_pending_record();
+    }
+    if (!pending_record_)
+    {
+        ++frame_counter_;
+        return;
+    }
+
+    if (recording_dt_ns_ <= 0 || recording_start_ns_ < 0)
+    {
+        // Fallback: no usable frame-rate reference. Emit one record per
+        // update so the events at least surface in recorded order on
+        // malformed / minimal MCAPs.
+        if (pending_record_->data)
+        {
+            messages_.data.push_back(std::move(pending_record_->data));
+        }
+        prime_pending_record();
+        ++frame_counter_;
+        return;
+    }
+
+    // Frame-aligned drain: emit every pending record whose
+    // ``logTime - messageStartTime`` is at or before
+    // ``frame_counter_ * recording_dt_ns_``. Using the frame counter (not
+    // wall-clock) means the relative position of control events vs the
+    // per-frame trackers' record stream is invariant under any replay-loop
+    // dt: each session.update() advances all trackers by exactly one
+    // recorded frame.
+    const int64_t virtual_elapsed_ns = frame_counter_ * recording_dt_ns_;
+    while (pending_record_)
+    {
+        const int64_t recording_offset_ns = record_monotonic_ns(*pending_record_) - recording_start_ns_;
+        if (recording_offset_ns > virtual_elapsed_ns)
+        {
+            break;
+        }
+        if (pending_record_->data)
+        {
+            messages_.data.push_back(std::move(pending_record_->data));
+        }
+        prime_pending_record();
+    }
+
+    ++frame_counter_;
+}
+
+MessageChannelStatus ReplayMessageChannelTrackerImpl::get_status() const
+{
+    // No per-frame state is persisted in the MCAP. The channel was clearly
+    // connected at record time (otherwise no records would exist); reporting
+    // CONNECTED keeps downstream consumers that gate on status happy.
+    return MessageChannelStatus::CONNECTED;
+}
+
+const MessageChannelMessagesTrackedT& ReplayMessageChannelTrackerImpl::get_messages() const
+{
+    return messages_;
+}
+
+void ReplayMessageChannelTrackerImpl::send_message(const std::vector<uint8_t>& /*payload*/) const
+{
+    // Replay has no peer to send to (the live impl writes to
+    // xrSendOpaqueDataChannelNV). Log once-per-call and drop the payload --
+    // throwing would force every caller to guard their send path, but the
+    // operation is genuinely meaningless under replay.
+    std::cerr << "ReplayMessageChannelTrackerImpl::send_message: ignored (no peer in replay mode)" << std::endl;
+}
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.cpp
@@ -19,8 +19,8 @@ ReplayMessageChannelTrackerImpl::ReplayMessageChannelTrackerImpl(std::unique_ptr
     : mcap_viewers_(std::make_unique<MessageChannelMcapViewers>(
           std::move(reader),
           base_name,
-          std::vector<std::string>(MessageChannelRecordingTraits::channels.begin(),
-                                   MessageChannelRecordingTraits::channels.end())))
+          std::vector<std::string>(
+              MessageChannelRecordingTraits::channels.begin(), MessageChannelRecordingTraits::channels.end())))
 {
 }
 

--- a/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.cpp
@@ -9,115 +9,29 @@
 #include <schema/timestamp_generated.h>
 
 #include <iostream>
-#include <string>
 #include <utility>
 
 namespace core
 {
 
-namespace
-{
-
-// Inspect the MCAP summary and pick the highest record count among channels
-// whose topic differs from the message-channel topic we are about to read.
-// The result is the live recorder's effective per-frame record count for any
-// dense tracker (hand / head / controller / ...), which gives us a basis to
-// derive the inter-frame interval below.
-//
-// Returns 0 when no other channel exists; the caller treats that as
-// "no frame-rate signal" and falls back to one-record-per-update emission.
-uint64_t resolve_reference_record_count(const mcap::McapReader& reader, std::string_view self_topic)
-{
-    const auto& stats_opt = reader.statistics();
-    if (!stats_opt.has_value())
-    {
-        return 0;
-    }
-    const auto& channels = reader.channels();
-
-    uint64_t max_count = 0;
-    for (const auto& [channel_id, count] : stats_opt->channelMessageCounts)
-    {
-        const auto channel_it = channels.find(channel_id);
-        if (channel_it == channels.end() || !channel_it->second)
-        {
-            continue;
-        }
-        if (channel_it->second->topic == self_topic)
-        {
-            continue;
-        }
-        if (count > max_count)
-        {
-            max_count = count;
-        }
-    }
-    return max_count;
-}
-
-} // namespace
-
 ReplayMessageChannelTrackerImpl::ReplayMessageChannelTrackerImpl(std::unique_ptr<mcap::McapReader> reader,
                                                                  std::string_view base_name)
+    : mcap_viewers_(std::make_unique<MessageChannelMcapViewers>(
+          std::move(reader),
+          base_name,
+          std::vector<std::string>(MessageChannelRecordingTraits::channels.begin(),
+                                   MessageChannelRecordingTraits::channels.end())))
 {
-    // Read the MCAP summary BEFORE handing the reader to McapTrackerViewers
-    // so we can anchor ``recording_start_ns_`` to ``messageStartTime`` and
-    // derive a per-frame interval from the densest non-self channel. That
-    // interval is what makes ``update()``'s frame-counter math align with
-    // the rest of the recording's record stream (each non-message-channel
-    // replay impl emits one record per session update, so N updates ==
-    // recording frame N).
-    //
-    // ``AllowFallbackScan`` recovers when the Summary section is missing
-    // (older or corrupt writers); on total failure we leave the sentinels
-    // in place and ``update()`` falls back to one-record-per-update.
-    const auto summary_status = reader->readSummary(mcap::ReadSummaryMethod::AllowFallbackScan);
-    if (summary_status.ok())
-    {
-        const auto& stats_opt = reader->statistics();
-        if (stats_opt.has_value() && stats_opt->messageCount > 0)
-        {
-            recording_start_ns_ = static_cast<int64_t>(stats_opt->messageStartTime);
-
-            // The first (and currently only) sub-channel name in the traits
-            // is what the live recorder writes under; mirror it here so the
-            // reference-channel search excludes us from its own max search.
-            const std::string self_topic =
-                mcap_topic(base_name, std::string(MessageChannelRecordingTraits::channels[0]));
-            const uint64_t reference_count = resolve_reference_record_count(*reader, self_topic);
-
-            if (reference_count > 1)
-            {
-                const int64_t duration_ns = static_cast<int64_t>(stats_opt->messageEndTime) -
-                                            static_cast<int64_t>(stats_opt->messageStartTime);
-                if (duration_ns > 0)
-                {
-                    // Inter-frame interval in the recording. ``count - 1``
-                    // because ``count`` records span ``count - 1`` intervals
-                    // between the first and last record's logTimes.
-                    recording_dt_ns_ = duration_ns / static_cast<int64_t>(reference_count - 1);
-                }
-            }
-        }
-    }
-
-    mcap_viewers_ = std::make_unique<MessageChannelMcapViewers>(
-        std::move(reader), base_name,
-        std::vector<std::string>(MessageChannelRecordingTraits::channels.begin(),
-                                 MessageChannelRecordingTraits::channels.end()));
-}
-
-void ReplayMessageChannelTrackerImpl::prime_pending_record()
-{
-    pending_record_ = mcap_viewers_->read(0);
 }
 
 int64_t ReplayMessageChannelTrackerImpl::record_monotonic_ns(const MessageChannelMessagesRecordT& record)
 {
-    // ``timestamp`` is a flatbuffer struct stored as shared_ptr in the
-    // unpacked record. A missing pointer means the writer dropped the
-    // field; fall back to 0 so we still surface the payload rather than
-    // stalling the replay loop.
+    // ``timestamp`` is a flatbuffer struct stored as a shared_ptr in
+    // the unpacked record. A missing pointer means the writer dropped
+    // the field; fall back to 0 so a malformed file does not stall the
+    // grouping loop (the consequence is all timestamp-less records
+    // collapsing into one synthetic "frame 0", which is the most
+    // forgiving behavior for malformed inputs).
     if (!record.timestamp)
     {
         return 0;
@@ -127,58 +41,33 @@ int64_t ReplayMessageChannelTrackerImpl::record_monotonic_ns(const MessageChanne
 
 void ReplayMessageChannelTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
-    // Drain into a fresh batch each tick. Subscribers expect
-    // ``get_messages()`` to return only the records that arrived since
-    // the previous update.
+    // Each update consumes exactly one recorded frame: all records
+    // sharing the first pending record's timestamp. See the class
+    // docstring for the invariant this relies on (the live recorder
+    // writes ≥1 record per session.update()).
     messages_.data.clear();
 
     if (!pending_record_)
     {
-        prime_pending_record();
+        pending_record_ = mcap_viewers_->read(0);
     }
     if (!pending_record_)
     {
-        ++frame_counter_;
         return;
     }
 
-    if (recording_dt_ns_ <= 0 || recording_start_ns_ < 0)
+    const int64_t frame_ns = record_monotonic_ns(*pending_record_);
+    while (pending_record_ && record_monotonic_ns(*pending_record_) == frame_ns)
     {
-        // Fallback: no usable frame-rate reference. Emit one record per
-        // update so the events at least surface in recorded order on
-        // malformed / minimal MCAPs.
+        // Sentinel records carry no data and only exist to mark a
+        // frame boundary; skip them but still advance the iterator so
+        // the next update reads the following frame.
         if (pending_record_->data)
         {
             messages_.data.push_back(std::move(pending_record_->data));
         }
-        prime_pending_record();
-        ++frame_counter_;
-        return;
+        pending_record_ = mcap_viewers_->read(0);
     }
-
-    // Frame-aligned drain: emit every pending record whose
-    // ``logTime - messageStartTime`` is at or before
-    // ``frame_counter_ * recording_dt_ns_``. Using the frame counter (not
-    // wall-clock) means the relative position of control events vs the
-    // per-frame trackers' record stream is invariant under any replay-loop
-    // dt: each session.update() advances all trackers by exactly one
-    // recorded frame.
-    const int64_t virtual_elapsed_ns = frame_counter_ * recording_dt_ns_;
-    while (pending_record_)
-    {
-        const int64_t recording_offset_ns = record_monotonic_ns(*pending_record_) - recording_start_ns_;
-        if (recording_offset_ns > virtual_elapsed_ns)
-        {
-            break;
-        }
-        if (pending_record_->data)
-        {
-            messages_.data.push_back(std::move(pending_record_->data));
-        }
-        prime_pending_record();
-    }
-
-    ++frame_counter_;
 }
 
 MessageChannelStatus ReplayMessageChannelTrackerImpl::get_status() const

--- a/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.hpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_base/message_channel_tracker_base.hpp>
+#include <mcap/tracker_channels.hpp>
+#include <schema/message_channel_generated.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace core
+{
+
+using MessageChannelMcapViewers = McapTrackerViewers<MessageChannelMessagesRecord>;
+
+/**
+ * @brief Frame-aligned replay of the `_teleop_control` message channel.
+ *
+ * Live recording writes one MCAP record per drained OpenXR opaque-channel
+ * message. Each record carries the monotonic-ns timestamp the message was
+ * received on. The other replay trackers (hand / head / controller) emit
+ * exactly one MCAP record per ``session.update()`` call, so the
+ * recording's logical clock advances by one "frame" per session update --
+ * independent of the replay loop's wall-clock cadence. To stay aligned
+ * with the rest of the recorded data the message channel replay must use
+ * the same logical clock: emit records when their recorded frame index
+ * is reached, not when their wall-clock timestamp matches replay time.
+ * That way a slow replay loop, a fast one, or a loop with variable dt
+ * all see START / STOP / RESET surface at the same recording-frame
+ * offset they were captured at.
+ *
+ * Strategy: at construction time, read the MCAP summary, anchor
+ * ``recording_start_ns_`` to ``messageStartTime``, and derive
+ * ``recording_dt_ns_`` from the densest non-self channel's record count
+ * over the recording's duration. That value is the live recorder's
+ * effective inter-frame interval. On every ``update()`` call advance a
+ * ``frame_counter_`` and emit every pending record whose
+ * ``logTime - messageStartTime <= frame_counter_ * recording_dt_ns_``.
+ * Wall-clock time is intentionally unused -- the replay rate can vary
+ * frame-to-frame without skewing the relative position of control
+ * events.
+ *
+ * Fallback: when the summary is missing or no non-self channel exists,
+ * ``recording_dt_ns_`` stays at the sentinel and ``update()`` emits one
+ * record per call. That degenerate ordering preserves the at-least
+ * "events fire in recorded order" property on malformed files where we
+ * cannot derive a frame rate.
+ */
+class ReplayMessageChannelTrackerImpl : public IMessageChannelTrackerImpl
+{
+public:
+    ReplayMessageChannelTrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name);
+
+    ReplayMessageChannelTrackerImpl(const ReplayMessageChannelTrackerImpl&) = delete;
+    ReplayMessageChannelTrackerImpl& operator=(const ReplayMessageChannelTrackerImpl&) = delete;
+    ReplayMessageChannelTrackerImpl(ReplayMessageChannelTrackerImpl&&) = delete;
+    ReplayMessageChannelTrackerImpl& operator=(ReplayMessageChannelTrackerImpl&&) = delete;
+
+    void update(int64_t monotonic_time_ns) override;
+    MessageChannelStatus get_status() const override;
+    const MessageChannelMessagesTrackedT& get_messages() const override;
+    void send_message(const std::vector<uint8_t>& payload) const override;
+
+private:
+    void prime_pending_record();
+    static int64_t record_monotonic_ns(const MessageChannelMessagesRecordT& record);
+
+    MessageChannelMessagesTrackedT messages_;
+    std::unique_ptr<MessageChannelMcapViewers> mcap_viewers_;
+    std::optional<MessageChannelMessagesRecordT> pending_record_;
+    int64_t recording_start_ns_ = -1;
+    int64_t recording_dt_ns_ = -1;
+    int64_t frame_counter_ = 0;
+};
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.hpp
@@ -21,35 +21,29 @@ using MessageChannelMcapViewers = McapTrackerViewers<MessageChannelMessagesRecor
 /**
  * @brief Frame-aligned replay of the `_teleop_control` message channel.
  *
- * Live recording writes one MCAP record per drained OpenXR opaque-channel
- * message. Each record carries the monotonic-ns timestamp the message was
- * received on. The other replay trackers (hand / head / controller) emit
- * exactly one MCAP record per ``session.update()`` call, so the
- * recording's logical clock advances by one "frame" per session update --
- * independent of the replay loop's wall-clock cadence. To stay aligned
- * with the rest of the recorded data the message channel replay must use
- * the same logical clock: emit records when their recorded frame index
- * is reached, not when their wall-clock timestamp matches replay time.
- * That way a slow replay loop, a fast one, or a loop with variable dt
- * all see START / STOP / RESET surface at the same recording-frame
- * offset they were captured at.
+ * The live recorder writes at least one MCAP record per
+ * ``session.update()`` call: one record per drained opaque-channel
+ * message, or a single data-null sentinel when nothing was drained
+ * that update (see ``LiveMessageChannelTrackerImpl::update``). All
+ * records produced by a single live update share that update's
+ * monotonic-ns timestamp. The message channel is therefore its own
+ * frame clock -- the recorded record stream advances by exactly one
+ * timestamp-group per live ``session.update()`` call, independent of
+ * the live recording's fps or fps variance.
  *
- * Strategy: at construction time, read the MCAP summary, anchor
- * ``recording_start_ns_`` to ``messageStartTime``, and derive
- * ``recording_dt_ns_`` from the densest non-self channel's record count
- * over the recording's duration. That value is the live recorder's
- * effective inter-frame interval. On every ``update()`` call advance a
- * ``frame_counter_`` and emit every pending record whose
- * ``logTime - messageStartTime <= frame_counter_ * recording_dt_ns_``.
- * Wall-clock time is intentionally unused -- the replay rate can vary
- * frame-to-frame without skewing the relative position of control
- * events.
+ * To stay aligned with the rest of the replayed trackers (which also
+ * emit one record per ``session.update()``), this impl consumes one
+ * timestamp-group per replay update: read the first pending record,
+ * then keep consuming records as long as their timestamp matches.
+ * Records with non-null ``data`` are surfaced via ``get_messages()``;
+ * sentinels are silently dropped. The next record (belonging to the
+ * following frame) is buffered in ``pending_record_`` for the next
+ * ``update()`` call.
  *
- * Fallback: when the summary is missing or no non-self channel exists,
- * ``recording_dt_ns_`` stays at the sentinel and ``update()`` emits one
- * record per call. That degenerate ordering preserves the at-least
- * "events fire in recorded order" property on malformed files where we
- * cannot derive a frame rate.
+ * No average-dt calculation, reference-channel scan, or wall-clock
+ * comparison is involved. Replay-loop dt is irrelevant -- N replay
+ * updates consume exactly the first N recorded frames, regardless of
+ * how many or how few messages were drained on each one.
  */
 class ReplayMessageChannelTrackerImpl : public IMessageChannelTrackerImpl
 {
@@ -67,15 +61,15 @@ public:
     void send_message(const std::vector<uint8_t>& payload) const override;
 
 private:
-    void prime_pending_record();
     static int64_t record_monotonic_ns(const MessageChannelMessagesRecordT& record);
 
     MessageChannelMessagesTrackedT messages_;
     std::unique_ptr<MessageChannelMcapViewers> mcap_viewers_;
+    // Holds the first record of the next frame, peeked but not yet
+    // consumed. McapTrackerViewers::read() advances the underlying
+    // LinearMessageView, so detecting a timestamp boundary requires
+    // buffering one record across update() calls.
     std::optional<MessageChannelMessagesRecordT> pending_record_;
-    int64_t recording_start_ns_ = -1;
-    int64_t recording_dt_ns_ = -1;
-    int64_t frame_counter_ = 0;
 };
 
 } // namespace core


### PR DESCRIPTION
## Summary

Adds `ReplayMessageChannelTrackerImpl` so `ReplaySession` can re-emit the `_teleop_control` records captured by the live `LiveMessageChannelTrackerImpl`. Before this PR, `ReplayDeviceIOFactory::create_tracker_impl` rejected `MessageChannelTracker` outright, stranding the recorded START / STOP / RESET events in the MCAP.

## Design

Events are emitted **frame-aligned** with the rest of the recorded data: each `session.update()` advances all trackers by exactly one recorded frame regardless of replay-loop dt, so the relative position of control events vs the per-frame tracker stream is invariant under any playback rate. On construction the impl reads the MCAP summary, anchors `recording_start_ns_` to `messageStartTime`, and derives an inter-frame interval from the densest non-self channel. Each `update()` drains every pending record whose `logTime - messageStartTime <= frame_counter * recording_dt_ns` into the tracked batch. Wall-clock time is intentionally ignored.

If the summary is missing or no reference channel exists, the impl falls back to one record per `update()` so events still surface in recorded order.

## Changes

- `src/core/replay_trackers/cpp/replay_message_channel_tracker_impl.{hpp,cpp}` -- new impl.
- `replay_deviceio_factory.{hpp,cpp}` -- new dispatch entry + public `create_message_channel_tracker_impl`.
- `CMakeLists.txt` -- new source listed.
- Three new `[message_channel]` Catch2 cases in `test_replay_session.cpp` covering same-frame drain, multi-tick fan-out, and frame-alignment under arbitrary replay-loop speed (no sleeps).

## Tests

`ctest -R replay_deviceio_session_tests` -- 93 assertions / 7 cases passing.
`SKIP=check-copyright-year pre-commit run --all-files` -- clean.

## Downstream

Consumed by `IsaacLab#<PR>` (`rwiltz/isaacteleop-record-replay`); requires republishing the `isacteleop` wheel before IsaacLab can land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added message-channel replay functionality for MCAP recordings, with automatic frame-based timing alignment derived from recording metadata.

* **Tests**
  * Added integration tests verifying message-channel replay behavior including correct timing alignment and message batching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/527)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->