### PR TITLE
ROS: publish head pose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,12 +4,14 @@
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
     "ghcr.io/devcontainers/features/git-lfs:1": {},
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
     "ghcr.io/devcontainers-extra/features/apt-packages:1": {
       "packages": "clang-format-14,libx11-dev,libxrandr-dev,libxxf86vm-dev,libgl1-mesa-dev"
     },
     "ghcr.io/devcontainers-extra/features/cmake:1": {},
     "ghcr.io/devcontainers-extra/features/uv:1": {}
   },
+  "postCreateCommand": "uv tool install pre-commit && pre-commit install",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/examples/teleop_ros2/AGENTS.md
+++ b/examples/teleop_ros2/AGENTS.md
@@ -7,6 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Docker Validation
 
+- This example needs ROS 2 plus the built `isaacteleop` wheel, which are not present in the dev container. Run/validate it inside the `examples/teleop_ros2/Dockerfile` image (the same path CI's `test-teleop-ros2` job uses), not directly on the host.
+- To exercise it without live XR hardware, replay an MCAP fixture: build the image, run the installed `teleop_ros2_mcap_generator` to write a fixture, then run `teleop_ros2_node.py` with `-p mode:=<mode> -p mcap_replay_path:=<file>` and check topics (e.g. via `integration_tests/teleop_ros2_topic_verifier.py`). Replay mode does not launch CloudXR, so no GPU/NGC runtime is required. Share the fixture across containers with `-v /tmp:/tmp` and `--network host` for ROS 2 discovery.
+- The image build disables some CI gates (`-DENABLE_CLANG_FORMAT_CHECK=OFF`, `-DBUILD_TESTING=OFF`), so a green Docker build does not mean C++ formatting or ctest pass. Validate those separately.
 - When creating temporary Docker images for `examples/teleop_ros2` validation, remove them before finishing the task unless the user explicitly asks to keep them.
 
 ## Python Node Layout

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -65,12 +65,15 @@ Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
   - `poses[1]`: Right hand/controller EE pose (if active)
 - `xr_teleop/root_twist` (`geometry_msgs/TwistStamped`)
 - `xr_teleop/root_pose` (`geometry_msgs/PoseStamped`)
+- `xr_teleop/head_pose` (`geometry_msgs/PoseStamped`)
+  - Head pose; published in `controller_teleop` and `hand_teleop` modes when head tracking is valid
 - `xr_teleop/controller_data` (`std_msgs/ByteMultiArray`, msgpack-encoded dictionary)
 - `xr_teleop/finger_joints` (`sensor_msgs/JointState`)
   - Retargeted finger joint angles for the robot; contains joint names and position arrays corresponding to the robot finger joints (TriHand in default `controller_teleop`, selected Sharpa retargeter in `hand_teleop`, or explicit Sharpa retargeter in `controller_teleop`)
 - `/tf` (`tf2_msgs/TFMessage`)
   - `world_frame` → `right_wrist_frame`: Right wrist transform (published in `controller_teleop` and `hand_teleop` modes)
   - `world_frame` → `left_wrist_frame`: Left wrist transform (published in `controller_teleop` and `hand_teleop` modes)
+  - `world_frame` → `head_frame`: Head transform (published in `controller_teleop` and `hand_teleop` modes)
 
 ## Run in Docker
 
@@ -119,11 +122,11 @@ docker run --rm --gpus all --net=host --ipc=host \
   -r xr_teleop/hand:=my_robot/hand -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 
-Available topics for remapping: `xr_teleop/hand`, `xr_teleop/ee_poses`, `xr_teleop/root_twist`, `xr_teleop/root_pose`, `xr_teleop/controller_data`, `xr_teleop/full_body`, `xr_teleop/finger_joints`. Active remaps can be inspected with `ros2 node info /teleop_ros2_node`.
+Available topics for remapping: `xr_teleop/hand`, `xr_teleop/ee_poses`, `xr_teleop/root_twist`, `xr_teleop/root_pose`, `xr_teleop/head_pose`, `xr_teleop/controller_data`, `xr_teleop/full_body`, `xr_teleop/finger_joints`. Active remaps can be inspected with `ros2 node info /teleop_ros2_node`.
 
 ### Mode
 
@@ -131,8 +134,8 @@ The `mode` parameter selects the teleoperation scenario and which topics are pub
 
 | Mode | Topics published |
 |------|------------------|
-| `controller_teleop` (default) | `ee_poses` (from controller aim pose), `root_twist`, `root_pose`, `finger_joints` (TriHand by default; Sharpa from Manus/OpenXR hands when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`), `controller_data`, `tf` (from controller aim pose), and `hand` only for the explicit Sharpa retargeter path |
-| `hand_teleop` | `ee_poses` (from hand tracking wrist), `hand` (finger joints in pose space), `finger_joints` (finger joints in joint space), `root_twist`, `root_pose`, `tf` (from hand tracking wrist); locomotion comes from the configured foot pedal collection |
+| `controller_teleop` (default) | `ee_poses` (from controller aim pose), `root_twist`, `root_pose`, `head_pose`, `finger_joints` (TriHand by default; Sharpa from Manus/OpenXR hands when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`), `controller_data`, `tf` (from controller aim pose and head pose), and `hand` only for the explicit Sharpa retargeter path |
+| `hand_teleop` | `ee_poses` (from hand tracking wrist), `hand` (finger joints in pose space), `finger_joints` (finger joints in joint space), `root_twist`, `root_pose`, `head_pose`, `tf` (from hand tracking wrist and head pose); locomotion comes from the configured foot pedal collection |
 | `controller_raw` | `controller_data` only |
 | `full_body` | `full_body` and `controller_data` |
 
@@ -165,6 +168,7 @@ ros2 topic echo /xr_teleop/hand geometry_msgs/msg/PoseArray
 ros2 topic echo /xr_teleop/ee_poses geometry_msgs/msg/PoseArray
 ros2 topic echo /xr_teleop/root_twist geometry_msgs/msg/TwistStamped
 ros2 topic echo /xr_teleop/root_pose geometry_msgs/msg/PoseStamped
+ros2 topic echo /xr_teleop/head_pose geometry_msgs/msg/PoseStamped
 ros2 topic echo /xr_teleop/controller_data std_msgs/msg/ByteMultiArray
 ros2 topic echo /xr_teleop/full_body std_msgs/msg/ByteMultiArray
 ros2 topic echo /xr_teleop/finger_joints sensor_msgs/msg/JointState

--- a/examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp
+++ b/examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp
@@ -7,6 +7,7 @@
 #include <schema/controller_generated.h>
 #include <schema/full_body_generated.h>
 #include <schema/hand_generated.h>
+#include <schema/head_generated.h>
 #include <schema/pedals_generated.h>
 #include <schema/timestamp_generated.h>
 
@@ -24,6 +25,7 @@ namespace
 
 using ControllerChannels = core::McapTrackerChannels<core::ControllerSnapshotRecord, core::ControllerSnapshot>;
 using HandChannels = core::McapTrackerChannels<core::HandPoseRecord, core::HandPose>;
+using HeadChannels = core::McapTrackerChannels<core::HeadPoseRecord, core::HeadPose>;
 using PedalChannels = core::McapTrackerChannels<core::Generic3AxisPedalOutputRecord, core::Generic3AxisPedalOutput>;
 using FullBodyChannels = core::McapTrackerChannels<core::FullBodyPosePicoRecord, core::FullBodyPosePico>;
 
@@ -71,6 +73,16 @@ std::shared_ptr<core::HandPoseT> make_hand_sample(bool left, int frame)
         const core::Pose pose(position, core::Quaternion(0.0f, 0.0f, 0.0f, 1.0f));
         sample->joints->mutable_poses()->Mutate(joint, core::HandJointPose(pose, true, 0.010f));
     }
