### PR TITLE
Remove oak build from windows ci.

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -96,7 +96,6 @@ jobs:
         -DCMAKE_C_COMPILER="cl.exe"
         -DCMAKE_CXX_COMPILER="cl.exe"
         -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded
-        -DBUILD_PLUGIN_OAK_CAMERA=ON
         -DBUILD_VIZ=ON
 
     - name: Build


### PR DESCRIPTION
There is a upgrade on windows msvc that breaks hunter build system. Temporarily remove oak build from windows ci until we have a way to re-enable it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build workflow configuration to improve compiler settings and debug information handling during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->