### PR TITLE
ci: flip root /client/ redirect from ./main/ to ./stable/

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -208,8 +208,7 @@ jobs:
 
       # Web client lands at client/<slug>/: tag → v1.2.3, main → main, release branch → release-1.3.x.
       # Tag pushes also (re)point client/stable/ at the highest v* tag.
-      # The root client/ redirect (currently → ./main/) is owned by the main branch deploy;
-      # flip it to ./stable/ in a follow-up once 1.2.x ships.
+      # The root client/ redirect is owned by the main branch deploy and points at ./stable/.
       - name: Place web app under versioned subpath
         if: needs.build-app.result == 'success'
         run: |
@@ -238,12 +237,14 @@ jobs:
           <!DOCTYPE html>
           <html>
             <head>
-              <title>Redirecting to the latest Isaac Teleop web client</title>
+              <title>Redirecting to the stable Isaac Teleop web client</title>
               <meta charset="utf-8">
-              <meta http-equiv="refresh" content="0; url=./main/">
+              <meta http-equiv="refresh" content="0; url=./stable/">
+              <link rel="canonical" href="./stable/">
             </head>
             <body>
-              <p>Redirecting to <a href="./main/">the latest Isaac Teleop web client</a>.</p>
+              <p>Redirecting to <a href="./stable/">the stable Isaac Teleop web client</a>.</p>
+              <script>location.replace('./stable/' + location.search + location.hash);</script>
             </body>
           </html>
           HTML


### PR DESCRIPTION
## Summary

Flips the root `/client/index.html` redirect from `./main/` (in-flight main builds) to `./stable/` (highest tagged release). This was called out as the planned one-line follow-up in [#556](https://github.com/NVIDIA/IsaacTeleop/pull/556):

> The root `/client/` redirect is intentionally left at `./main/` — flipping it to `./stable/` is a one-line follow-up once 1.2.x is tagged, so users hitting `/client/` don't regress to a 1.1.x build that's missing fixes.

Also mirrors the `stable/index.html` shape (canonical link + JS `location.replace`) so query strings and fragments survive the redirect.

## ⚠️ Hold before merging

`/client/stable/` only exists on gh-pages **after** the first `v[1-9]*.[0-9]*.[0-9]*` tag has been pushed with the new workflow in place. Until that's happened, merging this turns `/client/` into a 404.

**Order of operations:**

1. Land the release-branch backports first: [#558](https://github.com/NVIDIA/IsaacTeleop/pull/558) (1.1.x), [#559](https://github.com/NVIDIA/IsaacTeleop/pull/559) (1.2.x).
2. Push the first v* tag (could be from `release/1.2.x`, `release/1.3.x`, or a manual `workflow_dispatch` of `promote-stable-client.yaml`).
3. Confirm `https://nvidia.github.io/IsaacTeleop/client/stable/` resolves.
4. Mark this PR ready and merge.

Kept as **draft** to make that explicit.

## Test plan

- [ ] `/client/stable/` exists on gh-pages before merging.
- [ ] After merge: visit `https://nvidia.github.io/IsaacTeleop/client/` → lands on the highest-tagged web client.
- [ ] Query string / fragment passthrough (`/client/?showVersion=1`) reaches `/client/<tag>/?showVersion=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation deployment redirect to point to the stable release version instead of the development version, ensuring users accessing documentation are directed to the stable client build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/560?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->