### PR TITLE
webxr client: add clear button to Server IP field

### DIFF
--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -82,6 +82,8 @@ export class CloudXR2DUI {
   private startButton!: HTMLButtonElement;
   /** Input field for the CloudXR server IP address */
   private serverIpInput!: HTMLInputElement;
+  /** Button to clear the prefilled server IP (re-enables the browser autocomplete dropdown) */
+  private serverIpClearButton!: HTMLButtonElement;
   /** Input field for the CloudXR server port number */
   private portInput!: HTMLInputElement;
   /** Input field for proxy URL configuration */
@@ -359,6 +361,7 @@ export class CloudXR2DUI {
   private initializeElements(): void {
     this.startButton = this.getElement<HTMLButtonElement>('startButton');
     this.serverIpInput = this.getElement<HTMLInputElement>('serverIpInput');
+    this.serverIpClearButton = this.getElement<HTMLButtonElement>('serverIpClearButton');
     this.portInput = this.getElement<HTMLInputElement>('portInput');
     this.proxyUrlInput = this.getElement<HTMLInputElement>('proxyUrl');
     this.immersiveSelect = this.getElement<HTMLSelectElement>('immersive');
@@ -545,6 +548,24 @@ export class CloudXR2DUI {
     addListener(this.serverTypeSelect, 'change', updateConfig);
     addListener(this.serverIpInput, 'input', updateConfig);
     addListener(this.serverIpInput, 'change', updateConfig);
+
+    // Show the clear ("x") button only while the server IP field has a value,
+    // and clear the prefill (incl. localStorage) on click so the browser's
+    // autocomplete dropdown of previously connected servers can show again.
+    const updateServerIpClearButton = () => {
+      this.serverIpClearButton.classList.toggle('visible', this.serverIpInput.value.length > 0);
+    };
+    addListener(this.serverIpInput, 'input', updateServerIpClearButton);
+    addListener(this.serverIpClearButton, 'click', () => {
+      this.serverIpInput.value = '';
+      // Update the live config + clear-button state directly; 'change' persists
+      // the now-empty value via the enableLocalStorage handler.
+      updateServerIpClearButton();
+      updateConfig();
+      this.serverIpInput.dispatchEvent(new Event('change', { bubbles: true }));
+      this.serverIpInput.focus();
+    });
+    updateServerIpClearButton();
     addListener(this.portInput, 'input', updateConfig);
     addListener(this.portInput, 'change', updateConfig);
     const updateResValidation = () => this.updateResolutionValidationMessage();

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -137,6 +137,55 @@ limitations under the License.
             color: #999;
         }
 
+        /* Server IP field paired with an inline clear ("x") button */
+        .input-with-clear {
+            position: relative;
+        }
+
+        .input-with-clear .ui-input {
+            /* leave room so the IP text never sits under the clear button */
+            padding-right: 44px;
+        }
+
+        .input-clear-btn {
+            position: absolute;
+            /* center on the 48px-tall input, ignoring its 16px margin-bottom */
+            top: 24px;
+            right: 8px;
+            transform: translateY(-50%);
+            display: none;
+            align-items: center;
+            justify-content: center;
+            /* equal width/height + override the global button min-height so the
+               hover highlight is a circle, not a tall pill */
+            width: 28px;
+            height: 28px;
+            min-height: 0;
+            padding: 0;
+            border: none;
+            border-radius: 50%;
+            background: transparent;
+            color: #999;
+            font-size: 1.25rem;
+            line-height: 1;
+            cursor: pointer;
+        }
+
+        /* Shown only while the field has a value (toggled in CloudXR2DUI) */
+        .input-clear-btn.visible {
+            display: flex;
+        }
+
+        .input-clear-btn:hover {
+            background: rgba(0, 0, 0, 0.08);
+            color: var(--text-main);
+        }
+
+        .input-clear-btn:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 3px rgba(118, 185, 0, 0.2);
+        }
+
         .settings-table {
             width: 100%;
             margin-bottom: 24px;
@@ -609,8 +658,12 @@ limitations under the License.
 
                     <div id="manualFields">
                         <label for="serverIpInput" class="input-label">Server IP</label>
-                        <input id="serverIpInput" class="ui-input" type="text" placeholder="Server IP (default: page URL hostname)"
-                            spellcheck="false" autocapitalize="off">
+                        <div class="input-with-clear">
+                            <input id="serverIpInput" class="ui-input" type="text" placeholder="Server IP (default: page URL hostname)"
+                                spellcheck="false" autocapitalize="off">
+                            <button id="serverIpClearButton" type="button" class="input-clear-btn"
+                                aria-label="Clear server IP" title="Clear server IP"><span aria-hidden="true">&times;</span></button>
+                        </div>
                         <label for="portInput" class="input-label">Port</label>
                         <input id="portInput" class="ui-input" type="number" placeholder="Port (default: 49100)"
                             spellcheck="false" min="1" max="65535">


### PR DESCRIPTION
The Server IP field prefills from the last connected server with no way to clear it, which suppressed the browser's autocomplete dropdown of previously used servers. Add an inline circular 'x' button that appears when the field has a value; clicking it clears the value (including the persisted localStorage entry) and refocuses the field so the dropdown can show again.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated clear button for the server IP input field. The button appears when a value is entered and clears the field when clicked, immediately updating the configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->