### PR TITLE
Add Haptikos documentation

### DIFF
--- a/docs/source/device/haptikos.rst
+++ b/docs/source/device/haptikos.rst
@@ -1,0 +1,116 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Haptikos Exoskeletons
+=====================
+
+Use the `Haptikos <https://haptikos.tech/>`_ Exoskeletons with the Isaac Teleop framework. Currently only Linux is supported. Tested on Meta Quest headsets. Other headsets with controllers may work as well.
+
+.. contents:: On this page
+   :local:
+   :depth: 2
+
+Components
+----------
+
+- **Core library** (``haptikos_core``) — wraps the Haptikos Core App(``libHaptikosCore.so``) and provides access to per-joint tracking data and haptics.
+- **Plugin executable** (``haptikos_plugin``) — the primary plugin binary that enables integration with the Teleop system via CloudXR and OpenXR.
+
+Prerequisites
+-------------
+- **Linux** — x86_64 (tested on Ubuntu 22.04 / 24.04).
+- **Haptikos API** for Linux.
+
+
+Quick Start
+-----------
+
+Step 1: Get the Haptikos API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Haptikos API must be downloaded separately due to licensing. Check our `website <https://haptikos.tech/>`_.
+
+1. Obtain a Haptikos account.
+2. Clone the `repository <https://github.com/Haptikostech/HaptikosAPI>`_.
+3. Copy the ``HaptikosCpp_API_Shared`` folder from our HaptikosAPI repository into the ``src/plugins/haptikos`` folder. The folder structure should be the following:
+
+.. code-block:: text
+
+   src/plugins/haptikos/
+   ├── CMakeLists.txt
+   ├── HaptikosCpp_API_Shared
+   │   ├── include
+   │   └── lib
+   ├── haptikos_hands_plugin.cpp
+   ├── haptikos_hands_plugin.hpp
+   ├── main.cpp
+   ├── plugin.yaml
+   └── README.md
+
+Step 2: Build the plugin
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: bash
+
+   cd ../../..  # Navigate to TeleopCore root
+   cmake -S . -B build
+   cd build
+   make haptikos_hands_plugin
+
+Step 3: Build the entire project
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: bash
+
+   cmake -B build -DENABLE_CLANG_FORMAT_CHECK=OFF #From Project root
+   cmake --build build --parallel 4
+   cmake --install build
+
+We use the ``-DENABLE_CLANG_FORMAT_CHECK=OFF`` because the headers in the HaptikosAPI library are not clang-formatted. You can clang format the headers to not include the flag by running:
+
+.. code-block:: bash
+
+   clang-format -i src/plugins/haptikos/HaptikosCpp_API_Shared/include/*
+
+Step 4: Run the plugin
+~~~~~~~~~~~~~~~~~~~~~~
+
+The Haptikos plugin connects to the Teleop session through the CloudXR / OpenXR runtime, so the runtime must be running and its environment sourced in the shell that launches the plugin.
+
+In one terminal, start the CloudXR runtime (keep it running for the duration of the session):
+
+.. code-block:: bash
+
+   source isaac_teleop_env/bin/activate
+   python -m isaacteleop.cloudxr
+
+In a second terminal, source the environment file that the runtime writes on startup. This points the OpenXR loader at CloudXR:
+
+.. code-block:: bash
+
+   cd IsaacTeleop/
+   source ~/.cloudxr/run/cloudxr.env
+
+In the same terminal, run the plugin with the following:
+
+.. code-block:: bash
+
+   ./install/plugins/haptikos/haptikos_hands_plugin
+
+Important Information
+---------------------
+
+1. To use the plugin properly it is necessary to attach the controllers on our exoskeletons using the included mount.
+
+2. The orientation calibration defines the direction the Haptikos gloves define as forward. This needs to be aligned with the Head Mounted Display's forward direction.
+
+3. To inject the hand tracking data and haptic feedback, the controllers, the Haptikos App and the exoskeletons need to be active.
+
+4. The executable will be located in the ``build/src/plugins/haptikos``. If you installed the project by running ``cmake --install build`` the executable will also be found in the ``install/plugins/haptikos`` folder.
+
+
+License
+-------
+
+Source files are covered by their stated licenses (Apache-2.0). The Haptikos API is
+proprietary to Haptikos and is subject to its own license; it is **not** redistributed
+by this project.

--- a/docs/source/device/index.rst
+++ b/docs/source/device/index.rst
@@ -7,7 +7,7 @@ Isaac Teleop device plugin (C++ level)
 --------------------------------------
 
 For new hardware that requires a custom driver or SDK. Plugins push data via OpenXR tensor
-collections. Existing plugins include Manus gloves, OAK-D camera, controller synthetic hands,
+collections. Existing plugins include Manus gloves, OAK-D camera, Haptikos exoskeletons, controller synthetic hands,
 and foot pedals. After creating the plugin, update the retargeting pipeline config to consume
 data from the new plugin's source node.
 
@@ -23,3 +23,4 @@ See the `Plugins directory <https://github.com/NVIDIA/IsaacTeleop/tree/main/src/
    haptic_feedback
    manus
    oak
+   haptikos

--- a/docs/source/overview/ecosystem.rst
+++ b/docs/source/overview/ecosystem.rst
@@ -88,6 +88,9 @@ session is running via USB or Bluetooth. See :ref:`device-interface-device-plugi
    * - `OAK-D Camera`_
      - Offline data recording
      - `OAK-D Camera Plugin`_ (CLI tool)
+   * - `Haptikos Exoskeletons`_
+     -  High-fidelity finger tracking and haptic feedback (Haptikos Robotics API)
+     - `Haptikos Plugin`_ (CLI tool) 
 
 Planned Input Device Support
 -----------------------------
@@ -173,12 +176,15 @@ directly. Each device name in the tables above links to the corresponding manufa
    * - `Luxonis`_
      - OAK-D Camera
      -
+   * - `Haptikos`_
+     - Haptikos Exoskeletons
+     -      
    * - `Haply`_
      - Haply (planned)
      -
    * - `3Dconnexion`_
      - 3D Space Mouse (planned)
-     -
+     - 
 
 ..
    References
@@ -190,6 +196,7 @@ directly. Each device name in the tables above links to the corresponding manufa
 .. _Manus: https://www.manus-meta.com/
 .. _Logitech: https://www.logitechg.com/
 .. _Luxonis: https://www.luxonis.com/
+.. _Haptikos: https://haptikos.tech/
 .. _Haply: https://www.haply.co/
 .. _`3Dconnexion`: https://3dconnexion.com/
 
@@ -202,6 +209,7 @@ directly. Each device name in the tables above links to the corresponding manufa
 .. _`Logitech Rudder Pedals`: https://www.logitechg.com/en-us/products/flight/flight-simulator-rudder-pedals.html
 .. _`OAK-D Camera`: https://shop.luxonis.com/products/oak-d
 .. _`3D Space Mouse`: https://3dconnexion.com/us/spacemouse/
+.. _`Haptikos Exoskeletons`: https://haptikos.tech/product/haptikos/ 
 
 .. Other references
 .. _`Isaac XR Teleop Sample Client`: https://github.com/isaac-sim/isaac-xr-teleop-sample-client-apple
@@ -209,3 +217,4 @@ directly. Each device name in the tables above links to the corresponding manufa
 .. _`Manus Gloves Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/manus
 .. _`Generic 3-axis Pedal Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/generic_3axis_pedal
 .. _`OAK-D Camera Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/oak
+.. _`Haptikos Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/haptikos

--- a/docs/source/overview/ecosystem.rst
+++ b/docs/source/overview/ecosystem.rst
@@ -90,7 +90,7 @@ session is running via USB or Bluetooth. See :ref:`device-interface-device-plugi
      - `OAK-D Camera Plugin`_ (CLI tool)
    * - `Haptikos Exoskeletons`_
      -  High-fidelity finger tracking and haptic feedback (Haptikos Robotics API)
-     - `Haptikos Plugin`_ (CLI tool) 
+     - `Haptikos Plugin`_ (CLI tool)
 
 Planned Input Device Support
 -----------------------------
@@ -178,13 +178,13 @@ directly. Each device name in the tables above links to the corresponding manufa
      -
    * - `Haptikos`_
      - Haptikos Exoskeletons
-     -      
+     -
    * - `Haply`_
      - Haply (planned)
      -
    * - `3Dconnexion`_
      - 3D Space Mouse (planned)
-     - 
+     -
 
 ..
    References
@@ -209,7 +209,7 @@ directly. Each device name in the tables above links to the corresponding manufa
 .. _`Logitech Rudder Pedals`: https://www.logitechg.com/en-us/products/flight/flight-simulator-rudder-pedals.html
 .. _`OAK-D Camera`: https://shop.luxonis.com/products/oak-d
 .. _`3D Space Mouse`: https://3dconnexion.com/us/spacemouse/
-.. _`Haptikos Exoskeletons`: https://haptikos.tech/product/haptikos/ 
+.. _`Haptikos Exoskeletons`: https://haptikos.tech/product/haptikos/
 
 .. Other references
 .. _`Isaac XR Teleop Sample Client`: https://github.com/isaac-sim/isaac-xr-teleop-sample-client-apple

--- a/docs/source/references/build.rst
+++ b/docs/source/references/build.rst
@@ -39,7 +39,8 @@ The layout below reflects the actual ``CMakeLists.txt`` hierarchy (root ``CMakeL
    │   ├── controller_synthetic_hands/
    │   ├── generic_3axis_pedal/
    │   ├── manus/
-   │   └── oak/                    # When BUILD_PLUGIN_OAK_CAMERA=ON
+   │   ├── oak/                    # When BUILD_PLUGIN_OAK_CAMERA=ON
+   |   └── haptikos/
    └── examples/
        ├── oxr/                    # OpenXR examples (C++ and Python)
        ├── retargeting/

--- a/docs/source/references/requirements.rst
+++ b/docs/source/references/requirements.rst
@@ -12,7 +12,7 @@ Teleoperation to Robots with Input Devices
     :alt: Hardware requirements for teleoperation with extra input devices
     :class: no-image-zoom
 
-When using extra input devices (such as Manus Gloves, Logitech Rudder Pedals, OAK-D Camera, etc.),
+When using extra input devices (such as Manus Gloves, Logitech Rudder Pedals, OAK-D Camera, Haptikos Exoskeletons etc.),
 Isaac Teleop needs to be **run on a laptop or workstation**, that is connected to the robot via
 network.  The minimum requirements for the laptop/workstation are:
 


### PR DESCRIPTION
Haptikos Documentation added to the current documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive Haptikos Exoskeletons integration guide for Isaac Teleop framework with prerequisites, setup instructions, quick-start steps, and operational notes.
  * Expanded ecosystem documentation to include Haptikos as a supported input device with vendor information and product links.
  * Updated device and project structure references to reflect Haptikos plugin availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->