### PR TITLE
Add CloudXRLauncher CLI helpers for in-process runtime launch

### DIFF
--- a/src/core/cloudxr/python/env_config.py
+++ b/src/core/cloudxr/python/env_config.py
@@ -18,10 +18,11 @@ from pathlib import Path
 class EnvConfig:
     """Singleton holding CloudXR env configuration and resolved state.
 
-    Configuration can come from three sources, with this precedence order:
+    Configuration can come from four sources, with this precedence order:
     1. Env file (highest precedence)
     2. Process environment variables
-    3. Hard-coded defaults in this class (_DEFAULT_ENV)
+    3. Launcher defaults (e.g. ``NV_DEVICE_PROFILE`` from :class:`~isaacteleop.cloudxr.launcher.CloudXRLauncher`)
+    4. Hard-coded defaults in this class (_DEFAULT_ENV)
 
     Process environment variables are primarily intended for containerized
     environments (for example Docker/docker-compose). For local development,
@@ -75,11 +76,13 @@ class EnvConfig:
         cls,
         install_dir: str,
         env_file: str | Path | None = None,
+        *,
+        launcher_defaults: dict[str, str] | None = None,
     ) -> "EnvConfig":
         """Create (or get) the singleton, set install dir, load/resolve/apply env, and return it."""
         cfg = cls()
         cfg._set_install_dir(install_dir)
-        cfg._load_resolve_and_apply(env_file)
+        cfg._load_resolve_and_apply(env_file, launcher_defaults=launcher_defaults)
         return cfg
 
     def openxr_run_dir(self) -> str:
@@ -166,6 +169,8 @@ class EnvConfig:
     def _load_resolve_and_apply(
         self,
         env_file: str | Path | None = None,
+        *,
+        launcher_defaults: dict[str, str] | None = None,
     ) -> dict[str, str]:
         """
         Load defaults, apply optional user env file overrides, resolve path vars,
@@ -182,7 +187,7 @@ class EnvConfig:
                 )
                 del overrides[key]
 
-        merged = self._merge_env(self._DEFAULT_ENV, overrides)
+        merged = self._merge_env(self._DEFAULT_ENV, launcher_defaults or {})
 
         # Respect existing process environment values (e.g. docker-compose
         # container env) unless explicitly overridden via env_file.
@@ -192,6 +197,8 @@ class EnvConfig:
             value = os.environ.get(key)
             if value is not None:
                 merged[key] = value
+
+        merged = self._merge_env(merged, overrides)
 
         return self._resolve_and_apply(merged)
 

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -10,8 +10,10 @@ Isaac Lab Teleop) without requiring a separate terminal.
 
 from __future__ import annotations
 
+import argparse
 import asyncio
 import atexit
+import contextlib
 import logging
 import os
 import signal
@@ -31,6 +33,8 @@ from .runtime import (
 )
 
 logger = logging.getLogger(__name__)
+
+DEFAULT_DEVICE_PROFILE = "Quest3"
 
 _RUNTIME_WORKER_CODE = """\
 import sys, os
@@ -72,6 +76,7 @@ class CloudXRLauncher:
         self,
         install_dir: str = "~/.cloudxr",
         env_config: str | Path | None = None,
+        device_profile: str = DEFAULT_DEVICE_PROFILE,
         accept_eula: bool = False,
         setup_oob: bool = False,
         usb_local: bool = False,
@@ -89,6 +94,8 @@ class CloudXRLauncher:
             install_dir: CloudXR install directory.
             env_config: Optional path to a KEY=value env file for
                 CloudXR env-var overrides.
+            device_profile: CloudXR ``NV_DEVICE_PROFILE`` when not set in
+                *env_config* or the process environment (default: Quest3).
             accept_eula: Accept the NVIDIA CloudXR EULA
                 non-interactively.  When ``False`` and the EULA marker
                 does not exist, the user is prompted on stdin.
@@ -111,6 +118,7 @@ class CloudXRLauncher:
         """
         self._install_dir = install_dir
         self._env_config = str(env_config) if env_config is not None else None
+        self._device_profile = device_profile
         self._accept_eula = accept_eula
         self._setup_oob = setup_oob
         self._usb_local = usb_local
@@ -128,7 +136,11 @@ class CloudXRLauncher:
         self._wss_log_path: Path | None = None
         self._atexit_registered = False
 
