### PR TITLE
[TeleViz] camera_viz/setup: venv-isolate Python deps

### DIFF
--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -7,113 +7,87 @@ SPDX-License-Identifier: Apache-2.0
 
 > Camera streaming + visualization on Televiz (`isaacteleop.viz`).
 
-Two ways to use it:
-
 | Mode | What it does |
 |---|---|
 | **Direct** | Workstation runs the viewer with cameras attached locally. |
-| **Split**  | Robot runs the sender, ships RTP H.264 to a workstation receiver. Wired Ethernet only — the current sender doesn't handle packet loss / jitter beyond GStreamer's stock RTP layer. |
+| **Split**  | Robot runs the sender, ships RTP H.264 to a workstation receiver. Wired Ethernet only. |
 
 ## Supported cameras
 
 | YAML `type:` | Notes |
 |---|---|
-| `synthetic` | GPU test pattern — no hardware, useful for sanity checks |
+| `synthetic` | GPU test pattern — no hardware |
 | `v4l2`      | USB / UVC — anything `v4l2-ctl --list-formats-ext` shows |
 | `oakd`      | OAK-D mono RGB / LEFT / RIGHT |
 | `zed`       | ZED 2 / Mini / X One, left-eye mono (stereo XR not wired yet) |
 
-Output: window or XR headset; one plane per camera, aspect-fit by default. XR placements support `world` / `head` / `lazy` lock modes.
+Output: window or XR headset; one plane per camera, aspect-fit. XR placements: `world` / `head` / `lazy`.
 
 ---
 
 ## Setup (one-time)
 
 ```bash
-# Build the IsaacTeleop wheel.
 cmake -B build -DBUILD_VIZ=ON
 cmake --build build --target python_wheel --parallel
-
-# Provision the camera_viz venv + native codec.
 examples/camera_viz/camera_viz.sh setup
 source examples/camera_viz/.venv/bin/activate
 ```
 
-What `setup` does:
+`setup` installs every Python dep into `.venv/` via `uv` (no `--system-site-packages`), builds the native NVENC/NVDEC codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts.
 
-- **Strict venv isolation.** Every Python dep — `cupy`, `numpy`, `scipy`, `opencv-python`, `depthai`, `PyGObject`, `pycairo`, the IsaacTeleop wheel — installs into `examples/camera_viz/.venv/` via `uv`. No `--system-site-packages`, no system-Python pollution.
-- **Builds the native NVENC/NVDEC codec** under `codec/`.
-- **Probes system prerequisites** (GStreamer plugins, `cairo` / `girepository` dev headers, `cuda-nvrtc` on Jetson, `ld.so` wiring). If anything is missing it prints the exact `apt-get` / `ln` / `ldconfig` commands and asks `Run those now? [y/N]` on the TTY. Reply `n` — or run non-interactively — to abort. The script never escalates without that explicit yes.
-
-Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only` (skip wheel + Vulkan), `--jetson` (adds JetPack-only checks).
+Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`.
 
 ---
 
-## Mode 1 — Direct (cameras on the workstation)
-
-Set `source: local` in the YAML, plug cameras in, run:
+## Mode 1 — Direct
 
 ```bash
 ./camera_viz.sh run configs/v4l2.yaml
 ```
 
-Swap config for `oakd.yaml`, `zed.yaml`, `synthetic.yaml`, `multi_camera.yaml`. Synthetic is the fastest sanity check (no hardware).
+Set `source: local`. Swap config for `oakd.yaml`, `zed.yaml`, `synthetic.yaml`, `multi_camera.yaml`.
 
-## Mode 2 — Split (robot → workstation over RTP, wired)
+## Mode 2 — Split (robot → workstation, RTP)
 
-The robot sends RTP H.264; the workstation receives + renders.
-
-> ⚠ **Wired Ethernet only.** No retransmit, no FEC; one dropped packet means one corrupted frame until the next IDR (default every 5 s).
+> ⚠ **Wired only.** No retransmit / FEC; one lost packet = one corrupted frame until the next IDR (default 5 s).
 
 ```bash
-# 1. In the YAML: set source: rtp (so the viewer listens instead of
-#    opening cameras). streaming.host can stay at 127.0.0.1 — we'll
-#    override it at deploy time without rewriting the file.
+# YAML: set source: rtp. Leave streaming.host as-is — overridden at deploy time.
 $EDITOR configs/v4l2.yaml
 
-# 2. (Optional but recommended) Export remote creds once per shell so
-#    the password stays out of your shell history and `ps`.
+# Export creds once per shell (keeps password out of history / argv):
 export REMOTE_HOST=10.0.0.5 REMOTE_USER=nvidia
-read -s REMOTE_PASSWORD && export REMOTE_PASSWORD   # only if no SSH keys
+read -s REMOTE_PASSWORD && export REMOTE_PASSWORD   # if no SSH keys
 export STREAMING_HOST=10.0.0.42                      # workstation IP
 
-# 3. Deploy the sender to the robot. ``--streaming-host`` (or
-#    $STREAMING_HOST) is injected as ``--host`` on camera_streamer.py's
-#    CLI inside the systemd unit — the YAML on disk stays untouched.
-./camera_viz.sh deploy configs/v4l2.yaml
-# Or fully explicit, no env vars:
-# ./camera_viz.sh deploy --host 10.0.0.5 --user nvidia \
-#     --streaming-host 10.0.0.42 configs/v4l2.yaml
-# Add --no-service to stop after deps so you can run camera_streamer.py by hand first.
-
-# 4. Run the viewer on the workstation.
-./camera_viz.sh run configs/v4l2.yaml
-
-# Operate the service:
-./camera_viz.sh service-logs
-./camera_viz.sh service-status
-./camera_viz.sh service-restart
+./camera_viz.sh deploy configs/v4l2.yaml             # full deploy + systemd
+./camera_viz.sh run    configs/v4l2.yaml             # viewer on the workstation
+./camera_viz.sh service-{status,logs,restart}        # operate the unit
 ```
 
-`deploy` rsyncs source, then runs `setup --sender-only --jetson` over `ssh -t`. The same `[y/N]` prompt fires for any missing apt packages / CUDA symlinks **on the Jetson** — nothing under sudo runs on the robot without your explicit yes. After deps are in place it installs a systemd user unit at `~/.config/systemd/user/camera-streamer.service` and runs `loginctl enable-linger` (one-time sudo, same TTY).
+What `deploy` does:
 
-The sender supervises per-camera retries forever — camera unplug, SDK errors, network blips all recover. The service never voluntarily exits.
+1. `rsync` source to `~/camera_viz` on the robot.
+2. `ssh -t` runs `_install_deps.sh --sender-only --jetson`; the `[y/N]` prompt fires for any missing apt / CUDA wiring on the Jetson.
+3. Renders `~/.config/systemd/user/camera-streamer.service`. `--streaming-host` (or `$STREAMING_HOST`) injects `--host IP` into the unit's `ExecStart`; the YAML on disk stays untouched.
+4. `sudo loginctl enable-linger` (one-time) + `systemctl --user enable --now`.
 
-### Loopback (sender + viewer on one host)
+`--no-service` stops after step 2. The sender retries forever (unplug, SDK errors, network blips); the service never voluntarily exits.
 
-`./camera_viz.sh loopback configs/v4l2.yaml` runs both on `127.0.0.1`. Useful for testing the RTP path before involving a robot.
+### Loopback
+
+`./camera_viz.sh loopback configs/v4l2.yaml` runs sender + viewer on `127.0.0.1`. Quickest way to smoke-test the RTP path.
 
 ---
 
 ## Config
 
