### PR TITLE
fix(build): inline async chunks into bundle.js for production (cherry-pick to release/1.1.x)

### DIFF
--- a/deps/cloudxr/webxr_client/webpack.prod.js
+++ b/deps/cloudxr/webxr_client/webpack.prod.js
@@ -20,4 +20,7 @@ const common = require('./webpack.common.js');
 
 module.exports = merge(common, {
   mode: 'production',
+  // Inline async chunks (from @pmndrs/xr emulate.js and @pmndrs/uikit msdf-generator)
+  // into bundle.js so the build produces a single JS file alongside index.html.
+  output: { asyncChunks: false },
 });


### PR DESCRIPTION
Cherry-pick of 4c242a71b9fb50f8656e5d5eb018d9686bfaca29 from main.

## Summary
- Fixes webpack emitting numbered chunk files (`372.bundle.js`, etc.) alongside `bundle.js` in production
- Sets `output.asyncChunks=false` so `@pmndrs/xr` and `@pmndrs/uikit` dynamic imports are inlined into a single `bundle.js`
- Production build now produces only `bundle.js` + `index.html`

## Original PR
#633