### PR TITLE
feat(cmake): add comprehensive CMake structure documentation and rules

### DIFF
--- a/.claude/skills/cmake-structure/SKILL.md
+++ b/.claude/skills/cmake-structure/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: cmake-structure
+description: >-
+  IsaacTeleop CMake target layout and #include conventions. Use whenever you
+  create or edit a CMakeLists.txt, add or move a module/library/executable/test
+  target, set up target_include_directories or target_link_libraries, decide
+  where a header file goes (private vs public inc/), write or reorder #include
+  directives in C/C++ sources, or restructure directories under src/ or deps/.
+  Also use when reviewing diffs that touch CMakeLists.txt, header placement,
+  include paths, or the overall project/directory structure.
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# IsaacTeleop CMake & include structure
+
+The rules, recommended structure, repo conventions, and review checklist live in
+the repo's single source of truth:
+**[`cmake/cmake-structure.md`](../../../cmake/cmake-structure.md)**.
+
+Read that file and apply it before changing CMake files, header placement, or
+include paths — for both authoring and review.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,10 +41,15 @@ reviews:
 
   # --- Per-path review focus (tell the reviewer what matters) ---
   path_instructions:
-    - path: "**/*.{cpp,h,hpp,cxx,hxx}"
+    - path: "**/*.{cpp,h,hpp,cxx,hxx,cc}"
       instructions: >-
         C++20 code. Focus on memory safety, thread safety, resource leaks, and correctness.
         Ignore style, clang-format enforces it at build time.
+        Also enforce the #include conventions documented in cmake/cmake-structure.md.
+    - path: "**/{CMakeLists.txt,*.cmake}"
+      instructions: >-
+        CMake build files. Enforce the target/include structure rules documented in
+        cmake/cmake-structure.md.
     - path: "**/*.py"
       instructions: >-
         Python code (bindings, retargeters, examples, scripts). Focus on logic errors and security

--- a/.cursor/rules/cmake-structure.mdc
+++ b/.cursor/rules/cmake-structure.mdc
@@ -1,0 +1,12 @@
+---
+description: IsaacTeleop CMake target layout and #include conventions — apply when editing CMakeLists.txt, adding/moving targets, placing headers, or writing #include directives.
+globs: **/CMakeLists.txt,**/*.cmake,**/*.h,**/*.hpp,**/*.hxx,**/*.cpp,**/*.cxx,**/*.cc
+alwaysApply: false
+---
+
+# CMake & include structure
+
+Follow the repo's canonical CMake/include rules before changing build files,
+header placement, or include paths. Full rules and review checklist:
+
+@cmake/cmake-structure.md

--- a/.github/instructions/cmake-structure.instructions.md
+++ b/.github/instructions/cmake-structure.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "**/CMakeLists.txt,**/*.cmake,**/*.h,**/*.hpp,**/*.hxx,**/*.cpp,**/*.cxx,**/*.cc"
+---
+
+# CMake & include structure
+
+Follow the repo's canonical CMake and `#include` conventions. The full rules and
+review checklist are in [`cmake/cmake-structure.md`](../../cmake/cmake-structure.md)
+— read and apply that file before changing build files, header placement, or
+include paths.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,18 @@ If you cannot run a shell, use your search/glob tools on the pattern `**/AGENTS.
 
 Optional context index: [`src/core/AGENTS.md`](src/core/AGENTS.md) (also on the ancestor walk—read it when working under `src/core/`).
 
+## CMake & include structure
+
+When you create or edit a `CMakeLists.txt`, add or move a target, place a header,
+write `#include` directives, or restructure directories, follow the repo's
+canonical CMake/include rules in **[`cmake/cmake-structure.md`](cmake/cmake-structure.md)**.
+Read that file before touching build files, header placement, or include paths.
+
+Per-tool shims auto-load the same doc for Claude Code, Cursor, Copilot, and
+CodeRabbit (`.claude/skills/cmake-structure/`, `.cursor/rules/cmake-structure.mdc`,
+`.github/instructions/cmake-structure.instructions.md`, `.coderabbit.yaml`); they
+only point here — edit the rules in the doc, not the shims.
+
 ## Pre-commit — match CI before you stop
 
 - From the **IsaacTeleop repo root** (this directory), run pre-commit and **fix all failures** before you treat a change as finished (do not only rely on “should pass” reasoning).

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -27,3 +27,11 @@ path = "examples/cxrjs/**"
 precedence = "override"
 SPDX-FileCopyrightText = "Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved."
 SPDX-License-Identifier = "Apache-2.0"