-One YAML drives both ends. Top-level keys:
-
 ```yaml
-source: local | rtp           # camera_viz only: open cameras or listen for RTP
+source: local | rtp           # camera_viz only
 streaming:
-  host: 192.168.1.100         # workstation IP — used by camera_streamer in rtp mode
-encoder: auto | native | gstreamer   # auto picks native NVENC on desktop, GStreamer on Jetson
+  host: 192.168.1.100         # workstation IP (override at deploy time)
+encoder: auto | native | gstreamer
 
 cameras:
   - name: cam
@@ -122,25 +96,25 @@ cameras:
     width: 2560
     height: 720
     fps: 30
-    # … type-specific fields (device, resolution preset, etc.)
+    # … type-specific fields
     rtp:
       port: 5000
-      bitrate_mbps: 15        # tune for your uplink
-      # gop: 150              # frames between IDRs; default fps*5
-      # gpu_id: 0             # multi-GPU: pin encoder/decoder to a specific device
+      bitrate_mbps: 15
+      # gop: 150              # default fps*5
+      # gpu_id: 0             # multi-GPU pin
 
 display:                      # camera_viz only
   mode: window | xr
   window: { width, height }
-  xr: { near_z, far_z }
-  clear_color: [r, g, b, a]   # default [0,0,0,0] (transparent)
+  xr:     { near_z, far_z }
+  clear_color: [r, g, b, a]
   placements:
-    cam:                      # keyed by camera YAML name
+    cam:
       lock_mode: lazy         # world | head | lazy
       distance: 1.5
       offset_x: 0.0
       offset_y: 0.0
-      # size: [w_m, h_m]      # default: 1.0 m wide, height from camera aspect
+      # size: [w_m, h_m]
 ```
 
 Multiple cameras → multiple `cameras:` entries; each gets its own `rtp.port` and renders as its own plane.
@@ -149,11 +123,11 @@ Multiple cameras → multiple `cameras:` entries; each gets its own `rtp.port` a
 
 | Mode | Behavior |
 |---|---|
-| `world` | Place once in front of you; stays put |
+| `world` | Placed once in front of you; stays put |
 | `head`  | Follows your head every frame |
 | `lazy`  | World-locked, re-snaps when you look away (default) |
 
-Lazy timing knobs: `look_away_angle_deg`, `reposition_distance`, `reposition_delay_s`, `transition_duration_s` under `placements.<name>`.
+Lazy knobs under `placements.<name>`: `look_away_angle_deg`, `reposition_distance`, `reposition_delay_s`, `transition_duration_s`.
 
 ---
 
@@ -163,14 +137,14 @@ Lazy timing knobs: `look_away_angle_deg`, `reposition_distance`, `reposition_del
 camera_viz/
 ├── camera_viz.sh        — CLI: setup / loopback / run / deploy / service-*
 ├── camera_viz.py        — receiver / viewer
-├── camera_streamer.py   — robot-side RTP sender (per-camera supervisor, retries forever)
+├── camera_streamer.py   — robot-side RTP sender (per-camera supervisor)
 ├── pipeline/            — source ABC + threaded runner
 ├── placements/          — XR lock-mode strategies
 ├── sources/             — V4L2 / OAK-D / ZED / synthetic / rtp_h264
-├── transports/          — RTP sender + receiver, native + GStreamer encoders
+├── transports/          — RTP sender + receiver, native + GStreamer
 ├── codec/               — native NVENC/NVDEC pybind module
 ├── configs/             — one YAML per camera kind
 └── scripts/
-    ├── _install_deps.sh             — shared installer (used by setup + deploy)
+    ├── _install_deps.sh             — installer (setup + deploy)
     └── camera-streamer.service.in   — systemd unit template
 ```

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -148,3 +148,34 @@ camera_viz/
     ├── _install_deps.sh             — installer (setup + deploy)
     └── camera-streamer.service.in   — systemd unit template
 ```
+
+---
+
+## Sharing the XR session with TeleopSession
+
+Only one OpenXR session is allowed per process. `VizSession` can own it and hand its live handles to `TeleopSession` / `DeviceIOSession` so they skip creating their own:
+
+```python
+import isaacteleop.viz as viz
+from teleopcore.oxr import OpenXRSessionHandles
+
+cfg = viz.VizSessionConfig()
+cfg.mode = viz.DisplayMode.kXr
+# Aggregate the XR extensions downstream trackers need (e.g.
+# XR_NVX1_action_context for ControllerTracker) so they're present
+# on the XrInstance we're about to create.
+cfg.required_extensions = DeviceIOSession.get_required_extensions(trackers)
+viz_session = viz.VizSession.create(cfg)
+
+# Pass the live handles into TeleopSession via its config.
+config = TeleopSessionConfig(
+    app_name="MyApp",
+    pipeline=pipeline,
+    oxr_handles=OpenXRSessionHandles(*viz_session.get_oxr_handles()),
+)
+with TeleopSession(config) as session:
+    ...
+```
+
+`viz_session.get_oxr_handles()` returns `(instance, session, space, proc_addr)` as raw `uint64`s, or `None` outside `kXr`.
+

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -66,24 +66,33 @@ The robot sends RTP H.264; the workstation receives + renders.
 > ⚠ **Wired Ethernet only.** No retransmit, no FEC; one dropped packet means one corrupted frame until the next IDR (default every 5 s).
 
 ```bash
-# 1. In the YAML: set streaming.host to the workstation's IP, and
-#    source: rtp (so the viewer listens instead of opening cameras).
+# 1. In the YAML: set source: rtp (so the viewer listens instead of
+#    opening cameras). streaming.host can stay at 127.0.0.1 — we'll
+#    override it at deploy time without rewriting the file.
 $EDITOR configs/v4l2.yaml
 
-# 2. Deploy the sender to the robot. The deployed copy is rsync'd
-#    with the YAML as-is; the robot's camera_streamer.py ignores
-#    `source:` and always opens local cameras.
-./camera_viz.sh deploy --host 10.0.0.5 --user nvidia configs/v4l2.yaml
-# Add --password PW if you don't have SSH keys (requires sshpass).
+# 2. (Optional but recommended) Export remote creds once per shell so
+#    the password stays out of your shell history and `ps`.
+export REMOTE_HOST=10.0.0.5 REMOTE_USER=nvidia
+read -s REMOTE_PASSWORD && export REMOTE_PASSWORD   # only if no SSH keys
+export STREAMING_HOST=10.0.0.42                      # workstation IP
+
+# 3. Deploy the sender to the robot. ``--streaming-host`` (or
+#    $STREAMING_HOST) is injected as ``--host`` on camera_streamer.py's
+#    CLI inside the systemd unit — the YAML on disk stays untouched.
+./camera_viz.sh deploy configs/v4l2.yaml
+# Or fully explicit, no env vars:
+# ./camera_viz.sh deploy --host 10.0.0.5 --user nvidia \
+#     --streaming-host 10.0.0.42 configs/v4l2.yaml
 # Add --no-service to stop after deps so you can run camera_streamer.py by hand first.
 
-# 3. Run the viewer on the workstation.
+# 4. Run the viewer on the workstation.
 ./camera_viz.sh run configs/v4l2.yaml
 
 # Operate the service:
-./camera_viz.sh service-logs    --host 10.0.0.5 --user nvidia
-./camera_viz.sh service-status  --host 10.0.0.5 --user nvidia
-./camera_viz.sh service-restart --host 10.0.0.5 --user nvidia
+./camera_viz.sh service-logs
+./camera_viz.sh service-status
+./camera_viz.sh service-restart
 ```
 
 `deploy` rsyncs source, then runs `setup --sender-only --jetson` over `ssh -t`. The same `[y/N]` prompt fires for any missing apt packages / CUDA symlinks **on the Jetson** — nothing under sudo runs on the robot without your explicit yes. After deps are in place it installs a systemd user unit at `~/.config/systemd/user/camera-streamer.service` and runs `loginctl enable-linger` (one-time sudo, same TTY).

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -178,4 +178,3 @@ with TeleopSession(config) as session:
 ```
 
 `viz_session.get_oxr_handles()` returns `(instance, session, space, proc_addr)` as raw `uint64`s, or `None` outside `kXr`.
