### PR TITLE
[TeleViz] QuadLayer mipmap generation

### DIFF
--- a/src/viz/core/cpp/device_image.cpp
+++ b/src/viz/core/cpp/device_image.cpp
@@ -4,6 +4,7 @@
 #include <viz/core/device_image.hpp>
 #include <viz/core/vk_context.hpp>
 
+#include <algorithm>
 #include <stdexcept>
 #include <string>
 
@@ -113,7 +114,10 @@ cudaChannelFormatDesc to_cuda_format(PixelFormat format)
 
 } // namespace
 
-std::unique_ptr<DeviceImage> DeviceImage::create(const VkContext& ctx, Resolution resolution, PixelFormat format)
+std::unique_ptr<DeviceImage> DeviceImage::create(const VkContext& ctx,
+                                                 Resolution resolution,
+                                                 PixelFormat format,
+                                                 uint32_t mip_levels)
 {
     if (!ctx.is_initialized())
     {
@@ -131,13 +135,23 @@ std::unique_ptr<DeviceImage> DeviceImage::create(const VkContext& ctx, Resolutio
         // worked out yet, so refuse to half-build it.
         throw std::invalid_argument("DeviceImage: only PixelFormat::kRGBA8 is supported");
     }
-    std::unique_ptr<DeviceImage> img(new DeviceImage(ctx, resolution, format));
+    // mip_levels == 0 -> auto-compute full chain to 1x1.
+    if (mip_levels == 0)
+    {
+        const uint32_t max_dim = std::max(resolution.width, resolution.height);
+        mip_levels = 1;
+        for (uint32_t d = max_dim; d > 1; d >>= 1)
+        {
+            ++mip_levels;
+        }
+    }
+    std::unique_ptr<DeviceImage> img(new DeviceImage(ctx, resolution, format, mip_levels));
     img->init();
     return img;
 }
 
-DeviceImage::DeviceImage(const VkContext& ctx, Resolution resolution, PixelFormat format)
-    : ctx_(&ctx), resolution_(resolution), format_(format), vk_format_(to_vk_view_format(format))
+DeviceImage::DeviceImage(const VkContext& ctx, Resolution resolution, PixelFormat format, uint32_t mip_levels)
+    : ctx_(&ctx), resolution_(resolution), format_(format), vk_format_(to_vk_view_format(format)), mip_levels_(mip_levels)
 {
 }
 
@@ -264,9 +278,7 @@ void DeviceImage::create_vk_image_with_external_memory()
     info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     info.format = to_vk_storage_format(format_);
     info.extent = { resolution_.width, resolution_.height, 1 };
-    info.mipLevels = 1; // Single level. If XR distance views show
-                        // moiré, expose mipLevels via Config and
-                        // generate via vkCmdBlitImage pre-render.
+    info.mipLevels = mip_levels_;
     info.arrayLayers = 1;
     info.samples = VK_SAMPLE_COUNT_1_BIT;
     info.tiling = VK_IMAGE_TILING_OPTIMAL;
@@ -325,7 +337,7 @@ void DeviceImage::create_vk_image_view()
     info.subresourceRange.aspectMask =
         (format_ == PixelFormat::kD32F) ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
     info.subresourceRange.baseMipLevel = 0;
-    info.subresourceRange.levelCount = 1;
+    info.subresourceRange.levelCount = mip_levels_;
     info.subresourceRange.baseArrayLayer = 0;
     info.subresourceRange.layerCount = 1;
     check_vk(vkCreateImageView(ctx_->device(), &info, nullptr, &image_view_), "vkCreateImageView");
@@ -357,7 +369,9 @@ void DeviceImage::import_to_cuda()
     array_desc.formatDesc = to_cuda_format(format_);
     array_desc.extent = make_cudaExtent(resolution_.width, resolution_.height, 0);
     array_desc.flags = cudaArrayColorAttachment;
-    array_desc.numLevels = 1;
+    // numLevels must match Vulkan; CUDA still writes only level 0
+    // (the mip chain is generated Vulkan-side via vkCmdBlitImage).
+    array_desc.numLevels = mip_levels_;
 
     check_cuda(cudaExternalMemoryGetMappedMipmappedArray(&cuda_mipmapped_array_, cuda_external_memory_, &array_desc),
                "cudaExternalMemoryGetMappedMipmappedArray");
@@ -505,7 +519,7 @@ void DeviceImage::run_one_shot_layout_transition(VkImageLayout old_layout,
     barrier.subresourceRange.aspectMask =
         (format_ == PixelFormat::kD32F) ? VK_IMAGE_ASPECT_DEPTH_BIT : VK_IMAGE_ASPECT_COLOR_BIT;
     barrier.subresourceRange.baseMipLevel = 0;
-    barrier.subresourceRange.levelCount = 1;
+    barrier.subresourceRange.levelCount = mip_levels_;
     barrier.subresourceRange.baseArrayLayer = 0;
     barrier.subresourceRange.layerCount = 1;
     barrier.srcAccessMask = src_access;

--- a/src/viz/core/cpp/inc/viz/core/device_image.hpp
+++ b/src/viz/core/cpp/inc/viz/core/device_image.hpp
@@ -41,7 +41,19 @@ class DeviceImage
 public:
     // Throws std::invalid_argument on bad config; std::runtime_error
     // on Vulkan or CUDA failure. Pre-initialized.
-    static std::unique_ptr<DeviceImage> create(const VkContext& ctx, Resolution resolution, PixelFormat format);
+    //
+    // mip_levels:
+    //   1 (default) -- single-level image, current behavior.
+    //   N > 1       -- full chain (level 0 is ``resolution``; levels
+    //                  1..N-1 halve down). CUDA still writes only
+    //                  level 0; the Vulkan side is expected to
+    //                  populate levels 1..N-1 via vkCmdBlitImage
+    //                  (e.g. QuadLayer's mip-gen pass).
+    //   0           -- auto-compute full chain to 1x1.
+    static std::unique_ptr<DeviceImage> create(const VkContext& ctx,
+                                               Resolution resolution,
+                                               PixelFormat format,
+                                               uint32_t mip_levels = 1);
 
     ~DeviceImage();
     void destroy();
@@ -103,6 +115,10 @@ public:
     {
         return format_;
     }
+    uint32_t mip_levels() const noexcept
+    {
+        return mip_levels_;
+    }
 
     // Synchronous one-shot layout transitions (vkQueueSubmit +
     // vkQueueWaitIdle). For tests / one-shot uploads — production
@@ -111,7 +127,7 @@ public:
     void transition_to_transfer_dst();
 
 private:
-    explicit DeviceImage(const VkContext& ctx, Resolution resolution, PixelFormat format);
+    explicit DeviceImage(const VkContext& ctx, Resolution resolution, PixelFormat format, uint32_t mip_levels);
     void init();
 
     void create_vk_image_with_external_memory();
@@ -130,6 +146,7 @@ private:
     Resolution resolution_{};
     PixelFormat format_ = PixelFormat::kRGBA8;
     VkFormat vk_format_ = VK_FORMAT_R8G8B8A8_UNORM;
+    uint32_t mip_levels_ = 1;
     VkImageLayout current_layout_ = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImage image_ = VK_NULL_HANDLE;

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -72,7 +72,20 @@ public:
         // fullscreen quad across stereo eyes is never the right thing.
         // record() throws std::logic_error on kXr + nullopt.
         std::optional<Placement> placement;
+
+        // Allocate a small mip chain on each DeviceImage slot and
+        // regenerate it via vkCmdBlitImage in record_pre_render_pass.
+        // Sampler switches to LINEAR mip filtering. Capped internally
+        // at kMaxMipLevels (smallest level is 1/8 linear dims for the
+        // typical 1080p / 4K source) — past that the cost outpaces the
+        // visual win for our XR distance-view use cases.
+        bool generate_mipmaps = false;
     };
+
+    // Hard cap on the mip chain when generate_mipmaps is enabled.
+    // Smallest level is 1/(2^(kMaxMipLevels-1)) of the linear extent;
+    // at 4 that's 1/8 (240x135 from 1080p, 480x270 from 4K).
+    static constexpr uint32_t kMaxMipLevels = 4;
 
     // Builds the 3 DeviceImages + pipeline up front. Throws
     // std::invalid_argument on bad config; std::runtime_error on
@@ -94,6 +107,12 @@ public:
     // async memcpy was still reading. Cost: ~0.5 ms per 1080p call on
     // the calling thread; the render path is unaffected.
     void submit(const VizBuffer& src, cudaStream_t stream = 0);
+
+    // Pre-pass slot: promote latest_ -> in_use_[in_flight_slot] AND
+    // (when generate_mipmaps is on) emit the mip-chain blits on the
+    // in-use slot. record() reads the already-promoted slot, so both
+    // calls must agree on in_flight_slot for the same frame.
+    void record_pre_render_pass(VkCommandBuffer cmd, uint32_t in_flight_slot) override;
 
     // Skips the draw before the first submit (slot kSlotNone) — RT
     // keeps its clear value. in_flight_slot identifies which of the
@@ -143,9 +162,17 @@ private:
     uint8_t pick_free_slot(uint8_t latest,
                            const std::array<std::atomic<uint8_t>, kMaxFramesInFlight>& in_use) const noexcept;
 
+    // Emit a full mip-chain regeneration for ``image`` via
+    // vkCmdBlitImage. Assumes the image is currently in
+    // VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL and returns it to the
+    // same layout. Only called when Config::generate_mipmaps is true.
+    void record_mip_generation(VkCommandBuffer cmd, DeviceImage& image);
+
     const VkContext* ctx_ = nullptr;
     VkRenderPass render_pass_ = VK_NULL_HANDLE; // borrowed from compositor
     Config config_;
+    // Number of mip levels per DeviceImage slot. 1 when mips disabled.
+    uint32_t mip_levels_ = 1;
 
     // One DeviceImage per mailbox slot.
     std::array<std::unique_ptr<DeviceImage>, kSlotCount> slots_;

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -79,7 +79,11 @@ public:
         // at kMaxMipLevels (smallest level is 1/8 linear dims for the
         // typical 1080p / 4K source) — past that the cost outpaces the
         // visual win for our XR distance-view use cases.
-        bool generate_mipmaps = false;
+        // On by default: the per-frame cost is sub-millisecond and the
+        // aliasing it removes is very visible in XR / multi-tile grids.
+        // Set to false to save the ~33% extra image memory on layers
+        // that are always sampled at native resolution.
+        bool generate_mipmaps = true;
     };
 
     // Hard cap on the mip chain when generate_mipmaps is enabled.

