### PR TITLE
[TeleViz] Adds stereo quad layer support to camera_viz example

### DIFF
--- a/examples/camera_viz/camera_streamer.py
+++ b/examples/camera_viz/camera_streamer.py
@@ -45,7 +45,9 @@ RETRY_S = 5.0
 SUPERVISOR_TICK_S = 1.0
 
 
-def _eye_sources(sources: List[FrameSource], camera_name: str) -> List[FrameSource]:
+def _eye_sources(
+    sources: List[FrameSource], camera_name: str, expect_stereo: bool = False
+) -> List[FrameSource]:
     """Unwrap build_local_camera()'s output: [src] mono, [left, right] stereo."""
     if len(sources) == 1 and isinstance(sources[0], PairedFrameSource):
         paired = sources[0]
@@ -55,6 +57,18 @@ def _eye_sources(sources: List[FrameSource], camera_name: str) -> List[FrameSour
         raise ValueError(
             f"camera {camera_name!r} produced {len(sources)} streams {names}; "
             "expected 1 (mono) or a PairedFrameSource (stereo)."
+        )
+    # Single source but the YAML asked for stereo. Single-producer stereo
+    # (SyntheticStereoSource) emits paired Frames but doesn't expose
+    # per-eye streams for two independent RTP senders — fail loudly
+    # rather than silently send only the left eye on the wire.
+    if expect_stereo:
+        raise ValueError(
+            f"camera {camera_name!r}: stereo configured but the source "
+            f"({type(sources[0]).__name__}) doesn't expose per-eye streams. "
+            "Streamer-side stereo currently requires PairedFrameSource "
+            "(ZED / OAK-D); single-producer stereo (e.g. SyntheticStereoSource) "
+            "isn't supported over RTP."
         )
     return [sources[0]]
 
@@ -108,7 +122,9 @@ class CameraSupervisor:
                 self._name,
             )
 
-        eyes = _eye_sources(sources, self._name)
+        eyes = _eye_sources(
+            sources, self._name, expect_stereo=bool(self._cfg.get("stereo", False))
+        )
         rtp = self._cfg.get("rtp", {})
         if "port" not in rtp:
             raise ValueError(f"camera {self._name!r} missing rtp.port")

--- a/examples/camera_viz/camera_streamer.py
+++ b/examples/camera_viz/camera_streamer.py
@@ -30,7 +30,7 @@ from typing import List, Optional
 import yaml
 
 from pipeline import FrameSource
-from sources import PairedFrameSource, build_local_camera
+from sources import PairedFrameSource, build_local_camera, set_verbose
 from transports import RtpH264Sender, make_encoder
 
 logger = logging.getLogger("camera_streamer")
@@ -273,6 +273,11 @@ def main(argv: Optional[List[str]] = None) -> int:
             type(cfg).__name__,
         )
         return 2
+
+    # YAML top-level ``verbose: true`` turns on the per-source periodic
+    # breadcrumbs (per-eye fps, etc.). CAMERA_VIZ_VERBOSE=1 in the env
+    # also works without editing the YAML.
+    set_verbose(bool(cfg.get("verbose", False)))
 
     streaming = cfg.get("streaming", {})
     host = args.host or streaming.get("host")

--- a/examples/camera_viz/camera_streamer.py
+++ b/examples/camera_viz/camera_streamer.py
@@ -30,7 +30,7 @@ from typing import List, Optional
 import yaml
 
 from pipeline import FrameSource
-from sources import build_local_camera
+from sources import PairedFrameSource, build_local_camera
 from transports import RtpH264Sender, make_encoder
 
 logger = logging.getLogger("camera_streamer")
@@ -45,16 +45,22 @@ RETRY_S = 5.0
 SUPERVISOR_TICK_S = 1.0
 
 
-def _pick_mono_source(sources: List[FrameSource], camera_name: str) -> FrameSource:
-    """Mono-only sender: exactly one source per camera. Stereo cameras
-    aren't supported here pending per-eye QuadLayer binding."""
+def _eye_sources(sources: List[FrameSource], camera_name: str) -> List[FrameSource]:
+    """Normalize ``build_local_camera`` output into a 1-or-2 element list.
+
+    Mono cameras → [src]. Stereo cameras → [left, right] unwrapped from
+    the PairedFrameSource wrapper that ``build_local_camera`` returns.
+    The streamer then fires one independent RTP stream per element."""
+    if len(sources) == 1 and isinstance(sources[0], PairedFrameSource):
+        paired = sources[0]
+        return [paired.left, paired.right]
     if len(sources) != 1:
         names = [s.spec.name for s in sources]
         raise ValueError(
             f"camera {camera_name!r} produced {len(sources)} streams {names}; "
-            "only mono cameras are supported here. Set mode/stereo to mono/false."
+            "expected 1 (mono) or a PairedFrameSource (stereo)."
         )
-    return sources[0]
+    return [sources[0]]
 
 
 class CameraSupervisor:
@@ -96,66 +102,91 @@ class CameraSupervisor:
                 return
             self._thread = None
 
-    def _build_sender(self) -> RtpH264Sender:
-        source = _pick_mono_source(build_local_camera(self._cfg), self._name)
+    def _build_senders(self) -> List[RtpH264Sender]:
+        eyes = _eye_sources(build_local_camera(self._cfg), self._name)
         rtp = self._cfg.get("rtp", {})
         if "port" not in rtp:
             raise ValueError(f"camera {self._name!r} missing rtp.port")
-        encoder = make_encoder(
-            rtp.get("encoder", self._default_encoder),
-            width=int(self._cfg["width"]),
-            height=int(self._cfg["height"]),
-            bitrate=int(rtp.get("bitrate_mbps", 15)) * 1_000_000,
-            fps=int(self._cfg.get("fps", 30)),
-            gop=int(rtp["gop"]) if "gop" in rtp else None,
-            gpu_id=int(rtp.get("gpu_id", 0)),
-        )
-        return RtpH264Sender(
-            source=source,
-            encoder=encoder,
-            host=self._host,
-            port=int(rtp["port"]),
-            width=int(self._cfg["width"]),
-            height=int(self._cfg["height"]),
-            fps=int(self._cfg.get("fps", 30)),
-            mtu=int(rtp.get("mtu", 1400)),
-        )
+        is_stereo = len(eyes) == 2
+        if is_stereo and "port_right" not in rtp:
+            raise ValueError(
+                f"camera {self._name!r}: stereo requires rtp.port_right (the "
+                "left eye goes to rtp.port, the right eye to rtp.port_right)"
+            )
+
+        def build_one(source: FrameSource, port: int) -> RtpH264Sender:
+            encoder = make_encoder(
+                rtp.get("encoder", self._default_encoder),
+                width=int(self._cfg["width"]),
+                height=int(self._cfg["height"]),
+                bitrate=int(rtp.get("bitrate_mbps", 15)) * 1_000_000,
+                fps=int(self._cfg.get("fps", 30)),
+                gop=int(rtp["gop"]) if "gop" in rtp else None,
+                gpu_id=int(rtp.get("gpu_id", 0)),
+            )
+            return RtpH264Sender(
+                source=source,
+                encoder=encoder,
+                host=self._host,
+                port=port,
+                width=int(self._cfg["width"]),
+                height=int(self._cfg["height"]),
+                fps=int(self._cfg.get("fps", 30)),
+                mtu=int(rtp.get("mtu", 1400)),
+            )
+
+        if is_stereo:
+            return [
+                build_one(eyes[0], int(rtp["port"])),
+                build_one(eyes[1], int(rtp["port_right"])),
+            ]
+        return [build_one(eyes[0], int(rtp["port"]))]
 
     def _run(self) -> None:
         attempt = 0
         while not self._stop.is_set():
             attempt += 1
-            sender: Optional[RtpH264Sender] = None
+            senders: List[RtpH264Sender] = []
             started_at: Optional[float] = None
             try:
                 logger.info("camera %r: building (attempt %d)", self._name, attempt)
-                sender = self._build_sender()
-                sender.start()
+                senders = self._build_senders()
+                for s in senders:
+                    s.start()
                 started_at = time.monotonic()
-                logger.info(
-                    "camera %r: streaming → %s:%s",
-                    self._name,
-                    self._host,
-                    self._cfg["rtp"]["port"],
-                )
-                # Poll sender liveness. If the send-loop thread dies
+                rtp = self._cfg.get("rtp", {})
+                if len(senders) == 2:
+                    logger.info(
+                        "camera %r: streaming stereo → %s:%s (L) + %s:%s (R)",
+                        self._name,
+                        self._host,
+                        rtp.get("port"),
+                        self._host,
+                        rtp.get("port_right"),
+                    )
+                else:
+                    logger.info(
+                        "camera %r: streaming → %s:%s",
+                        self._name,
+                        self._host,
+                        rtp.get("port"),
+                    )
+                # Poll sender liveness. If any send-loop thread dies
                 # after startup (GStreamer pipeline error, encoder
-                # crash, etc.) raise into the retry path; otherwise a
-                # silent-but-dead supervisor would keep the service
-                # "healthy" while nothing is being streamed.
+                # crash, etc.) raise into the retry path — for stereo
+                # we treat the pair atomically: if one eye drops, we
+                # restart both.
                 while not self._stop.is_set():
                     self._stop.wait(timeout=SUPERVISOR_TICK_S)
-                    if not sender.is_alive():
-                        raise RuntimeError("RtpH264Sender thread exited unexpectedly")
+                    dead = [s for s in senders if not s.is_alive()]
+                    if dead:
+                        raise RuntimeError(
+                            f"{len(dead)}/{len(senders)} RtpH264Sender thread(s) exited unexpectedly"
+                        )
             except KeyboardInterrupt:
-                # SIGINT during ``sender.start()`` arrives as KeyboardInterrupt
-                # in this thread; surface as a stop, not a retry.
                 self._stop.set()
                 break
             except Exception as e:
-                # ``camera_streamer`` is supposed to never exit. Log full
-                # traceback at debug and a one-liner at warning so journalctl
-                # stays readable while preserving the detail for triage.
                 uptime = (time.monotonic() - started_at) if started_at else 0.0
                 logger.warning(
                     "camera %r: failure after %.1fs uptime: %s — retrying in %.1fs",
@@ -166,9 +197,9 @@ class CameraSupervisor:
                 )
                 logger.debug("camera %r: traceback", self._name, exc_info=True)
             finally:
-                if sender is not None:
+                for s in senders:
                     try:
-                        sender.stop()
+                        s.stop()
                     except Exception:
                         logger.debug(
                             "camera %r: sender.stop() raised", self._name, exc_info=True

--- a/examples/camera_viz/camera_streamer.py
+++ b/examples/camera_viz/camera_streamer.py
@@ -103,7 +103,20 @@ class CameraSupervisor:
             self._thread = None
 
     def _build_senders(self) -> List[RtpH264Sender]:
-        eyes = _eye_sources(build_local_camera(self._cfg), self._name)
+        sources = build_local_camera(self._cfg)
+        # mode: stereo_rgb on OAK-D returns a PairedFrameSource of just
+        # (left, right) — the rgb stream is still being grabbed +
+        # processed by depthai but never reaches the wire. Burn-without-
+        # use is wasteful enough that we'd rather flag it loudly than
+        # let a user wonder why their USB / VPU is saturated.
+        if self._cfg.get("type") == "oakd" and self._cfg.get("mode") == "stereo_rgb":
+            logger.warning(
+                "camera %r: mode=stereo_rgb on the streamer wastes the rgb stream "
+                "(only left + right go on the wire). Use mode: stereo to save USB + VPU.",
+                self._name,
+            )
+
+        eyes = _eye_sources(sources, self._name)
         rtp = self._cfg.get("rtp", {})
         if "port" not in rtp:
             raise ValueError(f"camera {self._name!r} missing rtp.port")
@@ -135,12 +148,29 @@ class CameraSupervisor:
                 mtu=int(rtp.get("mtu", 1400)),
             )
 
+        # Build incrementally so a partial-failure mid-list (stereo with
+        # NVENC contention on the second encoder is the realistic case)
+        # rolls back the first sender's NVENC session via .stop()
+        # instead of leaving it dangling until Python GC.
+        ports = [int(rtp["port"])]
         if is_stereo:
-            return [
-                build_one(eyes[0], int(rtp["port"])),
-                build_one(eyes[1], int(rtp["port_right"])),
-            ]
-        return [build_one(eyes[0], int(rtp["port"]))]
+            ports.append(int(rtp["port_right"]))
+        built: List[RtpH264Sender] = []
+        try:
+            for eye, port in zip(eyes, ports):
+                built.append(build_one(eye, port))
+            return built
+        except Exception:
+            for s in built:
+                try:
+                    s.stop()
+                except Exception:
+                    logger.debug(
+                        "camera %r: partial-build rollback s.stop() raised",
+                        self._name,
+                        exc_info=True,
+                    )
+            raise
 
     def _run(self) -> None:
         attempt = 0

--- a/examples/camera_viz/camera_streamer.py
+++ b/examples/camera_viz/camera_streamer.py
@@ -46,11 +46,7 @@ SUPERVISOR_TICK_S = 1.0
 
 
 def _eye_sources(sources: List[FrameSource], camera_name: str) -> List[FrameSource]:
