### PR TITLE
deps: bump @nvidia/cloudxr to 6.2.0

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -6,7 +6,7 @@
 # CloudXR Docker Images and Configs
 ###########################################################
 CXR_RUNTIME_SDK_VERSION=6.1.0
-CXR_WEB_SDK_VERSION=6.1.0
+CXR_WEB_SDK_VERSION=6.2.0
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 
 ###########################################################

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudxr-isaac-lab-teleop",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "private": true,
   "description": "NVIDIA Isaac Teleop Web Client",
   "author": "NVIDIA Corporation",
@@ -20,7 +20,7 @@
     "clean": "rimraf dist"
   },
   "dependencies": {
-    "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.1.0.tgz",
+    "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.2.0.tgz",
     "@preact/signals-react": "^2.2.0",
     "@react-three/drei": "^10.6.1",
     "@react-three/fiber": "^9.3.0",


### PR DESCRIPTION
SDK supports haptics. Runtime updates required to enable controller haptics. A follow up client app update is also recommended. Suggest to cherrypick 6.2.0 into 1.2 release if necessary.