### PR TITLE
fix(retargeters): gate SO-101 clutch on grip pose validity

### DIFF
--- a/src/core/retargeting_engine_tests/python/test_so101_retargeters.py
+++ b/src/core/retargeting_engine_tests/python/test_so101_retargeters.py
@@ -92,15 +92,18 @@ def _make_controller(
     grip_ori=_ID_QUAT,
     aim_ori=_ID_QUAT,
     trigger: float = 0.0,
+    grip_is_valid: bool = True,
 ) -> TensorGroup:
-    """Build a present (valid) ControllerInput TensorGroup with the given grip/aim pose / trigger.
+    """Build a present ControllerInput TensorGroup with the given grip/aim pose / trigger.
 
-    The grip pose drives roll; the aim pose (pointer ray) drives pitch.
+    The grip pose drives roll; the aim pose (pointer ray) drives pitch. ``grip_is_valid`` sets the
+    grip pose validity flag (OpenXR location-flag derived); pass ``False`` to model a present
+    controller whose grip pose is not yet localizable.
     """
     tg = TensorGroup(ControllerInput())
     tg[ControllerInputIndex.GRIP_POSITION] = np.asarray(grip_pos, dtype=np.float32)
     tg[ControllerInputIndex.GRIP_ORIENTATION] = np.asarray(grip_ori, dtype=np.float32)
-    tg[ControllerInputIndex.GRIP_IS_VALID] = True
+    tg[ControllerInputIndex.GRIP_IS_VALID] = grip_is_valid
     tg[ControllerInputIndex.AIM_ORIENTATION] = np.asarray(aim_ori, dtype=np.float32)
     tg[ControllerInputIndex.AIM_IS_VALID] = True
     tg[ControllerInputIndex.TRIGGER_VALUE] = float(trigger)
@@ -456,3 +459,63 @@ class TestSO101ClutchRetargeter:
         expected = expected / np.linalg.norm(expected)
         np.testing.assert_allclose(emitted, expected, atol=1e-6)
         assert np.linalg.norm(emitted) == pytest.approx(1.0, abs=1e-6)
+
+    @pytest.mark.parametrize(
+        "bad_grip_ori",
+        [
+            # valid-flagged but zero-norm composed quaternion
+            np.zeros(4, dtype=np.float32),
+            # valid-flagged but non-finite grip quaternion
+            np.full(4, np.nan, dtype=np.float32),
+        ],
+    )
+    def test_degenerate_grip_orientation_emits_finite_pose(self, bad_grip_ori):
+        """Defense-in-depth: a valid-flagged but degenerate grip quaternion must not emit NaN.
+
+        Even when the grip pose is flagged valid (so the ``GRIP_IS_VALID`` gate passes), a source
+        that emits a zero or non-finite grip quaternion would, after composing the calibration
+        offset, normalize to NaN and poison the downstream SE3 IK (``svdvals`` -> ``LinAlgError``
+        -> PhysX non-finite bounds). The clutch must instead emit a finite, unit-norm orientation,
+        holding the last good one (the seeded identity on the first frame).
+        """
+        r = SO101ClutchRetargeter(name="ee_pose")
+        inputs, outputs = _build_io(r)
+        inputs[ControllersSource.RIGHT] = _make_controller(
+            grip_pos=(0.5, -0.3, 0.7), grip_ori=bad_grip_ori
+        )
+        r.compute(inputs, outputs, _make_context())
+        pose = _read_pose(outputs)
+        assert np.all(np.isfinite(pose)), f"non-finite pose emitted: {pose}"
+        np.testing.assert_allclose(pose[3:], _ID_QUAT, atol=1e-6)
+        assert np.linalg.norm(pose[3:]) == pytest.approx(1.0, abs=1e-6)
+
+    def test_invalid_grip_pose_holds_last_without_latching(self):
+        """An invalid grip pose (OpenXR validity bits clear) is treated like a dropped frame.
+
+        When the controller is present but its grip pose is not localizable, the source flags
+        ``GRIP_IS_VALID`` False and passes through an untrusted (often all-zero) pose. The clutch
+        must hold the last commanded pose and must NOT latch its origin off that garbage pose, so
+        the first *valid* RUNNING frame still latches cleanly at the configured home.
+        """
+        r = SO101ClutchRetargeter(name="ee_pose")
+        home = np.array(_CLUTCH_HOME_EE_POS)
+
+        # Invalid grip pose on the first RUNNING frame: hold home + identity, do not latch.
+        inputs, outputs = _build_io(r)
+        inputs[ControllersSource.RIGHT] = _make_controller(
+            grip_pos=(9.0, 9.0, 9.0),
+            grip_ori=np.zeros(4, dtype=np.float32),
+            grip_is_valid=False,
+        )
+        r.compute(inputs, outputs, _make_context())
+        pose = _read_pose(outputs)
+        np.testing.assert_allclose(pose[:3], home, atol=1e-6)
+        np.testing.assert_allclose(pose[3:], _ID_QUAT, atol=1e-6)
+        assert r._origin is None  # not latched off the invalid pose
+
+        # A subsequent valid frame latches cleanly at home (no jump from the garbage pose).
+        inputs2, outputs2 = _build_io(r)
+        inputs2[ControllersSource.RIGHT] = _make_controller(grip_pos=(0.5, -0.3, 0.7))
+        r.compute(inputs2, outputs2, _make_context())
+        np.testing.assert_allclose(_read_pose(outputs2)[:3], home, atol=1e-6)
+        assert r._origin is not None

--- a/src/retargeters/SO101/clutch_retargeter.py
+++ b/src/retargeters/SO101/clutch_retargeter.py
@@ -53,7 +53,9 @@ Clutch behavior:
   translation drives the position command (the orientation is the live controller grip
   orientation composed with the fixed calibration offset, not read from this home transform). It
   is **never** ``(0, 0, 0)`` (that would command the EE into the robot base / floor).
-- The last pose is held on a dropped frame.
+- The last pose is held on a dropped frame, and likewise on a frame whose controller grip pose
+  is flagged invalid (the OpenXR location-validity bits are clear): the untrusted pose is
+  ignored and the clutch origin is not latched off it.
 """
 
 import numpy as np
