### PR TITLE
feat(camera_viz): add Intel RealSense 435i V4L2 config

### DIFF
--- a/examples/camera_viz/configs/v4l2-realsense.yaml
+++ b/examples/camera_viz/configs/v4l2-realsense.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# V4L2 source configured for the Intel RealSense Depth Camera 435i.
+# Same YAML drives both camera_viz (receiver) and camera_streamer (RTP sender).
+# Flip top-level ``source: local|rtp`` to control what camera_viz opens;
+# camera_streamer always reads cameras + rtp ports + streaming.host.
+#
+# RealSense 435i V4L2 node layout:
+#   /dev/video0, /dev/video2  — depth (capture)
+#   /dev/video1, /dev/video3  — depth metadata (no capture)
+#   /dev/video4               — RGB color (capture)  ← used here
+#   /dev/video5               — RGB metadata (no capture)
+#
+# To inspect available resolutions and formats on the color node:
+#   sudo apt install v4l-utils
+#   v4l2-ctl --device=/dev/video4 --list-formats-ext
+
+source: local                   # local | rtp
+streaming:
+  host: 127.0.0.1               # camera_streamer target (override with --host)
+encoder: auto                   # auto | native | gstreamer
+                                # auto picks native NVENC on desktop, GStreamer on Jetson
+
+cameras:
+  - name: cam
+    enabled: true
+    type: v4l2
+    device: /dev/video4         # RealSense 435i RGB color node
+    width: 1920
+    height: 1080
+    fps: 30
+    # fourcc: MJPG              # only if the device offers MJPG (RealSense V4L2 is YUYV-only)
+    rtp:                        # used by camera_streamer + source: rtp receivers
+      port: 5000
+      bitrate_mbps: 15          # camera_streamer default; lower for tight uplinks
+      # gop:                    # default: fps*5 (IDR every 5 s, ULL tuning)
+
+display:
+  mode: window                  # window | xr
+  window:
+    width: 1920
+    height: 1080
+  xr:
+    near_z: 0.05
+    far_z: 100.0
+  clear_color: [0.0, 0.0, 0.0, 0.0]
+  placements:
+    cam:                        # size defaults to 1.0 m wide × aspect-derived height
+      lock_mode: lazy
+      distance: 1.5


### PR DESCRIPTION
## Summary
Adds `examples/camera_viz/configs/v4l2-realsense.yaml`, an example V4L2 config for the **Intel RealSense Depth Camera 435i**.

- Drives both `camera_viz` (receiver) and `camera_streamer` (RTP sender) from a single YAML.
- Uses the RealSense RGB color node (`/dev/video4`) at 1920×1080@30.
- Documents the RealSense 435i V4L2 node layout and how to inspect available formats with `v4l2-ctl`.
- Toggle `source: local|rtp` to control what `camera_viz` opens.

## Test plan
- [ ] Validate config loads in `camera_viz` against a connected RealSense 435i.
- [ ] Validate `camera_streamer` RTP path with `source: rtp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Intel RealSense 435i camera configuration example with V4L2 support, enabling dual streaming modes (local and RTP), 1920x1080@30fps resolution, configurable bitrate (15 Mbps), and visualization settings for camera placement and lock modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->