### PR TITLE
docs(quick-start): note to update headset firmware before connecting

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -198,6 +198,12 @@ running the CloudXR runtime and wss proxy in containerized environment; or using
    convenience, we host a prebuilt CloudXR web client at `nvidia.github.io/IsaacTeleop/client`_.
    You can just open this URL in your headset's browser. No need to build or install a separate client.
 
+   .. important::
+
+      Make sure your headset is updated to the latest firmware (system software) version before
+      connecting. Older firmware may ship an outdated browser/WebXR runtime that fails to connect or
+      streams with reduced functionality.
+
    .. tip::
 
       For quick validation, you can also open the `nvidia.github.io/IsaacTeleop/client`_ URL in a


### PR DESCRIPTION
Add an admonition in the "Connect an XR headset" step reminding users to update their headset to the latest firmware, since outdated firmware can ship an old browser/WebXR runtime that fails to connect or degrades streaming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated quick start guide with an important notice for Meta Quest and Pico headset users to ensure their device firmware and system software are updated to the latest version before connecting, as older versions may cause connection failures or reduced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->