### PR TITLE
ROS: Fix controller placeholder quaternion

### DIFF
--- a/examples/teleop_ros2/python/messages.py
+++ b/examples/teleop_ros2/python/messages.py
@@ -39,7 +39,7 @@ def build_controller_payload(
 
     def _as_quat(ctrl, index):
         if ctrl.is_none:
-            return [1.0, 0.0, 0.0, 0.0]
+            return [0.0, 0.0, 0.0, 1.0]
         return [float(x) for x in ctrl[index]]
 
     def _as_float(ctrl, index):


### PR DESCRIPTION
Use XYZW identity ordering for missing controller orientation fields so placeholder payloads match the rest of the ROS pose conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected default controller orientation values when a controller input is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/553?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->