-

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -36,7 +36,7 @@ source examples/camera_viz/.venv/bin/activate
 
 `setup` installs every Python dep into `.venv/` via `uv` (no `--system-site-packages`), builds the native NVENC/NVDEC codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts.
 
-Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`.
+Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`. Pass `--venv PATH` to install into an existing venv (symlinks `.venv` → PATH so `run` / `loopback` pick it up too).
 
 ---
 

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -5,23 +5,27 @@ SPDX-License-Identifier: Apache-2.0
 
 # camera_viz
 
-Camera streaming + visualization on Televiz (`isaacteleop.viz`).
+> Camera streaming + visualization on Televiz (`isaacteleop.viz`).
 
 Two ways to use it:
 
-1. **Direct**: workstation runs the viewer with cameras attached locally.
-2. **Split**: robot runs the sender, ships RTP H.264 to a workstation receiver. Wired Ethernet only -- the current sender doesn't handle packet loss / jitter beyond what GStreamer's stock RTP layer provides.
+| Mode | What it does |
+|---|---|
+| **Direct** | Workstation runs the viewer with cameras attached locally. |
+| **Split**  | Robot runs the sender, ships RTP H.264 to a workstation receiver. Wired Ethernet only — the current sender doesn't handle packet loss / jitter beyond GStreamer's stock RTP layer. |
 
 ## Supported cameras
 
 | YAML `type:` | Notes |
 |---|---|
-| `synthetic` | GPU test pattern -- no hardware, useful for sanity checks |
-| `v4l2` | USB / UVC -- anything `v4l2-ctl --list-formats-ext` shows |
-| `oakd` | OAK-D mono RGB / LEFT / RIGHT |
-| `zed` | ZED 2 / Mini / X One, left-eye mono (stereo XR not wired yet) |
+| `synthetic` | GPU test pattern — no hardware, useful for sanity checks |
+| `v4l2`      | USB / UVC — anything `v4l2-ctl --list-formats-ext` shows |
+| `oakd`      | OAK-D mono RGB / LEFT / RIGHT |
+| `zed`       | ZED 2 / Mini / X One, left-eye mono (stereo XR not wired yet) |
 
 Output: window or XR headset; one plane per camera, aspect-fit by default. XR placements support `world` / `head` / `lazy` lock modes.
+
+---
 
 ## Setup (one-time)
 
@@ -35,11 +39,17 @@ examples/camera_viz/camera_viz.sh setup
 source examples/camera_viz/.venv/bin/activate
 ```
 
-`setup` apt-installs missing `python3-gi` / GStreamer plugins on Debian/Ubuntu, builds the native NVENC/NVDEC codec under `codec/`, and creates `.venv/`. Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only` (skip wheel + Vulkan), `--jetson` (JetPack cuda-nvrtc + symlink fixups).
+What `setup` does:
+
+- **Strict venv isolation.** Every Python dep — `cupy`, `numpy`, `scipy`, `opencv-python`, `depthai`, `PyGObject`, `pycairo`, the IsaacTeleop wheel — installs into `examples/camera_viz/.venv/` via `uv`. No `--system-site-packages`, no system-Python pollution.
+- **Builds the native NVENC/NVDEC codec** under `codec/`.
+- **Probes system prerequisites** (GStreamer plugins, `cairo` / `girepository` dev headers, `cuda-nvrtc` on Jetson, `ld.so` wiring). If anything is missing it prints the exact `apt-get` / `ln` / `ldconfig` commands and asks `Run those now? [y/N]` on the TTY. Reply `n` — or run non-interactively — to abort. The script never escalates without that explicit yes.
+
+Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only` (skip wheel + Vulkan), `--jetson` (adds JetPack-only checks).
 
 ---
 
-## Mode 1 -- Direct (cameras on the workstation)
+## Mode 1 — Direct (cameras on the workstation)
 
 Set `source: local` in the YAML, plug cameras in, run:
 
@@ -49,9 +59,11 @@ Set `source: local` in the YAML, plug cameras in, run:
 
 Swap config for `oakd.yaml`, `zed.yaml`, `synthetic.yaml`, `multi_camera.yaml`. Synthetic is the fastest sanity check (no hardware).
 
-## Mode 2 -- Split (robot -> workstation over RTP, wired)
+## Mode 2 — Split (robot → workstation over RTP, wired)
 
-The robot sends RTP H.264; the workstation receives + renders. **Wired Ethernet only.** No retransmit, no FEC; one dropped packet means one corrupted frame until the next IDR (default every 5 s).
+The robot sends RTP H.264; the workstation receives + renders.
+
+> ⚠ **Wired Ethernet only.** No retransmit, no FEC; one dropped packet means one corrupted frame until the next IDR (default every 5 s).
 
 ```bash
 # 1. In the YAML: set streaming.host to the workstation's IP, and
@@ -60,7 +72,7 @@ $EDITOR configs/v4l2.yaml
 
 # 2. Deploy the sender to the robot. The deployed copy is rsync'd
 #    with the YAML as-is; the robot's camera_streamer.py ignores
-#    ``source:`` and always opens local cameras.
+#    `source:` and always opens local cameras.
 ./camera_viz.sh deploy --host 10.0.0.5 --user nvidia configs/v4l2.yaml
 # Add --password PW if you don't have SSH keys (requires sshpass).
 # Add --no-service to stop after deps so you can run camera_streamer.py by hand first.
@@ -74,9 +86,9 @@ $EDITOR configs/v4l2.yaml
 ./camera_viz.sh service-restart --host 10.0.0.5 --user nvidia
 ```
 
-`deploy` rsyncs source, runs `setup --sender-only --jetson`, installs a systemd user unit at `~/.config/systemd/user/camera-streamer.service`, and enables `loginctl enable-linger` (one-time sudo).
+`deploy` rsyncs source, then runs `setup --sender-only --jetson` over `ssh -t`. The same `[y/N]` prompt fires for any missing apt packages / CUDA symlinks **on the Jetson** — nothing under sudo runs on the robot without your explicit yes. After deps are in place it installs a systemd user unit at `~/.config/systemd/user/camera-streamer.service` and runs `loginctl enable-linger` (one-time sudo, same TTY).
 
-The sender supervises per-camera retries forever -- camera unplug, SDK errors, network blips all recover. The service never voluntarily exits.
+The sender supervises per-camera retries forever — camera unplug, SDK errors, network blips all recover. The service never voluntarily exits.
 
 ### Loopback (sender + viewer on one host)
 
@@ -91,7 +103,7 @@ One YAML drives both ends. Top-level keys:
 ```yaml
 source: local | rtp           # camera_viz only: open cameras or listen for RTP
 streaming:
-  host: 192.168.1.100         # workstation IP -- used by camera_streamer in rtp mode
+  host: 192.168.1.100         # workstation IP — used by camera_streamer in rtp mode
 encoder: auto | native | gstreamer   # auto picks native NVENC on desktop, GStreamer on Jetson
 
 cameras:
@@ -101,7 +113,7 @@ cameras:
     width: 2560
     height: 720
     fps: 30
-    # ... type-specific fields (device, resolution preset, etc.)
+    # … type-specific fields (device, resolution preset, etc.)
     rtp:
       port: 5000
       bitrate_mbps: 15        # tune for your uplink
