### PR TITLE
Clear WebGL errors on startup

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/WebGlUtils.ts
+++ b/deps/cloudxr/webxr_client/helpers/WebGlUtils.ts
@@ -36,6 +36,21 @@ export function getOrCreateCanvas(
   return canvas;
 }
 
+/** Upper bound on consecutive getError drains (guards broken drivers). */
+const kMaxGLErrorDrain = 64;
+
+/**
+ * Drain pending WebGL errors on `gl` until {@link WebGL2RenderingContext.NO_ERROR}.
+ * Shared contexts may carry stale errors from the host app (e.g. R3F/XR) before CloudXR runs.
+ */
+export function clearPendingGLErrors(gl: WebGL2RenderingContext): void {
+  for (let i = 0; i < kMaxGLErrorDrain; i++) {
+    if (gl.getError() === gl.NO_ERROR) {
+      break;
+    }
+  }
+}
+
 export function logOrThrow(tagString: string, gl: WebGL2RenderingContext) {
   const err = gl.getError();
   if (err !== gl.NO_ERROR) {

--- a/deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx
+++ b/deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx
@@ -36,6 +36,7 @@
 import { MetricsTracker } from '@helpers/Metrics';
 import { getConnectionConfig, ConnectionConfiguration, CloudXRConfig } from '@helpers/utils';
 import { bindGL } from '@helpers/WebGLStateBinding';
+import { clearPendingGLErrors } from '@helpers/WebGlUtils';
 import * as CloudXR from '@nvidia/cloudxr';
 import { useThree, useFrame } from '@react-three/fiber';
 import { useXR } from '@react-three/xr';
@@ -320,6 +321,10 @@ export default function CloudXRComponent({
               }
             },
           };
+
+          // Shared GL contexts may still have queued errors from the host app (e.g. R3F/XR).
+          // Clear them before createSession so CloudXR setup only sees errors from its own path.
+          clearPendingGLErrors(gl);
 
           // Create the CloudXR session.
           let cxrSession: CloudXR.Session;


### PR DESCRIPTION
Clears the `GL_INVALID_OPERATION: glTexImage2DRobustANGLE: Texture is immutable error we are getting` from IWER before we reach our GL init function.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced CloudXR session initialization stability by clearing accumulated WebGL errors before establishing a new session, preventing stale errors from interfering with session setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/537)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->