-    """Normalize ``build_local_camera`` output into a 1-or-2 element list.
-
-    Mono cameras → [src]. Stereo cameras → [left, right] unwrapped from
-    the PairedFrameSource wrapper that ``build_local_camera`` returns.
-    The streamer then fires one independent RTP stream per element."""
+    """Unwrap build_local_camera()'s output: [src] mono, [left, right] stereo."""
     if len(sources) == 1 and isinstance(sources[0], PairedFrameSource):
         paired = sources[0]
         return [paired.left, paired.right]
@@ -104,11 +100,7 @@ class CameraSupervisor:
 
     def _build_senders(self) -> List[RtpH264Sender]:
         sources = build_local_camera(self._cfg)
-        # mode: stereo_rgb on OAK-D returns a PairedFrameSource of just
-        # (left, right) — the rgb stream is still being grabbed +
-        # processed by depthai but never reaches the wire. Burn-without-
-        # use is wasteful enough that we'd rather flag it loudly than
-        # let a user wonder why their USB / VPU is saturated.
+        # stereo_rgb's third stream is processed by depthai but never wired.
         if self._cfg.get("type") == "oakd" and self._cfg.get("mode") == "stereo_rgb":
             logger.warning(
                 "camera %r: mode=stereo_rgb on the streamer wastes the rgb stream "
@@ -148,10 +140,8 @@ class CameraSupervisor:
                 mtu=int(rtp.get("mtu", 1400)),
             )
 
-        # Build incrementally so a partial-failure mid-list (stereo with
-        # NVENC contention on the second encoder is the realistic case)
-        # rolls back the first sender's NVENC session via .stop()
-        # instead of leaving it dangling until Python GC.
+        # Incremental build so a mid-list failure rolls back the
+        # already-built sender's NVENC session via .stop().
         ports = [int(rtp["port"])]
         if is_stereo:
             ports.append(int(rtp["port_right"]))
@@ -201,11 +191,7 @@ class CameraSupervisor:
                         self._host,
                         rtp.get("port"),
                     )
-                # Poll sender liveness. If any send-loop thread dies
-                # after startup (GStreamer pipeline error, encoder
-                # crash, etc.) raise into the retry path — for stereo
-                # we treat the pair atomically: if one eye drops, we
-                # restart both.
+                # Stereo treats the pair atomically: if either eye dies, restart both.
                 while not self._stop.is_set():
                     self._stop.wait(timeout=SUPERVISOR_TICK_S)
                     dead = [s for s in senders if not s.is_alive()]
@@ -274,9 +260,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         )
         return 2
 
-    # YAML top-level ``verbose: true`` turns on the per-source periodic
-    # breadcrumbs (per-eye fps, etc.). CAMERA_VIZ_VERBOSE=1 in the env
-    # also works without editing the YAML.
+    # Top-level ``verbose:`` enables per-source periodic breadcrumbs.
     set_verbose(bool(cfg.get("verbose", False)))
 
     streaming = cfg.get("streaming", {})

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import signal
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -31,7 +32,21 @@ from pipeline import FrameSource, VizRunner
 from placements import PlacementConfig, PlacementStrategy, build as build_placement
 from sources import RtpH264Source, build_local_camera
 
-SourceEntry = Tuple[FrameSource, Optional[PlacementStrategy]]
+
+@dataclass
+class SourceEntry:
+    """One row in the layer plan: a source + its placement + stereo cfg.
+
+    ``stereo`` and ``stereo_baseline_mm`` are pulled from the camera spec
+    (``cameras.<cam>.stereo``) and the placement spec
+    (``placements.<cam>.stereo_baseline_mm``) respectively. They drive
+    the QuadLayer Config when the layer is added to the session.
+    """
+
+    source: FrameSource
+    placement: Optional[PlacementStrategy]
+    stereo: bool = False
+    stereo_baseline_mm: float = 0.0
 
 
 def _build_placement(spec: Optional[dict], is_xr: bool) -> Optional[PlacementStrategy]:
@@ -82,14 +97,36 @@ def _placement_with_aspect(
     return _build_placement(spec, is_xr)
 
 
+def _stereo_for(cam: dict, placements_cfg: dict) -> Tuple[bool, float]:
+    """Resolve stereo + baseline for one camera.
+
+    ``stereo`` lives on the camera (so the producer side knows). The
+    rendering knob ``stereo_baseline_mm`` lives on the placement (it's
+    a display-time parameter). 0.0 means both eyes see the same world
+    quad — all parallax comes from the captured frames.
+    """
+    stereo = bool(cam.get("stereo", False))
+    pspec = placements_cfg.get(cam["name"]) or {}
+    baseline_mm = float(pspec.get("stereo_baseline_mm", 0.0))
+    return stereo, baseline_mm
+
+
 def _build_local_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
     """source=local: open each enabled camera directly."""
     placements_cfg = cfg.get("display", {}).get("placements", {})
     entries: List[SourceEntry] = []
     for cam in _enabled_cameras(cfg):
         placement = _placement_with_aspect(placements_cfg.get(cam["name"]), cam, is_xr)
+        stereo, baseline_mm = _stereo_for(cam, placements_cfg)
         for source in build_local_camera(cam):
-            entries.append((source, placement))
+            entries.append(
+                SourceEntry(
+                    source=source,
+                    placement=placement,
+                    stereo=stereo,
+                    stereo_baseline_mm=baseline_mm,
+                )
+            )
     return entries
 
 
@@ -113,7 +150,10 @@ def _build_rtp_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
             gpu_id=int(rtp.get("gpu_id", 0)),
         )
         placement = _placement_with_aspect(placements_cfg.get(cam["name"]), cam, is_xr)
-        entries.append((source, placement))
+        # NOTE: RTP stereo wiring (C4) — paired receivers — isn't in
+        # this entry's scope yet. ``stereo`` flips false here so the
+        # layer stays mono until that lands.
+        entries.append(SourceEntry(source=source, placement=placement))
     return entries
 
 
@@ -168,14 +208,19 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     # Build sources, layers, and placement strategies in parallel arrays.
     sources, layers, strategies = [], [], []
-    for source, placement in entries:
-        sources.append(source)
+    for entry in entries:
+        sources.append(entry.source)
         layer_cfg = viz.QuadLayerConfig()
-        layer_cfg.name = source.spec.name
-        layer_cfg.resolution = viz.Resolution(source.spec.width, source.spec.height)
+        layer_cfg.name = entry.source.spec.name
+        layer_cfg.resolution = viz.Resolution(
+            entry.source.spec.width, entry.source.spec.height
+        )
         layer_cfg.format = viz.PixelFormat.kRGBA8
+        if entry.stereo:
+            layer_cfg.stereo = True
+            layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
         layers.append(session.add_quad_layer(layer_cfg))
-        strategies.append(placement)
+        strategies.append(entry.placement)
 
     print(
         f"camera_viz: source={source_mode}, mode={cfg.get('display', {}).get('mode')}, "

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -286,8 +286,25 @@ def main(argv: Optional[list[str]] = None) -> int:
     try:
         runner.wait()
     finally:
-        runner.stop()
-        session.destroy()
+        # ``runner.stop()`` returns False when a worker thread (render
+        # or submit) is still alive after the join budget — typically
+        # because it's wedged inside session.render() / layer.submit().
+        # Destroying the session under a live worker is a use-after-
+        # free on the Vulkan / CUDA handles it's still touching, so we
+        # skip session.destroy() in that case. The non-daemon worker
+        # keeps the process alive until it eventually exits; the OS
+        # reaps the session on process exit.
+        clean = runner.stop()
+        if clean:
+            session.destroy()
+        else:
+            print(
+                "camera_viz: a worker thread did not exit; leaving VizSession "
+                "alive to avoid a use-after-free. Process will keep running "
+                "until the stuck thread completes.",
+                file=sys.stderr,
+                flush=True,
+            )
     return 0
 
 

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -30,7 +30,7 @@ import isaacteleop.viz as viz
 
 from pipeline import FrameSource, VizRunner
 from placements import PlacementConfig, PlacementStrategy, build as build_placement
-from sources import PairedFrameSource, RtpH264Source, build_local_camera
+from sources import PairedFrameSource, RtpH264Source, build_local_camera, set_verbose
 
 
 @dataclass
@@ -233,6 +233,11 @@ def main(argv: Optional[list[str]] = None) -> int:
             f"camera_viz: {args.config} must be a YAML mapping at the top level, "
             f"got {type(cfg).__name__}"
         )
+
+    # YAML top-level ``verbose: true`` turns on the per-source periodic
+    # breadcrumbs (per-eye fps, etc.). CAMERA_VIZ_VERBOSE=1 in the env
+    # also works for ad-hoc debugging without editing the YAML.
+    set_verbose(bool(cfg.get("verbose", False)))
 
     source_mode = cfg.get("source", "local").lower()
     if source_mode not in ("local", "rtp"):

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -35,13 +35,7 @@ from sources import PairedFrameSource, RtpH264Source, build_local_camera, set_ve
 
 @dataclass
 class SourceEntry:
-    """One row in the layer plan: a source + its placement + stereo cfg.
-
-    ``stereo`` and ``stereo_baseline_mm`` are pulled from the camera spec
-    (``cameras.<cam>.stereo``) and the placement spec
-    (``placements.<cam>.stereo_baseline_mm``) respectively. They drive
-    the QuadLayer Config when the layer is added to the session.
-    """
+    """source + placement + stereo cfg; drives QuadLayer construction."""
 
     source: FrameSource
     placement: Optional[PlacementStrategy]
@@ -98,13 +92,7 @@ def _placement_with_aspect(
 
 
 def _stereo_for(cam: dict, placements_cfg: dict) -> Tuple[bool, float]:
-    """Resolve stereo + baseline for one camera.
-
-    ``stereo`` lives on the camera (so the producer side knows). The
-    rendering knob ``stereo_baseline_mm`` lives on the placement (it's
-    a display-time parameter). 0.0 means both eyes see the same world
-    quad — all parallax comes from the captured frames.
-    """
+    """``cameras.<cam>.stereo`` (producer toggle) + ``placements.<cam>.stereo_baseline_mm``."""
     stereo = bool(cam.get("stereo", False))
     pspec = placements_cfg.get(cam["name"]) or {}
     baseline_mm = float(pspec.get("stereo_baseline_mm", 0.0))
@@ -131,14 +119,8 @@ def _build_local_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
 
 
 def _build_rtp_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
-    """source=rtp: build an RTP listener per camera using its ``rtp.port``.
-
-    Stereo cameras open TWO listeners (rtp.port for left, rtp.port_right
-    for right) and pair them via PairedFrameSource. The wire path treats
-    the two eyes as independent streams — drift is acceptable (the user
-    accepted "no sync" for RTP stereo); paired-frame atomicity at the
-    QuadLayer mailbox is what stops torn pairs from reaching the GPU.
-    """
+    """One RTP listener per camera; stereo uses rtp.port + rtp.port_right
+    and pairs them at the receiver (no wire-level sync — drift OK)."""
     placements_cfg = cfg.get("display", {}).get("placements", {})
     entries: List[SourceEntry] = []
     for cam in _enabled_cameras(cfg):
@@ -234,9 +216,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             f"got {type(cfg).__name__}"
         )
 
-    # YAML top-level ``verbose: true`` turns on the per-source periodic
-    # breadcrumbs (per-eye fps, etc.). CAMERA_VIZ_VERBOSE=1 in the env
-    # also works for ad-hoc debugging without editing the YAML.
+    # Top-level ``verbose:`` enables per-source periodic breadcrumbs.
     set_verbose(bool(cfg.get("verbose", False)))
 
     source_mode = cfg.get("source", "local").lower()
@@ -286,21 +266,17 @@ def main(argv: Optional[list[str]] = None) -> int:
     try:
         runner.wait()
     finally:
-        # ``runner.stop()`` returns False when a worker thread (render
-        # or submit) is still alive after the join budget — typically
-        # because it's wedged inside session.render() / layer.submit().
-        # Destroying the session under a live worker is a use-after-
-        # free on the Vulkan / CUDA handles it's still touching, so we
-        # skip session.destroy() in that case. The non-daemon worker
-        # keeps the process alive until it eventually exits; the OS
-        # reaps the session on process exit.
+        # Skip session.destroy() when a worker thread is still alive —
+        # it may be inside session.render() and destroying under it
+        # would UAF on the Vulkan / CUDA handles. Non-daemon thread
+        # keeps the process alive; OS reaps at exit.
         clean = runner.stop()
         if clean:
             session.destroy()
         else:
             print(
-                "camera_viz: a worker thread did not exit; leaving VizSession "
-                "alive to avoid a use-after-free. Process will keep running "
+                "camera_viz: worker thread did not exit; leaving VizSession "
+                "alive to avoid use-after-free. Process will keep running "
                 "until the stuck thread completes.",
                 file=sys.stderr,
                 flush=True,

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -30,7 +30,7 @@ import isaacteleop.viz as viz
 
 from pipeline import FrameSource, VizRunner
 from placements import PlacementConfig, PlacementStrategy, build as build_placement
-from sources import RtpH264Source, build_local_camera
+from sources import PairedFrameSource, RtpH264Source, build_local_camera
 
 
 @dataclass
@@ -131,7 +131,14 @@ def _build_local_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
 
 
 def _build_rtp_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
-    """source=rtp: build an RTP listener per camera using its ``rtp.port``."""
+    """source=rtp: build an RTP listener per camera using its ``rtp.port``.
+
+    Stereo cameras open TWO listeners (rtp.port for left, rtp.port_right
+    for right) and pair them via PairedFrameSource. The wire path treats
+    the two eyes as independent streams — drift is acceptable (the user
+    accepted "no sync" for RTP stereo); paired-frame atomicity at the
+    QuadLayer mailbox is what stops torn pairs from reaching the GPU.
+    """
     placements_cfg = cfg.get("display", {}).get("placements", {})
     entries: List[SourceEntry] = []
     for cam in _enabled_cameras(cfg):
@@ -141,19 +148,52 @@ def _build_rtp_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
                 f"camera_viz: camera {cam.get('name')!r} missing rtp.port; "
                 "required when source: rtp"
             )
