### PR TITLE
ci: backport per-tag web client publish + stable seed to 1.1.x

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Build docs and Teleop web app, then deploy to GitHub Pages.
-# - Push to main/release (canonical repo): deploy docs at site root, web app at /client/<slug>/.
+# - Push to main/release/v* tag (canonical repo): deploy docs at site root, web app at /client/<slug>/.
+#   Tag pushes also promote /client/stable/ to the highest v* tag.
 # - Pull requests: deploy preview to preview/pr-<N>/ (docs at root, app at preview/pr-<N>/client/).
 #
 # Builds are gated on changed paths by the `changes` job; gh-pages
@@ -19,6 +20,8 @@ on:
     branches:
       - main
       - 'release/**'
+    tags:
+      - 'v[1-9]*.[0-9]*.[0-9]*'
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
@@ -45,7 +48,10 @@ jobs:
       if: github.repository == 'NVIDIA/IsaacTeleop'
       run: echo "defined=true" >> "$GITHUB_OUTPUT"
     - id: is-deploy-branch
-      if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/heads/release/')
+      if: >-
+        github.ref == 'refs/heads/main'
+        || startsWith(github.ref, 'refs/heads/release/')
+        || startsWith(github.ref, 'refs/tags/v')
       run: echo "defined=true" >> "$GITHUB_OUTPUT"
     - id: ngc-allowlist
       run: |
@@ -213,6 +219,12 @@ jobs:
     permissions:
       contents: write  # push to gh-pages
     steps:
+      - name: Checkout (for tag lookup)
+        if: github.event_name == 'push' && github.ref_type == 'tag'
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
       - name: Download docs artifact
         if: needs.build-docs.result == 'success'
         uses: actions/download-artifact@v7
@@ -227,24 +239,32 @@ jobs:
           name: webapp
           path: ./webapp
 
-      # Each push lands at client/<slug>/ so a release-branch deploy can no
-      # longer trample the canonical /client/, which is just a redirect to
-      # ./main/.
+      # Web client lands at client/<slug>/: tag → v1.2.3, main → main, release branch → release-1.3.x.
+      # Tag pushes also (re)point client/stable/ at the highest v* tag.
+      # The root client/ redirect (currently → ./main/) is owned by the main branch deploy;
+      # flip it to ./stable/ in a follow-up once 1.2.x ships.
       - name: Place web app under versioned subpath
         if: needs.build-app.result == 'success'
         run: |
           set -euo pipefail
+          CLIENT_BASE=./docs/build/client
+
           if [ "${{ github.event_name }}" = 'pull_request' ]; then
-            # PR previews live under preview/pr-<N>/ and are pinned to the PR,
-            # so they don't need the multi-version layout.
-            CLIENT_DIR=./docs/build/current/client
-            mkdir -p "$CLIENT_DIR"
-            cp -r ./webapp/. "$CLIENT_DIR/"
+            mkdir -p ./docs/build/current/client
+            cp -r ./webapp/. ./docs/build/current/client/
+            exit 0
+          fi
+
+          if [ "$GITHUB_REF_TYPE" = 'tag' ]; then
+            target="$GITHUB_REF_NAME"
           else
-            slug="${GITHUB_REF_NAME//\//-}"
-            CLIENT_BASE=./docs/build/client
-            mkdir -p "$CLIENT_BASE/$slug"
-            cp -r ./webapp/. "$CLIENT_BASE/$slug/"
+            target="${GITHUB_REF_NAME//\//-}"
+          fi
+          mkdir -p "$CLIENT_BASE/$target"
+          cp -r ./webapp/. "$CLIENT_BASE/$target/"
+          echo "Deployed web client to /client/$target/"
+
+          if [ "$GITHUB_REF" = 'refs/heads/main' ]; then
             cat > "$CLIENT_BASE/index.html" <<'HTML'
           <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
           <!-- SPDX-License-Identifier: Apache-2.0 -->
@@ -260,10 +280,38 @@ jobs:
             </body>
           </html>
           HTML
-            echo "Deployed web client to /client/$slug/"
           fi
 
