### PR TITLE
camera_viz: add --mode override and fix setup pipefail bugs

### DIFF
--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -179,9 +179,10 @@ def _build_rtp_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
     return entries
 
 
-def _make_session(cfg: dict) -> viz.VizSession:
+def _make_session(cfg: dict, mode_override: Optional[str] = None) -> viz.VizSession:
     display = cfg.get("display", {})
-    mode_str = display.get("mode", "window").lower()
+    # --mode overrides display.mode when given.
+    mode_str = (mode_override or display.get("mode", "window")).lower()
     session_cfg = viz.VizSessionConfig()
     if mode_str == "window":
         session_cfg.mode = viz.DisplayMode.kWindow
@@ -206,6 +207,12 @@ def _make_session(cfg: dict) -> viz.VizSession:
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Televiz camera_viz — display side")
     parser.add_argument("config", type=Path, help="YAML config file")
+    parser.add_argument(
+        "--mode",
+        choices=("window", "xr"),
+        default=None,
+        help="Override display.mode from the config (default: use the config's value).",
+    )
     args = parser.parse_args(argv)
 
     with open(args.config) as f:
@@ -223,7 +230,8 @@ def main(argv: Optional[list[str]] = None) -> int:
     if source_mode not in ("local", "rtp"):
         raise ValueError(f"camera_viz: source must be local|rtp, got {source_mode!r}")
 
-    session = _make_session(cfg)
+    effective_mode = (args.mode or cfg.get("display", {}).get("mode", "window")).lower()
+    session = _make_session(cfg, mode_override=args.mode)
     is_xr = session.is_xr_mode()
 
     if source_mode == "local":
@@ -248,7 +256,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         strategies.append(entry.placement)
 
     print(
-        f"camera_viz: source={source_mode}, mode={cfg.get('display', {}).get('mode')}, "
+        f"camera_viz: source={source_mode}, mode={effective_mode}, "
         f"xr={is_xr}, {len(sources)} layer(s)",
         flush=True,
     )

--- a/examples/camera_viz/camera_viz.sh
+++ b/examples/camera_viz/camera_viz.sh
@@ -187,13 +187,13 @@ PY
 }
 
 # ──────────────────────────────────────────────────────────────────────
-# run (run the viewer with the YAML as-is)
+# run (the viewer; args after CONFIG forward to camera_viz.py, e.g. --mode xr)
 # ──────────────────────────────────────────────────────────────────────
 
 cmd_run() {
     _require_local_config run "${1:-}"
     log_step "Starting camera_viz — Ctrl-C to exit"
-    "$LOCAL_VENV/bin/python" "$HERE/camera_viz.py" "$1"
+    "$LOCAL_VENV/bin/python" "$HERE/camera_viz.py" "$@"
 }
 
 # ──────────────────────────────────────────────────────────────────────

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -122,7 +122,8 @@ check_system_deps() {
     # cuda-nvrtc on Jetson — JetPack ships partial CUDA without it.
     # Desktop CUDA installer drops libnvrtc into /usr/local/cuda; if it's
     # missing there, the user needs to fix their CUDA install.
-    if $JETSON && ! find /usr -name 'libnvrtc.so*' 2>/dev/null | grep -q .; then
+    # capture, not `find | grep -q`: find's non-zero on an unreadable /usr dir trips pipefail.
+    if $JETSON && [[ -z "$(find /usr -name 'libnvrtc.so*' -print -quit 2>/dev/null)" ]]; then
         pkgs+=("cuda-nvrtc-${cuda_major}-${cuda_minor}")
     fi
 
@@ -330,7 +331,8 @@ $WITH_RTP  && PKGS+=("pybind11>=2.11" "PyGObject>=3.42,<3.52")
 EXTRA_UV=()
 if [[ "$MODE" == full && -f "$WHEEL" ]]; then
     wheel_mtime=$(stat -c %Y "$WHEEL" 2>/dev/null || echo 0)
-    installed_dist=$(ls -d "$VENV_DIR"/lib/python*/site-packages/isaacteleop-*.dist-info 2>/dev/null | head -1)
+    # Empty on a fresh venv; `|| true` keeps the no-match from aborting under pipefail+set -e.
+    installed_dist=$(ls -d "$VENV_DIR"/lib/python*/site-packages/isaacteleop-*.dist-info 2>/dev/null | head -1 || true)
     if [[ -n "$installed_dist" ]]; then
         installed_mtime=$(stat -c %Y "$installed_dist" 2>/dev/null || echo 0)
         if (( wheel_mtime > installed_mtime )); then


### PR DESCRIPTION
Add a --mode {window,xr} flag to camera_viz.py that overrides display.mode from the YAML, and forward extra args through camera_viz.sh run, so one config drives both a local window and a headless XR (CloudXR) run without editing the file.

Fix two `set -o pipefail` bugs in _install_deps.sh that blocked setup:
- the Jetson cuda-nvrtc probe used `find /usr ... | grep -q`, whose pipeline fails when find hits an unreadable /usr subdir, falsely flagging cuda-nvrtc as missing even when libnvrtc is present;
- the isaacteleop dist-info probe `ls ... | head -1` aborted the first full install on a fresh venv (glob matches nothing) before it ran.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add CLI option to set display mode (window or XR) that overrides config; startup now reports the effective mode.

* **Bug Fixes**
  * Ensure additional CLI flags are forwarded to the visualization command.
  * Improve Jetson dependency detection and installation checks to avoid failures on systems with unreadable directories or missing package metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->