+    return sample;
+}
+
+std::shared_ptr<core::HeadPoseT> make_head_sample(int frame)
+{
+    const float delta = 0.0005f * static_cast<float>(frame);
+    auto sample = std::make_shared<core::HeadPoseT>();
+    sample->pose =
+        std::make_shared<core::Pose>(core::Point(0.0f, 0.10f + delta, 1.60f), core::Quaternion(0.0f, 0.0f, 0.0f, 1.0f));
+    sample->is_valid = true;
     return sample;
 }
 
@@ -124,12 +136,14 @@ void write_fixture(const std::filesystem::path& output_path, int frame_count)
     auto writer = open_writer(output_path);
     const auto controller_names = to_strings(core::ControllerRecordingTraits::recording_channels);
     const auto hand_names = to_strings(core::HandRecordingTraits::recording_channels);
+    const auto head_names = to_strings(core::HeadRecordingTraits::recording_channels);
     const auto pedal_names = to_strings(core::PedalRecordingTraits::recording_channels);
     const auto full_body_names = to_strings(core::FullBodyPicoRecordingTraits::recording_channels);
 
     ControllerChannels controller_channels(
         *writer, "controllers", core::ControllerRecordingTraits::schema_name, controller_names);
     HandChannels hand_channels(*writer, "hands", core::HandRecordingTraits::schema_name, hand_names);