-        source = RtpH264Source(
-            name=cam["name"],
-            width=int(cam["width"]),
-            height=int(cam["height"]),
-            port=int(rtp["port"]),
-            rtp_buffer_size=int(rtp.get("rtp_buffer_size", 212992)),
-            gpu_id=int(rtp.get("gpu_id", 0)),
-        )
         placement = _placement_with_aspect(placements_cfg.get(cam["name"]), cam, is_xr)
-        # NOTE: RTP stereo wiring (C4) — paired receivers — isn't in
-        # this entry's scope yet. ``stereo`` flips false here so the
-        # layer stays mono until that lands.
-        entries.append(SourceEntry(source=source, placement=placement))
+        stereo, baseline_mm = _stereo_for(cam, placements_cfg)
+
+        if stereo:
+            if "port_right" not in rtp:
+                raise ValueError(
+                    f"camera_viz: stereo camera {cam.get('name')!r} missing "
+                    "rtp.port_right (required when stereo + source: rtp)"
+                )
+            left = RtpH264Source(
+                name=f"{cam['name']}.left",
+                width=int(cam["width"]),
+                height=int(cam["height"]),
+                port=int(rtp["port"]),
+                rtp_buffer_size=int(rtp.get("rtp_buffer_size", 212992)),
+                gpu_id=int(rtp.get("gpu_id", 0)),
+            )
+            right = RtpH264Source(
+                name=f"{cam['name']}.right",
+                width=int(cam["width"]),
+                height=int(cam["height"]),
+                port=int(rtp["port_right"]),
+                rtp_buffer_size=int(rtp.get("rtp_buffer_size", 212992)),
+                gpu_id=int(rtp.get("gpu_id", 0)),
+            )
+            source: FrameSource = PairedFrameSource(
+                name=cam["name"], left=left, right=right
+            )
+        else:
+            source = RtpH264Source(
+                name=cam["name"],
+                width=int(cam["width"]),
+                height=int(cam["height"]),
+                port=int(rtp["port"]),
+                rtp_buffer_size=int(rtp.get("rtp_buffer_size", 212992)),
+                gpu_id=int(rtp.get("gpu_id", 0)),
+            )
+
+        entries.append(
+            SourceEntry(
+                source=source,
+                placement=placement,
+                stereo=stereo,
+                stereo_baseline_mm=baseline_mm,
+            )
+        )
     return entries
 
 

--- a/examples/camera_viz/configs/synthetic_stereo.yaml
+++ b/examples/camera_viz/configs/synthetic_stereo.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Synthetic stereo source — exercises the stereo QuadLayer path without
+# stereo camera hardware. Same animated pattern as synthetic.yaml, but
+# with a horizontal pixel disparity between the eyes so the parallax is
+# visible in XR. Window mode renders the LEFT eye (per the documented
+# single-view fallback).
+
+source: local
+streaming:
+  host: 127.0.0.1
+encoder: auto
+
+cameras:
+  - name: synth
+    enabled: true
+    type: synthetic
+    stereo: true                  # → SyntheticStereoSource + stereo QuadLayer
+    width: 1280
+    height: 720
+    fps: 60
+    hue_speed_hz: 0.25
+    disparity_px: 20              # horizontal pixel offset between eyes
+    rtp:
+      port: 5000
+      bitrate_mbps: 15
+
+display:
+  mode: xr                        # window | xr — stereo really only shines in xr
+  window:
+    width: 1280
+    height: 720
+  xr:
+    near_z: 0.05
+    far_z: 100.0
+  clear_color: [0.05, 0.05, 0.08, 1.0]
+  placements:
+    synth:
+      lock_mode: lazy
+      distance: 1.5
+      stereo_baseline_mm: 0.0     # 0 → both eyes see the same world quad
+                                  # (parallax purely from the captured frames).
+                                  # Try 65.0 (typical IPD) to virtually push the
+                                  # screen further; -30.0 to bring it closer.

--- a/examples/camera_viz/configs/synthetic_stereo.yaml
+++ b/examples/camera_viz/configs/synthetic_stereo.yaml
@@ -23,7 +23,8 @@ cameras:
     hue_speed_hz: 0.25
     disparity_px: 20              # horizontal pixel offset between eyes
     rtp:
-      port: 5000
+      port: 5000                  # left eye
+      port_right: 5001            # right eye (required when stereo + source: rtp)
       bitrate_mbps: 15
 
 display:

--- a/examples/camera_viz/configs/zed.yaml
+++ b/examples/camera_viz/configs/zed.yaml
@@ -28,7 +28,8 @@ cameras:
     serial_number: 0            # 0 → first available
     stereo: true
     rtp:
-      port: 5000
+      port: 5000                # left eye
+      port_right: 5001          # right eye (required when stereo + source: rtp)
       bitrate_mbps: 15
       # gop:                    # default: fps*5 (ULL tuning)
 

--- a/examples/camera_viz/configs/zed.yaml
+++ b/examples/camera_viz/configs/zed.yaml
@@ -1,12 +1,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# ZED (left mono) — same YAML drives camera_viz + camera_streamer.
-#
-# stereo: false until per-eye QuadLayer binding lands (see memory note
-# "Stereo XR rendering needs per-view QuadLayer buffers"). Placement
-# below is keyed by the camera's YAML ``name`` ("zed"), which covers
-# every source ZedSource produces from this entry.
+# ZED — same YAML drives camera_viz + camera_streamer. Placement below
+# is keyed by the camera's YAML ``name`` ("zed"), which covers every
+# source ZedSource produces from this entry.
 #
 # Zero H2D in the steady state — pyzed's retrieve_image(MEM.GPU) hands
 # back BGRA8 already in VRAM. Our GPU kernel D2D-channel-swaps into the
@@ -21,13 +18,15 @@ cameras:
   - name: zed
     enabled: true
     type: zed
-    resolution: HD720           # HD2K | HD1080 | HD720 | VGA
+    # Per-eye dims pick the SDK preset (HD2K=2208x1242, HD1080=1920x1080,
+    # HD720=1280x720, VGA=672x376). Mismatch errors at startup with the
+    # full list.
+    width: 1280
+    height: 720
     fps: 30
     bus_type: usb               # usb | gmsl
     serial_number: 0            # 0 → first available
-    stereo: false
-    width: 1280                 # must match the HD720 preset (per-eye)
-    height: 720
+    stereo: true
     rtp:
       port: 5000
       bitrate_mbps: 15
@@ -45,4 +44,5 @@ display:
   placements:
     zed:                        # size defaults to 1.0 m wide × aspect-derived height
       lock_mode: lazy
-      distance: 1.5
+      distance: 1.0
+      stereo_baseline_mm: 50.0

--- a/examples/camera_viz/pipeline/interface.py
+++ b/examples/camera_viz/pipeline/interface.py
@@ -35,12 +35,18 @@ class Frame:
     ``image`` is anything that exposes ``__cuda_array_interface__`` —
     CuPy / PyTorch / Numba arrays all work. ``stream`` is the producer's
     CUDA stream so the consumer can synchronize when it's not 0/default.
+
+    Stereo: when the source produces a second eye, set ``image_right``
+    to the right-eye buffer. ``image`` is the left eye. Both eyes MUST
+    come from the same capture instant — the renderer submits them as
+    an atomic pair. Mono sources leave ``image_right`` as None.
     """
 
     image: Any
     timestamp_ns: int
     source_id: str
     stream: int = 0
+    image_right: Optional[Any] = None
 
 
 class FrameSource(ABC):

--- a/examples/camera_viz/pipeline/interface.py
+++ b/examples/camera_viz/pipeline/interface.py
@@ -36,10 +36,8 @@ class Frame:
     CuPy / PyTorch / Numba arrays all work. ``stream`` is the producer's
     CUDA stream so the consumer can synchronize when it's not 0/default.
 
-    Stereo: when the source produces a second eye, set ``image_right``
-    to the right-eye buffer. ``image`` is the left eye. Both eyes MUST
-    come from the same capture instant — the renderer submits them as
-    an atomic pair. Mono sources leave ``image_right`` as None.
+    Stereo: ``image`` is the left eye; ``image_right`` carries the
+    right eye when paired (both from the same capture instant).
     """
 
     image: Any

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -200,7 +200,13 @@ class VizRunner:
                 if not device_pinned:
                     self._pin_to_device(frame)
                     device_pinned = True
-                layer.submit(frame.image, stream=frame.stream)
+                # Stereo dispatch: when the source carries a second eye,
+                # hand both to QuadLayer in one atomic submit. The layer
+                # validates that its stereo-ness matches.
+                if frame.image_right is not None:
+                    layer.submit(frame.image, frame.image_right, stream=frame.stream)
+                else:
+                    layer.submit(frame.image, stream=frame.stream)
                 published_any = True
             if published_any:
                 with self._data_cond:

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -114,27 +114,46 @@ class VizRunner:
         )
         self._render_thread.start()
 
-    def stop(self) -> None:
+    def stop(self) -> bool:
+        """Stop both worker threads and the source producers.
+
+        Returns ``True`` iff both the render and submit threads exited
+        within the join budget. Returns ``False`` if either is still
+        running when this method gives up.
+
+        **Callers MUST NOT destroy the VizSession when this returns
+        False.** The still-running thread may be inside
+        ``session.render()`` or ``layer.submit()`` and is touching
+        Vulkan / CUDA handles the session owns; tearing the session
+        down under it is a use-after-free. The non-daemon threads
+        keep the process alive until they finish on their own — let
+        the OS reap them on process exit.
+        """
         self._stop.set()
         # Wake the render thread out of cond.wait so it sees the stop.
         with self._data_cond:
             self._data_cond.notify_all()
         # Bounded joins so a wedged session.render() / source doesn't
-        # block Ctrl-C. Non-daemon threads still block process exit, so
-        # we keep stuck thread references for a later retry. Sources
-        # ALWAYS get stop()ped — they own camera/GStreamer handles and
-        # leaking them on a stuck thread is worse than retrying later.
+        # block Ctrl-C. Stuck thread references stay set so the caller
+        # can still poll is_alive() / our return value, and so the non-
+        # daemon thread can keep the process alive until it exits.
+        # Sources ALWAYS get stop()ped — they own camera/GStreamer
+        # handles and leaking them on a stuck thread is worse than
+        # retrying later.
+        clean = True
         try:
             if self._render_thread is not None:
                 self._render_thread.join(timeout=5.0)
                 if self._render_thread.is_alive():
                     logger.warning("render thread did not exit within 5s")
+                    clean = False
                 else:
                     self._render_thread = None
             if self._submit_thread is not None:
                 self._submit_thread.join(timeout=5.0)
                 if self._submit_thread.is_alive():
                     logger.warning("submit thread did not exit within 5s")
+                    clean = False
                 else:
                     self._submit_thread = None
         finally:
@@ -143,6 +162,7 @@ class VizRunner:
                     s.stop()
                 except Exception:
                     logger.exception("source.stop() raised")
+        return clean
 
     def wait(self) -> None:
         """Block until the render thread exits, then re-raise any captured

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -115,31 +115,21 @@ class VizRunner:
         self._render_thread.start()
 
     def stop(self) -> bool:
-        """Stop both worker threads and the source producers.
+        """Returns True iff both worker threads exited within the join budget.
 
-        Returns ``True`` iff both the render and submit threads exited
-        within the join budget. Returns ``False`` if either is still
-        running when this method gives up.
-
-        **Callers MUST NOT destroy the VizSession when this returns
-        False.** The still-running thread may be inside
-        ``session.render()`` or ``layer.submit()`` and is touching
-        Vulkan / CUDA handles the session owns; tearing the session
-        down under it is a use-after-free. The non-daemon threads
-        keep the process alive until they finish on their own — let
-        the OS reap them on process exit.
+        Callers MUST NOT destroy the VizSession on False — a thread is
+        still inside session.render() / layer.submit() and tearing the
+        session down under it is a use-after-free on Vulkan / CUDA
+        handles. The non-daemon thread keeps the process alive until
+        it exits; the OS reaps the session at process exit.
         """
         self._stop.set()
-        # Wake the render thread out of cond.wait so it sees the stop.
+        # Wake the render thread's cond.wait.
         with self._data_cond:
             self._data_cond.notify_all()
         # Bounded joins so a wedged session.render() / source doesn't
-        # block Ctrl-C. Stuck thread references stay set so the caller
-        # can still poll is_alive() / our return value, and so the non-
-        # daemon thread can keep the process alive until it exits.
-        # Sources ALWAYS get stop()ped — they own camera/GStreamer
-        # handles and leaking them on a stuck thread is worse than
-        # retrying later.
+        # block Ctrl-C. Sources always get stop()ped (camera / gst
+        # handles) even if a thread is stuck.
         clean = True
         try:
             if self._render_thread is not None:
@@ -220,9 +210,6 @@ class VizRunner:
                 if not device_pinned:
                     self._pin_to_device(frame)
                     device_pinned = True
-                # Stereo dispatch: when the source carries a second eye,
-                # hand both to QuadLayer in one atomic submit. The layer
-                # validates that its stereo-ness matches.
                 if frame.image_right is not None:
                     layer.submit(frame.image, frame.image_right, stream=frame.stream)
                 else:

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -325,11 +325,8 @@ $WITH_V4L2 && PKGS+=("opencv-python>=4.5")
 $WITH_OAKD && PKGS+=("depthai>=3.0")
 $WITH_RTP  && PKGS+=("pybind11>=2.11" "PyGObject>=3.42,<3.52")
 
-# Local wheels keep the version string ``1.3+local`` across rebuilds,
-# so ``uv pip install --upgrade`` treats them as already-installed and
-# skips. Compare mtimes: if the wheel on disk is newer than the
-# installed copy's dist-info directory, force-reinstall just that one
-# package — other deps keep their normal upgrade-if-newer behavior.
+# Local wheels keep version ``1.3+local`` across rebuilds; uv's --upgrade
+# no-ops on them. mtime probe forces a reinstall when the wheel's newer.
 EXTRA_UV=()
 if [[ "$MODE" == full && -f "$WHEEL" ]]; then
     wheel_mtime=$(stat -c %Y "$WHEEL" 2>/dev/null || echo 0)

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -325,8 +325,30 @@ $WITH_V4L2 && PKGS+=("opencv-python>=4.5")
 $WITH_OAKD && PKGS+=("depthai>=3.0")
 $WITH_RTP  && PKGS+=("pybind11>=2.11" "PyGObject>=3.42,<3.52")
 
+# Local wheels keep the version string ``1.3+local`` across rebuilds,
+# so ``uv pip install --upgrade`` treats them as already-installed and
+# skips. Compare mtimes: if the wheel on disk is newer than the
+# installed copy's dist-info directory, force-reinstall just that one
+# package — other deps keep their normal upgrade-if-newer behavior.
+EXTRA_UV=()
+if [[ "$MODE" == full && -f "$WHEEL" ]]; then
+    wheel_mtime=$(stat -c %Y "$WHEEL" 2>/dev/null || echo 0)
+    installed_dist=$(ls -d "$VENV_DIR"/lib/python*/site-packages/isaacteleop-*.dist-info 2>/dev/null | head -1)
+    if [[ -n "$installed_dist" ]]; then
+        installed_mtime=$(stat -c %Y "$installed_dist" 2>/dev/null || echo 0)
+        if (( wheel_mtime > installed_mtime )); then
+            echo "==> wheel newer than installed copy — forcing reinstall of isaacteleop"
+            EXTRA_UV+=(--reinstall-package isaacteleop)
+        fi
+    fi
+fi
+
 echo "==> installing: ${PKGS[*]}"
