### PR TITLE
ROS: add oob teleop control hub and usb local parameters

### DIFF
--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -122,7 +122,7 @@ docker run --rm --gpus all --net=host --ipc=host \
   -r xr_teleop/hand:=my_robot/hand -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 
@@ -140,6 +140,32 @@ The `mode` parameter selects the teleoperation scenario and which topics are pub
 | `full_body` | `full_body` and `controller_data` |
 
 Example: `--ros-args -p mode:=controller_raw`
+
+### OOB Teleop Control
+
+For live sessions, the node can enable the out-of-band (OOB) teleop control hub
+that the in-process `CloudXRLauncher` provides. The hub shares the CloudXR proxy
+TLS port (default 48322) and lets you read streaming metrics, inspect connected
+headsets, and push config from outside the headset:
+
+```bash
+docker run --rm --gpus all --net=host --ipc=host \
+  -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all \
+  -e ROS_LOCALHOST_ONLY=1 \
+  -v $HOME/.cloudxr:/root/.cloudxr \
+  --name teleop_ros2_ref \
+  teleop_ros2_ref --ros-args -p cloudxr_accept_eula:=true \
+  -p cloudxr_setup_oob:=true
+```
+
+`cloudxr_usb_local:=true` additionally routes teleop signalling, the web client,
+and WebRTC media over the USB cable via `adb reverse`. It requires
+`cloudxr_setup_oob:=true` (the node raises a parameter error otherwise) and the
+`adb` and `coturn` host tools. Both parameters are ignored in MCAP replay mode,
+since no CloudXR runtime is launched.
+
+See the [Out-of-Band Teleop Control](../../docs/source/references/oob_teleop_control.rst)
+reference for the hub HTTP/WebSocket API, ADB automation, and USB-local details.
 
 ### MCAP Replay
 

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -39,6 +39,21 @@ from constants import (
 
 
 @dataclass(frozen=True)
+class CloudXRParams:
+    """CloudXR launcher settings, mirroring ``CloudXRLauncher.__init__`` kwargs.
+
+    Field names match the launcher constructor so the resolved snapshot maps
+    cleanly onto explicit keyword arguments at the call site.
+    """
+
+    install_dir: str
+    env_config: str | None
+    accept_eula: bool
+    setup_oob: bool
+    usb_local: bool
+
+
+@dataclass(frozen=True)
 class NodeParameters:
     """Resolved snapshot of every ROS parameter consumed by TeleopRos2Node."""
 
@@ -50,9 +65,7 @@ class NodeParameters:
     config_asset_root: Path
     session_mode: SessionMode
     mcap_config: McapReplayConfig | None
-    cloudxr_install_dir: str
-    cloudxr_env_config: str | None
-    cloudxr_accept_eula: bool
+    cloudxr: CloudXRParams
     pedal_collection_id: str
     world_frame: str
     right_wrist_frame: str
@@ -64,7 +77,7 @@ class NodeParameters:
     right_finger_joint_name_aliases: list[str] | None
 
 
-def _load_cloudxr(node: Node) -> tuple[str, str | None, bool]:
+def _load_cloudxr(node: Node) -> CloudXRParams:
     node.declare_parameter(
         "cloudxr_install_dir",
         "~/.cloudxr",
@@ -100,6 +113,31 @@ def _load_cloudxr(node: Node) -> tuple[str, str | None, bool]:
             ),
         ),
     )
+    node.declare_parameter(
+        "cloudxr_setup_oob",
+        False,
+        ParameterDescriptor(
+            type=ParameterType.PARAMETER_BOOL,
+            description=(
+                "Enable the OOB (out-of-band) teleop control hub and USB adb "
+                "automation in the WSS proxy. The hub shares the proxy TLS "
+                "port. Only takes effect for live sessions, not MCAP replay."
+            ),
+        ),
+    )
+    node.declare_parameter(
+        "cloudxr_usb_local",
+        False,
+        ParameterDescriptor(
+            type=ParameterType.PARAMETER_BOOL,
+            description=(
+                "Route teleop traffic over the USB headset loopback via "
+                "'adb reverse' (also starts coturn and serves the WebXR "
+                "static files). Requires cloudxr_setup_oob. Only takes effect "
+                "for live sessions, not MCAP replay."
+            ),
+        ),
+    )
 
     install_dir = (
         node.get_parameter("cloudxr_install_dir")
@@ -124,7 +162,15 @@ def _load_cloudxr(node: Node) -> tuple[str, str | None, bool]:
     accept_eula = (
         node.get_parameter("cloudxr_accept_eula").get_parameter_value().bool_value
     )
-    return install_dir, env_config, accept_eula
+    setup_oob = node.get_parameter("cloudxr_setup_oob").get_parameter_value().bool_value
+    usb_local = node.get_parameter("cloudxr_usb_local").get_parameter_value().bool_value
+    # CloudXRLauncher allows usb_local only alongside setup_oob; reject the
+    # invalid combination here so it surfaces as a clear parameter error.
+    if usb_local and not setup_oob:
+        raise ValueError(
+            "Parameter 'cloudxr_usb_local' requires 'cloudxr_setup_oob' to be true"
+        )
+    return CloudXRParams(install_dir, env_config, accept_eula, setup_oob, usb_local)
 
 
 def _load_config_asset_root(node: Node) -> Path:
@@ -421,7 +467,7 @@ def create_node_parameters(node: Node) -> NodeParameters:
     ) = _load_hand_retargeter(node, mode)
     config_asset_root = _load_config_asset_root(node)
     session_mode, mcap_config = _load_mcap_replay(node)
