### PR TITLE
Document Python environment activation in quick start

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -28,7 +28,8 @@ to clone the repository for a couple quick samples to run.
 2. Install the ``isaacteleop`` pip package
 ------------------------------------------
 
-In a new terminal, install the package from PyPI (or from a local wheel if you built from source):
+In a new terminal, activate your preferred virtual or conda environment, then install the package
+from PyPI (or from a local wheel if you built from source):
 
 .. code-block:: bash
 


### PR DESCRIPTION
Fixes #453.

The quick start now reminds users to activate their preferred virtual or conda environment before running the pip install command, without prescribing a specific environment manager.

Validation:
- SKIP=check-copyright-year pre-commit run --all-files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to clarify the need to activate a virtual or conda environment before installing the isaacteleop package from PyPI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->