### PR TITLE
Bump CloudXR Runtime SDK to 6.2.0

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.1.0
+CXR_RUNTIME_SDK_VERSION=6.2.0
 CXR_WEB_SDK_VERSION=6.2.0
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 


### PR DESCRIPTION
## Summary
- Bumps `CXR_RUNTIME_SDK_VERSION` from 6.1.0 to 6.2.0 in `deps/cloudxr/.env.default`
- `CXR_WEB_SDK_VERSION` is already 6.2.0 on `main` (bumped in #555); after rebasing both versions are now aligned at 6.2.0

## Test plan
- [x] CI passes (CloudXR Runtime SDK 6.2.0 is published to NGC and pulls cleanly)
- [ ] Smoke test runtime container starts and serves a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CloudXR Runtime SDK to version 6.2.0

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/564?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->