### PR TITLE
wip: bundle nlopt into isaacteleop wheel [do not merge — LGPL]

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -42,7 +42,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache libvulkan-dev glslang-tools \
           libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libxkbcommon-dev \
-          libwayland-dev wayland-protocols
+          libwayland-dev wayland-protocols swig
 
     - name: Install patchelf (Release only)
       if: ${{ matrix.build_type == 'Release' }}
@@ -349,7 +349,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache libvulkan-dev glslang-tools \
           libxrandr-dev libxinerama-dev libxcursor-dev libxi-dev libxext-dev libxkbcommon-dev \
-          libwayland-dev wayland-protocols
+          libwayland-dev wayland-protocols swig
 
     - name: Install CUDA toolkit
       uses: ./.github/actions/setup-cuda

--- a/deps/third_party/CMakeLists.txt
+++ b/deps/third_party/CMakeLists.txt
@@ -156,6 +156,48 @@ add_library(mcap::mcap ALIAS mcap_interface)
 message(STATUS "MCAP interface library configured")
 
 # ==============================================================================
+# nlopt-python wheel
+# ==============================================================================
+# PyPI does not publish pre-built nlopt wheels for all platforms (e.g. aarch64).
+# Build a local wheel at cmake --build time so the pip install step always works
+# via --find-links=./install/wheels/ regardless of host architecture.
+if(BUILD_PYTHON_BINDINGS)
+    find_program(SWIG_EXECUTABLE swig)
+    if(NOT SWIG_EXECUTABLE)
+        message(FATAL_ERROR
+            "swig not found – required to build the nlopt Python wheel.\n"
+            "Install with: sudo apt-get install -y swig")
+    endif()
+
+    include(ExternalProject)
+
+    set(_nlopt_venv "${CMAKE_BINARY_DIR}/_deps/nlopt-python-venv")
+    if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        set(_nlopt_python "${_nlopt_venv}/Scripts/python.exe")
+    else()
+        set(_nlopt_python "${_nlopt_venv}/bin/python")
+    endif()
+
+    message(STATUS "Configuring nlopt-python wheel build (DanielBok/nlopt-python 2.10.0)...")
+    ExternalProject_Add(nlopt_python_wheel
+        GIT_REPOSITORY       https://github.com/DanielBok/nlopt-python.git
+        GIT_TAG              2.10.0
+        GIT_SUBMODULES_RECURSE YES
+        GIT_SHALLOW          YES
+        SOURCE_DIR           "${CMAKE_BINARY_DIR}/_deps/nlopt-python-src"
+        CONFIGURE_COMMAND
+            "${UV_EXECUTABLE}" venv --python "${Python3_EXECUTABLE}" "${_nlopt_venv}"
+            COMMAND "${UV_EXECUTABLE}" pip install --python "${_nlopt_python}"
+                numpy setuptools wheel
+        BUILD_COMMAND
+            ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/wheels"
+            COMMAND "${_nlopt_python}" setup.py bdist_wheel -d "${CMAKE_BINARY_DIR}/wheels"
+        BUILD_IN_SOURCE      YES
+        INSTALL_COMMAND      ""
+    )
+endif()
+
+# ==============================================================================
 # GLM (Vulkan/GLSL math)
 # ==============================================================================
 # Header-only math library used by the viz module for matrix / vector / quaternion

--- a/deps/third_party/CMakeLists.txt
+++ b/deps/third_party/CMakeLists.txt
@@ -186,7 +186,8 @@ if(BUILD_PYTHON_BINDINGS)
         GIT_SHALLOW          YES
         SOURCE_DIR           "${CMAKE_BINARY_DIR}/_deps/nlopt-python-src"
         CONFIGURE_COMMAND
