### PR TITLE
feat(webclient): warn users when browser version is below minimum requirement

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
+++ b/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
@@ -146,7 +146,7 @@ const capabilities: CapabilityCheck[] = [
         return false;
       }
     },
-    message: 'AV1 codec support is recommended for optimal streaming quality',
+    message: 'AV1 codec is not supported on this device. Streaming quality may be reduced.',
   },
 ];
 

--- a/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
+++ b/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
@@ -59,7 +59,9 @@ export function checkBrowserVersion(): string | null {
   }
 
   // Desktop Chrome / Chromium. Safari and Firefox are not warned.
-  const chromeMatch = ua.match(/Chrome\/(\d+)\./);
+  // Skip other Chromium-based browsers (Edge, Opera) that also include "Chrome/" in their UA.
+  const isNonChromeChromium = /Edg\/|OPR\/|Opera\//.test(ua);
+  const chromeMatch = !isNonChromeChromium && ua.match(/Chrome\/(\d+)\./);
   if (chromeMatch) {
     const major = parseInt(chromeMatch[1], 10);
     if (major < MIN_CHROME_MAJOR) {

--- a/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
+++ b/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
@@ -146,7 +146,7 @@ const capabilities: CapabilityCheck[] = [
         return false;
       }
     },
-    message: 'AV1 codec is not supported on this device. Streaming quality may be reduced.',
+    message: 'AV1 codec is not supported on this device. H.264 or HEVC can be selected as an alternative.',
   },
   {
     name: 'HEVC Codec Support',
@@ -175,7 +175,7 @@ const capabilities: CapabilityCheck[] = [
         return false;
       }
     },
-    message: 'HEVC (H.265) codec is not supported on this device. Use AV1 or H.264 for streaming.',
+    message: 'HEVC (H.265) codec is not supported on this device. H.264 or AV1 can be selected as an alternative.',
   },
 ];
 

--- a/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
+++ b/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
@@ -148,6 +148,35 @@ const capabilities: CapabilityCheck[] = [
     },
     message: 'AV1 codec is not supported on this device. Streaming quality may be reduced.',
   },