@@ -122,32 +134,34 @@ display:                      # camera_viz only
       # size: [w_m, h_m]      # default: 1.0 m wide, height from camera aspect
 ```
 
-Multiple cameras -> multiple `cameras:` entries; each gets its own `rtp.port` and renders as its own plane.
+Multiple cameras → multiple `cameras:` entries; each gets its own `rtp.port` and renders as its own plane.
 
 ## Lock modes (XR)
 
 | Mode | Behavior |
 |---|---|
 | `world` | Place once in front of you; stays put |
-| `head` | Follows your head every frame |
-| `lazy` | World-locked, re-snaps when you look away (default) |
+| `head`  | Follows your head every frame |
+| `lazy`  | World-locked, re-snaps when you look away (default) |
 
 Lazy timing knobs: `look_away_angle_deg`, `reposition_distance`, `reposition_delay_s`, `transition_duration_s` under `placements.<name>`.
+
+---
 
 ## Layout
 
 ```
 camera_viz/
-├── camera_viz.sh        # CLI: setup / loopback / run / deploy / service-*
-├── camera_viz.py        # receiver / viewer
-├── camera_streamer.py   # robot-side RTP sender (per-camera supervisor, retries forever)
-├── pipeline/            # source ABC + threaded runner
-├── placements/          # XR lock-mode strategies
-├── sources/             # V4L2 / OAK-D / ZED / synthetic / rtp_h264
-├── transports/          # RTP sender + receiver, native + GStreamer encoders
-├── codec/               # native NVENC/NVDEC pybind module
-├── configs/             # one YAML per camera kind
+├── camera_viz.sh        — CLI: setup / loopback / run / deploy / service-*
+├── camera_viz.py        — receiver / viewer
+├── camera_streamer.py   — robot-side RTP sender (per-camera supervisor, retries forever)
+├── pipeline/            — source ABC + threaded runner
+├── placements/          — XR lock-mode strategies
+├── sources/             — V4L2 / OAK-D / ZED / synthetic / rtp_h264
+├── transports/          — RTP sender + receiver, native + GStreamer encoders
+├── codec/               — native NVENC/NVDEC pybind module
+├── configs/             — one YAML per camera kind
 └── scripts/
