### PR TITLE
ROS: extract tensor group helpers from messages.py

### DIFF
--- a/examples/teleop_ros2/python/messages.py
+++ b/examples/teleop_ros2/python/messages.py
@@ -28,6 +28,12 @@ from geometry import (
     apply_transform_to_pose,
     to_pose,
 )
+from tensor_group_helpers import (
+    controller_aim_is_valid,
+    hand_wrist_is_valid,
+    head_is_valid,
+    joint_names_from_group_type,
+)
 
 
 def build_controller_payload(
@@ -165,7 +171,7 @@ def build_ee_msg_from_hands(
     msg.header.stamp = now
     msg.header.frame_id = frame_id
 
-    if hand_joint_is_valid(left_hand, HandJointIndex.WRIST):
+    if hand_wrist_is_valid(left_hand):
         left_positions = np.asarray(left_hand[HandInputIndex.JOINT_POSITIONS])
         left_orientations = np.asarray(left_hand[HandInputIndex.JOINT_ORIENTATIONS])
         pose = to_pose(
@@ -178,7 +184,7 @@ def build_ee_msg_from_hands(
     else:
         msg.poses.append(to_pose([0.0, 0.0, 0.0]))
 
-    if hand_joint_is_valid(right_hand, HandJointIndex.WRIST):
+    if hand_wrist_is_valid(right_hand):
         right_positions = np.asarray(right_hand[HandInputIndex.JOINT_POSITIONS])
         right_orientations = np.asarray(right_hand[HandInputIndex.JOINT_ORIENTATIONS])
         pose = to_pose(
@@ -313,26 +319,3 @@ def build_head_msg(
     msg.header.frame_id = frame_id
     msg.pose = pose
     return msg
-
-
-def controller_aim_is_valid(ctrl: OptionalTensorGroup) -> bool:
-    # DeviceIO's AIM_IS_VALID flag is the usability contract for aim poses.
-    return not ctrl.is_none and bool(ctrl[ControllerInputIndex.AIM_IS_VALID])
-
-
-def hand_joint_is_valid(hand: OptionalTensorGroup, joint_idx: HandJointIndex) -> bool:
-    if hand.is_none:
-        return False
-    return bool(hand[HandInputIndex.JOINT_VALID][joint_idx])
-
-
-def hand_wrist_is_valid(hand: OptionalTensorGroup) -> bool:
-    return hand_joint_is_valid(hand, HandJointIndex.WRIST)
-
-
-def head_is_valid(head: OptionalTensorGroup) -> bool:
-    return not head.is_none and bool(head[HeadPoseIndex.IS_VALID])
-
-
-def joint_names_from_group_type(group_type) -> list[str]:
-    return [tensor_type.name for tensor_type in group_type.types]

--- a/examples/teleop_ros2/python/session_config.py
+++ b/examples/teleop_ros2/python/session_config.py
@@ -42,8 +42,8 @@ from constants import (
     SHARPA_FINGER_JOINT_COUNT,
     SHARPA_HAND_RETARGETERS,
 )
-from messages import joint_names_from_group_type
 from node_parameters import NodeParameters
+from tensor_group_helpers import joint_names_from_group_type
 
 
 def build_controller_raw_config(params: NodeParameters) -> TeleopSessionConfig:

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -67,15 +67,17 @@ from messages import (
     build_full_body_payload,
     build_hand_msg_from_hands,
     build_head_msg,
-    controller_aim_is_valid,
-    hand_wrist_is_valid,
-    head_is_valid,
 )
 from node_parameters import (
     NodeParameters,
     create_node_parameters,
 )
 from session_config import build_session_config
+from tensor_group_helpers import (
+    controller_aim_is_valid,
+    hand_wrist_is_valid,
+    head_is_valid,
+)
 
 
 class TeleopRos2Node(Node):

--- a/examples/teleop_ros2/python/tensor_group_helpers.py
+++ b/examples/teleop_ros2/python/tensor_group_helpers.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for reading retargeting-engine tensor groups and group types."""
+
+from isaacteleop.retargeting_engine.interface import OptionalTensorGroup
+from isaacteleop.retargeting_engine.tensor_types.indices import (
+    ControllerInputIndex,
+    HandInputIndex,
+    HandJointIndex,
+    HeadPoseIndex,
+)
+
+
+def _flag_is_valid(group: OptionalTensorGroup, *indices: int) -> bool:
+    if group.is_none:
+        return False
+    value = group[indices[0]]
+    for index in indices[1:]:
+        value = value[index]
+    return bool(value)
+
+
+def controller_aim_is_valid(ctrl: OptionalTensorGroup) -> bool:
+    return _flag_is_valid(ctrl, ControllerInputIndex.AIM_IS_VALID)
+
+
+def hand_wrist_is_valid(hand: OptionalTensorGroup) -> bool:
+    return _flag_is_valid(hand, HandInputIndex.JOINT_VALID, HandJointIndex.WRIST)
+
+
+def head_is_valid(head: OptionalTensorGroup) -> bool:
+    return _flag_is_valid(head, HeadPoseIndex.IS_VALID)
+
+
+def joint_names_from_group_type(group_type) -> list[str]:
+    return [tensor_type.name for tensor_type in group_type.types]


### PR DESCRIPTION
Move the OptionalTensorGroup validity predicates (controller_aim_is_valid, hand_wrist_is_valid, head_is_valid) and joint_names_from_group_type into a new tensor_group_helpers module so messages.py stays focused on building ROS messages and msgpack payloads. The three predicates now funnel through a single variadic _flag_is_valid helper, and importers (teleop_ros2_node.py, session_config.py) point at the new module.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated validation utilities in the teleop ROS2 example code into a dedicated module for improved organization and consistency.
  * Updated related example modules to reference the centralized utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->