### PR TITLE
[TeleViz] expose required_extensions + get_oxr_handles for TeleopSession

### DIFF
--- a/src/viz/python/session_bindings.cpp
+++ b/src/viz/python/session_bindings.cpp
@@ -63,6 +63,7 @@ void bind_session(py::module_& m)
         .def_readwrite("xr_system_wait_seconds", &viz::VizSession::Config::xr_system_wait_seconds)
         .def_readwrite("xr_near_z", &viz::VizSession::Config::xr_near_z)
         .def_readwrite("xr_far_z", &viz::VizSession::Config::xr_far_z)
+        .def_readwrite("required_extensions", &viz::VizSession::Config::required_extensions)
         .def_readwrite("gpu_timing", &viz::VizSession::Config::gpu_timing)
         .def_property(
             "clear_color",
@@ -120,6 +121,24 @@ Construct via ``VizSession.create(config)``. Add layers with
         .def("has_xr_time_conversion", &viz::VizSession::has_xr_time_conversion)
         .def("head_pose_now", &viz::VizSession::head_pose_now,
              "Current head pose (kXr only). None on tracking loss or missing time-conversion ext.")
+        // OpenXR handle bundle for sharing with TeleopSession / DeviceIOSession.
+        // Returns (instance, session, space, xrGetInstanceProcAddr) as raw
+        // uint64_t — pass to ``OpenXRSessionHandles(*tuple)`` on the Python
+        // side. None unless in kXr mode and the backend is initialized.
+        .def(
+            "get_oxr_handles",
+            [](const viz::VizSession& s) -> py::object
+            {
+                auto h = s.get_oxr_handles();
+                if (!h.has_value())
+                {
+                    return py::none();
+                }
+                return py::make_tuple(reinterpret_cast<uint64_t>(h->instance), reinterpret_cast<uint64_t>(h->session),
+                                      reinterpret_cast<uint64_t>(h->space),
+                                      reinterpret_cast<uint64_t>(h->xrGetInstanceProcAddr));
+            },
+            "OpenXR (instance, session, space, proc_addr) as raw uint64 tuple, or None outside kXr.")
         // Raw handle accessors as integers — for callers wiring Televiz into
         // a foreign Vulkan / OpenXR app. Most users won't touch these.
         .def_property_readonly(


### PR DESCRIPTION
Two bindings on VizSession needed to share an OpenXR session with TeleopSession / DeviceIOSession from Python:

- VizSessionConfig.required_extensions (read/write list[str]): forwarded to XrBackend::Config::extra_xr_extensions at instance creation. Lets callers request extra XR extensions TeleopSession needs

- VizSession.get_oxr_handles() -> (instance, session, space, proc_addr) | None: returns the live XR handles as raw uint64. Caller constructs isaacteleop.oxr.OpenXRSessionHandles(*tuple) and hands it to DeviceIOSession.run(trackers, handles).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration field for managing required extensions
  * Added method to retrieve OpenXR handle values for advanced integration scenarios

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/531)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->