### PR TITLE
backport: Clear WebGL errors on startup (#537) to release/1.1.x

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/WebGlUtils.ts
+++ b/deps/cloudxr/webxr_client/helpers/WebGlUtils.ts
@@ -36,6 +36,21 @@ export function getOrCreateCanvas(
   return canvas;
 }
 
+/** Upper bound on consecutive getError drains (guards broken drivers). */
+const kMaxGLErrorDrain = 64;
+
+/**
+ * Drain pending WebGL errors on `gl` until {@link WebGL2RenderingContext.NO_ERROR}.
+ * Shared contexts may carry stale errors from the host app (e.g. R3F/XR) before CloudXR runs.
+ */
+export function clearPendingGLErrors(gl: WebGL2RenderingContext): void {
+  for (let i = 0; i < kMaxGLErrorDrain; i++) {
+    if (gl.getError() === gl.NO_ERROR) {
+      break;
+    }
+  }
+}
+
 export function logOrThrow(tagString: string, gl: WebGL2RenderingContext) {
   const err = gl.getError();
   if (err !== gl.NO_ERROR) {

--- a/deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx
+++ b/deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx
@@ -36,6 +36,7 @@
 import { MetricsTracker } from '@helpers/Metrics';
 import { getConnectionConfig, ConnectionConfiguration, CloudXRConfig } from '@helpers/utils';
 import { bindGL } from '@helpers/WebGLStateBinding';
+import { clearPendingGLErrors } from '@helpers/WebGlUtils';
 import * as CloudXR from '@nvidia/cloudxr';
 import { useThree, useFrame } from '@react-three/fiber';
 import { useXR } from '@react-three/xr';
@@ -296,6 +297,10 @@ export default function CloudXRComponent({
               }
             },
           };
+
+          // Shared GL contexts may still have queued errors from the host app (e.g. R3F/XR).
+          // Clear them before createSession so CloudXR setup only sees errors from its own path.
+          clearPendingGLErrors(gl);
 
           // Create the CloudXR session.
           let cxrSession: CloudXR.Session;


### PR DESCRIPTION
Cherry-picks b8a0e39a9b0ed545dc6fc61691d66db07a1e8f7c (#537) from main to `release/1.1.x`.

## Summary
- Clear WebGL errors on startup
- Touches `deps/cloudxr/webxr_client/helpers/WebGlUtils.ts` and `deps/cloudxr/webxr_client/helpers/react/CloudXRComponent.tsx`
- Clean cherry-pick (auto-merged, no conflicts)

## Test plan
- [ ] CI passes on release/1.1.x

🤖 Generated with [Claude Code](https://claude.com/claude-code)