+
+# Cursor rule files (.mdc) keep frontmatter clean (no SPDX header); cover them
+# here so REUSE lint passes, mirroring the .github/** override above.
+[[annotations]]
+path = ".cursor/**"
+precedence = "override"
+SPDX-FileCopyrightText = "Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved."
+SPDX-License-Identifier = "Apache-2.0"

--- a/cmake/cmake-structure.md
+++ b/cmake/cmake-structure.md
@@ -1,0 +1,146 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# IsaacTeleop CMake & include structure
+
+Single source of truth for how CMake targets, directories, and `#include` paths
+are organized in this repo. These rules apply to **all** coding agents and AI
+reviewers (Claude Code, Codex, Copilot, Cursor, CodeRabbit, Greptile, …) as well
+as humans. Apply them both when **authoring** code/build files and when
+**reviewing** changes that touch CMake, headers, include paths, or layout.
+
+> This file is the canonical copy. The per-tool config files
+> (`.claude/skills/cmake-structure/`, `.cursor/rules/cmake-structure.mdc`,
+> `.github/instructions/cmake-structure.instructions.md`, `.coderabbit.yaml`,
+> and the root `AGENTS.md`) point here — edit the rules **here**, not in those
+> shims.
+
+## The six rules (non-negotiable)
+
+1. **One CMake target per leaf directory.** A directory that defines a target
+   defines exactly one (one library, one executable, or one test executable).
+2. **Never use `../` in include paths** — not in CMake files, not in `#include`
+   directives, not anywhere. If you reach for `../`, the layout or the target's
+   include dirs are wrong.
+3. **Use `"..."` with relative paths for a target's OWN includes:**
+   ```cpp
+   // foo.cpp - a target-root source
+   #include "implementation.h"   // own private headers, next to cpp
+   #include "inc/foo/core.h"     // own exported (public) headers, relative to cpp
+
+   // foo.h - a public header at inc/foo
+   #include "core.h"             // own exported (public) sibling headers
+   ```
+   Enforce this by **never** adding the target's own `inc/` or `.` to its own
+   include paths. Own headers are always reached by relative `"..."` paths.
+4. **Use `<...>` only for std and other modules' headers** found via *external*
+   (interface) include paths.
+5. **Prefix the module name to public includes:**
+   ```cpp
+   #include <foo/core.h>   // another module's public header
+   ```
+   This is enforced by exposing only the parent of the module dir:
+   `target_include_directories(foo INTERFACE inc)` — so consumers must write
+   `<foo/...>`. **Use `INTERFACE`** (not `PUBLIC`/`PRIVATE` for the exported
+   path) to keep a target's own includes separate from what it exports.
+6. **`inc/` holds only exported headers.** A header that no other target is
+   meant to consume must **not** live in `inc/` — keep it next to its `.cpp`
+   as a private header, reached by a relative `"..."` path. It follows that a
+   **non-library leaf module** (an executable or a loadable plugin — it links
+   *consumers* and exports nothing) has **no `inc/` directory at all**: every
+   one of its headers is private and sits beside its source.
+
+### Include ordering inside a `.cpp`
+
+Own private → own public → other modules' public → std:
+
+```cpp
+#include "z.h"               // own private header        — "" + relative path
+#include "inc/mod1/pub_a.h"  // own public header          — "" + relative path
+#include <mod2/pub_q.h>      // another module's public    — <> + module prefix
+#include <string>            // std                        — <>
+```
+
+## Recommended structure
+
+Any layout that obeys the six rules is valid. The recommended shape:
+
+```
+CMakeLists.txt            ← top level: adds deps/ and src/ subdirectories
+  deps/
+    CMakeLists.txt        ← adds all libs, sets per-lib options
+      lib1/ ...
+      lib2/ ...
+  src/
+    CMakeLists.txt        ← adds all module + executable subdirectories
+    exe1/                 ← executable: only private headers, NO inc/ dir
+      CMakeLists.txt      ← links deps + modules, but NOT other executables
+      bar.cpp             ← private implementation
+      bar.h               ← private header
+      main.cpp            ← entry point
+    exe2/ ...             ← another executable (one CMake target per dir)
+    mod1/                 ← a module (library)
+      CMakeLists.txt      ← defines mod1::mod1; may link deps + other modules
+      inc/                ← public headers (keep the name short: "inc")
+        mod1/             ← subdir named after the module → part of the #include
+          pub_a.h         ← public header; must NOT include own private headers
+          pub_b.h         ← may include own public headers by relative "" path
+      x.cpp               ← private implementation
+      x.h                 ← private header
+      z.cpp               ← (see include-ordering example above)
+    mod1_tests/ ...       ← test executable; links mod1::mod1 + deps (e.g. gtest)
+    mod2/ ...             ← another module (one CMake target per dir)
+```
+
+## This repo's concrete conventions
+
+Real modules in `src/` follow the rules above with a `cpp/` layer and a
+namespaced alias. A header-only / interface module looks like:
+
+```cmake
+add_library(deviceio_base INTERFACE)
+
+target_include_directories(deviceio_base
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/inc>   # exports inc/, so consumers write <deviceio_base/...>
+)
+
+target_link_libraries(deviceio_base
+    INTERFACE
+        isaacteleop_schema
+)
+
+add_library(deviceio::deviceio_base ALIAS deviceio_base)     # mod::mod alias
+```
+
+So the on-disk path is `src/core/<module>/cpp/{CMakeLists.txt, inc/<module>/*.hpp, *.cpp, *.h}`,
+and `src/core/<module>/CMakeLists.txt` simply `add_subdirectory(cpp)`. Match the
+neighbouring modules' style (alias namespace, `$<BUILD_INTERFACE:...>`, INTERFACE
+vs compiled library) rather than introducing a new pattern.
+
+## Review checklist
+
+When reviewing a diff that touches CMake, headers, or layout, flag any of:
+
+- [ ] More than one target defined in a single leaf directory.
+- [ ] Any `../` in an `#include` or in a CMake path.
+- [ ] A target adding its own `inc/` or `.` to its include paths (breaks rule 3).
+- [ ] Own headers included via `<...>` instead of relative `"..."`.
+- [ ] Another module's / std headers included via `"..."` instead of `<...>`.
+- [ ] Public include missing the module-name prefix (e.g. `<core.h>` not `<foo/core.h>`).
+- [ ] Exported include dir using `PUBLIC`/`PRIVATE` instead of `INTERFACE`.
+- [ ] A public header (`inc/...`) that includes the module's private headers.
+- [ ] A never-exported (private) header placed under `inc/` instead of beside its `.cpp` (breaks rule 6).
+- [ ] A non-library leaf module (executable / loadable plugin) that has an `inc/` directory at all (breaks rule 6).
+- [ ] An executable that links against another executable.
+- [ ] Include block not ordered: own private → own public → other public → std.
+- [ ] New module that omits the `mod::mod` alias or diverges from neighbour style.
+
+## Related repo policy
+
+This complements the repo's `AGENTS.md` files: before editing/creating files
+under a directory, read every `AGENTS.md` on the path up to the repo root, and
+run `SKIP=check-copyright-year pre-commit run --all-files` before treating work
+as done. New build files need the SPDX header used elsewhere in the repo.


### PR DESCRIPTION
Fixes #598

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive CMake structure conventions documentation serving as the repository's canonical reference.
  * Added CMake structure guidance across multiple contributor tools and instruction files.

* **Chores**
  * Updated code review and build configuration to enforce CMake conventions.
  * Updated license configuration for new documentation files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->