+    HeadChannels head_channels(*writer, "head", core::HeadRecordingTraits::schema_name, head_names);
     PedalChannels pedal_channels(*writer, "pedals", core::PedalRecordingTraits::schema_name, pedal_names);
     FullBodyChannels full_body_channels(
         *writer, "full_body", core::FullBodyPicoRecordingTraits::schema_name, full_body_names);
@@ -142,6 +156,7 @@ void write_fixture(const std::filesystem::path& output_path, int frame_count)
         controller_channels.write(1, timestamp, make_controller_sample(false, frame));
         hand_channels.write(0, timestamp, make_hand_sample(true, frame));
         hand_channels.write(1, timestamp, make_hand_sample(false, frame));
+        head_channels.write(0, timestamp, make_head_sample(frame));
         pedal_channels.write(0, timestamp, make_pedal_sample(frame));
         full_body_channels.write(0, timestamp, make_full_body_sample(frame));
     }

--- a/examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp
+++ b/examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp
@@ -78,6 +78,11 @@ std::shared_ptr<core::HandPoseT> make_hand_sample(bool left, int frame)
 
 std::shared_ptr<core::HeadPoseT> make_head_sample(int frame)
 {
+    // Arbitrary-but-plausible deterministic head pose for the replay fixture: the
+    // verifier only requires valid/finite/non-zero values, so the literals just
+    // describe a centered head ~1.6 m up (standing height) with identity orientation.
+    // `delta` adds a slow per-frame drift (0.5 mm/frame, matching the hand/full-body
+    // samples) so the pose varies over time rather than being static.
     const float delta = 0.0005f * static_cast<float>(frame);
     auto sample = std::make_shared<core::HeadPoseT>();
     sample->pose =

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -23,7 +23,7 @@ from tf2_msgs.msg import TFMessage
 
 
 _MODES = ("controller_teleop", "hand_teleop", "controller_raw", "full_body")
-_EXPECTED_TF_FRAMES = {"right_wrist", "left_wrist"}
+_EXPECTED_TF_FRAMES = {"right_wrist", "left_wrist", "head"}
 
 
 def _is_finite_sequence(values) -> bool:
@@ -232,6 +232,7 @@ class TopicVerifier(Node):
                 ),
                 ("root_twist", "xr_teleop/root_twist", TwistStamped, _assert_twist),
                 ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_root_pose),
+                ("head_pose", "xr_teleop/head_pose", PoseStamped, _assert_root_pose),
                 (
                     "finger_joints",
                     "xr_teleop/finger_joints",
@@ -261,6 +262,7 @@ class TopicVerifier(Node):
                 ),
                 ("root_twist", "xr_teleop/root_twist", TwistStamped, _assert_twist),
                 ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_root_pose),