@@ -97,6 +99,12 @@ _IDENTITY_QUAT = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
 _DEFAULT_ORIENTATION_OFFSET = np.array(
     [0.0, 0.0, 1.0, 0.0], dtype=np.float64
 )  # Rz(pi), xyzw
+# Minimum norm below which the composed command quaternion is treated as degenerate. The
+# ``GRIP_IS_VALID`` gate in :meth:`SO101ClutchRetargeter._compute_fn` is the primary guard against
+# untracked poses; this is a secondary "never divide by zero" net for the unlikely case of a
+# source that flags the grip pose valid yet still emits a zero/non-finite quaternion (normalizing
+# which would feed NaN into the downstream SE3 IK -> svdvals LinAlgError -> PhysX non-finite bounds).
+_MIN_QUAT_NORM = 1e-6
 
 
 def _quat_mul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
@@ -273,6 +281,15 @@ class SO101ClutchRetargeter(BaseRetargeter):
             # Dropped frame: hold the last commanded pose.
             ee_pose[0] = self._last_pose
             return
+        if not bool(inp[ControllerInputIndex.GRIP_IS_VALID]):
+            # Controller present but its grip pose is not localizable this frame: the OpenXR
+            # XR_SPACE_LOCATION_{POSITION,ORIENTATION}_VALID_BIT are clear (just engaged, or
+            # tracking briefly lost), so the source passes through an untrusted pose -- the
+            # orientation typically arrives as the all-zero quaternion. Treat it like a dropped
+            # frame: hold the last commanded pose and do NOT latch the clutch origin off a garbage
+            # position.
+            ee_pose[0] = self._last_pose
+            return
 
         grip_pos = np.from_dlpack(inp[ControllerInputIndex.GRIP_POSITION]).astype(
             np.float64
@@ -284,7 +301,15 @@ class SO101ClutchRetargeter(BaseRetargeter):
         # and renormalize, so a controller rotation maps 1:1 onto the commanded gripper orientation
         # that drives the SE3 IK.
         cmd_ori = _quat_mul(grip_ori, self._orientation_offset)
-        cmd_ori = cmd_ori / np.linalg.norm(cmd_ori)
+        cmd_ori_norm = float(np.linalg.norm(cmd_ori))
+        if not np.isfinite(cmd_ori_norm) or cmd_ori_norm < _MIN_QUAT_NORM:
+            # Defense-in-depth: the GRIP_IS_VALID gate above already drops untrusted poses, but
+            # never divide by zero -- if a source ever reports a valid-flagged yet degenerate
+            # (zero / non-finite) quaternion, hold the last emitted (unit) orientation rather than
+            # feeding NaN into the downstream SE3 IK. See _MIN_QUAT_NORM.
+            cmd_ori = self._last_pose[3:7].astype(np.float64)
+        else:
+            cmd_ori = cmd_ori / cmd_ori_norm
         cmd_ori = cmd_ori.astype(np.float32)
 
         if self._origin is None:


### PR DESCRIPTION
## Description

A new SO-101 teleop env crashed on reset with `torch._C._LinAlgError`
(`svdvals` got non-finite input) followed by PhysX "non-finite bounds".
Root cause: on a frame where the controller is present but its grip pose
is not yet localizable (OpenXR `XR_SPACE_LOCATION_{POSITION,ORIENTATION}_VALID_BIT`
clear, e.g. just after engage/reset), `ControllersSource` still passes the
untrusted pose through — its orientation arrives as the all-zero quaternion.
`SO101ClutchRetargeter` normalized that to `NaN`, which propagated into the
downstream SE3 IK and PhysX. The garbage position was also latched as the
clutch origin, corrupting the next valid frame.

- Gate `SO101ClutchRetargeter` on the `GRIP_IS_VALID` flag: an invalid grip
  pose is treated like a dropped frame (hold last commanded pose, do not
  latch the clutch origin). This is the authoritative, location-flag-derived
  signal and matches the existing `Se3AbsRetargeter` hand-path precedent
  (`joint_valid[WRIST]`).
- Keep a quaternion-norm check as defense-in-depth so a valid-flagged but
  degenerate (zero / non-finite) quaternion can never divide by zero.
- Add regression tests for the validity gate (holds home, origin not latched,
  next valid frame latches cleanly) and the degenerate-quaternion net.

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Regression unit test

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness when handling invalid or malformed controller grip sensor data—the system now gracefully holds the last known valid pose instead of attempting to use corrupted input.
  * Enhanced orientation validation to detect and prevent degenerate or non-finite values, automatically reverting to safe fallback orientations when necessary.

* **Tests**
  * Added comprehensive test coverage for edge cases involving invalid and malformed controller grip inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->