-      - name: Deploy to gh-pages (main branch)
+          if [ "$GITHUB_REF_TYPE" = 'tag' ]; then
+            stable_slug="$(git ls-remote --tags origin 'v[1-9]*.[0-9]*.[0-9]*' \
+              | awk -F'refs/tags/' '{print $2}' \
+              | sed 's/\^{}$//' | sort -uV | tail -n1)"
+            if [ -z "$stable_slug" ]; then
+              echo "::warning::No v* tags resolved; leaving client/stable/ untouched."
+              exit 0
+            fi
+            mkdir -p "$CLIENT_BASE/stable"
+            cat > "$CLIENT_BASE/stable/index.html" <<HTML
+          <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+          <!-- SPDX-License-Identifier: Apache-2.0 -->
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <title>Redirecting to the stable Isaac Teleop web client (${stable_slug})</title>
+              <meta charset="utf-8">
+              <meta http-equiv="refresh" content="0; url=../${stable_slug}/">
+              <link rel="canonical" href="../${stable_slug}/">
+            </head>
+            <body>
+              <p>Redirecting to <a href="../${stable_slug}/">the stable Isaac Teleop web client</a>.</p>
+              <script>location.replace('../${stable_slug}/' + location.search + location.hash);</script>
+            </body>
+          </html>
+          HTML
+            echo "Stable now points to /client/${stable_slug}/"
+          fi
+
+      - name: Deploy to gh-pages
         if: github.event_name == 'push' && needs.check-repo.outputs.is-deploy-branch == 'true'
         uses: peaceiris/actions-gh-pages@v3
         with:

--- a/.github/workflows/promote-stable-client.yaml
+++ b/.github/workflows/promote-stable-client.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Re-resolve /client/stable/ to the highest existing v* tag.
+# Fires on tag deletion (rollback) and manual dispatch. Tag creation is handled
+# by docs.yaml as part of the per-tag deploy.
+
+name: Promote stable web client
+
+on:
+  delete:
+  workflow_dispatch:
+
+concurrency:
+  group: promote-stable-client
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    if: >-
+      github.repository == 'NVIDIA/IsaacTeleop'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || (github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v'))
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - id: build
+        run: |
+          set -euo pipefail
+          slug="$(git ls-remote --tags origin 'v[1-9]*.[0-9]*.[0-9]*' \
+            | awk -F'refs/tags/' '{print $2}' \
+            | sed 's/\^{}$//' | sort -uV | tail -n1)"
+          if [ -z "$slug" ]; then
+            echo "::warning::No v* tags remain; leaving client/stable/ untouched."
+            exit 0
+          fi
+          mkdir -p out/client/stable
+          cat > out/client/stable/index.html <<HTML
+          <!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+          <!-- SPDX-License-Identifier: Apache-2.0 -->
+          <!DOCTYPE html>
+          <html>
+            <head>
+              <title>Redirecting to the stable Isaac Teleop web client (${slug})</title>
+              <meta charset="utf-8">
+              <meta http-equiv="refresh" content="0; url=../${slug}/">
+              <link rel="canonical" href="../${slug}/">
+            </head>
+            <body>
+              <p>Redirecting to <a href="../${slug}/">the stable Isaac Teleop web client</a>.</p>
+              <script>location.replace('../${slug}/' + location.search + location.hash);</script>
+            </body>
+          </html>
+          HTML
+          echo "slug=$slug" >> "$GITHUB_OUTPUT"
+          echo "Stable resolved to /client/${slug}/"
+
+      - if: steps.build.outputs.slug != ''
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./out
+          keep_files: true


### PR DESCRIPTION
## Summary

Backport of [#556](https://github.com/NVIDIA/IsaacTeleop/pull/556) (`0be0f6c0`) to `release/1.1.x`. Adds the tag trigger to `docs.yaml` and the new `promote-stable-client.yaml` so:

- A future `v1.1.X` tag pushed on this branch deploys the web client to `/client/v1.1.X/`.
- `/client/stable/` is re-seeded to the highest `v[1-9]*.[0-9]*.[0-9]*` tag in the repo on every tag push and on tag deletion / manual dispatch.

## Cherry-pick notes

- Conflict was limited to the docs.yaml header comment. Kept the 1.1.x preview model (this branch has no `/preview-docs` flow / `docs-preview-on-demand.yaml`) and folded in the new tag note.
- `peaceiris/actions-gh-pages` is intentionally left at `@v3` — the bump to `@v4` is a separate change (`37d3345e`) and out of scope for this backport.

## Companion PRs

- `release/1.2.x` backport: follow-up PR (without it, a future `v1.2.x` tag won't publish and stable could resolve to a non-existent `/client/v1.2.0/`).

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: a dry-run tag (e.g., `v1.1.6-rc1`) — verify `docs.yaml` triggers, `/client/v1.1.6-rc1/` lands on gh-pages, `/client/stable/` resolves to the expected slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)