-            "${UV_EXECUTABLE}" venv --python "${Python3_EXECUTABLE}" "${_nlopt_venv}"
+            ${CMAKE_COMMAND} -E rm -rf "${_nlopt_venv}"
+            COMMAND "${UV_EXECUTABLE}" venv --python "${Python3_EXECUTABLE}" "${_nlopt_venv}"
             COMMAND "${UV_EXECUTABLE}" pip install --python "${_nlopt_python}"
                 numpy setuptools wheel
         BUILD_COMMAND

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -36,7 +36,7 @@ the list of dependencies. On **Ubuntu**, install build tools and clang-format:
 .. code-block:: bash
 
    sudo apt-get update
-   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf
+   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf swig
 
 Runtime-only dependencies (needed to actually run teleop, not to build):
 
@@ -268,46 +268,10 @@ The CI uses ``ctest`` (see :code-file:`build-ubuntu.yml <.github/workflows/build
 4. Install the ``isaacteleop`` pip package
 ------------------------------------------
 
-The wheels are built in the ``./install/wheels/`` directory. Install the package from the wheels.
+The wheels are built in the ``./install/wheels/`` directory, including an ``nlopt`` wheel built
+from source by CMake (``swig`` required; see :ref:`one-time-setup`). Install the package from the wheels.
 Using ``pip``, you need to pass the ``--no-index`` option to automatically find the right wheel
 based on the Python version.  Note that ``pip`` and ``uv pip`` has slightly different options.
-
-.. note::
-   **ARM64 / aarch64 systems only** (e.g. NVIDIA DGX Spark): PyPI does not publish pre-built
-   ``nlopt`` wheels for ARM64, so pip cannot satisfy the ``retargeters`` extra automatically.
-   Build an ``nlopt`` wheel from source before running the install commands below
-   (see `issue #452 <https://github.com/NVIDIA/IsaacTeleop/issues/452>`_):
-
-   .. code-block:: bash
-
-      # Install build tools
-      sudo apt-get install -y build-essential cmake git pkg-config swig
-
-      # Clone nlopt-python and build a wheel
-      git clone --depth 1 --branch 2.10.0 https://github.com/DanielBok/nlopt-python.git /tmp/nlopt-python
-      cd /tmp/nlopt-python
-      git submodule update --init --recursive
-
-      uv venv --python=${PYTHON_VERSION} /tmp/nlopt-wheel-venv
-      VIRTUAL_ENV=/tmp/nlopt-wheel-venv uv pip install numpy setuptools wheel
-      /tmp/nlopt-wheel-venv/bin/python setup.py bdist_wheel -d /tmp/nlopt-wheels/
-
-   Then pass ``--find-links=/tmp/nlopt-wheels/`` when installing so the locally-built wheel is
-   used instead of attempting a PyPI download:
-
-   .. code-block:: bash
-
-      # pip
-      pip install "isaacteleop[retargeters,cloudxr,ui]" \
-          --find-links=./install/wheels/ \
-          --find-links=/tmp/nlopt-wheels/ \
-          --no-index --force-reinstall
-
-      # uv pip
-      uv pip install "isaacteleop[retargeters,cloudxr,ui]" \
-          --find-links=./install/wheels/ \
-          --find-links=/tmp/nlopt-wheels/ \
-          --reinstall
 
 .. code-block:: bash
 

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -272,16 +272,53 @@ The wheels are built in the ``./install/wheels/`` directory. Install the package
 Using ``pip``, you need to pass the ``--no-index`` option to automatically find the right wheel
 based on the Python version.  Note that ``pip`` and ``uv pip`` has slightly different options.
 
+.. note::
+   **ARM64 / aarch64 systems only** (e.g. NVIDIA DGX Spark): PyPI does not publish pre-built
+   ``nlopt`` wheels for ARM64, so pip cannot satisfy the ``retargeters`` extra automatically.
+   Build an ``nlopt`` wheel from source before running the install commands below
+   (see `issue #452 <https://github.com/NVIDIA/IsaacTeleop/issues/452>`_):
+
+   .. code-block:: bash
+
+      # Install build tools
+      sudo apt-get install -y build-essential cmake git pkg-config swig
+
+      # Clone nlopt-python and build a wheel
+      git clone --depth 1 --branch 2.10.0 https://github.com/DanielBok/nlopt-python.git /tmp/nlopt-python
+      cd /tmp/nlopt-python
+      git submodule update --init --recursive
+
+      uv venv --python=${PYTHON_VERSION} /tmp/nlopt-wheel-venv
+      VIRTUAL_ENV=/tmp/nlopt-wheel-venv uv pip install numpy setuptools wheel
+      /tmp/nlopt-wheel-venv/bin/python setup.py bdist_wheel -d /tmp/nlopt-wheels/
+
+   Then pass ``--find-links=/tmp/nlopt-wheels/`` when installing so the locally-built wheel is
+   used instead of attempting a PyPI download:
+
+   .. code-block:: bash
+
+      # pip
+      pip install "isaacteleop[retargeters,cloudxr,ui]" \
+          --find-links=./install/wheels/ \
+          --find-links=/tmp/nlopt-wheels/ \
+          --no-index --force-reinstall
+
+      # uv pip
+      uv pip install "isaacteleop[retargeters,cloudxr,ui]" \
+          --find-links=./install/wheels/ \
+          --find-links=/tmp/nlopt-wheels/ \
+          --reinstall
+
 .. code-block:: bash
 
    # Pass --no-index to use only wheels in ./install/wheels/;
    # Pass --force-reinstall to replace an existing install.
-   pip install isaacteleop[retargeters,cloudxr,ui] --find-links=./install/wheels/ --no-index --force-reinstall
+   pip install "isaacteleop[retargeters,cloudxr,ui]" --find-links=./install/wheels/ --no-index --force-reinstall
 
 .. code-block:: bash
 
    # Pass --reinstall to replace an existing install.
-   uv pip install isaacteleop[retargeters,cloudxr,ui] --find-links=./install/wheels/ --reinstall
+   uv pip install "isaacteleop[retargeters,cloudxr,ui]" --find-links=./install/wheels/ --reinstall
 
 .. toctree::
    :hidden:

--- a/src/core/python/CMakeLists.txt
+++ b/src/core/python/CMakeLists.txt
@@ -42,6 +42,17 @@ else()
     set(ROBOTIC_GROUNDING_PACKAGE_DATA_BLOCK "")
 endif()
 
+# nlopt is built from source by CMake (deps/third_party/CMakeLists.txt) and
+# bundled directly into the isaacteleop wheel so that `pip install isaacteleop`
+# works on all platforms without a separate nlopt wheel on PyPI.
+if(TARGET nlopt_python_wheel)
+    set(NLOPT_PACKAGES_BLOCK "    \"nlopt\",\n")
+    set(NLOPT_PACKAGE_DATA_BLOCK "\"nlopt\" = [\"*.so\", \"*.pyd\"]\n")
+else()
+    set(NLOPT_PACKAGES_BLOCK "")
+    set(NLOPT_PACKAGE_DATA_BLOCK "")
+endif()
+
 # Generate pyproject.toml from template with ISAAC_TELEOP_PYPROJECT_VERSION
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml.in"
@@ -106,6 +117,17 @@ if(BUNDLE_ROBOTIC_GROUNDING)
             "${ROBOTIC_GROUNDING_SRC}"
             "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>/robotic_grounding"
         COMMENT "Bundling robotic_grounding/ into wheel staging dir for [grounding] extra"
+    )
+endif()
+
+if(TARGET nlopt_python_wheel)
+    add_dependencies(python_package nlopt_python_wheel)
+    add_custom_command(TARGET python_package POST_BUILD
+        COMMAND ${Python3_EXECUTABLE}
+            "${CMAKE_CURRENT_SOURCE_DIR}/bundle_nlopt.py"
+            "${CMAKE_BINARY_DIR}/wheels"
+            "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
+        COMMENT "Bundling nlopt package files into isaacteleop wheel staging dir"
     )
 endif()
 

