### PR TITLE
feat(webclient): add auto-refresh-on-session-end option

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/react/utils.ts
+++ b/deps/cloudxr/webxr_client/helpers/react/utils.ts
@@ -64,8 +64,30 @@ export interface ReactUIConfig {
   panelHiddenAtStart?: boolean;
   /** When true, all WebGL rendering is skipped. */
   headless?: boolean;
+  /** Page-refresh behavior when the XR session ends. See {@link AutoRefreshMode}. */
+  autoRefreshMode?: AutoRefreshMode;
   /** Active teleop project path (a key path in `TELEOP_PROJECTS`). */
   teleopPath: string;
+}
+
+/** When to reload the page once the XR session ends: never, only on a clean end, or on any end. */
+export type AutoRefreshMode = 'never' | 'clean' | 'any';
+
+const AUTO_REFRESH_MODES: readonly AutoRefreshMode[] = ['never', 'clean', 'any'];
+
+/**
+ * Parses a string into a valid auto-refresh mode.
+ * @param unvalidatedValue - String to validate (e.g. from URL, config, or form). May be invalid or empty.
+ * @param fallback - Value to return when unvalidatedValue is not valid.
+ */
+export function parseAutoRefreshMode(
+  unvalidatedValue: string,
+  fallback: AutoRefreshMode
+): AutoRefreshMode {
+  if (AUTO_REFRESH_MODES.includes(unvalidatedValue as AutoRefreshMode)) {
+    return unvalidatedValue as AutoRefreshMode;
+  }
+  return fallback;
 }
 
 const CONTROL_PANEL_POSITIONS: readonly ControlPanelPosition[] = ['left', 'center', 'right'];

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -356,7 +356,7 @@ function App() {
     // URL query params override localStorage so bookmarked links always win.
     const urlSeeds: Record<string, string> = {};
     const p = new URLSearchParams(window.location.search);
-    for (const key of ['serverIP', 'port', 'codec', 'panelHiddenAtStart', 'headless', 'turnServer', 'turnUsername', 'turnCredential']) {
+    for (const key of ['serverIP', 'port', 'codec', 'panelHiddenAtStart', 'headless', 'autoRefreshMode', 'turnServer', 'turnUsername', 'turnCredential']) {
       const v = p.get(key);
       if (v !== null) urlSeeds[key] = v;
     }
@@ -497,6 +497,15 @@ function App() {
     setIsConnected(connected);
     setSessionStatus(status);
     controlChannelRef.current?.sendStreamStatus(connected && status === 'Connected');
+
+    // Reload on session end per mode; read live off the stable 2D UI to avoid a stale closure.
+    const autoRefreshMode = cloudXR2DUI?.getConfiguration().autoRefreshMode;
+    if (
+      (status === 'Disconnected' && (autoRefreshMode === 'clean' || autoRefreshMode === 'any')) ||
+      (status === 'Error' && autoRefreshMode === 'any')
+    ) {
+      window.location.reload();
+    }
   };
 
   // Render performance metrics callback handler - updates raw data signal
@@ -671,6 +680,7 @@ function App() {
       }
     }
 
+    // Auto-refresh is handled centrally in handleStatusChange on the resulting stream-stop.
     const xrState = store.getState();
     const session = xrState.session;
     if (session) {

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -37,7 +37,9 @@ import {
   type DeviceProfileId,
 } from '@helpers/DeviceProfiles';
 import {
+  type AutoRefreshMode,
   loadPerProject,
+  parseAutoRefreshMode,
   parseControlPanelPosition,
   ReactUIConfig,
   savePerProject,
@@ -154,6 +156,8 @@ export class CloudXR2DUI {
   private controllerModelVisibilitySelect!: HTMLSelectElement;
   /** Skip client CloudXR `render` (headless: client blit off; tracking on) */
   private headlessInput!: HTMLInputElement;
+  /** When to reload the page after the XR session ends (never / clean / any) */
+  private autoRefreshModeSelect!: HTMLSelectElement;
   /** Breadcrumb subtitle in header (e.g. "for Real Robot › GEAR › Dexmate"). */
   private teleopModeSubtitle!: HTMLElement;
   /** Hierarchical project selector in header */
@@ -348,6 +352,15 @@ export class CloudXR2DUI {
       savePerProject('headless', this.teleopPath, headlessSeed);
       this.applyHeadlessImmersiveDropdown();
     }
+    const autoRefreshSeed = seeds['autoRefreshMode'];
+    if (autoRefreshSeed !== undefined) {
+      const mode = parseAutoRefreshMode(
+        autoRefreshSeed,
+        this.autoRefreshModeSelect.value as AutoRefreshMode
+      );
+      this.autoRefreshModeSelect.value = mode;
+      try { localStorage.setItem('autoRefreshMode', mode); } catch (_) { /* localStorage unavailable */ }
+    }
   }
 
   /**
@@ -408,6 +421,7 @@ export class CloudXR2DUI {
       'controllerModelVisibility'
     );
     this.headlessInput = this.getElement<HTMLInputElement>('cloudxrHeadless');
+    this.autoRefreshModeSelect = this.getElement<HTMLSelectElement>('cloudxrAutoRefreshMode');
     this.teleopModeSubtitle = this.getElement<HTMLElement>('teleopModeSubtitle');
     this.teleopProjectSelect = this.getElement<HTMLSelectElement>('teleopProjectSelect');
   }
@@ -458,6 +472,7 @@ export class CloudXR2DUI {
       useQuestColorWorkaround: false,
       hideControllerModel: false,
       headless: false,
+      autoRefreshMode: 'clean',
       teleopPath: DEFAULT_TELEOP_PATH,
     };
   }
@@ -493,6 +508,7 @@ export class CloudXR2DUI {
     enableLocalStorage(this.mediaAddressInput, 'mediaAddress');
     enableLocalStorage(this.mediaPortInput, 'mediaPort');
     enableLocalStorage(this.controllerModelVisibilitySelect, 'controllerModelVisibility');
+    enableLocalStorage(this.autoRefreshModeSelect, 'autoRefreshMode');
   }
 
   /**
@@ -609,6 +625,7 @@ export class CloudXR2DUI {
       this.applyHeadlessImmersiveDropdown();
       this.updateConfiguration();
     });
+    addListener(this.autoRefreshModeSelect, 'change', updateConfig);
 
     addListener(this.deviceProfileSelect, 'change', () => {
       this.applyDeviceProfileToForm(resolveDeviceProfileId(this.deviceProfileSelect.value));
@@ -790,6 +807,10 @@ export class CloudXR2DUI {
       hideControllerModel: this.controllerModelVisibilitySelect.value === 'hide',
       // See immersiveMode above: when true, callers must start an immersive-vr WebXR session.
       headless: this.headlessInput.checked,
+      autoRefreshMode: parseAutoRefreshMode(
+        this.autoRefreshModeSelect.value,
+        this.getDefaultConfiguration().autoRefreshMode ?? 'clean'
+      ),
       panelHiddenAtStart: this.panelHiddenAtStartSelect.value === 'true',
       teleopPath: this.teleopPath,
     };

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -691,6 +691,21 @@ limitations under the License.
                 </div>
 
                 <div class="config-section">
+                    <label for="cloudxrAutoRefreshMode" class="input-label">Auto Refresh on Session End</label>
+                    <select id="cloudxrAutoRefreshMode" name="cloudxrAutoRefreshMode" class="ui-input config-input"
+                        aria-label="When to reload the page after the XR session ends">
+                        <option value="never">Never refresh</option>
+                        <option value="clean" selected>Refresh on clean session end</option>
+                        <option value="any">Refresh on any session end (including errors)</option>
+                    </select>
+                    <div class="config-text">
+                        Reload the page after the XR session ends to return to a fresh state. Choose to refresh
+                        only on a clean end (Disconnect, headset exit, server stop), on any end including a
+                        streaming error, or never.
+                    </div>
+                </div>
+
+                <div class="config-section">
                     <label class="input-label">Proxy Configuration</label>
                     <label for="proxyUrl" class="input-label">Proxy URL</label>
                     <input id="proxyUrl" class="ui-input config-input" type="text" placeholder="" spellcheck="false">


### PR DESCRIPTION
## Summary
Adds a configurable **Auto Refresh on Session End** option to the web client's 2D settings UI, so the page can reload itself when the XR session ends and return to a clean initial state.

The option is a three-way selector rather than a boolean, letting users choose the behavior they want:

| Mode | Behavior |
|------|----------|
| `never` | Page never reloads |
| `clean` (default) | Reload only on an error-free end (Disconnect button, headset exit, server stop) |
| `any` | Reload on any end, **including** a streaming error |

## Implementation
- New `AutoRefreshMode` type + `parseAutoRefreshMode()` helper in `helpers/react/utils.ts` (mirrors the existing `parseControlPanelPosition` pattern for safe parsing of stored/URL/form values).
- Refresh is handled centrally in `App.tsx` `handleStatusChange`, keyed off the CloudXR stream-stop status (`Disconnected` vs `Error`), so it covers **every** session-end path — not just the Disconnect button. Pre-stream connection failures are excluded since they aren't session ends. Config is read live off the stable 2D UI object to avoid a stale closure.
- New `<select id="cloudxrAutoRefreshMode">` in `index.html`, wired through `CloudXR2DUI.tsx` (element lookup, default, `enableLocalStorage` persistence, change listener, URL-seed handling, and inclusion in the built config).
- Persists in `localStorage` and is overridable via the `autoRefreshMode` URL query param.

## Testing
- `tsc --noEmit` passes (the only error is a pre-existing, unrelated one in `PerformanceCanvasImage.tsx`).
- Pre-commit hooks (REUSE/SPDX, copyright year, etc.) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Auto Refresh on Session End" configuration option
  * Three modes: never refresh, refresh on clean session end (default), or refresh on any session end
  * Setting can be configured via dropdown, URL parameter, and is persisted locally
  * Automatic page reload on stream/session stop or error based on selected mode

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->