### PR TITLE
ROS: order hand topic poses left-right and include wrist

### DIFF
--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -59,7 +59,7 @@ Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
 ## Published Topics
 
 - `xr_teleop/hand` (`geometry_msgs/PoseArray`)
-  - `poses`: Finger joint poses (all joints except palm/wrist, right then left); published by `hand_teleop` and by `controller_teleop` when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`
+  - `poses`: Hand joint poses (all joints except palm, left then right); published by `hand_teleop` and by `controller_teleop` when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`
 - `xr_teleop/ee_poses` (`geometry_msgs/PoseArray`)
   - `poses[0]`: Left hand/controller EE pose (if active)
   - `poses[1]`: Right hand/controller EE pose (if active)

--- a/examples/teleop_ros2/python/geometry.py
+++ b/examples/teleop_ros2/python/geometry.py
@@ -21,9 +21,7 @@ def append_hand_poses(
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
 ) -> None:
-    for joint_idx in range(
-        HandJointIndex.THUMB_METACARPAL, HandJointIndex.LITTLE_TIP + 1
-    ):
+    for joint_idx in range(HandJointIndex.WRIST, HandJointIndex.LITTLE_TIP + 1):
         if joint_valid[joint_idx]:
             pose = to_pose(joint_positions[joint_idx], joint_orientations[joint_idx])
             if transform_rot is not None or transform_trans is not None:

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -252,7 +252,7 @@ class TopicVerifier(Node):
                     "hand",
                     "xr_teleop/hand",
                     PoseArray,
-                    lambda msg: _assert_pose_array(msg, expected_count=48),
+                    lambda msg: _assert_pose_array(msg, expected_count=50),
                 ),
                 (
                     "ee_poses",

--- a/examples/teleop_ros2/python/messages.py
+++ b/examples/teleop_ros2/python/messages.py
@@ -257,26 +257,10 @@ def build_hand_msg_from_hands(
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
 ) -> PoseArray:
-    """Build a PoseArray with finger joint poses, right hand then left hand."""
+    """Build a PoseArray with finger joint poses, left hand then right hand."""
     msg = PoseArray()
     msg.header.stamp = now
     msg.header.frame_id = frame_id
-
-    if not right_hand.is_none:
-        right_positions = np.asarray(right_hand[HandInputIndex.JOINT_POSITIONS])
-        right_orientations = np.asarray(right_hand[HandInputIndex.JOINT_ORIENTATIONS])
-        right_valid = np.asarray(right_hand[HandInputIndex.JOINT_VALID])
-        append_hand_poses(
-            msg.poses,
-            right_positions,
-            right_orientations,
-            right_valid,
-            transform_rot,
-            transform_trans,
-        )
-    else:
-        for _ in range(HandJointIndex.THUMB_METACARPAL, HandJointIndex.LITTLE_TIP + 1):
-            msg.poses.append(to_pose([0.0, 0.0, 0.0]))
 
     if not left_hand.is_none:
         left_positions = np.asarray(left_hand[HandInputIndex.JOINT_POSITIONS])
@@ -291,7 +275,23 @@ def build_hand_msg_from_hands(
             transform_trans,
         )
     else:
-        for _ in range(HandJointIndex.THUMB_METACARPAL, HandJointIndex.LITTLE_TIP + 1):
+        for _ in range(HandJointIndex.WRIST, HandJointIndex.LITTLE_TIP + 1):
+            msg.poses.append(to_pose([0.0, 0.0, 0.0]))
+
+    if not right_hand.is_none:
+        right_positions = np.asarray(right_hand[HandInputIndex.JOINT_POSITIONS])
+        right_orientations = np.asarray(right_hand[HandInputIndex.JOINT_ORIENTATIONS])
+        right_valid = np.asarray(right_hand[HandInputIndex.JOINT_VALID])
+        append_hand_poses(
+            msg.poses,
+            right_positions,
+            right_orientations,
+            right_valid,
+            transform_rot,
+            transform_trans,
+        )
+    else:
+        for _ in range(HandJointIndex.WRIST, HandJointIndex.LITTLE_TIP + 1):
             msg.poses.append(to_pose([0.0, 0.0, 0.0]))
 
     return msg


### PR DESCRIPTION
Make xr_teleop/hand consistent with the other teleop topics. The hand PoseArray now publishes the left hand block before the right hand block, matching xr_teleop/ee_poses and xr_teleop/finger_joints (previously it was right-then-left).

Each hand block now also includes the wrist joint: append_hand_poses iterates WRIST..LITTLE_TIP instead of THUMB_METACARPAL..LITTLE_TIP, so each hand contributes 25 poses (wrist + all finger joints; palm still excluded) for 50 poses total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected hand joint pose data structure in the ROS2 teleoperations topic.

* **Documentation**
  * Clarified specifications for hand joint pose array content and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->