### PR TITLE
ci: Only run sheets sync workflow on main repository

### DIFF
--- a/.github/workflows/sync-github-project-to-sheets.yml
+++ b/.github/workflows/sync-github-project-to-sheets.yml
@@ -21,6 +21,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    if: github.repository == 'NVIDIA/IsaacTeleop' # don't run on forks
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
Guard the sync job with github.repository == 'NVIDIA/IsaacTeleop' so the scheduled/issue/manual triggers do not run on forks. As I have been getting a lot of emails from GitHub about the job not working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow configuration to optimize repository-specific processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->