-        env_cfg = EnvConfig.from_args(self._install_dir, self._env_config)
+        env_cfg = EnvConfig.from_args(
+            self._install_dir,
+            self._env_config,
+            launcher_defaults={"NV_DEVICE_PROFILE": self._device_profile},
+        )
         try:
             check_eula(accept_eula=self._accept_eula or None)
         except SystemExit as exc:
@@ -165,6 +177,114 @@ class CloudXRLauncher:
         self._wss_log_path = wss_log_path
         self._start_wss_proxy(wss_log_path)
         logger.info("CloudXR WSS proxy started (log=%s)", wss_log_path)
+
+    # ------------------------------------------------------------------
+    # CLI helpers for embedding applications and examples
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def add_cloudxr_install_dir_argument(parser: argparse.ArgumentParser) -> None:
+        """Register ``--cloudxr-install-dir`` on ``parser`` (default ``~/.cloudxr``)."""
+        parser.add_argument(
+            "--cloudxr-install-dir",
+            type=str,
+            default=os.path.expanduser("~/.cloudxr"),
+            metavar="PATH",
+            help="CloudXR install directory (default: ~/.cloudxr)",
+        )
+
+    @staticmethod
+    def add_launch_cloudxr_runtime_argument(parser: argparse.ArgumentParser) -> None:
+        """Register ``--launch-cloudxr-runtime`` on ``parser``.
+
+        Uses :class:`argparse.BooleanOptionalAction`, so callers may pass
+        ``--no-launch-cloudxr-runtime`` when the runtime is already running
+        (for example after sourcing ``~/.cloudxr/run/cloudxr.env``).
+        """
+        parser.add_argument(
+            "--launch-cloudxr-runtime",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help=(
+                "Launch the CloudXR runtime and WSS proxy in-process before running "
+                "(default: true). Pass --no-launch-cloudxr-runtime when the runtime is "
+                "already running (e.g. after sourcing ~/.cloudxr/run/cloudxr.env)."
+            ),
+        )
+
+    @staticmethod
+    def add_cloudxr_device_profile_argument(parser: argparse.ArgumentParser) -> None:
+        """Register ``--cloudxr-device-profile`` on ``parser`` (default Quest3)."""
+        parser.add_argument(
+            "--cloudxr-device-profile",
+            type=str,
+            default=DEFAULT_DEVICE_PROFILE,
+            metavar="PROFILE",
+            help=(
+                "CloudXR NV_DEVICE_PROFILE for the runtime "
+                f"(default: {DEFAULT_DEVICE_PROFILE}). "
+                "Examples: Quest3, auto-webrtc, auto-native, AppleVisionPro. "
+                "Overridden by --cloudxr-env-config or NV_DEVICE_PROFILE in the environment."
+            ),
+        )
+
+    @staticmethod
+    def add_launcher_arguments(parser: argparse.ArgumentParser) -> None:
+        """Register CloudXR launcher CLI arguments on ``parser``."""
+        CloudXRLauncher.add_cloudxr_install_dir_argument(parser)
+        CloudXRLauncher.add_cloudxr_device_profile_argument(parser)
+        CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
+
+    @staticmethod
+    def _resolve_install_dir(
+        args: argparse.Namespace,
+        install_dir: str | None = None,
+    ) -> str:
+        """Return ``install_dir`` or ``args.cloudxr_install_dir`` when registered."""
+        if install_dir is not None:
+            return install_dir
+        return getattr(args, "cloudxr_install_dir", "~/.cloudxr")
+
+    @staticmethod
+    def _resolve_device_profile(
+        args: argparse.Namespace,
+        device_profile: str | None = None,
+    ) -> str:
+        """Return ``device_profile`` or ``args.cloudxr_device_profile`` when registered."""
+        if device_profile is not None:
+            return device_profile
+        return getattr(args, "cloudxr_device_profile", DEFAULT_DEVICE_PROFILE)
+
+    @staticmethod
+    def launch_context(
+        args: argparse.Namespace,
+        *,
+        install_dir: str | None = None,
+        env_config: str | Path | None = None,
+        device_profile: str | None = None,
+        accept_eula: bool = False,
+        setup_oob: bool = False,
+        usb_local: bool = False,
+        host_client: bool = False,
+    ) -> contextlib.AbstractContextManager[CloudXRLauncher | None]:
+        """Start :class:`CloudXRLauncher` when ``args.launch_cloudxr_runtime`` is true.
+
+        Returns :func:`contextlib.nullcontext` when ``args.launch_cloudxr_runtime`` is
+        false so callers can always use ``with CloudXRLauncher.launch_context(args):``.
+        """
+        if not args.launch_cloudxr_runtime:
+            return contextlib.nullcontext(None)
+        return CloudXRLauncher(
+            install_dir=CloudXRLauncher._resolve_install_dir(args, install_dir),
+            env_config=env_config,
+            device_profile=CloudXRLauncher._resolve_device_profile(
+                args, device_profile
+            ),
+            accept_eula=accept_eula,
+            setup_oob=setup_oob,
+            usb_local=usb_local,
+            host_client=host_client,
+        )
 
     # ------------------------------------------------------------------
     # Context manager
