### PR TITLE
fix(build): inline async chunks into bundle.js for production

### DIFF
--- a/deps/cloudxr/webxr_client/webpack.prod.js
+++ b/deps/cloudxr/webxr_client/webpack.prod.js
@@ -20,4 +20,7 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'production',
+  // Inline async chunks (from @pmndrs/xr emulate.js and @pmndrs/uikit msdf-generator)
+  // into bundle.js so the build produces a single JS file alongside index.html.
+  output: { asyncChunks: false },
 });


### PR DESCRIPTION
## Summary

- `@pmndrs/xr` and `@pmndrs/uikit` use `import()` internally, causing webpack to emit numbered chunk files (e.g. `372.bundle.js`) alongside `bundle.js`
- Out-of-the-box deployments that only copy `bundle.js` + `index.html` were missing these chunks, breaking the app at runtime
- Setting `output.asyncChunks: false` in the production webpack config (`deps/cloudxr/webxr_client/webpack.prod.js`) inlines those chunks so the build produces only `bundle.js` + `index.html`

## Test plan

- [x] `npm run build` in `deps/cloudxr/webxr_client` — verify only `bundle.js` (no numbered chunks) in `build/`
- [x] Load the client in browser and verify no chunk-loading errors in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production build configuration to consolidate JavaScript assets into a single bundled file. All asynchronous chunks are now inlined into the main bundle, resulting in a simplified deployment structure with one JavaScript file alongside the HTML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->