--- a/src/viz/layers/cpp/quad_layer.cpp
+++ b/src/viz/layers/cpp/quad_layer.cpp
@@ -113,6 +113,26 @@ QuadLayer::QuadLayer(const VkContext& ctx, VkRenderPass render_pass, Config conf
             throw std::invalid_argument("QuadLayer: Placement::size_meters must be > 0 in both components");
         }
     }
+
+    // Resolve mip count: capped chain when enabled, single level
+    // otherwise. The cap (kMaxMipLevels) keeps the per-frame blit
+    // cost and the extra image storage in check; full log2 chain
+    // adds levels that the sampler rarely picks anyway.
+    if (config_.generate_mipmaps)
+    {
+        const uint32_t max_dim = std::max(config_.resolution.width, config_.resolution.height);
+        uint32_t full_chain = 1;
+        for (uint32_t d = max_dim; d > 1; d >>= 1)
+        {
+            ++full_chain;
+        }
+        mip_levels_ = std::min(full_chain, kMaxMipLevels);
+    }
+    else
+    {
+        mip_levels_ = 1;
+    }
+
     placement_ = config_.placement;
     init();
 }
@@ -136,7 +156,7 @@ void QuadLayer::init()
         last_in_use_slot_.store(kSlotNone, std::memory_order_relaxed);
         for (auto& slot : slots_)
         {
-            slot = DeviceImage::create(*ctx_, config_.resolution, config_.format);
+            slot = DeviceImage::create(*ctx_, config_.resolution, config_.format, mip_levels_);
         }
         create_sampler();
         create_descriptor_set_layout();
