### PR TITLE
deps: pin cmeel-urdfdom<5 and cmeel-tinyxml2<11 for pinocchio

### DIFF
--- a/src/core/python/requirements-grounding.txt
+++ b/src/core/python/requirements-grounding.txt
@@ -18,3 +18,9 @@ pin>=2.7.0
 pin-pink>=4.0.0
 loop-rate-limiters>=1.0.0
 daqp>=0.5.0
+# pin (Pinocchio) 3.9.0's compiled bindings link against specific cmeel sonames
+# (liburdfdom_sensor.so.4.0, libtinyxml2.so.10) but declare only `>=` floors on
+# their cmeel packages. Major bumps cmeel-urdfdom 6.0.0 and cmeel-tinyxml2 11.0.0
+# (both 2026-05-21) ship newer sonames and break `import pinocchio` at runtime.
+cmeel-urdfdom<5
+cmeel-tinyxml2<11


### PR DESCRIPTION
Pinocchio 3.9.0 wheels link against liburdfdom_sensor.so.4.0 and libtinyxml2.so.10 but declare only `>=` floors on their cmeel packages. Upstream published cmeel-urdfdom 6.0.0 and cmeel-tinyxml2 11.0.0 on 2026-05-21; both ship newer sonames, causing `import pinocchio` to fail at runtime in fresh teleop_ros2 image builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Updated dependency version constraints to ensure runtime compatibility with recent library updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->