-    cloudxr_install_dir, cloudxr_env_config, cloudxr_accept_eula = _load_cloudxr(node)
+    cloudxr = _load_cloudxr(node)
     pedal_collection_id = _load_pedal_collection_id(node)
     world_frame, right_wrist_frame, left_wrist_frame, head_frame = _load_frames(node)
     transform_translation = _load_transform_translation(node)
@@ -438,9 +484,7 @@ def create_node_parameters(node: Node) -> NodeParameters:
         config_asset_root=config_asset_root,
         session_mode=session_mode,
         mcap_config=mcap_config,
-        cloudxr_install_dir=cloudxr_install_dir,
-        cloudxr_env_config=cloudxr_env_config,
-        cloudxr_accept_eula=cloudxr_accept_eula,
+        cloudxr=cloudxr,
         pedal_collection_id=pedal_collection_id,
         world_frame=world_frame,
         right_wrist_frame=right_wrist_frame,

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -65,7 +65,7 @@ class NodeParameters:
     config_asset_root: Path
     session_mode: SessionMode
     mcap_config: McapReplayConfig | None
-    cloudxr: CloudXRParams
+    cloudxr_params: CloudXRParams
     pedal_collection_id: str
     world_frame: str
     right_wrist_frame: str
@@ -484,7 +484,7 @@ def create_node_parameters(node: Node) -> NodeParameters:
         config_asset_root=config_asset_root,
         session_mode=session_mode,
         mcap_config=mcap_config,
-        cloudxr=cloudxr,
+        cloudxr_params=cloudxr,
         pedal_collection_id=pedal_collection_id,
         world_frame=world_frame,
         right_wrist_frame=right_wrist_frame,

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -385,9 +385,11 @@ class TeleopRos2Node(Node):
             return self._run_session_loop()
 
         with CloudXRLauncher(
-            install_dir=self._params.cloudxr_install_dir,
-            env_config=self._params.cloudxr_env_config,
-            accept_eula=self._params.cloudxr_accept_eula,
+            install_dir=self._params.cloudxr.install_dir,
+            env_config=self._params.cloudxr.env_config,
+            accept_eula=self._params.cloudxr.accept_eula,
+            setup_oob=self._params.cloudxr.setup_oob,
+            usb_local=self._params.cloudxr.usb_local,
         ) as launcher:
             self.get_logger().info(
                 "CloudXR runtime and WSS proxy started "

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -385,11 +385,11 @@ class TeleopRos2Node(Node):
             return self._run_session_loop()
 
         with CloudXRLauncher(
-            install_dir=self._params.cloudxr.install_dir,
-            env_config=self._params.cloudxr.env_config,
-            accept_eula=self._params.cloudxr.accept_eula,
-            setup_oob=self._params.cloudxr.setup_oob,
-            usb_local=self._params.cloudxr.usb_local,
+            install_dir=self._params.cloudxr_params.install_dir,
+            env_config=self._params.cloudxr_params.env_config,
+            accept_eula=self._params.cloudxr_params.accept_eula,
+            setup_oob=self._params.cloudxr_params.setup_oob,
+            usb_local=self._params.cloudxr_params.usb_local,
         ) as launcher:
             self.get_logger().info(
                 "CloudXR runtime and WSS proxy started "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added out-of-band (OOB) teleop control support for live sessions with new configuration parameters `cloudxr_setup_oob` and `cloudxr_usb_local`.

* **Documentation**
  * Expanded parameter documentation with OOB teleop control setup instructions, Docker configuration examples, and MCAP replay guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->