### PR TITLE
feat(webclient): make CloudXR config URL-settable via a param registry

### DIFF
--- a/.github/actions/build-cloudxr-web-client/action.yml
+++ b/.github/actions/build-cloudxr-web-client/action.yml
@@ -58,3 +58,8 @@ runs:
       run: |
         npm install "../nvidia-cloudxr-${SDK_VERSION}.tgz"
         USE_LOCAL_WEBXR_ASSETS=0 npm run build
+
+    - name: Test web client
+      shell: bash
+      working-directory: deps/cloudxr/webxr_client
+      run: npm test

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -17,7 +17,15 @@
     "dev": "webpack --config ./webpack.dev.js",
     "dev-server": "webpack serve --config ./webpack.dev.js --no-open",
     "dev-server:https": "cross-env HTTPS=true webpack serve --config ./webpack.dev.js --no-open",
+    "test": "jest",
     "clean": "rimraf dist"
+  },
+  "jest": {
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "roots": [
+      "<rootDir>/src"
+    ]
   },
   "dependencies": {
     "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.2.0.tgz",
@@ -34,6 +42,8 @@
     "uuid": "^14.0.0"
   },
   "devDependencies": {
+    "@types/jest": "^30",
+    "@types/node": "^22",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@types/three": "^0.184.0",
@@ -43,8 +53,10 @@
     "css-loader": "^6.8.1",
     "html-webpack-plugin": "^5.6.7",
     "iwer": "^2.2.1",
+    "jest": "^30",
     "rimraf": "^5.0.5",
     "style-loader": "^3.3.3",
+    "ts-jest": "^29",
     "ts-loader": "^9.5.7",
     "typescript": "^5.8.2",
     "webpack-cli": "^6.0.1",

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -59,6 +59,7 @@ import { useState, useMemo, useEffect, useRef } from 'react';
 
 import { v5 } from 'uuid';
 import { CloudXR2DUI } from './CloudXR2DUI';
+import { readUrlParam } from './config/resolve';
 import CloudXR3DUI from './CloudXRUI';
 import { HeadsetControlChannel } from '@helpers/controlChannel';
 
@@ -118,14 +119,14 @@ const START_TELEOP_COMMAND = {
 
 /** When set with ``serverIP`` + ``port``, WebXR builds ``wss://{serverIP}:{port}/oob/v1/ws``. */
 function isOobEnabled(searchParams: URLSearchParams): boolean {
-  const v = searchParams.get('oobEnable');
+  const v = readUrlParam(searchParams, 'oobEnable');
   return v === '1' || v?.toLowerCase() === 'true';
 }
 
 function buildOobHubWsUrlFromQuery(searchParams: URLSearchParams): string | null {
   if (!isOobEnabled(searchParams)) return null;
-  const serverIP = searchParams.get('serverIP')?.trim();
-  const portStr = searchParams.get('port')?.trim();
+  const serverIP = readUrlParam(searchParams, 'serverIP')?.trim();
+  const portStr = readUrlParam(searchParams, 'port')?.trim();
   if (!serverIP || portStr === undefined || portStr === '') return null;
   if (!/^\d{1,5}$/.test(portStr)) return null;
   const host =
@@ -353,14 +354,8 @@ function App() {
     }
     saveStoredTeleopPath(resolvedPath);
 
-    // URL query params override localStorage so bookmarked links always win.
-    const urlSeeds: Record<string, string> = {};
-    const p = new URLSearchParams(window.location.search);
-    for (const key of ['serverIP', 'port', 'codec', 'panelHiddenAtStart', 'headless', 'autoRefreshMode', 'turnServer', 'turnUsername', 'turnCredential']) {
-      const v = p.get(key);
-      if (v !== null) urlSeeds[key] = v;
-    }
-    ui.initialize(Object.keys(urlSeeds).length > 0 ? urlSeeds : undefined, resolvedPath);
+    // URL query params (URL_PARAMS) are applied inside initialize() and win over stored values.
+    ui.initialize(resolvedPath);
     const doConnect = async () => {
       const config = ui.getConfiguration();
       const resolutionError = getResolutionValidationError(
@@ -705,7 +700,7 @@ function App() {
 
     const channel = new HeadsetControlChannel({
       url: hubWsUrl,
-      token: p.get('controlToken') ?? undefined,
+      token: readUrlParam(p, 'controlToken') ?? undefined,
       onConfig: () => {
         // Config push handling deferred to phase 2.
       },
@@ -762,11 +757,11 @@ function App() {
   // turnServer e.g. "turn:127.0.0.1:3478?transport=tcp", iceRelayOnly=1 forces relay-only ICE.
   const iceServersConfig = useMemo<CloudXR.SessionOptions['iceServers'] | undefined>(() => {
     const p = new URLSearchParams(window.location.search);
-    const turnServer = p.get('turnServer');
+    const turnServer = readUrlParam(p, 'turnServer');
     if (!turnServer) return undefined;
-    const turnUsername = p.get('turnUsername') ?? undefined;
-    const turnCredential = p.get('turnCredential') ?? undefined;
-    const iceRelayOnly = p.get('iceRelayOnly') === '1';
+    const turnUsername = readUrlParam(p, 'turnUsername') ?? undefined;
+    const turnCredential = readUrlParam(p, 'turnCredential') ?? undefined;
+    const iceRelayOnly = readUrlParam(p, 'iceRelayOnly') === '1';
     return {
       iceServers: [{
         urls: turnServer,

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -58,6 +58,8 @@ import {
   setSelectValueIfAvailable,
   setupCertificateAcceptanceLink,
 } from '@helpers/utils';
+import { URL_PARAMS } from './config/params';
+import { seedsFromParams } from './config/resolve';
 import {
   getGridValidationError,
   getGridValidationMessageForConnect,
@@ -194,7 +196,7 @@ export class CloudXR2DUI {
   /**
    * Initializes the CloudXR2DUI with all necessary components and event handlers
    */
-  public initialize(urlSeeds?: Record<string, string>, teleopPath?: string): void {
+  public initialize(teleopPath?: string): void {
     if (this.initialized) {
       return;
     }
@@ -209,9 +211,7 @@ export class CloudXR2DUI {
       }
       this.applyTeleopPath();
 
-      if (urlSeeds) {
-        this.applyUrlSeeds(urlSeeds);
-      }
+      this.applyUrlSeeds();
       this.setupProxyConfiguration();
       this.setupEventListeners();
       // Set initial display value
@@ -324,42 +324,31 @@ export class CloudXR2DUI {
   }
 
   /**
-   * Override form fields and localStorage from URL query params.
-   * Called after setupLocalStorage() so URL params win over stored values.
+   * Override form controls from URL query params. Values are applied but not persisted;
+   * called after setupLocalStorage() so URL params win over stored values for this load.
    */
-  private applyUrlSeeds(seeds: Record<string, string>): void {
-    const mapping: Array<[string, HTMLInputElement | HTMLSelectElement, string]> = [
-      ['serverIP', this.serverIpInput, 'serverIp'],
-      ['port', this.portInput, 'port'],
-      ['codec', this.codecSelect, 'codec'],
-    ];
-    for (const [paramKey, element, storageKey] of mapping) {
-      const v = seeds[paramKey];
-      if (v === undefined) continue;
-      element.value = v;
-      try { localStorage.setItem(storageKey, v); } catch (_) { /* localStorage unavailable */ }
+  private applyUrlSeeds(): void {
+    // Seed every form-backed URL_PARAMS control whose query param is present and valid.
+    // URL values override but are not persisted (next load without the param
+    // falls back to the stored/default value).
+    const seeds = seedsFromParams(new URLSearchParams(window.location.search));
+    for (const field of URL_PARAMS) {
+      if (!field.elementId) continue;
+      const raw = seeds.get(field.key);
+      if (raw === undefined) continue;
+      const el = document.getElementById(field.elementId) as
+        | HTMLInputElement
+        | HTMLSelectElement
+        | null;
+      if (!el) continue;
+      if (field.kind === 'checked') {
+        (el as HTMLInputElement).checked = raw === 'true';
+      } else {
+        el.value = raw;
+      }
     }
-    // panelHiddenAtStart persists per-project-path, so route it through savePerProject
-    // rather than the flat localStorage key nothing else reads.
-    const panelHidden = seeds['panelHiddenAtStart'];
-    if (panelHidden !== undefined) {
-      this.panelHiddenAtStartSelect.value = panelHidden;
-      savePerProject('panelHiddenAtStart', this.teleopPath, panelHidden);
-    }
-    const headlessSeed = seeds['headless'];
-    if (headlessSeed === 'true' || headlessSeed === 'false') {
-      this.headlessInput.checked = headlessSeed === 'true';
-      savePerProject('headless', this.teleopPath, headlessSeed);
+    if (seeds.has('headless')) {
       this.applyHeadlessImmersiveDropdown();
-    }
-    const autoRefreshSeed = seeds['autoRefreshMode'];
-    if (autoRefreshSeed !== undefined) {
-      const mode = parseAutoRefreshMode(
-        autoRefreshSeed,
-        this.autoRefreshModeSelect.value as AutoRefreshMode
-      );
-      this.autoRefreshModeSelect.value = mode;
-      try { localStorage.setItem('autoRefreshMode', mode); } catch (_) { /* localStorage unavailable */ }
     }
   }
 

--- a/deps/cloudxr/webxr_client/src/config/params.ts
+++ b/deps/cloudxr/webxr_client/src/config/params.ts
@@ -1,0 +1,90 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Single source of truth for every URL query parameter the web client accepts.
+ *
+ * Two kinds of param live here:
+ *  - form-backed (has `elementId`): seeded into a control in index.html, then read
+ *    back through the form into the CloudXR config.
+ *  - direct (no `elementId`): consumed straight from the URL by app logic (transport
+ *    and session bootstrap, e.g. TURN/ICE and the OOB hub). Never seeded or stored.
+ *
+ * See resolve.ts for how each kind is read.
+ */
+export interface UrlParam {
+  /** Canonical identifier for the parameter. */
+  key: string;
+  /** URL query parameter name. Defaults to `key` when omitted. */
+  url?: string;
+  /** id of the bound form control in index.html. Present only for form-backed params. */
+  elementId?: string;
+  /** How a form-backed value is applied to the control. Defaults to 'value'. */
+  kind?: 'value' | 'checked';
+  /** Optional check for the raw URL string; invalid values are ignored. */
+  isValid?: (raw: string) => boolean;
+}
+
+const oneOf =
+  (...allowed: string[]) =>
+  (raw: string): boolean =>
+    allowed.includes(raw);
+const isBool = oneOf('true', 'false');
+const isNumber = (raw: string): boolean => raw.trim() !== '' && Number.isFinite(Number(raw));
+
+export const URL_PARAMS: UrlParam[] = [
+  // --- Form-backed settings (seeded into a control, then read through the form) ---
+  { key: 'serverIP', elementId: 'serverIpInput' },
+  { key: 'port', elementId: 'portInput', isValid: isNumber },
+  { key: 'serverType', elementId: 'serverType', isValid: oneOf('manual', 'nvcf') },
+  { key: 'codec', elementId: 'codec', isValid: oneOf('h264', 'h265', 'av1') },
+  { key: 'immersiveMode', elementId: 'immersive', isValid: oneOf('ar', 'vr') },
+  // deviceProfile is intentionally omitted: it is a preset that bulk-fills the fields below via a
+  // change handler, which programmatic seeding does not trigger. Set the individual fields instead.
+  { key: 'deviceFrameRate', elementId: 'deviceFrameRate', isValid: isNumber },
+  { key: 'maxStreamingBitrateMbps', elementId: 'maxStreamingBitrateMbps', isValid: isNumber },
+  { key: 'perEyeWidth', elementId: 'perEyeWidth', isValid: isNumber },
+  { key: 'perEyeHeight', elementId: 'perEyeHeight', isValid: isNumber },
+  { key: 'reprojectionGridCols', elementId: 'reprojectionGridCols', isValid: isNumber },
+  { key: 'reprojectionGridRows', elementId: 'reprojectionGridRows', isValid: isNumber },
+  { key: 'enablePoseSmoothing', elementId: 'enablePoseSmoothing', isValid: isBool },
+  { key: 'posePredictionFactor', elementId: 'posePredictionFactor', isValid: isNumber },
+  { key: 'enableTexSubImage2D', elementId: 'enableTexSubImage2D', isValid: isBool },
+  { key: 'useQuestColorWorkaround', elementId: 'useQuestColorWorkaround', isValid: isBool },
+  { key: 'referenceSpace', elementId: 'referenceSpace', isValid: oneOf('auto', 'local-floor', 'local', 'viewer', 'unbounded') },
+  { key: 'xrOffsetX', elementId: 'xrOffsetX', isValid: isNumber },
+  { key: 'xrOffsetY', elementId: 'xrOffsetY', isValid: isNumber },
+  { key: 'xrOffsetZ', elementId: 'xrOffsetZ', isValid: isNumber },
+  { key: 'controlPanelPosition', elementId: 'controlPanelPosition', isValid: oneOf('left', 'center', 'right') },
+  { key: 'controllerModelVisibility', elementId: 'controllerModelVisibility', isValid: oneOf('show', 'hide') },
+  { key: 'panelHiddenAtStart', elementId: 'panelHiddenAtStart', isValid: isBool },
+  { key: 'headless', elementId: 'cloudxrHeadless', kind: 'checked', isValid: isBool },
+  { key: 'autoRefreshMode', elementId: 'cloudxrAutoRefreshMode', isValid: oneOf('never', 'clean', 'any') },
+  { key: 'proxyUrl', elementId: 'proxyUrl' },
+  { key: 'mediaAddress', elementId: 'mediaAddress' },
+  { key: 'mediaPort', elementId: 'mediaPort', isValid: isNumber },
+
+  // --- Direct params: read straight from the URL by app logic (no control, never stored) ---
+  // TURN/ICE for NAT traversal and OOB hub, typically set in USB-local mode by oob_teleop_env.py.
+  // No `isValid` here: the consumers apply their own interpretation (exact matching, regex, etc.).
+  { key: 'turnServer' },
+  { key: 'turnUsername' },
+  { key: 'turnCredential' },
+  { key: 'iceRelayOnly' },
+  { key: 'oobEnable' },
+  { key: 'controlToken' },
+];

--- a/deps/cloudxr/webxr_client/src/config/resolve.test.ts
+++ b/deps/cloudxr/webxr_client/src/config/resolve.test.ts
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { URL_PARAMS, type UrlParam } from './params';
+import { readUrlParam, seedsFromParams } from './resolve';
+
+const params = (query: string) => new URLSearchParams(query);
+const seed = (query: string) => seedsFromParams(params(query));
+const read = (query: string, key: string) => readUrlParam(params(query), key);
+
+describe('URL_PARAMS', () => {
+  it('has unique keys and unique element ids', () => {
+    const keys = URL_PARAMS.map(p => p.key);
+    const ids = URL_PARAMS.filter(p => p.elementId).map(p => p.elementId);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('still covers the params that were URL-settable before the registry', () => {
+    const keys = new Set(URL_PARAMS.map(p => p.key));
+    for (const k of ['serverIP', 'port', 'codec', 'panelHiddenAtStart', 'headless', 'autoRefreshMode']) {
+      expect(keys.has(k)).toBe(true);
+    }
+  });
+
+  it('declares the direct transport/OOB params (no element binding)', () => {
+    for (const k of ['turnServer', 'turnUsername', 'turnCredential', 'iceRelayOnly', 'oobEnable', 'controlToken']) {
+      const param = URL_PARAMS.find(p => p.key === k);
+      expect(param).toBeDefined();
+      expect(param!.elementId).toBeUndefined();
+    }
+  });
+});
+
+describe('seedsFromParams (form-backed params only)', () => {
+  it('returns values for present form params keyed by key', () => {
+    const seeds = seed('serverIP=10.0.0.2&port=49100&codec=av1');
+    expect(seeds.get('serverIP')).toBe('10.0.0.2');
+    expect(seeds.get('port')).toBe('49100');
+    expect(seeds.get('codec')).toBe('av1');
+  });
+
+  it('omits params that are absent', () => {
+    const seeds = seed('serverIP=10.0.0.2');
+    expect(seeds.has('port')).toBe(false);
+    expect(seeds.size).toBe(1);
+  });
+
+  it('never seeds direct (non-form) params even when present', () => {
+    expect(seed('turnServer=turn:host&controlToken=secret&oobEnable=1').size).toBe(0);
+  });
+
+  it('rejects values that fail validation', () => {
+    expect(seed('codec=mpeg2').has('codec')).toBe(false);
+    expect(seed('headless=banana').has('headless')).toBe(false);
+    expect(seed('autoRefreshMode=sometimes').has('autoRefreshMode')).toBe(false);
+    expect(seed('port=notanumber').has('port')).toBe(false);
+    expect(seed('immersiveMode=hologram').has('immersiveMode')).toBe(false);
+  });
+
+  it('accepts valid enum, boolean and numeric values', () => {
+    expect(seed('headless=true').get('headless')).toBe('true');
+    expect(seed('immersiveMode=vr').get('immersiveMode')).toBe('vr');
+    expect(seed('referenceSpace=local-floor').get('referenceSpace')).toBe('local-floor');
+    expect(seed('posePredictionFactor=0.5').get('posePredictionFactor')).toBe('0.5');
+    expect(seed('xrOffsetX=-12').get('xrOffsetX')).toBe('-12');
+  });
+
+  it('exposes every form-backed param as URL-settable', () => {
+    const formParams = URL_PARAMS.filter(p => p.elementId);
+    const query = formParams.map(p => `${p.url ?? p.key}=${encodeURIComponent(sampleValid(p.key))}`).join('&');
+    expect(seed(query).size).toBe(formParams.length);
+  });
+});
+
+describe('readUrlParam (direct params)', () => {
+  it('reads a present param value', () => {
+    expect(read('turnServer=turn:127.0.0.1:3478', 'turnServer')).toBe('turn:127.0.0.1:3478');
+    expect(read('controlToken=abc123', 'controlToken')).toBe('abc123');
+    expect(read('iceRelayOnly=1', 'iceRelayOnly')).toBe('1');
+  });
+
+  it('returns null for absent params and unknown keys', () => {
+    expect(read('oobEnable=1', 'turnServer')).toBeNull();
+    expect(read('totallyUnknown=1', 'totallyUnknown')).toBeNull();
+  });
+
+  it('applies validation to validated params', () => {
+    expect(read('codec=av1', 'codec')).toBe('av1');
+    expect(read('codec=mpeg2', 'codec')).toBeNull();
+  });
+});
+
+describe('url alias (param.url overrides param.key)', () => {
+  const aliased: UrlParam[] = [{ key: 'serverIP', url: 'ip', elementId: 'serverIpInput' }];
+
+  it('resolves by the url alias, not the key', () => {
+    expect(seedsFromParams(params('ip=10.0.0.9'), aliased).get('serverIP')).toBe('10.0.0.9');
+    expect(readUrlParam(params('ip=10.0.0.9'), 'serverIP', aliased)).toBe('10.0.0.9');
+  });
+
+  it('does not match the key when an alias is set', () => {
+    expect(seedsFromParams(params('serverIP=10.0.0.9'), aliased).has('serverIP')).toBe(false);
+    expect(readUrlParam(params('serverIP=10.0.0.9'), 'serverIP', aliased)).toBeNull();
+  });
+});
+
+/** A representative valid value per form param, for the coverage test above. */
+function sampleValid(key: string): string {
+  const numeric = new Set([
+    'port', 'deviceFrameRate', 'maxStreamingBitrateMbps', 'perEyeWidth', 'perEyeHeight',
+    'reprojectionGridCols', 'reprojectionGridRows', 'posePredictionFactor',
+    'xrOffsetX', 'xrOffsetY', 'xrOffsetZ', 'mediaPort',
+  ]);
+  if (numeric.has(key)) return '1';
+  const enums: Record<string, string> = {
+    serverType: 'manual',
+    codec: 'av1',
+    immersiveMode: 'ar',
+    referenceSpace: 'auto',
+    controlPanelPosition: 'center',
+    controllerModelVisibility: 'show',
+    autoRefreshMode: 'clean',
+    enablePoseSmoothing: 'true',
+    enableTexSubImage2D: 'true',
+    useQuestColorWorkaround: 'true',
+    panelHiddenAtStart: 'true',
+    headless: 'true',
+  };
+  return enums[key] ?? 'x';
+}

--- a/deps/cloudxr/webxr_client/src/config/resolve.ts
+++ b/deps/cloudxr/webxr_client/src/config/resolve.ts
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { URL_PARAMS, type UrlParam } from './params';
+
+/**
+ * Collects the form-backed URL params present in `params`, keyed by UrlParam.key.
+ * A param is included only when it has an `elementId`, its query param is present,
+ * and it passes its (optional) validation. Pure — no DOM access.
+ * `urlParams` is injectable for testing; it defaults to the real registry.
+ */
+export function seedsFromParams(
+  params: URLSearchParams,
+  urlParams: UrlParam[] = URL_PARAMS
+): Map<string, string> {
+  const seeds = new Map<string, string>();
+  for (const param of urlParams) {
+    if (!param.elementId) continue;
+    const raw = params.get(param.url ?? param.key);
+    if (raw === null) continue;
+    if (param.isValid && !param.isValid(raw)) continue;
+    seeds.set(param.key, raw);
+  }
+  return seeds;
+}
+
+/**
+ * Reads a single declared URL param's value, applying its (optional) validation.
+ * Returns null when the key is unknown, absent, or fails validation. Used by the
+ * direct (non-form) consumers so every accepted param is declared in one place.
+ * `urlParams` is injectable for testing; it defaults to the real registry.
+ */
+export function readUrlParam(
+  params: URLSearchParams,
+  key: string,
+  urlParams: UrlParam[] = URL_PARAMS
+): string | null {
+  const param = urlParams.find(p => p.key === key);
+  if (!param) return null;
+  const raw = params.get(param.url ?? param.key);
+  if (raw === null) return null;
+  if (param.isValid && !param.isValid(raw)) return null;
+  return raw;
+}


### PR DESCRIPTION
## Summary
Adds `URL_PARAMS` (`src/config/params.ts`) as the single source of truth for every accepted URL query param, replacing per-field handling that was scattered across `App.tsx` and `applyUrlSeeds`. Form-backed params seed their controls; direct params (TURN/ICE, OOB, `controlToken`) are read via `readUrlParam`.

## Notes
- All 27 form settings are now URL-settable (was 6).
- URL values override but no longer persist to localStorage (one-off OOB/USB links don't mutate saved prefs).
- `deviceProfile` intentionally excluded — it's a preset whose change handler isn't fired by seeding; set the individual fields.
- Direct params have no validator, so `readUrlParam == params.get` — TURN/ICE and OOB/USB behavior unchanged. `CloudXRConfig`/SDK mapping and `index.html` untouched.

## Test plan
- [ ] `npm test` passes (Jest via ts-jest, 14 cases: mapping, validation, form/direct split, `readUrlParam`, url-alias, registry integrity); runs in CI
- [ ] Load `?codec=h264&perEyeWidth=1920&headless=true` → those controls reflect the values
- [ ] Set a value in the UI, reload with a URL param overriding it → URL wins; reload again without the param → reverts to the stored value (override-not-persist)
- [ ] Invalid value ignored: `?codec=bogus` keeps the current/default codec
- [ ] OOB/USB regression: a link with `?oobEnable=1&serverIP=…&port=…&turnServer=…[&iceRelayOnly=1]` still builds the OOB ws URL and ICE config and connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)