### PR TITLE
feat(cloudxr): print matching WebXR client URL on startup

### DIFF
--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -170,17 +170,6 @@ def main() -> None:
         print(
             f"CloudXR WSS proxy: \033[36mrunning\033[0m, log file: \033[90m{wss_log}\033[0m"
         )
-        # Print the WebXR client matching this release line, derived from the
-        # installed version's leading MAJOR.MINOR (present for every build
-        # type). The client is published per release line on GitHub Pages.
-        client_base = "https://nvidia.github.io/IsaacTeleop/client/"
-        ver_match = re.match(r"(\d+)\.(\d+)", isaacteleop_version)
-        client_url = (
-            f"{client_base}release-{ver_match.group(1)}.{ver_match.group(2)}.x/"
-            if ver_match
-            else client_base
-        )
-        print(f"WebXR client:      \033[36m{client_url}\033[0m")
         if args.setup_oob:
             if args.usb_local:
                 print(
@@ -192,6 +181,22 @@ def main() -> None:
                     "        oob:       \033[32menabled\033[0m  (hub + USB adb automation — see OOB TELEOP block)"
                 )
                 print_oob_hub_startup_banner(lan_host=resolve_lan_host_for_oob())
+        else:
+            # Print the WebXR client matching this release line, derived from
+            # the installed version's leading MAJOR.MINOR (present for every
+            # build type). The client is published per release line on GitHub
+            # Pages. In OOB modes the banner above already prints a complete,
+            # mode-correct client URL instead (GitHub Pages /main/ for WiFi, a
+            # local https URL for USB-local), so this standalone line is
+            # skipped there to avoid a redundant or misleading second URL.
+            client_base = "https://nvidia.github.io/IsaacTeleop/client/"
+            ver_match = re.match(r"(\d+)\.(\d+)", isaacteleop_version)
+            client_url = (
+                f"{client_base}release-{ver_match.group(1)}.{ver_match.group(2)}.x/"
+                if ver_match
+                else client_base
+            )
+            print(f"WebXR client:      \033[36m{client_url}\033[0m")
         print(
             f"Activate CloudXR environment in another terminal: \033[1;32msource {env_cfg.env_filepath()}\033[0m"
         )

--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -5,6 +5,7 @@
 
 import argparse
 import os
+import re
 import signal
 import sys
 import time
@@ -169,6 +170,17 @@ def main() -> None:
         print(
             f"CloudXR WSS proxy: \033[36mrunning\033[0m, log file: \033[90m{wss_log}\033[0m"
         )
+        # Print the WebXR client matching this release line, derived from the
+        # installed version's leading MAJOR.MINOR (present for every build
+        # type). The client is published per release line on GitHub Pages.
+        client_base = "https://nvidia.github.io/IsaacTeleop/client/"
+        ver_match = re.match(r"(\d+)\.(\d+)", isaacteleop_version)
+        client_url = (
+            f"{client_base}release-{ver_match.group(1)}.{ver_match.group(2)}.x/"
+            if ver_match
+            else client_base
+        )
+        print(f"WebXR client:      \033[36m{client_url}\033[0m")
         if args.setup_oob:
             if args.usb_local:
                 print(


### PR DESCRIPTION
`python -m isaacteleop.cloudxr` now prints the GitHub Pages WebXR client URL that matches the running release line, so users open the right client version instead of guessing.

The URL is derived from the installed isaacteleop version's leading MAJOR.MINOR (present for every build type) and points at the published release line, e.g. https://nvidia.github.io/IsaacTeleop/client/release-1.2.x/. Versions with no parseable MAJOR.MINOR fall back to the generic /client/ URL.

Closes #585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced startup logging to dynamically generate and display a WebXR client URL based on the application version, with automatic fallback to the default client URL if version parsing fails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/588?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->