+                ("head_pose", "xr_teleop/head_pose", PoseStamped, _assert_root_pose),
                 (
                     "finger_joints",
                     "xr_teleop/finger_joints",

--- a/examples/teleop_ros2/python/messages.py
+++ b/examples/teleop_ros2/python/messages.py
@@ -8,7 +8,7 @@ import time
 from typing import Dict, Sequence
 
 import numpy as np
-from geometry_msgs.msg import PoseArray
+from geometry_msgs.msg import PoseArray, PoseStamped
 from scipy.spatial.transform import Rotation
 from sensor_msgs.msg import JointState
 
@@ -18,6 +18,7 @@ from isaacteleop.retargeting_engine.tensor_types.indices import (
     FullBodyInputIndex,
     HandInputIndex,
     HandJointIndex,
+    HeadPoseIndex,
 )
 
 from constants import BODY_JOINT_NAMES
@@ -290,6 +291,30 @@ def build_hand_msg_from_hands(
     return msg
 
 
+def build_head_msg(
+    head: OptionalTensorGroup,
+    now,
+    frame_id: str,
+    transform_rot: Rotation | None = None,
+    transform_trans: Sequence[float] | None = None,
+) -> PoseStamped | None:
+    """Build a PoseStamped for the head pose, or None when head is invalid."""
+    if not head_is_valid(head):
+        return None
+
+    position = [float(x) for x in head[HeadPoseIndex.POSITION]]
+    orientation = [float(x) for x in head[HeadPoseIndex.ORIENTATION]]
+    pose = to_pose(position, orientation)
+    if transform_rot is not None or transform_trans is not None:
+        pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
+
+    msg = PoseStamped()
+    msg.header.stamp = now
+    msg.header.frame_id = frame_id
+    msg.pose = pose
+    return msg
+
+
 def controller_aim_is_valid(ctrl: OptionalTensorGroup) -> bool:
     # DeviceIO's AIM_IS_VALID flag is the usability contract for aim poses.
     return not ctrl.is_none and bool(ctrl[ControllerInputIndex.AIM_IS_VALID])
@@ -303,6 +328,10 @@ def hand_joint_is_valid(hand: OptionalTensorGroup, joint_idx: HandJointIndex) ->
 
 def hand_wrist_is_valid(hand: OptionalTensorGroup) -> bool:
     return hand_joint_is_valid(hand, HandJointIndex.WRIST)
+
+
+def head_is_valid(head: OptionalTensorGroup) -> bool:
+    return not head.is_none and bool(head[HeadPoseIndex.IS_VALID])
 
 
 def joint_names_from_group_type(group_type) -> list[str]:

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -12,6 +12,7 @@ a startup message, and return the resolved value(s). The public entry point
 assembles a frozen ``NodeParameters`` snapshot.
 """
 
+import itertools
 import math
 from dataclasses import dataclass
 from pathlib import Path
@@ -56,6 +57,7 @@ class NodeParameters:
     world_frame: str
     right_wrist_frame: str
     left_wrist_frame: str
+    head_frame: str
     transform_translation: list[float] | None
     transform_rotation: Rotation | None
     left_finger_joint_name_aliases: list[str] | None
@@ -186,7 +188,7 @@ def _load_finger_joint_name_aliases(node: Node, side: str) -> list[str] | None:
     return names or None
 
 
-def _load_frames(node: Node) -> tuple[str, str, str]:
+def _load_frames(node: Node) -> tuple[str, str, str, str]:
     node.declare_parameter(
         "world_frame",
         "world",
@@ -207,33 +209,31 @@ def _load_frames(node: Node) -> tuple[str, str, str]:
         "left_wrist",
         ParameterDescriptor(description="TF child frame name for the left wrist."),
     )
+    node.declare_parameter(
+        "head_frame",
+        "head",
+        ParameterDescriptor(description="TF child frame name for the head."),
+    )
 
-    world_frame = node.get_parameter("world_frame").get_parameter_value().string_value
-    right_wrist_frame = (
-        node.get_parameter("right_wrist_frame").get_parameter_value().string_value
-    )
-    left_wrist_frame = (
-        node.get_parameter("left_wrist_frame").get_parameter_value().string_value
-    )
-    if not world_frame:
-        raise ValueError("Parameter 'world_frame' must not be empty")
-    if not right_wrist_frame:
-        raise ValueError("Parameter 'right_wrist_frame' must not be empty")
-    if not left_wrist_frame:
-        raise ValueError("Parameter 'left_wrist_frame' must not be empty")
-    if right_wrist_frame == left_wrist_frame:
-        raise ValueError(
-            f"'right_wrist_frame' and 'left_wrist_frame' must be different , got {right_wrist_frame!r}"
-        )
-    if right_wrist_frame == world_frame:
-        raise ValueError(
-            f"'right_wrist_frame' must be different from 'world_frame', got {right_wrist_frame!r}"
-        )
-    if left_wrist_frame == world_frame:
-        raise ValueError(
-            f"'left_wrist_frame' must be different from 'world_frame', got {left_wrist_frame!r}"
-        )
-    return world_frame, right_wrist_frame, left_wrist_frame
+    # Every frame must be non-empty and distinct from the others: they become
+    # TF frame names that all share the same world parent, so any collision
+    # would publish ambiguous transforms.
+    frame_names = ("world_frame", "right_wrist_frame", "left_wrist_frame", "head_frame")
+    frames = {
+        name: node.get_parameter(name).get_parameter_value().string_value
+        for name in frame_names
+    }
+    for name, value in frames.items():
+        if not value:
+            raise ValueError(f"Parameter '{name}' must not be empty")
+    for (name_a, value_a), (name_b, value_b) in itertools.combinations(
+        frames.items(), 2
+    ):
+        if value_a == value_b:
+            raise ValueError(
+                f"Parameters '{name_a}' and '{name_b}' must be different, got {value_a!r}"
+            )
+    return tuple(frames.values())
 
 
 def _load_hand_retargeter(
@@ -423,7 +423,7 @@ def create_node_parameters(node: Node) -> NodeParameters:
     session_mode, mcap_config = _load_mcap_replay(node)
     cloudxr_install_dir, cloudxr_env_config, cloudxr_accept_eula = _load_cloudxr(node)
     pedal_collection_id = _load_pedal_collection_id(node)
-    world_frame, right_wrist_frame, left_wrist_frame = _load_frames(node)
+    world_frame, right_wrist_frame, left_wrist_frame, head_frame = _load_frames(node)
     transform_translation = _load_transform_translation(node)
     transform_rotation = _load_transform_rotation(node)
     left_finger_joint_name_aliases = _load_finger_joint_name_aliases(node, "left")
@@ -445,6 +445,7 @@ def create_node_parameters(node: Node) -> NodeParameters:
         world_frame=world_frame,
         right_wrist_frame=right_wrist_frame,
         left_wrist_frame=left_wrist_frame,
+        head_frame=head_frame,
         transform_translation=transform_translation,
         transform_rotation=transform_rotation,
         left_finger_joint_name_aliases=left_finger_joint_name_aliases,

--- a/examples/teleop_ros2/python/session_config.py
+++ b/examples/teleop_ros2/python/session_config.py
@@ -11,6 +11,7 @@ from isaacteleop.retargeting_engine.deviceio_source_nodes import (
     FullBodySource,
     Generic3AxisPedalSource,
     HandsSource,
+    HeadSource,
 )
 from isaacteleop.retargeting_engine.interface import OutputCombiner
 from isaacteleop.retargeters import (
@@ -64,6 +65,7 @@ def build_controller_raw_config(params: NodeParameters) -> TeleopSessionConfig:
 
 def build_controller_teleop_config(params: NodeParameters) -> TeleopSessionConfig:
     controllers = ControllersSource(name="controllers")
+    head = HeadSource(name="head")
     locomotion = LocomotionRootCmdRetargeter(
         LocomotionRootCmdRetargeterConfig(), name="locomotion"
     )
@@ -77,6 +79,7 @@ def build_controller_teleop_config(params: NodeParameters) -> TeleopSessionConfi
     pipeline_outputs = {
         "controller_left": controllers.output(ControllersSource.LEFT),
         "controller_right": controllers.output(ControllersSource.RIGHT),
+        "head": head.output("head"),
         "root_command": locomotion_connected.output("root_command"),
     }
 
@@ -198,6 +201,7 @@ def build_hand_teleop_config(params: NodeParameters) -> TeleopSessionConfig:
     )
 
     hands = HandsSource(name="hands")
+    head = HeadSource(name="head")
     pedals = Generic3AxisPedalSource(
         name="pedals", collection_id=params.pedal_collection_id
     )
@@ -214,6 +218,7 @@ def build_hand_teleop_config(params: NodeParameters) -> TeleopSessionConfig:
         {
             "hand_left": hands.output(HandsSource.LEFT),
             "hand_right": hands.output(HandsSource.RIGHT),
+            "head": head.output("head"),
             "root_command": locomotion_connected.output("root_command"),
             "finger_joints_left": left_finger_joints,
             "finger_joints_right": right_finger_joints,

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -12,11 +12,12 @@ published:
 
   - controller_teleop (default): ee_poses (from controller aim pose), root_twist,
                        root_pose, finger_joints (retargeted TriHand angles),
-                       controller_data, and TF transforms for left/right wrists
+                       controller_data, head_pose, and TF transforms for
+                       left/right wrists and head
   - hand_teleop: ee_poses (from hand tracking wrist), hand (finger joint poses),
                  finger_joints (retargeted Sharpa joint angles),
-                 root_twist/root_pose (from foot pedal locomotion), and TF
-                 transforms for left/right wrists
+                 root_twist/root_pose (from foot pedal locomotion), head_pose,
+                 and TF transforms for left/right wrists and head
   - controller_raw: controller_data only
   - full_body: full_body and controller_data
 
@@ -25,6 +26,7 @@ Topic names (remappable via ROS 2 remapping):
   - xr_teleop/ee_poses (PoseArray): [left_ee, right_ee]
   - xr_teleop/root_twist (TwistStamped): root velocity command
   - xr_teleop/root_pose (PoseStamped): root pose command (height only)
+  - xr_teleop/head_pose (PoseStamped): head pose
   - xr_teleop/controller_data (ByteMultiArray): msgpack-encoded controller data
   - xr_teleop/full_body (ByteMultiArray): msgpack-encoded full body tracking data
   - xr_teleop/finger_joints (JointState): retargeted finger joint angles
@@ -32,6 +34,7 @@ Topic names (remappable via ROS 2 remapping):
 TF frames published in hand_teleop and controller_teleop modes (configurable via parameters):
   - world_frame -> right_wrist_frame
   - world_frame -> left_wrist_frame
+  - world_frame -> head_frame
 """
 
 import time
@@ -63,8 +66,10 @@ from messages import (
     build_finger_joints_msg,
     build_full_body_payload,
     build_hand_msg_from_hands,
+    build_head_msg,
     controller_aim_is_valid,
     hand_wrist_is_valid,
+    head_is_valid,
 )
 from node_parameters import (
     NodeParameters,
@@ -144,6 +149,7 @@ class TeleopRos2Node(Node):
         self._pub_finger_joints = self.create_publisher(
             JointState, "xr_teleop/finger_joints", 10
         )
+        self._pub_head = self.create_publisher(PoseStamped, "xr_teleop/head_pose", 10)
 
     def _publish_controller_outputs(self, result: dict, now) -> None:
         left_ctrl = result["controller_left"]
@@ -258,6 +264,40 @@ class TeleopRos2Node(Node):
         if wrist_tfs:
             self._tf_broadcaster.sendTransform(wrist_tfs)
 
+    def _publish_head(self, result: dict, now) -> None:
+        if self._params.mode not in ("controller_teleop", "hand_teleop"):
+            return
+
+        head = result["head"]
+        if not head_is_valid(head):
+            return
+
+        head_msg = build_head_msg(
+            head,
+            now,
+            self._params.world_frame,
+            self._params.transform_rotation,
+            self._params.transform_translation,
+        )
+        if head_msg is None:
+            return
+
+        self._pub_head.publish(head_msg)
+        pose = head_msg.pose
+        head_tf = make_transform(
+            now,
+            self._params.world_frame,
+            self._params.head_frame,
+            [pose.position.x, pose.position.y, pose.position.z],
+            [
+                pose.orientation.x,
+                pose.orientation.y,
+                pose.orientation.z,
+                pose.orientation.w,
+            ],
+        )
+        self._tf_broadcaster.sendTransform(head_tf)
+
     def _publish_root_command(self, result: dict, now) -> None:
         if self._params.mode not in ("hand_teleop", "controller_teleop"):
             return
@@ -309,6 +349,7 @@ class TeleopRos2Node(Node):
 
                         self._publish_root_command(result, now)
                         self._publish_finger_joints(result, now)
+                        self._publish_head(result, now)
                         self._publish_controller_payload(result)
                         self._publish_full_body_payload(result)
 


### PR DESCRIPTION
Wire the existing HeadSource into the hand_teleop and controller_teleop session pipelines and surface the head pose as a new xr_teleop/head_pose PoseStamped topic plus a world_frame -> head_frame TF, mirroring how wrist poses are handled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added head pose tracking and publishing to the ROS 2 teleop example in both controller and hand modes.
  * Added support for MCAP replay mode testing without live XR hardware.

* **Documentation**
  * Updated ROS 2 teleop guides to document head pose topic and parameters.
  * Added Docker validation instructions and MCAP replay workflow examples.

* **Chores**
  * Enhanced development container with pre-commit hook support for automated code quality checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->