### PR TITLE
docs: add pull request template with explicit linter-fix checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## Description
+
+<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->
+
+Fixes #(issue)
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+- [ ] Documentation update
+
+## Testing
+
+<!-- Describe how you tested your changes, including commands and platforms. -->
+
+## Checklist
+
+- [ ] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
+- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix/feature works (or explained why not)
+- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


### PR DESCRIPTION
Add a PULL_REQUEST_TEMPLATE.md so the PR description box is pre-populated with a submission checklist. The checklist explicitly calls out running the linter and formatter via pre-commit, alongside the contribution guidelines, documentation, testing, and DCO sign-off items.

Closes #666

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added standardized pull request template to improve internal development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->