### PR TITLE
fix: hunter doesn't work with MSVC 2026

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,8 +20,8 @@ concurrency:
 
 jobs:
   build-windows:
-    # Pin to windows-2025 (VS 2022) until VS 2026 is validated.
-    runs-on: windows-2025
+     # Pin to the VS 2022 image until newer MSVC toolchains are validated.
+    runs-on: windows-2022
 
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -57,12 +57,6 @@ jobs:
         sccache --version
 
     # Put cl.exe and other build tools in PATH.
-    # Pin to VS 2022: windows-2025 also ships the VS 2026 toolset, which
-    # msvc-dev-cmd would otherwise auto-select. Although Hunter v0.26.9 now
-    # *recognizes* VS 2026 (MSVC_VERSION 195x), depthai pins 2020-era deps
-    # (e.g. spdlog 1.8.2 + fmt 7) that do not *compile* with the VS 2026
-    # toolchain. VS 2022 is the newest compiler depthai's pinned deps build
-    # with. Drop this pin once depthai updates its Hunter config dep versions.
     - name: Setup MSVC (Developer Command Prompt)
       uses: ilammy/msvc-dev-cmd@v1
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -56,9 +56,17 @@ jobs:
       run: |
         sccache --version
 
-    # Put cl.exe and other build tools in PATH
+    # Put cl.exe and other build tools in PATH.
+    # Pin to VS 2022: windows-2025 also ships the VS 2026 toolset, which
+    # msvc-dev-cmd would otherwise auto-select. Although Hunter v0.26.9 now
+    # *recognizes* VS 2026 (MSVC_VERSION 195x), depthai pins 2020-era deps
+    # (e.g. spdlog 1.8.2 + fmt 7) that do not *compile* with the VS 2026
+    # toolchain. VS 2022 is the newest compiler depthai's pinned deps build
+    # with. Drop this pin once depthai updates its Hunter config dep versions.
     - name: Setup MSVC (Developer Command Prompt)
       uses: ilammy/msvc-dev-cmd@v1
+      with:
+        vsversion: "2022"
 
     # Install LunarG Vulkan SDK (headers + loader lib). Sets VULKAN_SDK
     # env var so CMake's FindVulkan locates the install. The Vulkan

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,8 +20,8 @@ concurrency:
 
 jobs:
   build-windows:
-    # Pin to windows-2025 (VS 2022) until VS 2026 is validated.
-    runs-on: windows-2025
+    # Pin to windows-2022 until VS 2026 is validated.
+    runs-on: windows-2022
 
     env:
       SCCACHE_GHA_ENABLED: "true"
@@ -65,8 +65,6 @@ jobs:
     # with. Drop this pin once depthai updates its Hunter config dep versions.
     - name: Setup MSVC (Developer Command Prompt)
       uses: ilammy/msvc-dev-cmd@v1
-      with:
-        vsversion: "2022"
 
     # Install LunarG Vulkan SDK (headers + loader lib). Sets VULKAN_SDK
     # env var so CMake's FindVulkan locates the install. The Vulkan

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,8 +20,8 @@ concurrency:
 
 jobs:
   build-windows:
-    # Pin to windows-2022 until VS 2026 is validated.
-    runs-on: windows-2022
+    # Pin to windows-2025 (VS 2022) until VS 2026 is validated.
+    runs-on: windows-2025
 
     env:
       SCCACHE_GHA_ENABLED: "true"

--- a/cmake/SetupHunter.cmake
+++ b/cmake/SetupHunter.cmake
@@ -105,8 +105,8 @@ if(BUILD_PLUGINS AND BUILD_PLUGIN_OAK_CAMERA)
     set(ENV{CMAKE_POLICY_VERSION_MINIMUM} "3.5")
 
     HunterGate(
-        URL "https://github.com/cpp-pm/hunter/archive/9d9242b60d5236269f894efd3ddd60a9ca83dd7f.tar.gz"
-        SHA1 "16cc954aa723bccd16ea45fc91a858d0c5246376"
+        URL "https://github.com/cpp-pm/hunter/archive/v0.26.9.tar.gz"
+        SHA1 "a962c9f0cfd6f8fc62ea25943d89debfa61d4d4a"
         LOCAL  # Uses cmake/Hunter/config.cmake
     )
 endif()

--- a/cmake/SetupHunter.cmake
+++ b/cmake/SetupHunter.cmake
@@ -105,8 +105,8 @@ if(BUILD_PLUGINS AND BUILD_PLUGIN_OAK_CAMERA)
     set(ENV{CMAKE_POLICY_VERSION_MINIMUM} "3.5")
 
     HunterGate(
-        URL "https://github.com/cpp-pm/hunter/archive/v0.26.9.tar.gz"
-        SHA1 "a962c9f0cfd6f8fc62ea25943d89debfa61d4d4a"
+        URL "https://github.com/cpp-pm/hunter/archive/9d9242b60d5236269f894efd3ddd60a9ca83dd7f.tar.gz"
+        SHA1 "16cc954aa723bccd16ea45fc91a858d0c5246376"
         LOCAL  # Uses cmake/Hunter/config.cmake
     )
 endif()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system dependencies to improve compatibility with newer Visual Studio toolsets on Windows CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->