--- a/src/core/python/bundle_nlopt.py
+++ b/src/core/python/bundle_nlopt.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Extract the nlopt package files from the standalone nlopt wheel into the
+isaacteleop wheel staging directory so they are co-installed by the isaacteleop
+wheel (making a separate 'pip install nlopt' unnecessary).
+
+Usage: python bundle_nlopt.py <wheels_dir> <staging_dir>
+"""
+
+import sys
+import zipfile
+import pathlib
+
+wheels_dir = pathlib.Path(sys.argv[1])
+staging_dir = pathlib.Path(sys.argv[2])
+
+wheels = sorted(wheels_dir.glob("nlopt-*.whl"))
+if not wheels:
+    raise FileNotFoundError(f"No nlopt wheel found in {wheels_dir}")
+
+with zipfile.ZipFile(wheels[0]) as z:
+    members = [
+        n for n in z.namelist() if n.startswith("nlopt/") and ".dist-info" not in n
+    ]
+    z.extractall(str(staging_dir), members)
+
+print(f"Bundled {wheels[0].name} → {staging_dir}/nlopt/ ({len(members)} files)")

--- a/src/core/python/pyproject.toml.in
+++ b/src/core/python/pyproject.toml.in
@@ -53,7 +53,7 @@ packages = [
     "isaacteleop.retargeting_engine_ui",
     "isaacteleop.teleop_session_manager",
     "isaacteleop.cloudxr",
-@VIZ_PACKAGES_BLOCK@@ROBOTIC_GROUNDING_PACKAGES_BLOCK@]
+@VIZ_PACKAGES_BLOCK@@ROBOTIC_GROUNDING_PACKAGES_BLOCK@@NLOPT_PACKAGES_BLOCK@]
 include-package-data = false
 
 [tool.setuptools.package-data]
@@ -66,7 +66,7 @@ isaacteleop = ["*.so", "*.pyd", "*.pyi", "py.typed"]
 "isaacteleop.plugin_manager" = ["*.so", "*.pyd", "*.pyi"]
 "isaacteleop.schema" = ["*.so", "*.pyd", "*.pyi"]
 "isaacteleop.cloudxr" = ["native/*.so", "native/*.so.*", "native/openxr_cloudxr.json"]
-@VIZ_PACKAGE_DATA_BLOCK@@ROBOTIC_GROUNDING_PACKAGE_DATA_BLOCK@
+@VIZ_PACKAGE_DATA_BLOCK@@ROBOTIC_GROUNDING_PACKAGE_DATA_BLOCK@@NLOPT_PACKAGE_DATA_BLOCK@
 
 [tool.uv]
 # Only use managed Python installations (not system Python)

--- a/src/core/python/requirements-retargeters.txt
+++ b/src/core/python/requirements-retargeters.txt
@@ -6,10 +6,6 @@ scipy>=1.15.0
 pyyaml>=6.0.3
 torch>=2.7.0
 
-# Do not pin Linux arm64 to nlopt==2.6.2 here: that forces dex-retargeting 0.4.x
-# and NumPy 1.x, which cannot coexist with Pinocchio 3.x in combined environments.
-nlopt>=2.6.2
-
 # NOTE: The Sharpa retargeter's Pinocchio/Pink/daqp/loop-rate-limiters deps live
 # in `requirements-grounding.txt`, transitively via the `robotic_grounding`
 # wheel. They were briefly listed here while sharpa_hand_retargeter.py imported


### PR DESCRIPTION
## Why this exists

This PR records a dead end for future reference.

Bundling nlopt (LGPL v2.1) directly into the isaacteleop wheel was explored as a zero-friction fix for aarch64 (`pip install isaacteleop[retargeters]` failing because PyPI has no aarch64 nlopt wheel — see #452).

## Why it cannot be merged

nlopt is **LGPL v2.1**. Bundling it into a proprietary NVIDIA wheel would require:
- Shipping the LGPL license text with every distribution
- Guaranteeing users can relink against a modified nlopt `.so`
- Legal review / sign-off

The LGPL relinking requirement is incompatible with a tightly-packaged binary wheel without additional legal work.

## Alternative (tracked in #589)

Build the nlopt wheel as a separate artifact via CMake ExternalProject so it can be distributed under its own license, and users supply it via `--find-links`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)