@@ -339,13 +459,17 @@ class CloudXRLauncher:
     def _terminate_runtime(self) -> None:
         """Terminate the runtime subprocess and all its children.
 
-        Because the subprocess is launched with ``start_new_session=True``
-        it is the leader of its own process group.  Sending the signal to
-        the negative PID kills the entire group (including Monado and any
-        other children), preventing stale processes from lingering.
+        On POSIX, the subprocess is launched with ``start_new_session=True``
+        so it leads its own process group; ``killpg`` tears down Monado and
+        other children.  Windows is not supported (see
+        :meth:`_terminate_runtime_windows`).
         """
         proc = self._runtime_proc
         if proc is None or proc.poll() is not None:
+            return
+
+        if sys.platform == "win32":
+            self._terminate_runtime_windows(proc)
             return
 
         try:
@@ -374,6 +498,13 @@ class CloudXRLauncher:
 
         if proc.poll() is None:
             raise RuntimeError("Failed to terminate or kill runtime process group")
+
+    @staticmethod
+    def _terminate_runtime_windows(_proc: subprocess.Popen) -> None:
+        """Windows runtime termination is not supported."""
+        raise RuntimeError(
+            "CloudXR runtime process termination is not supported on Windows"
+        )
 
     # ------------------------------------------------------------------
     # WSS proxy (background thread with its own event loop)

--- a/src/core/cloudxr_tests/python/test_launcher.py
+++ b/src/core/cloudxr_tests/python/test_launcher.py
@@ -3,6 +3,7 @@
 
 """Tests for isaacteleop.cloudxr.launcher — CloudXRLauncher lifecycle."""
 
+import argparse
 import os
 import signal
 import subprocess
@@ -13,11 +14,16 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from isaacteleop.cloudxr.launcher import CloudXRLauncher
+from isaacteleop.cloudxr.launcher import DEFAULT_DEVICE_PROFILE, CloudXRLauncher
 
 _posix_only = pytest.mark.skipif(
     sys.platform == "win32",
     reason="Process-group APIs (os.getpgid/os.killpg) are POSIX-only",
+)
+
+_windows_skip = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="CloudXR runtime process termination is not supported on Windows",
 )
 
 
@@ -47,8 +53,11 @@ class _FakeEnvConfig:
 
 def _make_mock_popen(pid: int = 12345, poll_returns: list | None = None) -> MagicMock:
     """Create a mock subprocess.Popen with configurable poll() behaviour."""
-    proc = MagicMock(spec=subprocess.Popen)
+    proc = MagicMock()
     proc.pid = pid
+    proc.terminate = MagicMock()
+    proc.kill = MagicMock()
+    proc.wait = MagicMock()
 
     if poll_returns is not None:
         seq = list(poll_returns)
@@ -127,16 +136,29 @@ class TestLauncherConstruction:
     """Tests for CloudXRLauncher construction (which starts the runtime)."""
 
     def test_construction_stores_parameters(self, tmp_path):
-        """Constructor stores install_dir, env_config, and accept_eula."""
+        """Constructor stores install_dir, env_config, device_profile, and accept_eula."""
         with mock_launcher_deps(tmp_path, ready=True):
             launcher = CloudXRLauncher(
                 install_dir="/opt/cloudxr",
                 env_config="/etc/cloudxr.env",
+                device_profile="AppleVisionPro",
                 accept_eula=True,
             )
         assert launcher._install_dir == "/opt/cloudxr"
         assert launcher._env_config == "/etc/cloudxr.env"