-uv pip install --python "$PY" --upgrade "${PKGS[@]}"
+if (( ${#EXTRA_UV[@]} > 0 )); then
+    uv pip install --python "$PY" --upgrade "${EXTRA_UV[@]}" "${PKGS[@]}"
+else
+    uv pip install --python "$PY" --upgrade "${PKGS[@]}"
+fi
 
 # ZED SDK ships get_python_api.py which downloads a matching pyzed wheel
 # and then tries ``pip install`` it (which fails in uv venvs, no pip).

--- a/examples/camera_viz/sources/__init__.py
+++ b/examples/camera_viz/sources/__init__.py
@@ -117,7 +117,8 @@ def build_local_camera(spec: dict) -> List[FrameSource]:
         eyes = list(
             ZedSource.build(
                 base_name=name,
-                resolution=spec.get("resolution", "HD720"),
+                width=int(spec["width"]),
+                height=int(spec["height"]),
                 fps=int(spec.get("fps", 30)),
                 serial_number=int(spec.get("serial_number", 0)),
                 bus_type=spec.get("bus_type", "usb"),

--- a/examples/camera_viz/sources/__init__.py
+++ b/examples/camera_viz/sources/__init__.py
@@ -12,16 +12,19 @@ from typing import List
 
 from pipeline import FrameSource
 
+from ._helpers import PairedFrameSource
 from .oakd import OakdSource
 from .rtp_h264 import RtpH264Source
-from .synthetic import SyntheticSource
+from .synthetic import SyntheticSource, SyntheticStereoSource
 from .v4l2 import V4l2Source
 from .zed import ZedSource
 
 __all__ = [
     "OakdSource",
+    "PairedFrameSource",
     "RtpH264Source",
     "SyntheticSource",
+    "SyntheticStereoSource",
     "V4l2Source",
     "ZedSource",
     "build_local_camera",
@@ -31,15 +34,33 @@ __all__ = [
 def build_local_camera(spec: dict) -> List[FrameSource]:
     """Build the local FrameSource(s) for one ``cameras:`` entry.
 
-    Returns a list because multi-stream cameras (OAK-D stereo, ZED stereo)
-    fan out to one source per stream. Single-stream cameras return [source].
+    Mono cameras return [source]. Stereo cameras (``stereo: true``)
+    return [PairedFrameSource] — a single FrameSource that emits a
+    ``Frame`` with both ``image`` (left eye) and ``image_right`` populated.
+    The camera_viz pipeline routes that to ``QuadLayer.submit(left, right)``.
+    For v4l2 the ``stereo`` toggle is rejected (USB cameras are mono);
+    OAK-D / ZED / synthetic each have their own native paths.
+
     Shared by camera_viz.py and camera_streamer.py — keep the schema stable.
     """
     kind = spec["type"]
+    stereo = bool(spec.get("stereo", False))
+    name = spec["name"]
     if kind == "synthetic":
+        if stereo:
+            return [
+                SyntheticStereoSource(
+                    name=name,
+                    width=int(spec["width"]),
+                    height=int(spec["height"]),
+                    fps=float(spec.get("fps", 60.0)),
+                    hue_speed_hz=float(spec.get("hue_speed_hz", 0.25)),
+                    disparity_px=int(spec.get("disparity_px", 20)),
+                )
+            ]
         return [
             SyntheticSource(
-                name=spec["name"],
+                name=name,
                 width=int(spec["width"]),
                 height=int(spec["height"]),
                 fps=float(spec.get("fps", 60.0)),
@@ -47,9 +68,14 @@ def build_local_camera(spec: dict) -> List[FrameSource]:
             )
         ]
     if kind == "v4l2":
+        if stereo:
+            raise ValueError(
+                f"build_local_camera: v4l2 camera {name!r} cannot be stereo "
+                "(single-stream USB / UVC). Use type: oakd or zed."
+            )
         return [
             V4l2Source(
-                name=spec["name"],
+                name=name,
                 device=spec.get("device", "/dev/video0"),
                 width=int(spec["width"]),
                 height=int(spec["height"]),
@@ -58,10 +84,13 @@ def build_local_camera(spec: dict) -> List[FrameSource]:
             )
         ]
     if kind == "oakd":
-        return list(
+        # ``stereo: true`` is a shorthand for the OAK-D ``mode: stereo``.
+        # If the user passed both, an explicit mode wins.
+        mode = spec.get("mode", "stereo" if stereo else "mono")
+        eyes = list(
             OakdSource.build(
-                base_name=spec["name"],
-                mode=spec.get("mode", "mono"),
+                base_name=name,
+                mode=mode,
                 device_id=spec.get("device_id", ""),
                 width=int(spec["width"]),
                 height=int(spec["height"]),
@@ -72,17 +101,37 @@ def build_local_camera(spec: dict) -> List[FrameSource]:
                 rgb_fps=int(spec.get("rgb_fps", 0)),
             )
         )
+        if stereo or mode in ("stereo", "stereo_rgb"):
+            # OakdSource.build returns 2 per-eye sources in stereo and 3
+            # in stereo_rgb; we pair the first two (left + right). The
+            # extra RGB stream of stereo_rgb is intentionally dropped —
+            # the QuadLayer takes exactly two eyes.
+            if len(eyes) < 2:
+                raise ValueError(
+                    f"build_local_camera: oakd {name!r} stereo mode produced {len(eyes)} "
+                    "source(s); expected at least 2"
+                )
+            return [PairedFrameSource(name=name, left=eyes[0], right=eyes[1])]
+        return eyes
     if kind == "zed":
-        return list(
+        eyes = list(
             ZedSource.build(
-                base_name=spec["name"],
+                base_name=name,
                 resolution=spec.get("resolution", "HD720"),
                 fps=int(spec.get("fps", 30)),
                 serial_number=int(spec.get("serial_number", 0)),
                 bus_type=spec.get("bus_type", "usb"),
-                stereo=bool(spec.get("stereo", False)),
+                stereo=stereo,
             )
         )
+        if stereo:
+            if len(eyes) != 2:
+                raise ValueError(
+                    f"build_local_camera: zed {name!r} stereo produced {len(eyes)} "
+                    "source(s); expected 2"
+                )
+            return [PairedFrameSource(name=name, left=eyes[0], right=eyes[1])]
+        return eyes
     raise ValueError(
         f"build_local_camera: unknown camera type {kind!r} "
         "(known: synthetic, v4l2, oakd, zed)"

--- a/examples/camera_viz/sources/__init__.py
+++ b/examples/camera_viz/sources/__init__.py
@@ -33,16 +33,10 @@ __all__ = [
 
 
 def build_local_camera(spec: dict) -> List[FrameSource]:
-    """Build the local FrameSource(s) for one ``cameras:`` entry.
+    """Build local FrameSource(s) for one ``cameras:`` entry.
 
-    Mono cameras return [source]. Stereo cameras (``stereo: true``)
-    return [PairedFrameSource] — a single FrameSource that emits a
-    ``Frame`` with both ``image`` (left eye) and ``image_right`` populated.
-    The camera_viz pipeline routes that to ``QuadLayer.submit(left, right)``.
-    For v4l2 the ``stereo`` toggle is rejected (USB cameras are mono);
-    OAK-D / ZED / synthetic each have their own native paths.
-
-    Shared by camera_viz.py and camera_streamer.py — keep the schema stable.
+    Mono → [source]; ``stereo: true`` → [PairedFrameSource]. v4l2 rejects
+    stereo (UVC is mono). Shared by camera_viz + camera_streamer.
     """
     kind = spec["type"]
     stereo = bool(spec.get("stereo", False))
@@ -85,8 +79,7 @@ def build_local_camera(spec: dict) -> List[FrameSource]:
             )
         ]
     if kind == "oakd":
-        # ``stereo: true`` is a shorthand for the OAK-D ``mode: stereo``.
-        # If the user passed both, an explicit mode wins.
+        # ``stereo: true`` shorthand for ``mode: stereo``; explicit mode wins.
         mode = spec.get("mode", "stereo" if stereo else "mono")
         eyes = list(
             OakdSource.build(
@@ -103,10 +96,7 @@ def build_local_camera(spec: dict) -> List[FrameSource]:
             )
         )
         if stereo or mode in ("stereo", "stereo_rgb"):
-            # OakdSource.build returns 2 per-eye sources in stereo and 3
-            # in stereo_rgb; we pair the first two (left + right). The
-            # extra RGB stream of stereo_rgb is intentionally dropped —
-            # the QuadLayer takes exactly two eyes.
+            # stereo_rgb's third stream is intentionally dropped here.
             if len(eyes) < 2:
                 raise ValueError(
                     f"build_local_camera: oakd {name!r} stereo mode produced {len(eyes)} "

--- a/examples/camera_viz/sources/__init__.py
+++ b/examples/camera_viz/sources/__init__.py
@@ -12,7 +12,7 @@ from typing import List
 
 from pipeline import FrameSource
 
-from ._helpers import PairedFrameSource
+from ._helpers import PairedFrameSource, set_verbose
 from .oakd import OakdSource
 from .rtp_h264 import RtpH264Source
 from .synthetic import SyntheticSource, SyntheticStereoSource
@@ -28,6 +28,7 @@ __all__ = [
     "V4l2Source",
     "ZedSource",
     "build_local_camera",
+    "set_verbose",
 ]
 
 

--- a/examples/camera_viz/sources/_helpers.py
+++ b/examples/camera_viz/sources/_helpers.py
@@ -47,28 +47,16 @@ from pipeline import Frame, FrameSource, SourceSpec
 
 
 def notify(tag: str, msg: str) -> None:
-    """Single-line user-visible breadcrumb.
-
-    Goes to stderr directly (not through ``logger``) so it shows up
-    even when the host app hasn't configured Python logging — the
-    common case for camera_viz. ``tag`` is the short source kind
-    (``zed`` / ``oakd`` / ``v4l2``); the rendered prefix is
-    ``[tag]``. Reserved for lifecycle transitions (opening, connected,
-    streaming, errors) — anything fired more than once per minute
-    belongs in :func:`notify_verbose`."""
+    # Stderr-direct so it shows without a configured Python logger.
+    # Reserved for lifecycle events; periodic stats use notify_verbose.
     print(f"[{tag}] {msg}", file=sys.stderr, flush=True)
 
 
-# Verbose state. Driven by the YAML's top-level ``verbose:`` flag
-# (set via :func:`set_verbose` after the entrypoint parses the
-# config); the ``CAMERA_VIZ_VERBOSE`` env var is also honored as a
-# no-YAML-edit override for ad-hoc debugging.
 _VERBOSE = False
 
 
 def set_verbose(enabled: bool) -> None:
-    """Enable / disable verbose breadcrumbs. Called by the entrypoint
-    (camera_viz.py / camera_streamer.py) after parsing the YAML."""
+    """Set by the entrypoint from the YAML ``verbose:`` flag."""
     global _VERBOSE
     _VERBOSE = bool(enabled)
 
@@ -85,12 +73,7 @@ def _verbose_enabled() -> bool:
 
 
 def notify_verbose(tag: str, msg: str) -> None:
-    """Diagnostic breadcrumb, gated on the YAML ``verbose:`` flag or
-    ``CAMERA_VIZ_VERBOSE=1`` env var.
-
-    Use for periodic stats (per-eye fps, queue depths, etc.) that are
-    useful while debugging but spam the terminal in steady state.
-    Default-off keeps the run output clean."""
+    """Periodic stats; gated by YAML ``verbose:`` or CAMERA_VIZ_VERBOSE."""
     if _verbose_enabled():
         print(f"[{tag}] {msg}", file=sys.stderr, flush=True)
 
@@ -360,26 +343,13 @@ class PolledSource(FrameSource):
 
 
 class PairedFrameSource(FrameSource):
-    """Pair two per-eye FrameSources into a single stereo source.
+    """Pair two per-eye FrameSources into one stereo source.
 
-    Owns no thread of its own. ``latest()`` reads both children and
-    caches whichever side returned a frame. Emits a paired Frame
-    whenever EITHER side updated since the last emit; the older eye
-    stays paired with its most recent frame until it produces.
-
-    Why caching, not "wait for both": the underlying per-eye source's
-    ``latest()`` is one-shot — it marks the frame consumed even if the
-    caller chooses not to use it. The producer publishes left and
-    right sequentially within microseconds, but the consumer polls at
-    ~1 kHz, so polls routinely land between the two publishes. The
-    earlier "consume both, drop if either is None" implementation
-    threw away the side that came first on every such race, which at
-    high producer rates collapsed the visible fps to half and gave a
-    very laggy / stuttery display. Caching turns that into bounded
-    inter-eye drift of at most one producer frame — well under any
-    perceptual threshold for stereo.
-
-    Both children MUST agree on (width, height, pixel_format).
+    Caches each child's latest Frame and emits a pair whenever either
+    side updates. The "wait for both, drop on miss" alternative loses
+    frames at the producer-publishes-L-then-R / consumer-polls-between
+    race, halving effective fps. Inter-eye drift is bounded to one
+    producer frame — well under perceptual threshold.
     """
 
     def __init__(self, name: str, left: FrameSource, right: FrameSource) -> None:
@@ -402,8 +372,6 @@ class PairedFrameSource(FrameSource):
         )
         self._left = left
         self._right = right
-        # Most recently observed Frame from each child. Updated whenever
-        # the child's latest() returns non-None (i.e. a fresh publish).
         self._cached_left: Optional[Frame] = None
         self._cached_right: Optional[Frame] = None
 
@@ -413,9 +381,7 @@ class PairedFrameSource(FrameSource):
 
     @property
     def left(self) -> FrameSource:
-        """Per-eye left source. Used by camera_streamer.py to fan out
-        two independent RTP streams for stereo cameras (paired
-        atomicity comes back at the receiver, not on the wire)."""
+        # camera_streamer fans out to two independent RTP senders.
         return self._left
 
     @property
@@ -431,11 +397,6 @@ class PairedFrameSource(FrameSource):
         self._right.stop()
 
     def latest(self) -> Optional[Frame]:
-        # Pull from each child; cache whichever side delivered a fresh
-        # publish. ``updated`` tracks whether EITHER side moved since
-        # the previous call — when neither updated there's nothing new
-        # to render, so we return None and let the layer keep its last
-        # mailbox slot.
         updated = False
         fl = self._left.latest()
         if fl is not None:
@@ -447,8 +408,7 @@ class PairedFrameSource(FrameSource):
             updated = True
         if not updated:
             return None
-        # Bootstrap: don't emit until both eyes have ever published.
-        # In steady state this only matters on the very first frame.
+        # Both eyes must have produced at least once before we emit.
         if self._cached_left is None or self._cached_right is None:
             return None
         return Frame(

--- a/examples/camera_viz/sources/_helpers.py
+++ b/examples/camera_viz/sources/_helpers.py
@@ -317,3 +317,70 @@ class PolledSource(FrameSource):
             pass
         self._connected = False
         self._last_reconnect_attempt_s = time.monotonic()
+
+
+class PairedFrameSource(FrameSource):
+    """Pair two per-eye FrameSources into a single stereo source.
+
+    Owns no thread of its own. latest() polls both children: when
+    each has produced a fresh Frame, emits one combined Frame with the
+    left source's image in Frame.image and the right source's image
+    in Frame.image_right. Skips the publish (returns None) if either
+    eye hasn't produced — the QuadLayer mailbox keeps the previous
+    matched pair until both eyes catch up. Acceptable because both eyes
+    share the camera producer (same SDK grab cycle), so they re-sync
+    within one frame.
+
+    Both children MUST agree on (width, height, pixel_format).
+    """
+
+    def __init__(self, name: str, left: FrameSource, right: FrameSource) -> None:
+        if left.spec.width != right.spec.width or left.spec.height != right.spec.height:
+            raise ValueError(
+                f"PairedFrameSource: left/right resolution mismatch "
+                f"({left.spec.width}x{left.spec.height} vs "
+                f"{right.spec.width}x{right.spec.height})"
+            )
+        if left.spec.pixel_format != right.spec.pixel_format:
+            raise ValueError(
+                f"PairedFrameSource: left/right pixel_format mismatch "
+                f"({left.spec.pixel_format!r} vs {right.spec.pixel_format!r})"
+            )
+        self._spec = SourceSpec(
+            name=name,
+            width=left.spec.width,
+            height=left.spec.height,
+            pixel_format=left.spec.pixel_format,
+        )
+        self._left = left
+        self._right = right
+
+    @property
+    def spec(self) -> SourceSpec:
+        return self._spec
+
+    def start(self) -> None:
+        self._left.start()
+        self._right.start()
+
+    def stop(self) -> None:
+        self._left.stop()
+        self._right.stop()
+
+    def latest(self) -> Optional[Frame]:
+        # Read both. We only publish when BOTH eyes have produced —
+        # otherwise the renderer would see a mismatched pair (or an
+        # update on one eye only, which submit() would treat as the
+        # left of a new pair with the previous right). Returning None
+        # leaves the layer rendering the prior matched pair.
+        fl = self._left.latest()
+        fr = self._right.latest()
+        if fl is None or fr is None:
+            return None
+        return Frame(
+            image=fl.image,
+            image_right=fr.image,
+            timestamp_ns=fl.timestamp_ns,
+            source_id=self._spec.name,
+            stream=fl.stream,
+        )

--- a/examples/camera_viz/sources/_helpers.py
+++ b/examples/camera_viz/sources/_helpers.py
@@ -34,6 +34,7 @@ into the writable GPU buffer using ``self._stream``).
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import threading
 import time
@@ -52,8 +53,46 @@ def notify(tag: str, msg: str) -> None:
     even when the host app hasn't configured Python logging — the
     common case for camera_viz. ``tag`` is the short source kind
     (``zed`` / ``oakd`` / ``v4l2``); the rendered prefix is
-    ``[tag]``."""
+    ``[tag]``. Reserved for lifecycle transitions (opening, connected,
+    streaming, errors) — anything fired more than once per minute
+    belongs in :func:`notify_verbose`."""
     print(f"[{tag}] {msg}", file=sys.stderr, flush=True)
+
+
+# Verbose state. Driven by the YAML's top-level ``verbose:`` flag
+# (set via :func:`set_verbose` after the entrypoint parses the
+# config); the ``CAMERA_VIZ_VERBOSE`` env var is also honored as a
+# no-YAML-edit override for ad-hoc debugging.
+_VERBOSE = False
+
+
+def set_verbose(enabled: bool) -> None:
+    """Enable / disable verbose breadcrumbs. Called by the entrypoint
+    (camera_viz.py / camera_streamer.py) after parsing the YAML."""
+    global _VERBOSE
+    _VERBOSE = bool(enabled)
+
+
+def _verbose_enabled() -> bool:
+    if _VERBOSE:
+        return True
+    return os.environ.get("CAMERA_VIZ_VERBOSE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def notify_verbose(tag: str, msg: str) -> None:
+    """Diagnostic breadcrumb, gated on the YAML ``verbose:`` flag or
+    ``CAMERA_VIZ_VERBOSE=1`` env var.
+
+    Use for periodic stats (per-eye fps, queue depths, etc.) that are
+    useful while debugging but spam the terminal in steady state.
+    Default-off keeps the run output clean."""
+    if _verbose_enabled():
+        print(f"[{tag}] {msg}", file=sys.stderr, flush=True)
 
 
 logger = logging.getLogger(__name__)

--- a/examples/camera_viz/sources/_helpers.py
+++ b/examples/camera_viz/sources/_helpers.py
@@ -323,14 +323,22 @@ class PolledSource(FrameSource):
 class PairedFrameSource(FrameSource):
     """Pair two per-eye FrameSources into a single stereo source.
 
-    Owns no thread of its own. latest() polls both children: when
-    each has produced a fresh Frame, emits one combined Frame with the
-    left source's image in Frame.image and the right source's image
-    in Frame.image_right. Skips the publish (returns None) if either
-    eye hasn't produced — the QuadLayer mailbox keeps the previous
-    matched pair until both eyes catch up. Acceptable because both eyes
-    share the camera producer (same SDK grab cycle), so they re-sync
-    within one frame.
+    Owns no thread of its own. ``latest()`` reads both children and
+    caches whichever side returned a frame. Emits a paired Frame
+    whenever EITHER side updated since the last emit; the older eye
+    stays paired with its most recent frame until it produces.
+
+    Why caching, not "wait for both": the underlying per-eye source's
+    ``latest()`` is one-shot — it marks the frame consumed even if the
+    caller chooses not to use it. The producer publishes left and
+    right sequentially within microseconds, but the consumer polls at
+    ~1 kHz, so polls routinely land between the two publishes. The
+    earlier "consume both, drop if either is None" implementation
+    threw away the side that came first on every such race, which at
+    high producer rates collapsed the visible fps to half and gave a
+    very laggy / stuttery display. Caching turns that into bounded
+    inter-eye drift of at most one producer frame — well under any
+    perceptual threshold for stereo.
 
     Both children MUST agree on (width, height, pixel_format).
     """
@@ -355,6 +363,10 @@ class PairedFrameSource(FrameSource):
         )
         self._left = left
         self._right = right
+        # Most recently observed Frame from each child. Updated whenever
+        # the child's latest() returns non-None (i.e. a fresh publish).
+        self._cached_left: Optional[Frame] = None
+        self._cached_right: Optional[Frame] = None
 
     @property
     def spec(self) -> SourceSpec:
@@ -380,19 +392,30 @@ class PairedFrameSource(FrameSource):
         self._right.stop()
 
     def latest(self) -> Optional[Frame]:
-        # Read both. We only publish when BOTH eyes have produced —
-        # otherwise the renderer would see a mismatched pair (or an
-        # update on one eye only, which submit() would treat as the
-        # left of a new pair with the previous right). Returning None
-        # leaves the layer rendering the prior matched pair.
+        # Pull from each child; cache whichever side delivered a fresh
+        # publish. ``updated`` tracks whether EITHER side moved since
+        # the previous call — when neither updated there's nothing new
+        # to render, so we return None and let the layer keep its last
+        # mailbox slot.
+        updated = False
         fl = self._left.latest()
+        if fl is not None:
+            self._cached_left = fl
+            updated = True
         fr = self._right.latest()
-        if fl is None or fr is None:
+        if fr is not None:
+            self._cached_right = fr
+            updated = True
+        if not updated:
+            return None
+        # Bootstrap: don't emit until both eyes have ever published.
+        # In steady state this only matters on the very first frame.
+        if self._cached_left is None or self._cached_right is None:
             return None
         return Frame(
-            image=fl.image,
-            image_right=fr.image,
-            timestamp_ns=fl.timestamp_ns,
+            image=self._cached_left.image,
+            image_right=self._cached_right.image,
+            timestamp_ns=self._cached_left.timestamp_ns,
             source_id=self._spec.name,
-            stream=fl.stream,
+            stream=self._cached_left.stream,
         )

--- a/examples/camera_viz/sources/_helpers.py
+++ b/examples/camera_viz/sources/_helpers.py
@@ -34,6 +34,7 @@ into the writable GPU buffer using ``self._stream``).
 from __future__ import annotations
 
 import logging
+import sys
 import threading
 import time
 from abc import abstractmethod
@@ -42,6 +43,18 @@ from typing import Optional
 import numpy as np
 
 from pipeline import Frame, FrameSource, SourceSpec
+
+
+def notify(tag: str, msg: str) -> None:
+    """Single-line user-visible breadcrumb.
+
+    Goes to stderr directly (not through ``logger``) so it shows up
+    even when the host app hasn't configured Python logging — the
+    common case for camera_viz. ``tag`` is the short source kind
+    (``zed`` / ``oakd`` / ``v4l2``); the rendered prefix is
+    ``[tag]``."""
+    print(f"[{tag}] {msg}", file=sys.stderr, flush=True)
+
 
 logger = logging.getLogger(__name__)
 
@@ -244,6 +257,8 @@ class PolledSource(FrameSource):
             self._produce_loop_inner()
 
     def _produce_loop_inner(self) -> None:
+        first_frame_seen = False
+        opening_notified = False
         while not self._stop.is_set():
             if not self._connected:
                 now = time.monotonic()
@@ -252,38 +267,25 @@ class PolledSource(FrameSource):
                     self._stop.wait(timeout=0.1)
                     continue
                 self._last_reconnect_attempt_s = now
+                if not opening_notified:
+                    notify(self._kind, "opening...")
+                    opening_notified = True
                 try:
                     self._connected = self._open_device()
                 except Exception as e:
-                    logger.warning(
-                        "%s '%s': open failed (%s); retrying in %.1fs",
-                        self._kind,
-                        self._spec.name,
-                        e,
-                        self._reconnect_delay_s,
-                    )
+                    notify(self._kind, f"open failed ({e})")
                     self._connected = False
                 if not self._connected:
                     self._reconnect_count += 1
                     continue
-                logger.info(
-                    "%s '%s': connected%s",
-                    self._kind,
-                    self._spec.name,
-                    f" (reconnect #{self._reconnect_count})"
-                    if self._reconnect_count
-                    else "",
-                )
+                notify(self._kind, "connected")
+                first_frame_seen = False
+                opening_notified = False
 
             try:
                 host = self._grab()
             except Exception as e:
-                logger.warning(
-                    "%s '%s': grab failed (%s); reconnecting",
-                    self._kind,
-                    self._spec.name,
-                    e,
-                )
+                notify(self._kind, f"grab failed ({e}); reconnecting")
                 self._mark_disconnected()
                 continue
             if host is None:
@@ -296,14 +298,13 @@ class PolledSource(FrameSource):
                 self._upload_and_convert(buf)
                 self._stream.synchronize()
             except Exception as e:
-                logger.warning(
-                    "%s '%s': upload failed (%s); reconnecting",
-                    self._kind,
-                    self._spec.name,
-                    e,
-                )
+                notify(self._kind, f"frame error ({e}); reconnecting")
                 self._mark_disconnected()
                 continue
+
+            if not first_frame_seen:
+                first_frame_seen = True
+                notify(self._kind, "streaming")
 
             with self._publish_lock:
                 self._publish_idx = self._write_idx

--- a/examples/camera_viz/sources/_helpers.py
+++ b/examples/camera_viz/sources/_helpers.py
@@ -359,6 +359,17 @@ class PairedFrameSource(FrameSource):
     def spec(self) -> SourceSpec:
         return self._spec
 
+    @property
+    def left(self) -> FrameSource:
+        """Per-eye left source. Used by camera_streamer.py to fan out
+        two independent RTP streams for stereo cameras (paired
+        atomicity comes back at the receiver, not on the wire)."""
+        return self._left
+
+    @property
+    def right(self) -> FrameSource:
+        return self._right
+
     def start(self) -> None:
         self._left.start()
         self._right.start()

--- a/examples/camera_viz/sources/oakd.py
+++ b/examples/camera_viz/sources/oakd.py
@@ -35,7 +35,7 @@ from typing import List, Optional
 import numpy as np
 
 from pipeline import Frame, FrameSource, SourceSpec
-from ._helpers import alloc_pinned_host, notify
+from ._helpers import alloc_pinned_host, notify, notify_verbose
 
 logger = logging.getLogger(__name__)
 
@@ -272,25 +272,6 @@ class _OakdDevice:
         else:
             notify("oakd", f"USB {speed_name}")
 
-        # Per-sensor capability dump. Lets us tell the user what the
-        # board's RGB / mono sensors actually max out at — when the
-        # requested fps is silently capped (depthai's pipeline syncs
-        # all streams to the slowest sensor's achievable rate) this is
-        # the only way to know whether the limit is our config or the
-        # sensor itself.
-        try:
-            for feat in device.getConnectedCameraFeatures():
-                supported = ", ".join(str(c.fps) for c in feat.configs) or "?"
-                notify(
-                    "oakd",
-                    f"sensor {feat.socket.name}={feat.sensorName} "
-                    f"max fps per mode: {supported}",
-                )
-        except Exception as e:
-            # getConnectedCameraFeatures isn't on every depthai version;
-            # don't fail open on a probe-only call.
-            notify("oakd", f"sensor capability probe skipped ({e})")
-
         pipeline = dai.Pipeline(device)
         for s in self._stream_specs:
             socket_key = self._SOCKET_MAP[s.socket.upper()]
@@ -422,7 +403,9 @@ class _OakdDevice:
             # Periodic actual-vs-target fps. Any stream running <80% of
             # its requested rate is almost certainly hitting USB / VPU
             # throttling; the absolute numbers tell the user how far off
-            # they are. Reset counters AFTER reporting so windows align.
+            # they are. Gated by CAMERA_VIZ_VERBOSE=1 — too chatty for
+            # the default run output. Reset counters AFTER reporting so
+            # windows align.
             now = time.monotonic()
             elapsed = now - last_fps_report_at
             if elapsed >= _FPS_REPORT_S and first_frame_seen:
@@ -436,7 +419,7 @@ class _OakdDevice:
                         throttled = True
                     last_fps_counts[s.name] = self._frame_counts[s.name]
                 tag = " ⚠ throttled" if throttled else ""
-                notify("oakd", f"fps {' '.join(parts)}{tag}")
+                notify_verbose("oakd", f"fps {' '.join(parts)}{tag}")
                 last_fps_report_at = now
 
 

--- a/examples/camera_viz/sources/oakd.py
+++ b/examples/camera_viz/sources/oakd.py
@@ -272,6 +272,25 @@ class _OakdDevice:
         else:
             notify("oakd", f"USB {speed_name}")
 
+        # Per-sensor capability dump. Lets us tell the user what the
+        # board's RGB / mono sensors actually max out at — when the
+        # requested fps is silently capped (depthai's pipeline syncs
+        # all streams to the slowest sensor's achievable rate) this is
+        # the only way to know whether the limit is our config or the
+        # sensor itself.
+        try:
+            for feat in device.getConnectedCameraFeatures():
+                supported = ", ".join(str(c.fps) for c in feat.configs) or "?"
+                notify(
+                    "oakd",
+                    f"sensor {feat.socket.name}={feat.sensorName} "
+                    f"max fps per mode: {supported}",
+                )
+        except Exception as e:
+            # getConnectedCameraFeatures isn't on every depthai version;
+            # don't fail open on a probe-only call.
+            notify("oakd", f"sensor capability probe skipped ({e})")
+
         pipeline = dai.Pipeline(device)
         for s in self._stream_specs:
             socket_key = self._SOCKET_MAP[s.socket.upper()]

--- a/examples/camera_viz/sources/oakd.py
+++ b/examples/camera_viz/sources/oakd.py
@@ -253,21 +253,16 @@ class _OakdDevice:
         )
         device = dai.Device(device_info)
 
-        # USB-speed sanity check. Throughput-sensitive configs (720p+/45fps,
-        # stereo, BGR) need SUPER (USB 3.0 / 5 Gbps); HIGH (USB 2.0 /
-        # 480 Mbps) silently caps the effective fps and is by far the
-        # most common cause of "looks like it's hitting USB bandwidth".
-        # Surfacing this on connect saves a lot of guesswork.
+        # SUPER = USB 3.0+; HIGH / FULL / LOW = USB 2, silently caps fps
+        # under stereo / BGR / 720p+ workloads.
         try:
-            usb_speed = device.getUsbSpeed()
-            speed_name = getattr(usb_speed, "name", str(usb_speed))
+            speed_name = getattr(device.getUsbSpeed(), "name", "?")
         except Exception:
             speed_name = "?"
         if speed_name in ("HIGH", "FULL", "LOW"):
             notify(
                 "oakd",
-                f"USB {speed_name} (NOT USB 3) — high fps / stereo / BGR will "
-                "drop frames. Try a different cable or USB-3 port.",
+                f"USB {speed_name} (NOT USB 3) — high fps / stereo / BGR will drop frames.",
             )
         else:
             notify("oakd", f"USB {speed_name}")
@@ -321,9 +316,7 @@ class _OakdDevice:
         first_frame_seen = False
         opening_notified = False
         unavailable_notified = False
-        # Measured-fps breadcrumb. Every _FPS_REPORT_S seconds we compare
-        # the actual delivered fps against the stream's requested fps;
-        # a big gap is the smoking gun for USB bandwidth / VPU throttling.
+        # Periodic actual-vs-requested fps; flags USB / VPU throttling.
         _FPS_REPORT_S = 5.0
         last_fps_report_at = time.monotonic()
         last_fps_counts = {s.name: 0 for s in self._stream_specs}
@@ -400,12 +393,7 @@ class _OakdDevice:
                 # No queue had data this tick — brief yield to avoid burning CPU.
                 self._stop.wait(timeout=0.001)
 
-            # Periodic actual-vs-target fps. Any stream running <80% of
-            # its requested rate is almost certainly hitting USB / VPU
-            # throttling; the absolute numbers tell the user how far off
-            # they are. Gated by CAMERA_VIZ_VERBOSE=1 — too chatty for
-            # the default run output. Reset counters AFTER reporting so
-            # windows align.
+            # Periodic actual-vs-target fps; <80% flagged as throttled.
             now = time.monotonic()
             elapsed = now - last_fps_report_at
             if elapsed >= _FPS_REPORT_S and first_frame_seen:

--- a/examples/camera_viz/sources/oakd.py
+++ b/examples/camera_viz/sources/oakd.py
@@ -252,6 +252,26 @@ class _OakdDevice:
             else dai.Device.getAllAvailableDevices()[0]
         )
         device = dai.Device(device_info)
+
+        # USB-speed sanity check. Throughput-sensitive configs (720p+/45fps,
+        # stereo, BGR) need SUPER (USB 3.0 / 5 Gbps); HIGH (USB 2.0 /
+        # 480 Mbps) silently caps the effective fps and is by far the
+        # most common cause of "looks like it's hitting USB bandwidth".
+        # Surfacing this on connect saves a lot of guesswork.
+        try:
+            usb_speed = device.getUsbSpeed()
+            speed_name = getattr(usb_speed, "name", str(usb_speed))
+        except Exception:
+            speed_name = "?"
+        if speed_name in ("HIGH", "FULL", "LOW"):
+            notify(
+                "oakd",
+                f"USB {speed_name} (NOT USB 3) — high fps / stereo / BGR will "
+                "drop frames. Try a different cable or USB-3 port.",
+            )
+        else:
+            notify("oakd", f"USB {speed_name}")
+
         pipeline = dai.Pipeline(device)
         for s in self._stream_specs:
             socket_key = self._SOCKET_MAP[s.socket.upper()]
@@ -301,6 +321,12 @@ class _OakdDevice:
         first_frame_seen = False
         opening_notified = False
         unavailable_notified = False
+        # Measured-fps breadcrumb. Every _FPS_REPORT_S seconds we compare
+        # the actual delivered fps against the stream's requested fps;
+        # a big gap is the smoking gun for USB bandwidth / VPU throttling.
+        _FPS_REPORT_S = 5.0
+        last_fps_report_at = time.monotonic()
+        last_fps_counts = {s.name: 0 for s in self._stream_specs}
         while not self._stop.is_set():
             if not self._connected:
                 now = time.monotonic()
@@ -373,6 +399,26 @@ class _OakdDevice:
             elif not emitted_any:
                 # No queue had data this tick — brief yield to avoid burning CPU.
                 self._stop.wait(timeout=0.001)
+
+            # Periodic actual-vs-target fps. Any stream running <80% of
+            # its requested rate is almost certainly hitting USB / VPU
+            # throttling; the absolute numbers tell the user how far off
+            # they are. Reset counters AFTER reporting so windows align.
+            now = time.monotonic()
+            elapsed = now - last_fps_report_at
+            if elapsed >= _FPS_REPORT_S and first_frame_seen:
+                parts = []
+                throttled = False
+                for s in self._stream_specs:
+                    delta = self._frame_counts[s.name] - last_fps_counts[s.name]
+                    actual = delta / elapsed
+                    parts.append(f"{s.name}={actual:.1f}/{s.fps}")
+                    if actual < 0.8 * s.fps:
+                        throttled = True
+                    last_fps_counts[s.name] = self._frame_counts[s.name]
+                tag = " ⚠ throttled" if throttled else ""
+                notify("oakd", f"fps {' '.join(parts)}{tag}")
+                last_fps_report_at = now
 
 
 # ── Mode → streams config ──────────────────────────────────────────────

--- a/examples/camera_viz/sources/oakd.py
+++ b/examples/camera_viz/sources/oakd.py
@@ -35,7 +35,7 @@ from typing import List, Optional
 import numpy as np
 
 from pipeline import Frame, FrameSource, SourceSpec
-from ._helpers import alloc_pinned_host
+from ._helpers import alloc_pinned_host, notify
 
 logger = logging.getLogger(__name__)
 
@@ -298,7 +298,9 @@ class _OakdDevice:
             self._produce_loop_inner(dai)
 
     def _produce_loop_inner(self, dai) -> None:
-
+        first_frame_seen = False
+        opening_notified = False
+        unavailable_notified = False
         while not self._stop.is_set():
             if not self._connected:
                 now = time.monotonic()
@@ -307,32 +309,29 @@ class _OakdDevice:
                     continue
                 self._last_reconnect_attempt_s = now
                 if not self._is_device_available():
-                    logger.info(
-                        "OAK-D '%s' not visible on USB; retrying in %.1fs",
-                        self._device_id or "auto",
-                        RECONNECT_DELAY_S,
-                    )
+                    if not unavailable_notified:
+                        notify("oakd", "device not visible on USB; waiting")
+                        unavailable_notified = True
                     continue
+                if not opening_notified:
+                    notify("oakd", "opening...")
+                    opening_notified = True
                 try:
                     self._connected = self._open_device()
                 except Exception as e:
-                    logger.warning("OAK-D open failed (%s); retrying", e)
+                    notify("oakd", f"open failed ({e})")
                     self._close_device()
                     self._reconnect_count += 1
                     continue
-                logger.info(
-                    "OAK-D '%s' connected (streams=%s)%s",
-                    self._device_id or "auto",
-                    [s.name for s in self._stream_specs],
-                    f" (reconnect #{self._reconnect_count})"
-                    if self._reconnect_count
-                    else "",
-                )
+                notify("oakd", "connected")
+                first_frame_seen = False
+                opening_notified = False
+                unavailable_notified = False
 
             try:
                 self._pipeline.processTasks()
             except Exception as e:
-                logger.warning("OAK-D processTasks failed (%s); reconnecting", e)
+                notify("oakd", f"pipeline error ({e}); reconnecting")
                 self._close_device()
                 self._reconnect_count += 1
                 continue
@@ -363,12 +362,15 @@ class _OakdDevice:
                     self._frame_counts[stream_spec.name] += 1
                     emitted_any = True
             except Exception as e:
-                logger.warning("OAK-D emit failed (%s); reconnecting", e)
+                notify("oakd", f"frame error ({e}); reconnecting")
                 self._close_device()
                 self._reconnect_count += 1
                 continue
 
-            if not emitted_any:
+            if emitted_any and not first_frame_seen:
+                first_frame_seen = True
+                notify("oakd", "streaming")
+            elif not emitted_any:
                 # No queue had data this tick — brief yield to avoid burning CPU.
                 self._stop.wait(timeout=0.001)
 

--- a/examples/camera_viz/sources/synthetic.py
+++ b/examples/camera_viz/sources/synthetic.py
@@ -142,3 +142,134 @@ class SyntheticSource(FrameSource):
                     # Coarse pacing — CuPy fill kernels at 1080p are well under
                     # the budget, so a simple sleep keeps us at target fps.
                     time.sleep(self._frame_interval_s)
+
+
+class SyntheticStereoSource(FrameSource):
+    """GPU-resident stereo source emitting a paired RGBA8 test pattern.
+
+    Same animated pattern as ``SyntheticSource``, but with a horizontal
+    pixel shift between the eyes so the disparity is visible — useful
+    for sanity-checking a stereo QuadLayer end-to-end without a real
+    camera. The left/right kernels run on the same stream and are
+    pre-synced before publish, so the renderer always reads a
+    same-instant pair.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        width: int,
+        height: int,
+        fps: float = 60.0,
+        hue_speed_hz: float = 0.25,
+        disparity_px: int = 20,
+    ) -> None:
+        try:
+            import cupy as cp
+        except ImportError as e:
+            raise RuntimeError(
+                "SyntheticStereoSource requires CuPy (cupy-cuda12x). Install via "
+                "`uv pip install cupy-cuda12x` or skip this source."
+            ) from e
+
+        self._cp = cp
+        self._spec = SourceSpec(
+            name=name, width=width, height=height, pixel_format="rgba8"
+        )
+        self._frame_interval_s = 1.0 / fps if fps > 0.0 else 0.0
+        self._hue_speed_hz = hue_speed_hz
+        self._disparity_px = int(disparity_px)
+
+        # Triple-buffer per eye. Indices stay in lock-step so latest()
+        # always returns matching (left[i], right[i]).
+        self._left = [cp.zeros((height, width, 4), dtype=cp.uint8) for _ in range(3)]
+        self._right = [cp.zeros((height, width, 4), dtype=cp.uint8) for _ in range(3)]
+        self._write_idx = 0
+        self._publish_idx: int = -1
+        self._consumed_idx: int = -2
+        self._lock = threading.Lock()
+
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._t0_ns = 0
+
+    @property
+    def spec(self) -> SourceSpec:
+        return self._spec
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._t0_ns = time.monotonic_ns()
+        self._thread = threading.Thread(
+            target=self._produce_loop,
+            name=f"synth_stereo_{self._spec.name}",
+            daemon=False,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join()
+            self._thread = None
+
+    def latest(self) -> Optional[Frame]:
+        with self._lock:
+            if self._publish_idx < 0 or self._publish_idx == self._consumed_idx:
+                return None
+            idx = self._publish_idx
+            self._consumed_idx = idx
+        return Frame(
+            image=self._left[idx],
+            image_right=self._right[idx],
+            timestamp_ns=time.monotonic_ns(),
+            source_id=self._spec.name,
+            stream=0,
+        )
+
+    def _produce_loop(self) -> None:
+        cp = self._cp
+        h, w = self._spec.height, self._spec.width
+        with cp.cuda.Device(int(self._left[0].device.id)):
+            y_grid = cp.arange(h, dtype=cp.float32).reshape(h, 1)
+            x_grid_l = cp.arange(w, dtype=cp.float32).reshape(1, w)
+            # Right-eye coord shifted by disparity_px so the same content
+            # appears at a slightly different x position. Visible parallax
+            # confirms the renderer routed both eyes correctly.
+            x_grid_r = (cp.arange(w, dtype=cp.float32) - self._disparity_px).reshape(
+                1, w
+            )
+            diag_l = (x_grid_l + y_grid) / float(w + h)
+            diag_r = (x_grid_r + y_grid) / float(w + h)
+
+            while not self._stop.is_set():
+                t = (time.monotonic_ns() - self._t0_ns) * 1e-9
+                phase = (t * self._hue_speed_hz) % 1.0
+
+                def fill(buf, diag):
+                    r = (cp.sin((diag + phase) * 6.2831853) * 127.0 + 128.0).astype(
+                        cp.uint8
+                    )
+                    g = (
+                        cp.sin((diag + phase + 0.3333) * 6.2831853) * 127.0 + 128.0
+                    ).astype(cp.uint8)
+                    b = (
+                        cp.sin((diag + phase + 0.6667) * 6.2831853) * 127.0 + 128.0
+                    ).astype(cp.uint8)
+                    buf[..., 0] = r
+                    buf[..., 1] = g
+                    buf[..., 2] = b
+                    buf[..., 3] = 255
+
+                fill(self._left[self._write_idx], diag_l)
+                fill(self._right[self._write_idx], diag_r)
+                cp.cuda.Stream.null.synchronize()
+
+                with self._lock:
+                    self._publish_idx = self._write_idx
+                self._write_idx = (self._write_idx + 1) % len(self._left)
+
+                if self._frame_interval_s > 0.0:
+                    time.sleep(self._frame_interval_s)

--- a/examples/camera_viz/sources/synthetic.py
+++ b/examples/camera_viz/sources/synthetic.py
@@ -145,15 +145,8 @@ class SyntheticSource(FrameSource):
 
 
 class SyntheticStereoSource(FrameSource):
-    """GPU-resident stereo source emitting a paired RGBA8 test pattern.
-
-    Same animated pattern as ``SyntheticSource``, but with a horizontal
-    pixel shift between the eyes so the disparity is visible — useful
-    for sanity-checking a stereo QuadLayer end-to-end without a real
-    camera. The left/right kernels run on the same stream and are
-    pre-synced before publish, so the renderer always reads a
-    same-instant pair.
-    """
+    """Stereo variant of SyntheticSource with a horizontal pixel
+    disparity between eyes; for hardware-free stereo testing."""
 
     def __init__(
         self,
@@ -180,8 +173,7 @@ class SyntheticStereoSource(FrameSource):
         self._hue_speed_hz = hue_speed_hz
         self._disparity_px = int(disparity_px)
 
-        # Triple-buffer per eye. Indices stay in lock-step so latest()
-        # always returns matching (left[i], right[i]).
+        # Lock-step per-eye triple-buffer; latest() returns matching pairs.
         self._left = [cp.zeros((height, width, 4), dtype=cp.uint8) for _ in range(3)]
         self._right = [cp.zeros((height, width, 4), dtype=cp.uint8) for _ in range(3)]
         self._write_idx = 0
@@ -235,9 +227,7 @@ class SyntheticStereoSource(FrameSource):
         with cp.cuda.Device(int(self._left[0].device.id)):
             y_grid = cp.arange(h, dtype=cp.float32).reshape(h, 1)
             x_grid_l = cp.arange(w, dtype=cp.float32).reshape(1, w)
-            # Right-eye coord shifted by disparity_px so the same content
-            # appears at a slightly different x position. Visible parallax
-            # confirms the renderer routed both eyes correctly.
+            # Right-eye x shifted by disparity_px → visible parallax.
             x_grid_r = (cp.arange(w, dtype=cp.float32) - self._disparity_px).reshape(
                 1, w
             )

--- a/examples/camera_viz/sources/zed.py
+++ b/examples/camera_viz/sources/zed.py
@@ -35,33 +35,26 @@ def _notify(msg: str) -> None:
     notify("zed", msg)
 
 
-# Wall-clock budget for ``Camera.open()`` before we nudge the user with
-# a USB-3 hint. The pyzed open call blocks inside a C extension — we
-# can't actually interrupt it, but we CAN tell the user what's likely
-# wrong so they don't sit watching a frozen terminal.
+# Open() blocks inside pyzed's C extension; print a USB-3 hint after this
+# long so the user has something to look at on a USB-2 hang.
 _OPEN_HINT_AFTER_S = 8.0
 
 
 RECONNECT_DELAY_S = 2.0
 MAX_CONSECUTIVE_FAILURES = 10
 
-# Resolution preset → (width, height) — must match pyzed.sl.RESOLUTION enums.
+# pyzed.sl.RESOLUTION enum mirror.
 _RESOLUTION_DIMS = {
     "HD2K": (2208, 1242),
     "HD1080": (1920, 1080),
     "HD720": (1280, 720),
     "VGA": (672, 376),
 }
-
-# Inverse lookup: (width, height) → preset name. Used to infer the
-# SDK preset from the YAML's width / height — keeps the schema single-
-# sourced and lets us reject mismatched dimensions with a useful error.
 _DIMS_TO_RESOLUTION = {dims: name for name, dims in _RESOLUTION_DIMS.items()}
 
 
 def _resolution_for_dims(width: int, height: int) -> str:
-    """Map per-eye dimensions to the ZED SDK preset. Raises with the
-    full list when the dimensions don't match any known preset."""
+    """YAML width × height → SDK preset. Raises with the valid list on mismatch."""
     key = (int(width), int(height))
     if key in _DIMS_TO_RESOLUTION:
         return _DIMS_TO_RESOLUTION[key]
@@ -148,9 +141,6 @@ class _ZedCamera:
                 "SDK's Python install instructions for pyzed."
             ) from e
 
-        # Single-source the dims: width/height come from the YAML and
-        # we look up the matching SDK preset. Mismatch raises with the
-        # full list of valid combinations.
         self._resolution_name = _resolution_for_dims(width, height)
 
         if bus_type.lower() not in ("usb", "gmsl"):
@@ -270,10 +260,7 @@ class _ZedCamera:
 
         _notify("opening...")
 
-        # Watchdog: ``Camera.open()`` blocks inside a C extension and
-        # can sit for tens of seconds on a USB-2 port (the camera
-        # negotiates but the SDK never gets a usable frame). Without
-        # this hint the user just sees a frozen terminal.
+        # Watchdog hint while pyzed.open() blocks in C. USB-2 is the usual cause.
         opened = threading.Event()
 
         def _hint():

--- a/examples/camera_viz/sources/zed.py
+++ b/examples/camera_viz/sources/zed.py
@@ -21,7 +21,7 @@ grab), count consecutive transients, force a reopen past the threshold.
 
 from __future__ import annotations
 
-import logging
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -29,7 +29,20 @@ from typing import List, Optional
 
 from pipeline import Frame, FrameSource, SourceSpec
 
-logger = logging.getLogger(__name__)
+
+# Wall-clock budget for ``Camera.open()`` before we nudge the user with
+# a USB-3 hint. The pyzed open call blocks inside a C extension — we
+# can't actually interrupt it, but we CAN tell the user what's likely
+# wrong so they don't sit watching a frozen terminal.
+_OPEN_HINT_AFTER_S = 8.0
+
+
+def _notify(msg: str) -> None:
+    """User-facing breadcrumb. Routed via stderr directly (not through
+    ``logger``) so it shows up even when the app hasn't configured
+    Python logging, which is the common case for camera_viz."""
+    print(f"[zed] {msg}", file=sys.stderr, flush=True)
+
 
 RECONNECT_DELAY_S = 2.0
 MAX_CONSECUTIVE_FAILURES = 10
@@ -239,7 +252,27 @@ class _ZedCamera:
         elif self._bus_type == "gmsl":
             init_params.input.setFromCameraID(-1, bus_enum)
 
-        if camera.open(init_params) != sl.ERROR_CODE.SUCCESS:
+        _notify("opening...")
+
+        # Watchdog: ``Camera.open()`` blocks inside a C extension and
+        # can sit for tens of seconds on a USB-2 port (the camera
+        # negotiates but the SDK never gets a usable frame). Without
+        # this hint the user just sees a frozen terminal.
+        opened = threading.Event()
+
+        def _hint():
+            if not opened.wait(timeout=_OPEN_HINT_AFTER_S):
+                _notify("camera not responding — check USB 3 connection")
+
+        threading.Thread(target=_hint, name="zed_open_hint", daemon=True).start()
+
+        try:
+            err = camera.open(init_params)
+        finally:
+            opened.set()
+
+        if err != sl.ERROR_CODE.SUCCESS:
+            _notify(f"open failed ({err})")
             try:
                 camera.close()
             except Exception:
@@ -250,13 +283,9 @@ class _ZedCamera:
         actual_w = info.camera_configuration.resolution.width
         actual_h = info.camera_configuration.resolution.height
         if actual_w != self._width or actual_h != self._height:
-            logger.warning(
-                "ZED resolution mismatch: expected %dx%d, got %dx%d — "
-                "pre-allocated buffers won't match; closing.",
-                self._width,
-                self._height,
-                actual_w,
-                actual_h,
+            _notify(
+                f"resolution mismatch (expected {self._width}x{self._height}, "
+                f"got {actual_w}x{actual_h})"
             )
             camera.close()
             return False
@@ -306,6 +335,7 @@ class _ZedCamera:
             sl.ERROR_CODE.CAMERA_NOT_INITIALIZED,
         }
 
+        first_frame_seen = False
         while not self._stop.is_set():
             if not self._connected:
                 now = time.monotonic()
@@ -316,23 +346,16 @@ class _ZedCamera:
                 try:
                     self._connected = self._open_camera()
                 except Exception as e:
-                    logger.warning("ZED open failed (%s); retrying", e)
+                    _notify(f"open failed ({e})")
                     self._close_camera()
                     self._reconnect_count += 1
                     continue
                 if not self._connected:
                     self._reconnect_count += 1
                     continue
-                logger.info(
-                    "ZED connected: SN=%s, %dx%d@%dfps%s",
-                    self._serial_number or "auto",
-                    self._width,
-                    self._height,
-                    self._fps,
-                    f" (reconnect #{self._reconnect_count})"
-                    if self._reconnect_count
-                    else "",
-                )
+                _notify("connected")
+                # Reset the first-frame breadcrumb after each (re)connect.
+                first_frame_seen = False
 
             err = self._camera.grab(self._runtime_params)
             if err != sl.ERROR_CODE.SUCCESS:
@@ -341,11 +364,7 @@ class _ZedCamera:
                     err in fatal_errors
                     or self._consecutive_failures >= MAX_CONSECUTIVE_FAILURES
                 ):
-                    logger.warning(
-                        "ZED grab failed (%s, %dx consecutive); reconnecting",
-                        err,
-                        self._consecutive_failures,
-                    )
+                    _notify(f"grab failed ({err}); reconnecting")
                     self._close_camera()
                 continue
             self._consecutive_failures = 0
@@ -372,15 +391,15 @@ class _ZedCamera:
                 if retrieve_failed:
                     self._consecutive_failures += 1
                     if self._consecutive_failures >= MAX_CONSECUTIVE_FAILURES:
-                        logger.warning(
-                            "ZED retrieve_image failing %dx; reconnecting",
-                            self._consecutive_failures,
-                        )
+                        _notify("camera connection problem; reconnecting")
                         self._close_camera()
                 else:
                     self._consecutive_failures = 0
+                    if not first_frame_seen:
+                        first_frame_seen = True
+                        _notify("streaming")
             except Exception as e:
-                logger.warning("ZED retrieve/convert failed (%s); reconnecting", e)
+                _notify(f"frame error ({e}); reconnecting")
                 self._close_camera()
                 self._reconnect_count += 1
                 continue

--- a/examples/camera_viz/sources/zed.py
+++ b/examples/camera_viz/sources/zed.py
@@ -21,7 +21,6 @@ grab), count consecutive transients, force a reopen past the threshold.
 
 from __future__ import annotations
 
-import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -29,19 +28,18 @@ from typing import List, Optional
 
 from pipeline import Frame, FrameSource, SourceSpec
 
+from ._helpers import notify
+
+
+def _notify(msg: str) -> None:
+    notify("zed", msg)
+
 
 # Wall-clock budget for ``Camera.open()`` before we nudge the user with
 # a USB-3 hint. The pyzed open call blocks inside a C extension — we
 # can't actually interrupt it, but we CAN tell the user what's likely
 # wrong so they don't sit watching a frozen terminal.
 _OPEN_HINT_AFTER_S = 8.0
-
-
-def _notify(msg: str) -> None:
-    """User-facing breadcrumb. Routed via stderr directly (not through
-    ``logger``) so it shows up even when the app hasn't configured
-    Python logging, which is the common case for camera_viz."""
-    print(f"[zed] {msg}", file=sys.stderr, flush=True)
 
 
 RECONNECT_DELAY_S = 2.0
@@ -54,6 +52,24 @@ _RESOLUTION_DIMS = {
     "HD720": (1280, 720),
     "VGA": (672, 376),
 }
+
+# Inverse lookup: (width, height) → preset name. Used to infer the
+# SDK preset from the YAML's width / height — keeps the schema single-
+# sourced and lets us reject mismatched dimensions with a useful error.
+_DIMS_TO_RESOLUTION = {dims: name for name, dims in _RESOLUTION_DIMS.items()}
+
+
+def _resolution_for_dims(width: int, height: int) -> str:
+    """Map per-eye dimensions to the ZED SDK preset. Raises with the
+    full list when the dimensions don't match any known preset."""
+    key = (int(width), int(height))
+    if key in _DIMS_TO_RESOLUTION:
+        return _DIMS_TO_RESOLUTION[key]
+    valid = ", ".join(f"{n} = {w}x{h}" for n, (w, h) in _RESOLUTION_DIMS.items())
+    raise ValueError(
+        f"ZedSource: {width}x{height} doesn't match any ZED SDK preset. "
+        f"Valid (per-eye): {valid}."
+    )
 
 
 @dataclass
@@ -117,7 +133,8 @@ class _ZedCamera:
         self,
         serial_number: int,
         bus_type: str,
-        resolution: str,
+        width: int,
+        height: int,
         fps: int,
         stereo: bool,
     ) -> None:
@@ -131,11 +148,11 @@ class _ZedCamera:
                 "SDK's Python install instructions for pyzed."
             ) from e
 
-        if resolution.upper() not in _RESOLUTION_DIMS:
-            raise ValueError(
-                f"ZedSource: unknown resolution {resolution!r} "
-                f"(known: {sorted(_RESOLUTION_DIMS)})"
-            )
+        # Single-source the dims: width/height come from the YAML and
+        # we look up the matching SDK preset. Mismatch raises with the
+        # full list of valid combinations.
+        self._resolution_name = _resolution_for_dims(width, height)
+
         if bus_type.lower() not in ("usb", "gmsl"):
             raise ValueError(
                 f"ZedSource: unknown bus_type {bus_type!r} (expected usb | gmsl)"
@@ -143,7 +160,6 @@ class _ZedCamera:
 
         self._serial_number = serial_number
         self._bus_type = bus_type.lower()
-        self._resolution_name = resolution.upper()
         self._fps = fps
         self._stereo = stereo
         self._width, self._height = _RESOLUTION_DIMS[self._resolution_name]
@@ -468,13 +484,14 @@ class ZedSource(FrameSource):
     def build(
         cls,
         base_name: str,
-        resolution: str = "HD720",
+        width: int,
+        height: int,
         fps: int = 30,
         serial_number: int = 0,
         bus_type: str = "usb",
         stereo: bool = True,
     ) -> List["ZedSource"]:
-        camera = _ZedCamera(serial_number, bus_type, resolution, fps, stereo)
+        camera = _ZedCamera(serial_number, bus_type, width, height, fps, stereo)
         eyes = ["left", "right"] if stereo else ["left"]
         return [
             cls(

--- a/examples/camera_viz/transports/rtp_h264_sender.py
+++ b/examples/camera_viz/transports/rtp_h264_sender.py
@@ -171,6 +171,13 @@ class RtpH264Sender:
         flow = self._appsrc.emit("push-buffer", buf)
         return flow == Gst.FlowReturn.OK
 
+    # Per-sender measured-fps breadcrumb cadence + how many encoder
+    # failures in a row trip a hard restart (lets the supervisor
+    # rebuild the pipeline instead of spinning forever on a wedged
+    # NVENC session).
+    _FPS_REPORT_S = 5.0
+    _ENCODE_FAIL_THRESHOLD = 30
+
     def _send_loop(self) -> None:
         # Idle poll interval. ``FrameSource.latest()`` returns None when no
         # NEW frame has arrived since the previous call, so the loop only
@@ -189,6 +196,9 @@ class RtpH264Sender:
         import cupy as cp
 
         device_pinned = False
+        consecutive_encode_failures = 0
+        last_fps_report_at = time.monotonic()
+        last_fps_count = 0
 
         while not self._stop.is_set():
             if not self._connected:
@@ -231,11 +241,26 @@ class RtpH264Sender:
 
             try:
                 packets = self._encoder.encode(frame.image)
+                consecutive_encode_failures = 0
             except Exception as e:
+                consecutive_encode_failures += 1
                 logger.warning(
-                    "RtpH264Sender: encode failed (%s); resetting encoder", e
+                    "RtpH264Sender: encode failed (%s); resetting encoder (%d/%d)",
+                    e,
+                    consecutive_encode_failures,
+                    self._ENCODE_FAIL_THRESHOLD,
                 )
                 self._encoder.reset()
+                # Fail-fast: persistent encode failures mean NVENC is
+                # wedged or the input format changed. Raise so the
+                # supervisor rebuilds the whole pipeline (camera +
+                # encoder + GStreamer) instead of spinning forever
+                # with the user seeing no stream + no error.
+                if consecutive_encode_failures >= self._ENCODE_FAIL_THRESHOLD:
+                    raise RuntimeError(
+                        f"RtpH264Sender: encode failed {consecutive_encode_failures} "
+                        f"times in a row; surfacing to supervisor for full restart"
+                    )
                 continue
 
             for pkt in packets:
@@ -246,3 +271,17 @@ class RtpH264Sender:
                     self._teardown_pipeline()
                     break
             self._frame_count += 1
+            now = time.monotonic()
+            elapsed = now - last_fps_report_at
+            if elapsed >= self._FPS_REPORT_S:
+                actual = (self._frame_count - last_fps_count) / elapsed
+                tag = " ⚠ throttled" if actual < 0.8 * self._fps else ""
+                logger.info(
+                    "RtpH264Sender :%d fps=%.1f/%d%s",
+                    self._port,
+                    actual,
+                    self._fps,
+                    tag,
+                )
+                last_fps_report_at = now
+                last_fps_count = self._frame_count

--- a/examples/camera_viz/transports/rtp_h264_sender.py
+++ b/examples/camera_viz/transports/rtp_h264_sender.py
@@ -171,10 +171,7 @@ class RtpH264Sender:
         flow = self._appsrc.emit("push-buffer", buf)
         return flow == Gst.FlowReturn.OK
 
-    # Per-sender measured-fps breadcrumb cadence + how many encoder
-    # failures in a row trip a hard restart (lets the supervisor
-    # rebuild the pipeline instead of spinning forever on a wedged
-    # NVENC session).
+    # fps log cadence + consecutive-encode-fail threshold for hard restart.
     _FPS_REPORT_S = 5.0
     _ENCODE_FAIL_THRESHOLD = 30
 
@@ -251,11 +248,7 @@ class RtpH264Sender:
                     self._ENCODE_FAIL_THRESHOLD,
                 )
                 self._encoder.reset()
-                # Fail-fast: persistent encode failures mean NVENC is
-                # wedged or the input format changed. Raise so the
-                # supervisor rebuilds the whole pipeline (camera +
-                # encoder + GStreamer) instead of spinning forever
-                # with the user seeing no stream + no error.
+                # Persistent failures = wedged NVENC; let the supervisor restart.
                 if consecutive_encode_failures >= self._ENCODE_FAIL_THRESHOLD:
                     raise RuntimeError(
                         f"RtpH264Sender: encode failed {consecutive_encode_failures} "


### PR DESCRIPTION
- Adds stereo quad layer support to camera_viz example
- Fixes oakd camera frame polling issue
- Fixes setup script stale wheel issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added end-to-end stereo camera support for ZED, OAK-D, synthetic, and RTP sources with left/right eye rendering.
  * Introduced stereo baseline configuration for XR depth perception control.
  * Added enhanced verbose diagnostics with per-source logging and periodic FPS monitoring.
  * New synthetic stereo source with configurable parallax.

* **Bug Fixes**
  * Improved encoder failure recovery with automatic restart on repeated failures.
  * Added USB 3.x speed validation with warnings for potential frame drops.
  * Fixed atomic stereo frame pairing to prevent eye misalignment.

* **Documentation**
  * Added stereo-enabled example configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/536)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->