+  {
+    name: 'HEVC Codec Support',
+    required: false,
+    check: async () => {
+      try {
+        if (!navigator.mediaCapabilities) {
+          return false;
+        }
+
+        const config = {
+          type: 'webrtc' as MediaDecodingType,
+          video: {
+            contentType: 'video/h265',
+            width: 1920,
+            height: 1080,
+            framerate: 60,
+            bitrate: 15000000,
+          },
+        };
+
+        const result = await navigator.mediaCapabilities.decodingInfo(config);
+        return result.supported;
+      } catch (error) {
+        console.warn('Error checking HEVC support:', error);
+        return false;
+      }
+    },
+    message: 'HEVC (H.265) codec is not supported on this device. Use AV1 or H.264 for streaming.',
+  },
 ];
 
 export async function checkCapabilities(emulated = false): Promise<{

--- a/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
+++ b/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
@@ -20,11 +20,16 @@
 // Quest OS version is not exposed in the UA; OculusBrowser 40 approximates the OS v79 era
 // (browser 41.2, Nov 2025, was the first to declare OS v81 as its minimum).
 const MIN_OCULUS_BROWSER_MAJOR = 40;
-const MIN_CHROME_MAJOR = 125;
+const MIN_PICO_CHROME_MAJOR = 125;
 
 // Returns a warning message if the current browser is below the documented minimum
 // version, or null if the version is acceptable or cannot be determined.
-export function checkBrowserVersion(): string | null {
+// Pass emulated=true when running under an XR emulator (e.g. IWER) to skip the check.
+export function checkBrowserVersion(emulated = false): string | null {
+  if (emulated) {
+    return null;
+  }
+
   const ua = navigator.userAgent;
 
   // Detect Pico first — Pico UAs also include "OculusBrowser/7.0" as a compat token
@@ -33,10 +38,10 @@ export function checkBrowserVersion(): string | null {
     const chromeMatch = ua.match(/Chrome\/(\d+)\./);
     if (chromeMatch) {
       const major = parseInt(chromeMatch[1], 10);
-      if (major < MIN_CHROME_MAJOR) {
+      if (major < MIN_PICO_CHROME_MAJOR) {
         return (
           `Pico Browser (Chrome ${major}) is outdated. ` +
-          `CloudXR requires Chrome ${MIN_CHROME_MAJOR} or later. ` +
+          `CloudXR requires Chrome ${MIN_PICO_CHROME_MAJOR} or later. ` +
           `Please update your headset firmware.`
         );
       }
@@ -53,21 +58,6 @@ export function checkBrowserVersion(): string | null {
         `CloudXR requires Meta Quest OS v79 or later ` +
         `(approximately OculusBrowser ${MIN_OCULUS_BROWSER_MAJOR}+). ` +
         `Please update your headset firmware.`
-      );
-    }
-    return null;
-  }
-
-  // Desktop Chrome / Chromium. Safari and Firefox are not warned.
-  // Skip other Chromium-based browsers (Edge, Opera) that also include "Chrome/" in their UA.
-  const isNonChromeChromium = /Edg\/|OPR\/|Opera\//.test(ua);
-  const chromeMatch = !isNonChromeChromium && ua.match(/Chrome\/(\d+)\./);
-  if (chromeMatch) {
-    const major = parseInt(chromeMatch[1], 10);
-    if (major < MIN_CHROME_MAJOR) {
-      return (
-        `Chrome ${major} detected. CloudXR requires Chrome ${MIN_CHROME_MAJOR} or later. ` +
-        `Please update your browser.`
       );
     }
   }
@@ -160,7 +150,7 @@ const capabilities: CapabilityCheck[] = [
   },
 ];
 
-export async function checkCapabilities(): Promise<{
+export async function checkCapabilities(emulated = false): Promise<{
   success: boolean;
   failures: string[];
   warnings: string[];
@@ -170,7 +160,7 @@ export async function checkCapabilities(): Promise<{
   const requiredFailures: string[] = [];
 
   // Check browser version first so the warning appears at the top of the list.
-  const versionWarning = checkBrowserVersion();
+  const versionWarning = checkBrowserVersion(emulated);
   if (versionWarning) {
     warnings.push(versionWarning);
     console.warn('Browser version warning:', versionWarning);

--- a/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
+++ b/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
@@ -15,6 +15,64 @@
  * limitations under the License.
  */
 
+// Minimum versions for CloudXR.js compatibility.
+// Requirements: https://docs.nvidia.com/cloudxr-sdk/latest/requirement/cloudxrjs_req.html
+// Quest OS version is not exposed in the UA; OculusBrowser 40 approximates the OS v79 era
+// (browser 41.2, Nov 2025, was the first to declare OS v81 as its minimum).
+const MIN_OCULUS_BROWSER_MAJOR = 40;
+const MIN_CHROME_MAJOR = 125;
+
+// Returns a warning message if the current browser is below the documented minimum
+// version, or null if the version is acceptable or cannot be determined.
+export function checkBrowserVersion(): string | null {
+  const ua = navigator.userAgent;
+
+  // Detect Pico first — Pico UAs also include "OculusBrowser/7.0" as a compat token
+  // which would otherwise match the Quest check below.
+  if (/PicoBrowser\//.test(ua)) {
+    const chromeMatch = ua.match(/Chrome\/(\d+)\./);
+    if (chromeMatch) {
+      const major = parseInt(chromeMatch[1], 10);
+      if (major < MIN_CHROME_MAJOR) {
+        return (
+          `Pico Browser (Chrome ${major}) is outdated. ` +
+          `CloudXR requires Chrome ${MIN_CHROME_MAJOR} or later. ` +
+          `Please update your headset firmware.`
+        );
+      }
+    }
+    return null;
+  }
+
+  const questMatch = ua.match(/OculusBrowser\/(\d+)\./);
+  if (questMatch) {
+    const major = parseInt(questMatch[1], 10);
+    if (major < MIN_OCULUS_BROWSER_MAJOR) {
+      return (
+        `Meta Quest Browser version ${major} detected. ` +
+        `CloudXR requires Meta Quest OS v79 or later ` +
+        `(approximately OculusBrowser ${MIN_OCULUS_BROWSER_MAJOR}+). ` +
+        `Please update your headset firmware.`
+      );
+    }
+    return null;
+  }
+
+  // Desktop Chrome / Chromium. Safari and Firefox are not warned.
+  const chromeMatch = ua.match(/Chrome\/(\d+)\./);
+  if (chromeMatch) {
+    const major = parseInt(chromeMatch[1], 10);
+    if (major < MIN_CHROME_MAJOR) {
+      return (
+        `Chrome ${major} detected. CloudXR requires Chrome ${MIN_CHROME_MAJOR} or later. ` +
+        `Please update your browser.`
+      );
+    }
+  }
+
+  return null;
+}
+
 interface CapabilityCheck {
   name: string;
   required: boolean;
@@ -108,6 +166,13 @@ export async function checkCapabilities(): Promise<{
   const failures: string[] = [];
   const warnings: string[] = [];
   const requiredFailures: string[] = [];
+
+  // Check browser version first so the warning appears at the top of the list.
+  const versionWarning = checkBrowserVersion();
+  if (versionWarning) {
+    warnings.push(versionWarning);
+    console.warn('Browser version warning:', versionWarning);
+  }
 
   for (const capability of capabilities) {
     try {

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -229,13 +229,14 @@ function App() {
       // Disable button and show checking status
       cloudXR2DUI.setStartButtonState(true, 'CONNECT (checking capabilities)');
 
+      const iwerWasLoaded = sessionStorage.getItem('iwerWasLoaded') === 'true';
       let result: { success: boolean; failures: string[]; warnings: string[] } = {
         success: false,
         failures: [],
         warnings: [],
       };
       try {
-        result = await checkCapabilities();
+        result = await checkCapabilities(iwerWasLoaded);
       } catch (error) {
         cloudXR2DUI.showStatus(`Capability check error: ${error}`, 'error');
         setCapabilitiesValid(false);
@@ -255,7 +256,6 @@ function App() {
       }
 
       // Show final status message with IWER info if applicable
-      const iwerWasLoaded = sessionStorage.getItem('iwerWasLoaded') === 'true';
       if (result.warnings.length > 0) {
         cloudXR2DUI.showStatus('Performance notice:\n' + result.warnings.join('\n'), 'info');
       } else if (iwerWasLoaded) {

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -229,6 +229,8 @@ function App() {
       // Disable button and show checking status
       cloudXR2DUI.setStartButtonState(true, 'CONNECT (checking capabilities)');
 
+      // Set by the IWER load effect above; passed to checkCapabilities to skip browser
+      // version checks that don't apply when running under a desktop XR emulator.
       const iwerWasLoaded = sessionStorage.getItem('iwerWasLoaded') === 'true';
       let result: { success: boolean; failures: string[]; warnings: string[] } = {
         success: false,


### PR DESCRIPTION
## Summary

- Adds `checkBrowserVersion()` to `BrowserCapabilities.ts` that parses the user-agent and returns a warning when the browser is below the documented [CloudXR.js minimum versions](https://docs.nvidia.com/cloudxr-sdk/latest/requirement/cloudxrjs_req.html)
- Meta Quest Browser: warns if `OculusBrowser` major version < 40 (approximate proxy for Quest OS v79; browser 41.2 was the first to declare OS v81 as its minimum — 40 is the conservative lower bound for the v79 era)
- Pico Browser: warns if `Chrome` in the Pico UA < 125 (Pico UA is detected first since it includes an `OculusBrowser/7.0` compat token that would otherwise trigger the Quest path)
- Desktop Chrome: warns if Chrome < 125
- Safari and Firefox: no warning (Safari works with IWER emulator; Firefox not officially tested)
- Warning is **non-blocking**: injected at the top of `checkCapabilities()` warnings, shown as an info notice in the 2D UI without disabling the Connect button

## Test plan

- [ ] Load the web client in a current Meta Quest browser — no warning
- [ ] Spoof UA to `OculusBrowser/39.x` — confirm warning appears
- [ ] Load in a current Pico browser (Chrome 125) — no warning
- [ ] Spoof Chrome UA to Chrome 110 — confirm warning appears
- [ ] Load in Safari with IWER — confirm no warning
- [ ] Verify `checkBrowserVersion()` is exported and callable independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser version compatibility validation to detect if your browser meets CloudXR minimum requirements
  * Displays warning notifications when browser version falls below supported minimums
  * Enhanced capability checks to include browser version verification as the first validation step

<!-- end of auto-generated comment: release notes by coderabbit.ai -->