-    ├── _install_deps.sh             # shared installer (used by setup + deploy)
-    └── camera-streamer.service.in   # systemd unit template
+    ├── _install_deps.sh             — shared installer (used by setup + deploy)
+    └── camera-streamer.service.in   — systemd unit template
 ```

--- a/examples/camera_viz/camera_viz.sh
+++ b/examples/camera_viz/camera_viz.sh
@@ -242,7 +242,9 @@ cmd_deploy() {
     log_step "Installing deps on robot (sender-only, jetson)"
     # ``deploy`` targets Jetson robots, so we always pass --jetson:
     # JetPack ships partial CUDA + skips the unversioned symlinks the
-    # cupy loader needs. TTY so apt's sudo can prompt.
+    # cupy loader needs. If the Jetson is missing system packages /
+    # symlinks, _install_deps.sh prompts on the TTY (ssh -t) and either
+    # runs the sudo commands after the operator types ``y`` or aborts.
     ssh_run_tty "cd $REMOTE_DIR && bash scripts/_install_deps.sh --sender-only --jetson"
     log_ok "deps installed"
 
@@ -328,15 +330,20 @@ camera_viz.sh — local development + Jetson deployment for camera_viz
 
 LOCAL
     setup [--sender-only] [--jetson] [--no-v4l2] [--no-oakd] [--no-rtp] [--with-zed]
-                          Create .venv, install deps, build native codec.
-                          Missing python3-gi / GStreamer plugins are
-                          apt-installed on Debian/Ubuntu regardless of
-                          host kind.
+                          Create .venv, install Python deps via uv into
+                          the venv, build native codec. Python deps stay
+                          inside .venv (no --system-site-packages).
+                          System-side prerequisites (GStreamer plugins,
+                          cairo/girepository dev headers, cuda-nvrtc on
+                          Jetson, etc.) are PROBED. If anything is
+                          missing the script prints the exact apt-get
+                          command and prompts ``y/N`` before running it.
+                          Reply N or run non-interactively to abort.
                           --sender-only skips the isaacteleop wheel + vulkan
                           deps (use on Jetson sender hosts).
-                          --jetson adds JetPack-only steps on top: apt-
-                          install cuda-nvrtc and create the unversioned
-                          CUDA lib symlinks JetPack skips. Off on desktop.
+                          --jetson adds JetPack-only checks: unversioned
+                          CUDA lib symlinks + ld.so wiring that JetPack
+                          skips. Off on desktop.
 
     loopback CONFIG       Run camera_streamer + camera_viz on 127.0.0.1.
 

--- a/examples/camera_viz/camera_viz.sh
+++ b/examples/camera_viz/camera_viz.sh
@@ -47,10 +47,12 @@ log_step()  { echo -e "\n\033[1m=== $* ===${_C_RESET}"; }
 # ──────────────────────────────────────────────────────────────────────
 
 # Sets REMOTE_{HOST,USER,PASSWORD}; remaining positionals → REMOTE_REST[].
+# Defaults come from $REMOTE_HOST / $REMOTE_USER / $REMOTE_PASSWORD if
+# those are exported in the calling shell; CLI flags override.
 parse_remote_args() {
-    REMOTE_HOST=""
-    REMOTE_USER=""
-    REMOTE_PASSWORD=""
+    : "${REMOTE_HOST:=}"
+    : "${REMOTE_USER:=}"
+    : "${REMOTE_PASSWORD:=}"
     REMOTE_REST=()
     while (( $# )); do
         case $1 in
@@ -61,10 +63,10 @@ parse_remote_args() {
             *)  REMOTE_REST+=("$1"); shift;;
         esac
     done
-    [[ -n "$REMOTE_HOST" ]] || { log_error "--host is required"; exit 1; }
-    [[ -n "$REMOTE_USER" ]] || { log_error "--user is required"; exit 1; }
+    [[ -n "$REMOTE_HOST" ]] || { log_error "--host (or \$REMOTE_HOST) is required"; exit 1; }
+    [[ -n "$REMOTE_USER" ]] || { log_error "--user (or \$REMOTE_USER) is required"; exit 1; }
     if [[ -n "$REMOTE_PASSWORD" ]] && ! command -v sshpass >/dev/null 2>&1; then
-        log_error "--password set but sshpass not installed. apt install sshpass, or drop --password and use key auth."
+        log_error "REMOTE_PASSWORD set but sshpass not installed. apt install sshpass, or drop the password and use key auth."
         exit 1
     fi
 }
@@ -353,28 +355,39 @@ LOCAL
                           receiver binds 0.0.0.0).
 
 REMOTE (Jetson robot)
-    deploy --host H --user U [--password P] [--no-service] CONFIG
+    deploy [--host H --user U [--password P]] [--no-service] CONFIG
                           rsync source, install deps, install + start
                           systemd user service running camera_streamer.py.
                           --no-service stops after deps so you can run
                           camera_streamer.py by hand first.
 
-    service-status   --host H --user U [--password P]
-    service-logs     --host H --user U [--password P]
-    service-restart  --host H --user U [--password P]
+    service-status   [--host H --user U [--password P]]
+    service-logs     [--host H --user U [--password P]]
+    service-restart  [--host H --user U [--password P]]
                           Inspect / manage the deployed service.
+
+ENVIRONMENT (remote commands)
+    REMOTE_HOST, REMOTE_USER, REMOTE_PASSWORD
+                          Defaults for --host / --user / --password. CLI
+                          flags override. Drop the flags from your shell
+                          history by exporting these once per session.
 
 EXAMPLES
     ./camera_viz.sh setup
     ./camera_viz.sh loopback configs/v4l2.yaml
     ./camera_viz.sh deploy --host 10.29.90.127 --user nvidia configs/v4l2.yaml
     ./camera_viz.sh run configs/v4l2.yaml
-    ./camera_viz.sh service-logs --host 10.29.90.127 --user nvidia
+
+    # Env-var style (avoids passwords in shell history / argv):
+    export REMOTE_HOST=10.29.90.127 REMOTE_USER=nvidia
+    read -s REMOTE_PASSWORD && export REMOTE_PASSWORD
+    ./camera_viz.sh deploy configs/v4l2.yaml
+    ./camera_viz.sh service-logs
 
 SSH AUTH
-    Without --password, uses your SSH keys. With --password, uses sshpass
-    (apt install sshpass). The password is passed via process args, so
-    avoid this on shared hosts.
+    Without a password set, uses your SSH keys. With one, uses sshpass
+    (apt install sshpass). Passwords are forwarded to sshpass via the
+    SSHPASS env var (sshpass -e), so they don't appear in process argv.
 EOF
 }
 

--- a/examples/camera_viz/camera_viz.sh
+++ b/examples/camera_viz/camera_viz.sh
@@ -122,8 +122,31 @@ rsync_to_remote() {
 # ──────────────────────────────────────────────────────────────────────
 
 cmd_setup() {
+    # Intercept --venv so $HERE/.venv becomes a symlink to the caller's
+    # path. The rest of camera_viz.sh (cmd_run / cmd_loopback) hardcodes
+    # $HERE/.venv; routing it through a symlink lets ``setup --venv PATH``
+    # work without touching every command.
+    local custom_venv=""
+    local rest=()
+    while (( $# )); do
+        case $1 in
+            --venv) custom_venv=$2; shift 2;;
+            *)      rest+=("$1"); shift;;
+        esac
+    done
+
+    if [[ -n "$custom_venv" ]]; then
+        custom_venv=$(realpath -m "$custom_venv")
+        if [[ -e "$HERE/.venv" && ! -L "$HERE/.venv" ]]; then
+            log_error "$HERE/.venv exists as a real directory; rm it (or move it) before using --venv."
+            exit 1
+        fi
+        ln -sfn "$custom_venv" "$HERE/.venv"
+        log_info "linked $HERE/.venv → $custom_venv"
+    fi
+
     log_step "Local setup"
-    exec "$SCRIPTS_DIR/_install_deps.sh" "$@"
+    exec "$SCRIPTS_DIR/_install_deps.sh" "${rest[@]}"
 }
 
 # ──────────────────────────────────────────────────────────────────────
@@ -355,7 +378,8 @@ show_help() {
 camera_viz.sh — local development + Jetson deployment for camera_viz
 
 LOCAL
-    setup [--sender-only] [--jetson] [--no-v4l2] [--no-oakd] [--no-rtp] [--with-zed]
+    setup [--venv PATH] [--sender-only] [--jetson]
+          [--no-v4l2] [--no-oakd] [--no-rtp] [--with-zed]
                           Create .venv, install Python deps via uv into
                           the venv, build native codec. Python deps stay
                           inside .venv (no --system-site-packages).
@@ -365,6 +389,10 @@ LOCAL
                           missing the script prints the exact apt-get
                           command and prompts ``y/N`` before running it.
                           Reply N or run non-interactively to abort.
+                          --venv PATH installs into an existing venv at
+                          PATH instead of creating one in-place.
+                          examples/camera_viz/.venv is symlinked → PATH
+                          so run / loopback pick it up too.
                           --sender-only skips the isaacteleop wheel + vulkan
                           deps (use on Jetson sender hosts).
                           --jetson adds JetPack-only checks: unversioned

--- a/examples/camera_viz/camera_viz.sh
+++ b/examples/camera_viz/camera_viz.sh
@@ -212,12 +212,21 @@ cmd_loopback() {
 # ──────────────────────────────────────────────────────────────────────
 
 cmd_deploy() {
-    # Filter --no-service out of "$@" before parse_remote_args runs;
-    # otherwise it lands in REMOTE_REST and gets mistaken for the config.
+    # Pull deploy-only flags out of "$@" before parse_remote_args runs;
+    # anything we don't recognize would land in REMOTE_REST (where the
+    # positional CONFIG lives).
     local no_service=false
+    # ``--streaming-host`` → injected as ``--host`` on camera_streamer.py's
+    # CLI inside the rendered systemd unit. Lets you keep the YAML at
+    # 127.0.0.1 for loopback and override only when deploying to a robot.
+    local streaming_host="${STREAMING_HOST:-}"
     local filtered=()
-    for arg in "$@"; do
-        if [[ "$arg" == "--no-service" ]]; then no_service=true; else filtered+=("$arg"); fi
+    while (( $# )); do
+        case $1 in
+            --no-service)     no_service=true; shift;;
+            --streaming-host) streaming_host=$2; shift 2;;
+            *)                filtered+=("$1"); shift;;
+        esac
     done
     set -- "${filtered[@]}"
 
@@ -252,10 +261,24 @@ cmd_deploy() {
 
     if $no_service; then
         log_ok "source + deps installed (service skipped)"
+        local manual_host_flag=""
+        if [[ -n "$streaming_host" ]]; then
+            manual_host_flag=" --host $streaming_host"
+            log_info "(--streaming-host has no effect in --no-service mode — pass it to camera_streamer.py yourself.)"
+        fi
         log_info "Run manually with:"
-        log_info "  ssh $REMOTE_USER@$REMOTE_HOST 'cd ~/camera_viz && .venv/bin/python camera_streamer.py $config'"
+        log_info "  ssh $REMOTE_USER@$REMOTE_HOST 'cd ~/camera_viz && .venv/bin/python camera_streamer.py $config$manual_host_flag'"
         log_info "Re-run without --no-service when you're ready to install the systemd unit."
         return 0
+    fi
+
+    # Empty when --streaming-host wasn't given — ExecStart falls back to
+    # streaming.host from the YAML. Leading space so the substituted
+    # template doesn't end with a trailing space when empty.
+    local extra_args=""
+    if [[ -n "$streaming_host" ]]; then
+        extra_args=" --host $streaming_host"
+        log_info "streaming.host overridden: --host $streaming_host"
     fi
 
     log_step "Installing systemd unit"
@@ -271,6 +294,7 @@ mkdir -p "\$unit_dir"
 sed -e "s|{{WORKDIR}}|\$workdir|g" \
     -e "s|{{VENV}}|\$venv|g" \
     -e "s|{{CONFIG}}|\$config|g" \
+    -e "s|{{EXTRA_ARGS}}|${extra_args}|g" \
     "\$workdir/scripts/${SERVICE_NAME}.service.in" \
     > "\$unit_dir/${SERVICE_NAME}.service"
 echo "wrote \$unit_dir/${SERVICE_NAME}.service"
@@ -355,11 +379,17 @@ LOCAL
                           receiver binds 0.0.0.0).
 
 REMOTE (Jetson robot)
-    deploy [--host H --user U [--password P]] [--no-service] CONFIG
+    deploy [--host H --user U [--password P]]
+           [--streaming-host IP] [--no-service] CONFIG
                           rsync source, install deps, install + start
                           systemd user service running camera_streamer.py.
                           --no-service stops after deps so you can run
                           camera_streamer.py by hand first.
+                          --streaming-host injects ``--host IP`` into the
+                          unit's ExecStart so the sender streams there
+                          regardless of streaming.host in the YAML. Same
+                          knob via $STREAMING_HOST env var. Leave unset
+                          to use the YAML value.
 
     service-status   [--host H --user U [--password P]]
     service-logs     [--host H --user U [--password P]]
@@ -371,6 +401,8 @@ ENVIRONMENT (remote commands)
                           Defaults for --host / --user / --password. CLI
                           flags override. Drop the flags from your shell
                           history by exporting these once per session.
+
+    STREAMING_HOST        Default for --streaming-host on ``deploy``.
 
 EXAMPLES
     ./camera_viz.sh setup

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -70,26 +70,26 @@ if [[ -e /usr/local/cuda ]]; then
     fi
 fi
 
-# Apt-install: Debian PyGObject (avoids a pycairo source-build) +
-# GStreamer plugins (always, when RTP is enabled), and cuda-nvrtc
-# (Jetson only — JetPack base image omits it; desktop CUDA installer
-# already ships it). Idempotent; each package is gated on a fast check.
-ensure_apt_deps() {
+# System-dep check. apt-installable bits are NOT auto-installed — we
+# only probe what's present and, if anything is missing, print the
+# exact ``apt-get install`` command for the user to run and exit. The
+# venv side (uv pip) is fully automated; the system side is opt-in by
+# the user so setup never escalates privileges on their behalf.
+check_system_deps() {
     if ! $WITH_RTP; then
         return 0
     fi
     if ! command -v apt-get >/dev/null 2>&1; then
-        return 0  # not Debian/Ubuntu, user is on their own
+        return 0  # not Debian/Ubuntu — user is on their own
     fi
 
     local pkgs=()
     # PyGObject lives in the venv (installed via uv below). What apt
     # owns here is purely non-Python:
     #   * C build deps for the source build (libcairo / libgirepository /
-    #     pkg-config / Python dev headers — uv-managed Python ships its
-    #     own headers, but system python3 doesn't).
+    #     pkg-config). uv-managed Python ships its own headers.
     #   * Runtime Gst typelib (PyGObject loads it via gobject-introspection).
-    #   * gst-inspect-1.0 for our own plugin-presence check below.
+    #   * gst-inspect-1.0 for the plugin-presence probe below.
     command -v pkg-config >/dev/null 2>&1                       || pkgs+=(pkg-config)
     pkg-config --exists cairo 2>/dev/null                       || pkgs+=(libcairo2-dev)
     # Debian's libgirepository1.0-dev publishes the .pc file as
@@ -101,7 +101,7 @@ ensure_apt_deps() {
     # GStreamer elements RtpH264Sender / RtpH264Receiver need at runtime.
     # Checked per-element via gst-inspect-1.0 so partially-provisioned
     # hosts (typelib present, plugins missing — a real failure mode) still
-    # get the right apt packages.
+    # get flagged correctly.
     local need_base=false need_good=false need_bad=false need_ugly=false
     if command -v gst-inspect-1.0 >/dev/null 2>&1; then
         gst-inspect-1.0 videoconvert >/dev/null 2>&1 || need_base=true
@@ -111,7 +111,7 @@ ensure_apt_deps() {
         # x264enc is the CPU fallback in GstNvH264Encoder's candidate list.
         gst-inspect-1.0 x264enc      >/dev/null 2>&1 || need_ugly=true
     else
-        # No gst-inspect → install everything.
+        # No gst-inspect → flag everything; user installs gst-tools and re-runs.
         need_base=true; need_good=true; need_bad=true; need_ugly=true
     fi
     $need_base && pkgs+=(gstreamer1.0-plugins-base)
@@ -119,10 +119,9 @@ ensure_apt_deps() {
     $need_bad  && pkgs+=(gstreamer1.0-plugins-bad gstreamer1.0-libav)
     $need_ugly && pkgs+=(gstreamer1.0-plugins-ugly)
 
-    # cuda-nvrtc is only apt-installed on Jetson — JetPack ships partial
-    # CUDA without it. Desktop CUDA installer already drops libnvrtc into
-    # /usr/local/cuda; if it's missing there, the user needs to fix their
-    # CUDA install, not have us apt-pull it.
+    # cuda-nvrtc on Jetson — JetPack ships partial CUDA without it.
+    # Desktop CUDA installer drops libnvrtc into /usr/local/cuda; if it's
+    # missing there, the user needs to fix their CUDA install.
     if $JETSON && ! find /usr -name 'libnvrtc.so*' 2>/dev/null | grep -q .; then
         pkgs+=("cuda-nvrtc-${cuda_major}-${cuda_minor}")
     fi
@@ -130,20 +129,26 @@ ensure_apt_deps() {
     if [[ ${#pkgs[@]} -eq 0 ]]; then
         return 0
     fi
-    echo "==> apt-installing system deps: ${pkgs[*]}"
-    if ! sudo -n true 2>/dev/null; then
-        echo "    sudo password required (one-time)"
-    fi
-    sudo apt-get update -qq
-    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${pkgs[@]}"
+
+    cat >&2 <<EOF
+_install_deps.sh: missing system packages required by camera_viz (RTP path):
+  ${pkgs[*]}
+
+Install them yourself (one-time) and re-run setup:
+  sudo apt-get update
+  sudo apt-get install -y --no-install-recommends ${pkgs[*]}
+
+Or pass --no-rtp to skip the GStreamer-based RTP path entirely.
+EOF
+    exit 1
 }
-ensure_apt_deps
+check_system_deps
 
 # JetPack ships versioned libs (libnvrtc.so.13) without the unversioned
 # symlink + ld.so cache entry that desktop CUDA creates. cupy looks up
 # ``libnvrtc.so`` and fails to resolve without these. Skipped on desktop
 # where the CUDA installer already lays down the right symlinks.
-ensure_cuda_symlinks() {
+check_cuda_symlinks() {
     if ! $JETSON; then
         return 0
     fi
@@ -151,42 +156,35 @@ ensure_cuda_symlinks() {
         return 0
     fi
     local lib64=/usr/local/cuda/lib64
-    local needs_sudo=false
-    for stem in libnvrtc.so libnvrtc-builtins.so libcudart.so; do
-        if [[ ! -e "$lib64/$stem" ]]; then
-            local versioned
-            versioned=$(ls "$lib64/$stem".[0-9]* 2>/dev/null | sort -V | tail -1)
-            [[ -n "$versioned" ]] && needs_sudo=true
-        fi
-    done
-    if ! ldconfig -p 2>/dev/null | grep -q "$lib64"; then
-        needs_sudo=true
-    fi
-    if ! $needs_sudo; then
-        return 0
-    fi
-
-    echo "==> wiring CUDA libs into ld.so + creating unversioned symlinks"
-    if ! sudo -n true 2>/dev/null; then
-        echo "    sudo password required (one-time)"
-    fi
+    local cmds=()
     for stem in libnvrtc.so libnvrtc-builtins.so libcudart.so; do
         if [[ ! -e "$lib64/$stem" ]]; then
             local versioned
             versioned=$(ls "$lib64/$stem".[0-9]* 2>/dev/null | sort -V | tail -1)
             if [[ -n "$versioned" ]]; then
-                sudo ln -sf "$(basename "$versioned")" "$lib64/$stem"
-                echo "    $lib64/$stem -> $(basename "$versioned")"
+                cmds+=("sudo ln -sf $(basename "$versioned") $lib64/$stem")
             fi
         fi
     done
     if ! ldconfig -p 2>/dev/null | grep -q "$lib64"; then
-        echo "$lib64" | sudo tee /etc/ld.so.conf.d/zz-camera-viz-cuda.conf >/dev/null
-        sudo ldconfig
-        echo "    registered $lib64 with ldconfig"
+        cmds+=("echo $lib64 | sudo tee /etc/ld.so.conf.d/zz-camera-viz-cuda.conf >/dev/null"
+               "sudo ldconfig")
     fi
+    if [[ ${#cmds[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    {
+        echo "_install_deps.sh: Jetson CUDA libs aren't wired into ld.so / unversioned"
+        echo "symlinks are missing. cupy will fail to dlopen libnvrtc.so without these."
+        echo "Run (one-time) and then re-run setup:"
+        for c in "${cmds[@]}"; do
+            echo "  $c"
+        done
+    } >&2
+    exit 1
 }
-ensure_cuda_symlinks
+check_cuda_symlinks
 
 # Bootstrap uv from astral.sh if missing (Jetson images don't ship it).
 if ! command -v uv >/dev/null 2>&1; then

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -134,13 +134,30 @@ check_system_deps() {
 _install_deps.sh: missing system packages required by camera_viz (RTP path):
   ${pkgs[*]}
 
-Install them yourself (one-time) and re-run setup:
+The exact command:
   sudo apt-get update
   sudo apt-get install -y --no-install-recommends ${pkgs[*]}
 
-Or pass --no-rtp to skip the GStreamer-based RTP path entirely.
+(--no-rtp skips the GStreamer-based RTP path entirely.)
 EOF
-    exit 1
+
+    local ans=""
+    if [[ -e /dev/tty ]]; then
+        read -r -p "Run those apt-get commands now? [y/N] " ans </dev/tty 2>/dev/null || ans=""
+    fi
+    case "${ans,,}" in
+        y|yes)
+            if ! sudo -n true 2>/dev/null; then
+                echo "    sudo password required (one-time)"
+            fi
+            sudo apt-get update -qq
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${pkgs[@]}"
+            ;;
+        *)
+            echo "_install_deps.sh: aborted. Install the listed packages and re-run." >&2
+            exit 1
+            ;;
+    esac
 }
 check_system_deps
 
@@ -177,12 +194,42 @@ check_cuda_symlinks() {
     {
         echo "_install_deps.sh: Jetson CUDA libs aren't wired into ld.so / unversioned"
         echo "symlinks are missing. cupy will fail to dlopen libnvrtc.so without these."
-        echo "Run (one-time) and then re-run setup:"
+        echo "Exact commands:"
         for c in "${cmds[@]}"; do
             echo "  $c"
         done
     } >&2
-    exit 1
+
+    local ans=""
+    if [[ -e /dev/tty ]]; then
+        read -r -p "Run those now? [y/N] " ans </dev/tty 2>/dev/null || ans=""
+    fi
+    case "${ans,,}" in
+        y|yes)
+            if ! sudo -n true 2>/dev/null; then
+                echo "    sudo password required (one-time)"
+            fi
+            for stem in libnvrtc.so libnvrtc-builtins.so libcudart.so; do
+                if [[ ! -e "$lib64/$stem" ]]; then
+                    local versioned
+                    versioned=$(ls "$lib64/$stem".[0-9]* 2>/dev/null | sort -V | tail -1)
+                    if [[ -n "$versioned" ]]; then
+                        sudo ln -sf "$(basename "$versioned")" "$lib64/$stem"
+                        echo "    $lib64/$stem -> $(basename "$versioned")"
+                    fi
+                fi
+            done
+            if ! ldconfig -p 2>/dev/null | grep -q "$lib64"; then
+                echo "$lib64" | sudo tee /etc/ld.so.conf.d/zz-camera-viz-cuda.conf >/dev/null
+                sudo ldconfig
+                echo "    registered $lib64 with ldconfig"
+            fi
+            ;;
+        *)
+            echo "_install_deps.sh: aborted. Run the listed commands and re-run setup." >&2
+            exit 1
+            ;;
+    esac
 }
 check_cuda_symlinks
 

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -143,7 +143,9 @@ EOF
 
     local ans=""
     if [[ -e /dev/tty ]]; then
-        read -r -p "Run those apt-get commands now? [y/N] " ans </dev/tty 2>/dev/null || ans=""
+        # NOTE: do NOT redirect stderr — ``read -p`` writes the prompt to
+        # stderr, and we want the user to actually see it.
+        read -r -p "Run those apt-get commands now? [y/N] " ans </dev/tty || ans=""
     fi
     case "${ans,,}" in
         y|yes)
@@ -202,7 +204,7 @@ check_cuda_symlinks() {
 
     local ans=""
     if [[ -e /dev/tty ]]; then
-        read -r -p "Run those now? [y/N] " ans </dev/tty 2>/dev/null || ans=""
+        read -r -p "Run those now? [y/N] " ans </dev/tty || ans=""
     fi
     case "${ans,,}" in
         y|yes)

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -237,9 +237,20 @@ PY="$VENV_DIR/bin/python"
 
 echo "==> cuda:   ${cuda_major}.${cuda_minor} (cupy-cuda${cuda_major}x, cuda-nvrtc-${cuda_major}-${cuda_minor})"
 
+# cupy ships separate packages per CUDA major (cupy-cuda12x, cupy-cuda13x...);
+# they coexist on disk and CuPy warns about "multiple CuPy packages installed."
+# If a prior setup picked a different major, uninstall the stale variant now.
+target_cupy="cupy-cuda${cuda_major}x"
+for v in cupy-cuda11x cupy-cuda12x cupy-cuda13x; do
+    if [[ "$v" != "$target_cupy" ]] && uv pip show --python "$PY" "$v" >/dev/null 2>&1; then
+        echo "==> removing stale $v (target is $target_cupy)"
+        uv pip uninstall --python "$PY" "$v" >/dev/null
+    fi
+done
+
 # Mirrors pyproject.toml. PyGObject comes from system python3-gi via
 # --system-site-packages, not pip.
-PKGS=("pyyaml>=6.0" "cupy-cuda${cuda_major}x" "numpy>=1.23" "scipy>=1.15")
+PKGS=("pyyaml>=6.0" "$target_cupy" "numpy>=1.23" "scipy>=1.15")
 [[ "$MODE" == full ]] && PKGS=("$WHEEL" "${PKGS[@]}")
 $WITH_V4L2 && PKGS+=("opencv-python>=4.5")
 $WITH_OAKD && PKGS+=("depthai>=3.0")

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -248,6 +248,15 @@ for v in cupy-cuda11x cupy-cuda12x cupy-cuda13x; do
     fi
 done
 
+# Broken-install guard: if dist-info is present but `import cupy` fails
+# (interrupted setup, manual `rm -rf cupy/`), uv treats the package as
+# installed and won't reinstall on the regular install line.
+if uv pip show --python "$PY" "$target_cupy" >/dev/null 2>&1 \
+        && ! "$PY" -c "import cupy" >/dev/null 2>&1; then
+    echo "==> $target_cupy metadata present but import fails — reinstalling"
+    uv pip uninstall --python "$PY" "$target_cupy" >/dev/null
+fi
+
 # Mirrors pyproject.toml. PyGObject comes from system python3-gi via
 # --system-site-packages, not pip.
 PKGS=("pyyaml>=6.0" "$target_cupy" "numpy>=1.23" "scipy>=1.15")

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -34,10 +34,9 @@ WITH_OAKD=true
 WITH_RTP=true
 WITH_ZED=false
 ZED_SDK_DIR=/usr/local/zed
-# Jetson-specific provisioning: apt-install python3-gi / GStreamer
-# plugins / cuda-nvrtc and create the unversioned CUDA lib symlinks +
-# ld.so cache entry that JetPack skips. Off on desktop where these are
-# already covered by the normal package manager / CUDA installer.
+# Jetson-specific provisioning: apt-install cuda-nvrtc and create the
+# unversioned CUDA lib symlinks + ld.so cache entry that JetPack skips.
+# Off on desktop where the normal CUDA installer covers both.
 JETSON=false
 
 while (( $# )); do
@@ -84,14 +83,25 @@ ensure_apt_deps() {
     fi
 
     local pkgs=()
-    # Python bindings.
-    if ! python3 -c "import gi; gi.require_version('Gst', '1.0'); from gi.repository import Gst" 2>/dev/null; then
-        pkgs+=(python3-gi python3-gst-1.0 gir1.2-gstreamer-1.0 gstreamer1.0-tools)
-    fi
+    # PyGObject lives in the venv (installed via uv below). What apt
+    # owns here is purely non-Python:
+    #   * C build deps for the source build (libcairo / libgirepository /
+    #     pkg-config / Python dev headers — uv-managed Python ships its
+    #     own headers, but system python3 doesn't).
+    #   * Runtime Gst typelib (PyGObject loads it via gobject-introspection).
+    #   * gst-inspect-1.0 for our own plugin-presence check below.
+    command -v pkg-config >/dev/null 2>&1                       || pkgs+=(pkg-config)
+    pkg-config --exists cairo 2>/dev/null                       || pkgs+=(libcairo2-dev)
+    # Debian's libgirepository1.0-dev publishes the .pc file as
+    # gobject-introspection-1.0, NOT girepository-1.0 — probe accordingly.
+    pkg-config --exists gobject-introspection-1.0 2>/dev/null   || pkgs+=(libgirepository1.0-dev)
+    ls /usr/lib/*-linux-gnu/girepository-1.0/Gst-1.0.typelib >/dev/null 2>&1 \
+                                                                || pkgs+=(gir1.2-gstreamer-1.0)
+    command -v gst-inspect-1.0 >/dev/null 2>&1                  || pkgs+=(gstreamer1.0-tools)
     # GStreamer elements RtpH264Sender / RtpH264Receiver need at runtime.
-    # Checked per-element via gst-inspect-1.0 so hosts that have python3-gi
-    # but missing plugins (a real failure mode on partially-provisioned
-    # systems) still get the right apt packages.
+    # Checked per-element via gst-inspect-1.0 so partially-provisioned
+    # hosts (typelib present, plugins missing — a real failure mode) still
+    # get the right apt packages.
     local need_base=false need_good=false need_bad=false need_ugly=false
     if command -v gst-inspect-1.0 >/dev/null 2>&1; then
         gst-inspect-1.0 videoconvert >/dev/null 2>&1 || need_base=true
@@ -218,19 +228,20 @@ echo "==> python: $PYTHON_VERSION"
 [[ "$MODE" == full ]] && echo "==> wheel:  $WHEEL"
 
 if [[ ! -d "$VENV_DIR" ]]; then
-    # --system-site-packages exposes Debian's python3-gi / python3-gst-1.0
-    # (no pycairo source-build); venv installs still shadow system pkgs.
-    # Sender mode must base on system python3 so /usr/lib/python3/dist-
-    # packages is reachable — uv's managed download has empty site-packages.
+    # Strict venv isolation: no --system-site-packages. PyGObject + every
+    # other Python dep is installed into the venv via uv below. Sender mode
+    # still defaults to system python3 because Jetson images sometimes
+    # don't have a uv-managed Python build for the JetPack arch+libc combo
+    # — but the venv itself stays isolated.
     if [[ "$MODE" == sender ]]; then
         sys_py="$(command -v python3 || true)"
         [[ -x "$sys_py" ]] || {
             echo "_install_deps.sh: system python3 required in --sender-only mode" >&2
             exit 1
         }
-        uv venv "$VENV_DIR" --python "$sys_py" --system-site-packages
+        uv venv "$VENV_DIR" --python "$sys_py"
     else
-        uv venv "$VENV_DIR" --python "$PYTHON_VERSION" --system-site-packages
+        uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
     fi
 fi
 PY="$VENV_DIR/bin/python"
@@ -257,13 +268,15 @@ if uv pip show --python "$PY" "$target_cupy" >/dev/null 2>&1 \
     uv pip uninstall --python "$PY" "$target_cupy" >/dev/null
 fi
 
-# Mirrors pyproject.toml. PyGObject comes from system python3-gi via
-# --system-site-packages, not pip.
+# Mirrors pyproject.toml. PyGObject is pinned <3.52: 3.52 dropped the
+# girepository-1.0 build path, and Ubuntu 22.04 only ships 1.0
+# (libgirepository1.0-dev). 3.50.x supports both. Source-builds against
+# the C deps installed in ensure_apt_deps(); pycairo is a transitive dep.
 PKGS=("pyyaml>=6.0" "$target_cupy" "numpy>=1.23" "scipy>=1.15")
 [[ "$MODE" == full ]] && PKGS=("$WHEEL" "${PKGS[@]}")
 $WITH_V4L2 && PKGS+=("opencv-python>=4.5")
 $WITH_OAKD && PKGS+=("depthai>=3.0")
-$WITH_RTP  && PKGS+=("pybind11>=2.11")
+$WITH_RTP  && PKGS+=("pybind11>=2.11" "PyGObject>=3.42,<3.52")
 
 echo "==> installing: ${PKGS[*]}"
 uv pip install --python "$PY" --upgrade "${PKGS[@]}"
@@ -309,8 +322,8 @@ if $WITH_RTP; then
     fi
 fi
 
-# Smoke imports. ``gi`` is in the list under RTP to confirm
-# --system-site-packages is wired up.
+# Smoke imports. ``gi`` is in the list under RTP to confirm PyGObject
+# built and installed cleanly into the venv.
 echo "==> import smoke"
 SMOKE_MODS="cupy yaml scipy.spatial.transform"
 [[ "$MODE" == full ]] && SMOKE_MODS="isaacteleop.viz $SMOKE_MODS"

--- a/examples/camera_viz/scripts/camera-streamer.service.in
+++ b/examples/camera_viz/scripts/camera-streamer.service.in
@@ -13,7 +13,7 @@ Wants=network-online.target
 Type=simple
 WorkingDirectory={{WORKDIR}}
 Environment=PATH={{VENV}}/bin:/usr/local/cuda/bin:/usr/bin:/bin
-ExecStart={{VENV}}/bin/python {{WORKDIR}}/camera_streamer.py {{CONFIG}}
+ExecStart={{VENV}}/bin/python {{WORKDIR}}/camera_streamer.py {{CONFIG}}{{EXTRA_ARGS}}
 Restart=always
 RestartSec=2
 StandardOutput=journal


### PR DESCRIPTION
  ## Summary
  - Python deps now install strictly into `examples/camera_viz/.venv` via uv. PyGObject + pycairo move from the system Python (`python3-gi` via apt + `--system-site-packages`) into the venv;
  the broken-cupy state from "multiple CuPy packages installed" is detected and reinstalled; stale `cupy-cudaXx` variants are uninstalled before the target variant lands.
  - System-side prerequisites (GStreamer plugins, cairo / girepository dev headers, `cuda-nvrtc` on Jetson, `ld.so` wiring) are now PROBED. If anything is missing, the script prints the exact
   `apt-get` / `ln` / `ldconfig` commands and asks `Run those now? [y/N]` on `/dev/tty`. Nothing under sudo runs without a `y`.
  - `camera_viz.sh deploy` is unchanged structurally — same prompt flows over `ssh -t` to the Jetson, so the operator confirms apt-get on the robot the same way as locally.
  - Custom venv path CLI for setup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency installation reliability for the camera visualization example by automatically removing conflicting CuPy CUDA package variants before installing the correct version.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/533)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->