### PR TITLE
Don't enforce a max python version 3.14

### DIFF
--- a/examples/camera_streamer/pyproject.toml
+++ b/examples/camera_streamer/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleop-camera-streamer"
 version = "0.1.0"
 description = "Isaac Teleop multi-camera streaming (Holoscan-based)"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "pyyaml",
     "loguru",

--- a/examples/camera_viz/pyproject.toml
+++ b/examples/camera_viz/pyproject.toml
@@ -10,7 +10,7 @@
 name = "camera-viz"
 version = "0.0.0"
 description = "Televiz camera-feed visualizer"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "pyyaml>=6.0",
     "cupy-cuda12x",

--- a/examples/camera_viz/tests/pyproject.toml
+++ b/examples/camera_viz/tests/pyproject.toml
@@ -10,7 +10,7 @@
 [project]
 name = "camera-viz-tests"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [

--- a/examples/mcap_record_replay/python/pyproject.toml
+++ b/examples/mcap_record_replay/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "mcap-record-replay-example"
 version = "0.0.0"  # Internal example - not versioned
 description = "Isaac Teleop MCAP record / replay example with viser visualization"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "isaacteleop[cloudxr]==1.3.9rc1",
     "mcap>=1.2.0",

--- a/examples/oxr/python/pyproject.toml
+++ b/examples/oxr/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "oxr-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "OpenXR Tracking Python Examples"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "isaacteleop",
     "numpy>=1.23.0",

--- a/examples/retargeting/python/pyproject.toml
+++ b/examples/retargeting/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "retargeting-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "Retargeting Engine Python Examples"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "isaacteleop[ui,retargeters-lite]",
     "numpy>=1.23.0",

--- a/examples/teleop/python/pyproject.toml
+++ b/examples/teleop/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleop-examples"
 version = "0.1.0"
 description = "Isaac Teleop Retargeting Examples"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "isaacteleop[retargeters]",
 ]

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleop-ros2-example"
 version = "0.1.0"
 description = "Isaac Teleop ROS2 Example"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "isaacteleop[cloudxr,grounding,retargeters]",
     "msgpack",

--- a/examples/teleop_session_manager/python/pyproject.toml
+++ b/examples/teleop_session_manager/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleop-utils-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "TeleopUtils Python Examples"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 dependencies = [
     "isaacteleop[ui]",
     "numpy>=1.23.0",

--- a/src/core/cloudxr_tests/python/pyproject.toml
+++ b/src/core/cloudxr_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleopcore-cloudxr-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "CloudXR launcher and runtime unit tests for TeleopCore"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/python/stubgen_pyproject.toml
+++ b/src/core/python/stubgen_pyproject.toml
@@ -8,7 +8,7 @@
 name = "isaacteleop-stubgen"
 version = "0.0.0"  # Internal tooling - not versioned
 description = "Stub generation dependencies for Isaac Teleop pybind11 modules"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 dependencies = [
     "pybind11-stubgen",

--- a/src/core/retargeting_engine_tests/python/pyproject.toml
+++ b/src/core/retargeting_engine_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "isaacteleop-retargeting-engine"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Retargeting engine type system for Isaac Teleop"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/schema_tests/python/pyproject.toml
+++ b/src/core/schema_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "isaacteleop-schema-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Tests for Isaac Teleop schema types"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/teleop_session_manager_tests/python/pyproject.toml
+++ b/src/core/teleop_session_manager_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleopcore-teleop-session-manager-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Teleop session manager tests for TeleopCore"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [

--- a/src/viz/python_tests/pyproject.toml
+++ b/src/viz/python_tests/pyproject.toml
@@ -11,7 +11,7 @@
 name = "isaacteleop-viz-tests"
 version = "0.0.0"
 description = "Python tests for isaacteleop.viz bindings"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Python version requirements across project modules to support Python 3.14+, removing the upper version constraint while maintaining Python 3.10 as the minimum supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->