+        assert launcher._device_profile == "AppleVisionPro"
         assert launcher._accept_eula is True
+
+    def test_construction_passes_device_profile_to_env_config(self, tmp_path):
+        """Constructor forwards device_profile to EnvConfig.from_args."""
+        with mock_launcher_deps(tmp_path, ready=True) as mocks:
+            CloudXRLauncher(device_profile="auto-native")
+
+            mocks["from_args"].assert_called_once_with(
+                "~/.cloudxr",
+                None,
+                launcher_defaults={"NV_DEVICE_PROFILE": "auto-native"},
+            )
 
     def test_construction_launches_runtime_and_wss(self, tmp_path):
         """Successful construction calls Popen and WSS proxy."""
@@ -148,6 +170,7 @@ class TestLauncherConstruction:
             mocks["check_eula"].assert_called_once()
             mocks["cleanup"].assert_called_once()
 
+    @_windows_skip
     def test_construction_raises_on_runtime_failure(self, tmp_path):
         """RuntimeError when the runtime fails to become ready."""
         with mock_launcher_deps(tmp_path, ready=False) as mocks:
@@ -171,6 +194,7 @@ class TestLauncherConstruction:
 # ============================================================================
 
 
+@_windows_skip
 class TestLauncherStop:
     """Tests for CloudXRLauncher.stop()."""
 
@@ -238,6 +262,7 @@ class TestLauncherStop:
 # ============================================================================
 
 
+@_windows_skip
 class TestLauncherContextManager:
     """Tests for CloudXRLauncher used as a context manager."""
 
@@ -312,6 +337,161 @@ class TestCleanupStaleRuntime:
         assert not os.path.exists(ipc_socket)
         assert not os.path.exists(sentinel)
         assert not os.path.exists(cloudxr_pid)