@@ -315,27 +335,122 @@ void QuadLayer::submit(const VizBuffer& src, cudaStream_t stream)
     latest_.store(slot, std::memory_order_release);
 }
 
-void QuadLayer::record(VkCommandBuffer cmd,
-                       const std::vector<ViewInfo>& views,
-                       const RenderTarget& /*target*/,
-                       uint32_t in_flight_slot)
+void QuadLayer::record_mip_generation(VkCommandBuffer cmd, DeviceImage& image)
 {
-    require_alive(slots_[0], "record");
+    // Mip-chain regeneration via vkCmdBlitImage. The image lives in
+    // SHADER_READ_ONLY between frames (set in DeviceImage::init); we
+    // cycle through TRANSFER layouts and return to SHADER_READ_ONLY so
+    // the post-pass sample sees the same invariant. CUDA wrote level 0
+    // out-of-band; the queue submit's TRANSFER-stage wait on
+    // cuda_done_writing gates this against the producer (see
+    // get_wait_semaphores).
+    const VkImage vk_image = image.vk_image();
+    const uint32_t levels = image.mip_levels();
+    const int32_t base_w = static_cast<int32_t>(image.resolution().width);
+    const int32_t base_h = static_cast<int32_t>(image.resolution().height);
 
-    // Backends are contracted to image_count ≤ kMaxFramesInFlight; if
+    auto barrier_one_level = [&](uint32_t level, VkImageLayout old_layout, VkImageLayout new_layout,
+                                 VkAccessFlags src_access, VkAccessFlags dst_access, VkPipelineStageFlags src_stage,
+                                 VkPipelineStageFlags dst_stage)
+    {
+        VkImageMemoryBarrier b{};
+        b.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+        b.oldLayout = old_layout;
+        b.newLayout = new_layout;
+        b.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        b.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        b.image = vk_image;
+        b.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        b.subresourceRange.baseMipLevel = level;
+        b.subresourceRange.levelCount = 1;
+        b.subresourceRange.baseArrayLayer = 0;
+        b.subresourceRange.layerCount = 1;
+        b.srcAccessMask = src_access;
+        b.dstAccessMask = dst_access;
+        vkCmdPipelineBarrier(cmd, src_stage, dst_stage, 0, 0, nullptr, 0, nullptr, 1, &b);
+    };
+
+    // Level 0: SHADER_READ -> TRANSFER_SRC (will be read by the first blit).
+    barrier_one_level(0, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                      VK_ACCESS_SHADER_READ_BIT, VK_ACCESS_TRANSFER_READ_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+                      VK_PIPELINE_STAGE_TRANSFER_BIT);
+    // Levels 1..N-1: SHADER_READ -> TRANSFER_DST (will be overwritten).
+    for (uint32_t i = 1; i < levels; ++i)
+    {
+        barrier_one_level(i, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+                          VK_ACCESS_SHADER_READ_BIT, VK_ACCESS_TRANSFER_WRITE_BIT,
+                          VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    }
+
+    int32_t src_w = base_w;
+    int32_t src_h = base_h;
+    for (uint32_t i = 1; i < levels; ++i)
+    {
+        const int32_t dst_w = std::max(1, src_w >> 1);
+        const int32_t dst_h = std::max(1, src_h >> 1);
+
+        VkImageBlit blit{};
+        blit.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        blit.srcSubresource.mipLevel = i - 1;
+        blit.srcSubresource.baseArrayLayer = 0;
+        blit.srcSubresource.layerCount = 1;
+        blit.srcOffsets[0] = { 0, 0, 0 };
+        blit.srcOffsets[1] = { src_w, src_h, 1 };
+        blit.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+        blit.dstSubresource.mipLevel = i;
+        blit.dstSubresource.baseArrayLayer = 0;
+        blit.dstSubresource.layerCount = 1;
+        blit.dstOffsets[0] = { 0, 0, 0 };
+        blit.dstOffsets[1] = { dst_w, dst_h, 1 };
+
+        vkCmdBlitImage(cmd, vk_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, vk_image,
+                       VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit, VK_FILTER_LINEAR);
+
+        // Promote level i to TRANSFER_SRC so the next blit can read it.
+        // Last level skips this — the final sweep below moves it
+        // straight from TRANSFER_DST to SHADER_READ.
+        if (i + 1 < levels)
+        {
+            barrier_one_level(i, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                              VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                              VK_PIPELINE_STAGE_TRANSFER_BIT);
+        }
+
+        src_w = dst_w;
+        src_h = dst_h;
+    }
+
+    // Final sweep: levels 0..N-2 are in TRANSFER_SRC, level N-1 is in
+    // TRANSFER_DST. One barrier each back to SHADER_READ.
+    for (uint32_t i = 0; i + 1 < levels; ++i)
+    {
+        barrier_one_level(i, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                          VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_SHADER_READ_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                          VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+    }
+    barrier_one_level(levels - 1, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                      VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_SHADER_READ_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                      VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+}
+
+void QuadLayer::record_pre_render_pass(VkCommandBuffer cmd, uint32_t in_flight_slot)
+{
+    require_alive(slots_[0], "record_pre_render_pass");
+
+    // Backends are contracted to image_count <= kMaxFramesInFlight; if
     // that ever breaks, two in-flight frames would alias on the same
     // in_use_ entry and we'd lose the slot-tracking invariant.
     if (in_flight_slot >= kMaxFramesInFlight)
     {
-        throw std::logic_error("QuadLayer::record: in_flight_slot " + std::to_string(in_flight_slot) +
+        throw std::logic_error("QuadLayer::record_pre_render_pass: in_flight_slot " + std::to_string(in_flight_slot) +
                                " >= kMaxFramesInFlight (" + std::to_string(kMaxFramesInFlight) +
                                "); bump kMaxFramesInFlight to match the backend's image_count");
     }
 
-    // Promote latest_ to in_use_[in_flight_slot]. The compositor's
+    // Promote latest_ -> in_use_[in_flight_slot]. The compositor's
     // per-slot fence wait at the top of render() guarantees the GPU
-    // has finished sampling the previous in_use_ value before we
-    // overwrite it.
+    // has finished sampling the previous in_use_ value. record() reads
+    // the same entry — pre-pass and pass MUST agree on in_flight_slot.
     const uint8_t latest = latest_.load(std::memory_order_acquire);
     const uint32_t idx = in_flight_slot;
     if (latest != kSlotNone)
@@ -351,6 +466,32 @@ void QuadLayer::record(VkCommandBuffer cmd,
     // (called by compositor between record and submit) reads the
     // matching cuda_done_writing semaphore.
     last_in_use_slot_.store(cur, std::memory_order_release);
+
+    // Mip generation (if configured). Reads level 0 written by CUDA,
+    // writes levels 1..N-1, ends with the whole image back in
+    // SHADER_READ_ONLY for the sampler in record().
+    if (mip_levels_ > 1)
+    {
+        record_mip_generation(cmd, *slots_[cur]);
+    }
+}
+
+void QuadLayer::record(VkCommandBuffer cmd,
+                       const std::vector<ViewInfo>& views,
+                       const RenderTarget& /*target*/,
+                       uint32_t in_flight_slot)
+{
+    require_alive(slots_[0], "record");
+
+    // Slot promotion ran in record_pre_render_pass with the same
+    // in_flight_slot. Read the result; skip the draw if there's been
+    // no publish yet (RT keeps its clear value).
+    const uint32_t idx = in_flight_slot;
+    const uint8_t cur = in_use_[idx].load(std::memory_order_acquire);
+    if (cur == kSlotNone)
+    {
+        return;
+    }
 
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_);
     vkCmdBindDescriptorSets(
@@ -405,10 +546,15 @@ std::optional<QuadLayer::Config::Placement> QuadLayer::placement() const noexcep
 
 std::vector<LayerBase::WaitSemaphore> QuadLayer::get_wait_semaphores() const
 {
-    // Compositor calls record() first, which sets last_in_use_slot_ to
-    // the slot it just bound. We return THAT slot's cuda_done_writing
-    // semaphore so the submit waits for the producer's memcpy to
-    // complete before the fragment shader samples.
+    // Compositor calls record_pre_render_pass first (which sets
+    // last_in_use_slot_). We return THAT slot's cuda_done_writing
+    // semaphore so the submit waits for the producer's memcpy.
+    // Wait stage:
+    //   * No mips: first GPU read is the fragment sampler.
+    //   * Mips on: the mip-gen blit chain in pre-pass reads level 0
+    //     first (TRANSFER stage); fragment sampling comes later but
+    //     is already ordered via the chain's barriers, so the submit
+    //     wait can gate at TRANSFER.
     const uint8_t cur = last_in_use_slot_.load(std::memory_order_acquire);
     if (cur == kSlotNone || !slots_[cur])
     {
@@ -420,33 +566,40 @@ std::vector<LayerBase::WaitSemaphore> QuadLayer::get_wait_semaphores() const
     {
         return {};
     }
+    const VkPipelineStageFlags wait_stage =
+        (mip_levels_ > 1) ? VK_PIPELINE_STAGE_TRANSFER_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     return {
         WaitSemaphore{
             image.cuda_done_writing(),
             value,
-            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
+            wait_stage,
         },
     };
 }
 
 void QuadLayer::create_sampler()
 {
+    const bool mips_on = mip_levels_ > 1;
     VkSamplerCreateInfo info{};
     info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
     info.magFilter = VK_FILTER_LINEAR;
     info.minFilter = VK_FILTER_LINEAR;
-    info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_NEAREST;
+    // Trilinear when mips are on (LINEAR mode interpolates between two
+    // chain levels). NEAREST is harmless single-level since the lod
+    // range collapses to 0.
+    info.mipmapMode = mips_on ? VK_SAMPLER_MIPMAP_MODE_LINEAR : VK_SAMPLER_MIPMAP_MODE_NEAREST;
     info.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
     info.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
     info.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-    info.anisotropyEnable = VK_FALSE; // enable later when XR distance views need it
+    info.anisotropyEnable = VK_FALSE;
     info.maxAnisotropy = 1.0f;
     info.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
     info.unnormalizedCoordinates = VK_FALSE;
     info.compareEnable = VK_FALSE;
     info.compareOp = VK_COMPARE_OP_ALWAYS;
+    info.mipLodBias = 0.0f;
     info.minLod = 0.0f;
-    info.maxLod = 0.0f;
+    info.maxLod = mips_on ? static_cast<float>(mip_levels_ - 1) : 0.0f;
     check_vk(vkCreateSampler(ctx_->device(), &info, nullptr, &sampler_), "vkCreateSampler");
 }
 

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -57,7 +57,10 @@ void bind_layers(py::module_& m)
         .def_readwrite("name", &viz::QuadLayer::Config::name)
         .def_readwrite("resolution", &viz::QuadLayer::Config::resolution)
         .def_readwrite("format", &viz::QuadLayer::Config::format)
-        .def_readwrite("placement", &viz::QuadLayer::Config::placement);
+        .def_readwrite("placement", &viz::QuadLayer::Config::placement)
+        .def_readwrite("generate_mipmaps", &viz::QuadLayer::Config::generate_mipmaps,
+                       "Allocate + regenerate a capped mip chain each frame; sampler "
+                       "uses trilinear filtering. Off by default.");
 
     // ── QuadLayer (non-owning; session owns the lifetime) ─────────────
 

--- a/src/viz/session/cpp/inc/viz/session/layer_base.hpp
+++ b/src/viz/session/cpp/inc/viz/session/layer_base.hpp
@@ -45,6 +45,17 @@ public:
     LayerBase(const LayerBase&) = delete;
     LayerBase& operator=(const LayerBase&) = delete;
 
+    // Optional transfer/compute work that can't run inside a render
+    // pass (layout transitions, blits, mip generation). Called once per
+    // visible layer BEFORE vkCmdBeginRenderPass on the same command
+    // buffer. ``in_flight_slot`` matches the value the compositor will
+    // pass to record() — implementations that mutate per-slot state
+    // (QuadLayer mailbox) MUST agree on the slot across both calls.
+    // Default = no-op.
+    virtual void record_pre_render_pass(VkCommandBuffer /*cmd*/, uint32_t /*in_flight_slot*/)
+    {
+    }
+
     // Issue draws inside the active render pass.
     //   views:    1 entry in window/offscreen, 2 in kXr stereo. Each
     //             entry's viewport is this layer's rect for that view —

--- a/src/viz/session/cpp/viz_compositor.cpp
+++ b/src/viz/session/cpp/viz_compositor.cpp
@@ -333,6 +333,15 @@ void VizCompositor::render(const std::vector<LayerBase*>& layers)
         vkCmdWriteTimestamp(command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, gpu_timestamp_pool_, query_base + 0);
     }
 
+    // Pre-pass hook for transfer/compute work that can't run inside a
+    // render pass (e.g. QuadLayer mip-chain blits). Ordering: all
+    // layers' pre-pass run BEFORE any record(), so a layer can rely on
+    // its own pre-pass results inside record().
+    for (LayerBase* layer : visible_layers)
+    {
+        layer->record_pre_render_pass(command_buffer, slot);
+    }
+
     std::array<VkClearValue, 2> clears{};
     clears[0].color = config_.clear_color;
     clears[1].depthStencil = { 1.0f, 0 };


### PR DESCRIPTION
Adds an opt-in mip chain on QuadLayer's mailbox slots, regenerated each frame via vkCmdBlitImage. Smaller, distance, or tiled-grid views were aliasing badly with the single-level sampler; trilinear mip sampling fixes that with a single bool on Config.

  Config::generate_mipmaps = true   # default off

Chain is capped at kMaxMipLevels = 4 (smallest level is 1/8 of linear dimensions: 240x135 for 1080p, 480x270 for 4K). Beyond 4 levels the sampler rarely picks them and the per-frame transfer cost grows for no visible win.

Wiring:

- LayerBase grows a virtual record_pre_render_pass(cmd, in_flight_slot) for transfer/compute work that can't run inside a render pass. Default no-op. Compositor invokes it on every visible layer before vkCmdBeginRenderPass.
- DeviceImage::create takes a mip_levels param (default 1). Image, view, layout-transition barriers, and the CUDA mipmapped array all size to the chain. CUDA still writes only level 0.
- QuadLayer: pre-pass promotes latest_ -> in_use_[slot] (was in record()) and, if mips enabled, emits the blit chain. record() now just reads the already-promoted slot. get_wait_semaphores waits at the TRANSFER stage when mips are on (the blit reads level 0 before the fragment sampler would), FRAGMENT stage otherwise.
- Sampler uses LINEAR mip mode + maxLod = mip_levels_-1 when mips on; unchanged when off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Images can now use configurable mipmap chains for multi-resolution rendering.
  * Layers can optionally auto-generate mipmaps per-frame to improve visual quality.
  * Compositor now invokes a per-layer pre-render pass hook for transfer/compute work before the main render pass.
  * Python layer configuration exposes a new generate_mipmaps property to toggle mipmap generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/532)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->