### PR TITLE
docs: nlopt wheel build for aarch64 (fixes #452)

### DIFF
--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -290,7 +290,8 @@ based on the Python version.  Note that ``pip`` and ``uv pip`` has slightly diff
       cd /tmp/nlopt-python
       git submodule update --init --recursive
 
-      uv venv --python=${PYTHON_VERSION} /tmp/nlopt-wheel-venv
+      # Use the same Python version as your isaacteleop install (3.10, 3.11, 3.12, or 3.13)
+      uv venv --python=3.11 /tmp/nlopt-wheel-venv
       VIRTUAL_ENV=/tmp/nlopt-wheel-venv uv pip install numpy setuptools wheel
       /tmp/nlopt-wheel-venv/bin/python setup.py bdist_wheel -d /tmp/nlopt-wheels/
 

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -272,16 +272,55 @@ The wheels are built in the ``./install/wheels/`` directory. Install the package
 Using ``pip``, you need to pass the ``--no-index`` option to automatically find the right wheel
 based on the Python version.  Note that ``pip`` and ``uv pip`` has slightly different options.
 
+.. _aarch64-nlopt-wheel:
+
+.. note::
+   **ARM64 / aarch64 systems only** (e.g. NVIDIA DGX Spark): PyPI does not publish pre-built
+   ``nlopt`` wheels for ARM64, so pip cannot satisfy the ``retargeters`` extra automatically.
+   Build an ``nlopt`` wheel from source before running the install commands below
+   (see `issue #452 <https://github.com/NVIDIA/IsaacTeleop/issues/452>`_):
+
+   .. code-block:: bash
+
+      # Install build tools
+      sudo apt-get install -y build-essential cmake git pkg-config swig
+
+      # Clone nlopt-python and build a wheel
+      git clone --depth 1 --branch 2.10.0 https://github.com/DanielBok/nlopt-python.git /tmp/nlopt-python
+      cd /tmp/nlopt-python
+      git submodule update --init --recursive
+
+      uv venv --python=${PYTHON_VERSION} /tmp/nlopt-wheel-venv
+      VIRTUAL_ENV=/tmp/nlopt-wheel-venv uv pip install numpy setuptools wheel
+      /tmp/nlopt-wheel-venv/bin/python setup.py bdist_wheel -d /tmp/nlopt-wheels/
+
+   Then pass ``--find-links=/tmp/nlopt-wheels/`` when installing so the locally-built wheel is
+   used instead of attempting a PyPI download:
+
+   .. code-block:: bash
+
+      # pip
+      pip install "isaacteleop[retargeters,cloudxr,ui]" \
+          --find-links=./install/wheels/ \
+          --find-links=/tmp/nlopt-wheels/ \
+          --no-index --force-reinstall
+
+      # uv pip
+      uv pip install "isaacteleop[retargeters,cloudxr,ui]" \
+          --find-links=./install/wheels/ \
+          --find-links=/tmp/nlopt-wheels/ \
+          --reinstall
+
 .. code-block:: bash
 
    # Pass --no-index to use only wheels in ./install/wheels/;
    # Pass --force-reinstall to replace an existing install.
-   pip install isaacteleop[retargeters,cloudxr,ui] --find-links=./install/wheels/ --no-index --force-reinstall
+   pip install "isaacteleop[retargeters,cloudxr,ui]" --find-links=./install/wheels/ --no-index --force-reinstall
 
 .. code-block:: bash
 
    # Pass --reinstall to replace an existing install.
-   uv pip install isaacteleop[retargeters,cloudxr,ui] --find-links=./install/wheels/ --reinstall
+   uv pip install "isaacteleop[retargeters,cloudxr,ui]" --find-links=./install/wheels/ --reinstall
 
 .. toctree::
    :hidden:

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -38,6 +38,19 @@ In a new terminal, install the package from PyPI (or from a local wheel if you b
 Instead of installing the package from PyPI, you can build from source and install the local wheel.
 See :doc:`build_from_source/index` for more details.
 
+.. note::
+   **ARM64 / aarch64 systems only** (e.g. NVIDIA DGX Spark): PyPI does not publish pre-built
+   ``nlopt`` wheels for ARM64, so the ``retargeters`` extra cannot be installed directly from PyPI
+   (see `issue #452 <https://github.com/NVIDIA/IsaacTeleop/issues/452>`_). Follow the
+   :ref:`aarch64 nlopt wheel build steps <aarch64-nlopt-wheel>` from the build-from-source guide
+   first, then install ``isaacteleop`` with an additional ``--find-links``:
+
+   .. code-block:: bash
+
+      pip install 'isaacteleop[cloudxr,retargeters]~=1.0.0' \
+          --extra-index-url https://pypi.nvidia.com \
+          --find-links=/tmp/nlopt-wheels/
+
 .. _run-cloudxr-server:
 
 3. Run CloudXR Server


### PR DESCRIPTION
## Summary

- PyPI has no pre-built `nlopt` wheels for ARM64, causing `pip install 'isaacteleop[retargeters,...]'` to fail on aarch64 hosts (e.g. NVIDIA DGX Spark) — reported in #452.
- Adds a note to the **Build from Source** guide with step-by-step instructions to build an `nlopt` wheel from source using `swig` + `cmake` + [`DanielBok/nlopt-python`](https://github.com/DanielBok/nlopt-python) v2.10.0 (same approach used in `examples/teleop_ros2/Dockerfile`).
- Also quotes all `isaacteleop[extras]` package specs in shell code blocks to prevent shell glob expansion.

## Test plan

- [x] Follow the new ARM64 note on an aarch64 host; confirm `nlopt` wheel builds and `uv pip install` succeeds.
- [x] Verify no change in behaviour on x86-64 (note is clearly scoped to ARM64 only).
- [x] Build the docs (`sphinx`) and check the note renders correctly in HTML.

Closes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions for ARM64 systems installing the `retargeters` extra, including a workaround for building `nlopt` from source due to missing pre-built wheels on PyPI.
  * Enhanced installation commands for both `pip` and `uv pip` to use local wheel caches.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/IsaacTeleop/pull/589?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->