### PR TITLE
fix(webclient): fix XR panel snapping to face away from user when moved

### DIFF
--- a/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
@@ -39,11 +39,11 @@ import { PerformanceCanvasImage } from '@helpers/react/PerformanceCanvasImage';
 import { useXRButton } from '@helpers/react/useXRButton';
 import { ReadonlySignal } from '@preact/signals-react';
 import { useFrame } from '@react-three/fiber';
-import { Handle, HandleTarget } from '@react-three/handle';
+import { Handle, HandleTarget, HandleState } from '@react-three/handle';
 import { Container, Text, Image } from '@react-three/uikit';
 import { Button } from '@react-three/uikit-default';
 import React, { useRef, useState, useEffect } from 'react';
-import { Color, Group, Mesh, MeshStandardMaterial, Vector3 } from 'three';
+import { Color, Group, Mesh, MeshStandardMaterial, Object3D, Vector3 } from 'three';
 import { damp } from 'three/src/math/MathUtils.js';
 
 // Face-camera rotation constants
@@ -86,6 +86,18 @@ const uiPositionHelper = new Vector3();
 // Handle hover colors (module-level to avoid per-render allocations)
 const HANDLE_COLOR_DEFAULT = new Color('#666666');
 const HANDLE_COLOR_HOVER = new Color('#aaaaaa');
+
+// Workaround for @pmndrs/handle defaultApply behavior: defaultApply copies
+// state.current.quaternion to the target on every drag frame AND on drag release.
+// With rotate={false}, state.current.quaternion is always the drag-start quaternion,
+// so it resets our face-camera rotation on every frame (priority -1 runs before
+// face-camera priority 0) and wipes it entirely on drag release.
+// By providing a custom apply that skips quaternion, face-camera owns rotation fully.
+// Scale is intentionally omitted too: scale={false} keeps it constant, so copying
+// it would be a no-op. If scale is ever enabled on this Handle, add it back here.
+function applyPositionSkipRotation(state: HandleState<unknown>, target: Object3D): void {
+  target.position.copy(state.current.position);
+}
 
 export default function CloudXR3DUI({
   onStartTeleop,
@@ -193,6 +205,7 @@ export default function CloudXR3DUI({
           scale={false}
           multitouch={false}
           rotate={false}
+          apply={applyPositionSkipRotation}
         >
           <mesh
             ref={handleRef}

--- a/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
@@ -43,7 +43,7 @@ import { Handle, HandleTarget } from '@react-three/handle';
 import { Container, Text, Image } from '@react-three/uikit';
 import { Button } from '@react-three/uikit-default';
 import React, { useRef, useState, useEffect } from 'react';
-import { Color, Euler, Group, Mesh, MeshStandardMaterial, Quaternion, Vector3 } from 'three';
+import { Color, Group, Mesh, MeshStandardMaterial, Vector3 } from 'three';
 import { damp } from 'three/src/math/MathUtils.js';
 
 // Face-camera rotation constants
@@ -80,11 +80,8 @@ interface CloudXRUIProps {
 }
 
 // Reusable objects for face-camera rotation (avoid allocations in render loop)
-const eulerHelper = new Euler();
-const quaternionHelper = new Quaternion();
 const cameraPositionHelper = new Vector3();
 const uiPositionHelper = new Vector3();
-const zAxis = new Vector3(0, 0, 1);
 
 // Handle hover colors (module-level to avoid per-render allocations)
 const HANDLE_COLOR_DEFAULT = new Color('#666666');
@@ -161,17 +158,24 @@ export default function CloudXR3DUI({
     }
     state.camera.getWorldPosition(cameraPositionHelper);
     groupRef.current.getWorldPosition(uiPositionHelper);
-    quaternionHelper.setFromUnitVectors(
-      zAxis,
-      cameraPositionHelper.sub(uiPositionHelper).normalize()
-    );
-    eulerHelper.setFromQuaternion(quaternionHelper, 'YXZ');
-    groupRef.current.rotation.y = damp(
-      groupRef.current.rotation.y,
-      eulerHelper.y,
-      FACE_CAMERA_DAMPING,
-      dt
-    );
+
+    // Project onto the horizontal plane (XZ) to get a pure yaw angle.
+    // Using atan2 avoids the 3D-quaternion→Euler extraction that can give wrong
+    // yaw when the camera has significant height offset relative to the panel.
+    const dx = cameraPositionHelper.x - uiPositionHelper.x;
+    const dz = cameraPositionHelper.z - uiPositionHelper.z;
+    let targetY = Math.atan2(dx, dz);
+
+    // Wrap the angular difference to [-π, π] so damp() always takes the
+    // shortest path.  Without this, when the target crosses the ±π boundary
+    // (camera near the side/behind the panel), damp interpolates the long way
+    // around and the panel snaps to face away from the user.
+    const currentY = groupRef.current.rotation.y;
+    let diff = targetY - currentY;
+    diff = diff - Math.round(diff / (2 * Math.PI)) * (2 * Math.PI);
+    targetY = currentY + diff;
+
+    groupRef.current.rotation.y = damp(currentY, targetY, FACE_CAMERA_DAMPING, dt);
   });
 
   return (


### PR DESCRIPTION
Closes #546

## Summary

- **Bug 1 (yaw accuracy):** The old code used `setFromUnitVectors(zAxis, dir3D)` + `setFromQuaternion('YXZ')` to extract horizontal yaw. Because `dir3D` included the camera's height offset, the extracted Euler Y was not the true horizontal yaw. Replaced with `Math.atan2(dx, dz)` on the XZ plane.
- **Bug 2 (±π wrap):** The face-camera `damp()` call had no angle wrapping. When the target yaw crossed the ±π boundary, `damp()` took the ~2π wrong-way path, spinning the panel to face backward. Normalized `diff` to `[-π, π]` before calling `damp()`.
- **Bug 3 (Handle quaternion reset — root cause of 90° snap after drag):** `@pmndrs/handle`'s `defaultApply` copies `state.current.quaternion` to the target on every drag frame (useFrame priority -1, before face-camera at priority 0) and again on drag release. With `rotate={false}`, that quaternion is always the one captured at drag-start, so it continuously reset the face-camera rotation mid-drag and wiped it entirely on release — snapping the panel up to 90° off after every drag. Fixed by passing a custom `apply` function (`applyPositionSkipRotation`) to `Handle` that copies only position, leaving quaternion/rotation entirely under face-camera control.

## Test plan

- [x] Enter XR session and drag the panel to the left or right — panel should rotate to face you as it moves
- [x] Release the handle — panel should stay facing you, not snap back to a wrong angle
- [x] Move/walk around the panel in the emulator — panel should track you continuously
- [x] Walk behind the panel — it should smoothly rotate to re-face you
- [x] Verify normal forward-facing behaviour is unchanged when standing still

🤖 Generated with [Claude Code](https://claude.com/claude-code)