+
+
+class TestLaunchArgumentHelpers:
+    """Tests for CloudXRLauncher CLI helper methods."""
+
+    def test_add_cloudxr_install_dir_argument_default(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_cloudxr_install_dir_argument(parser)
+        args = parser.parse_args([])
+        assert args.cloudxr_install_dir == os.path.expanduser("~/.cloudxr")
+
+    def test_add_cloudxr_install_dir_argument_custom(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_cloudxr_install_dir_argument(parser)
+        args = parser.parse_args(["--cloudxr-install-dir", "/opt/cloudxr"])
+        assert args.cloudxr_install_dir == "/opt/cloudxr"
+
+    def test_add_launcher_arguments_registers_both(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_launcher_arguments(parser)
+        args = parser.parse_args(
+            [
+                "--cloudxr-install-dir",
+                "/opt/cloudxr",
+                "--cloudxr-device-profile",
+                "auto-webrtc",
+                "--no-launch-cloudxr-runtime",
+            ]
+        )
+        assert args.cloudxr_install_dir == "/opt/cloudxr"
+        assert args.cloudxr_device_profile == "auto-webrtc"
+        assert args.launch_cloudxr_runtime is False
+
+    def test_add_cloudxr_device_profile_argument_default(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_cloudxr_device_profile_argument(parser)
+        args = parser.parse_args([])
+        assert args.cloudxr_device_profile == DEFAULT_DEVICE_PROFILE
+
+    def test_add_cloudxr_device_profile_argument_custom(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_cloudxr_device_profile_argument(parser)
+        args = parser.parse_args(["--cloudxr-device-profile", "AppleVisionPro"])
+        assert args.cloudxr_device_profile == "AppleVisionPro"
+
+    def test_add_launch_cloudxr_runtime_argument_defaults_true(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
+        args = parser.parse_args([])
+        assert args.launch_cloudxr_runtime is True
+
+    def test_add_launch_cloudxr_runtime_argument_no_launch(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
+        args = parser.parse_args(["--no-launch-cloudxr-runtime"])
+        assert args.launch_cloudxr_runtime is False
+
+    def test_launch_context_skips_when_disabled(self) -> None:
+        args = argparse.Namespace(launch_cloudxr_runtime=False)
+        with CloudXRLauncher.launch_context(args) as launcher:
+            assert launcher is None
+
+    @_windows_skip
+    def test_launch_context_starts_when_enabled(self, tmp_path) -> None:
+        args = argparse.Namespace(
+            launch_cloudxr_runtime=True,
+            cloudxr_install_dir="/opt/cloudxr",
+            cloudxr_device_profile="Quest3",
+        )
+        with mock_launcher_deps(tmp_path) as mocks:
+            with CloudXRLauncher.launch_context(args) as launcher:
+                assert launcher is not None
+                assert launcher._runtime_proc is mocks["proc"]
+                assert launcher._install_dir == "/opt/cloudxr"
+                assert launcher._device_profile == "Quest3"
+            mocks["proc"].poll.return_value = 0
+
+    @_windows_skip
+    def test_launch_context_passes_device_profile_kwarg(self, tmp_path) -> None:
+        args = argparse.Namespace(
+            launch_cloudxr_runtime=True,
+            cloudxr_install_dir="/opt/cloudxr",
+            cloudxr_device_profile="Quest3",
+        )
+        with mock_launcher_deps(tmp_path) as mocks:
+            with CloudXRLauncher.launch_context(
+                args, device_profile="auto-native"
+            ) as launcher:
+                assert launcher is not None
+                assert launcher._device_profile == "auto-native"
+            mocks["proc"].poll.return_value = 0
+
+    def test_stop_on_windows_raises_unsupported(self, tmp_path) -> None:
+        """Simulated win32 platform raises instead of calling POSIX APIs."""
+        with mock_launcher_deps(tmp_path, ready=True) as mocks:
+            launcher = CloudXRLauncher()
+            mocks["proc"].poll.return_value = None
+
+            with patch("isaacteleop.cloudxr.launcher.sys.platform", "win32"):
+                with pytest.raises(RuntimeError, match="not supported on Windows"):
+                    launcher.stop()
+
+
+class TestEnvConfigLauncherDefaults:
+    """Tests for EnvConfig launcher_defaults precedence."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_env_config_singleton(self):
+        from isaacteleop.cloudxr.env_config import EnvConfig
+
+        EnvConfig._instance = None
+        yield
+        EnvConfig._instance = None
+
+    def test_launcher_defaults_apply_when_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NV_DEVICE_PROFILE", raising=False)
+
+        from isaacteleop.cloudxr.env_config import EnvConfig
+
+        cfg = EnvConfig.from_args(
+            str(tmp_path),
+            launcher_defaults={"NV_DEVICE_PROFILE": "Quest3"},
+        )
+
+        assert cfg._resolved_env is not None
+        assert cfg._resolved_env["NV_DEVICE_PROFILE"] == "Quest3"
+
+    def test_env_file_overrides_launcher_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("NV_DEVICE_PROFILE", raising=False)
+        env_file = tmp_path / "custom.env"
+        env_file.write_text("NV_DEVICE_PROFILE=auto-native\n", encoding="utf-8")
+
+        from isaacteleop.cloudxr.env_config import EnvConfig
+
+        cfg = EnvConfig.from_args(
+            str(tmp_path),
+            env_file,
+            launcher_defaults={"NV_DEVICE_PROFILE": "Quest3"},
+        )
+
+        assert cfg._resolved_env is not None
+        assert cfg._resolved_env["NV_DEVICE_PROFILE"] == "auto-native"
+
+    def test_process_env_overrides_launcher_defaults(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("NV_DEVICE_PROFILE", "AppleVisionPro")
+
+        from isaacteleop.cloudxr.env_config import EnvConfig
+
+        cfg = EnvConfig.from_args(
+            str(tmp_path),
+            launcher_defaults={"NV_DEVICE_PROFILE": "Quest3"},
+        )
+
+        assert cfg._resolved_env is not None
+        assert cfg._resolved_env["NV_DEVICE_PROFILE"] == "AppleVisionPro"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Expose argparse helpers so embedding apps and examples can default to launching the CloudXR runtime and WSS proxy, with --no-launch-cloudxr-runtime for environments where the runtime is already running.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Partial fix for #696

Fixes #(issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Ran the added test

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line option to enable or disable launching the CloudXR runtime.
  * The runtime now supports a “no launch” mode for embedding or external-managed setups, while keeping the default behavior unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->