### PR TITLE
feat(web): group debug settings, add reset-to-defaults and URL param help

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
+++ b/deps/cloudxr/webxr_client/helpers/BrowserCapabilities.ts
@@ -22,6 +22,21 @@
 const MIN_OCULUS_BROWSER_MAJOR = 40;
 const MIN_PICO_CHROME_MAJOR = 125;
 
+/** Headset family inferred from the browser user-agent. */
+export type HeadsetFamily = 'quest' | 'pico' | 'other';
+
+/**
+ * Classify the headset from the user-agent. Pico is checked first because Pico UAs
+ * also include an "OculusBrowser/7.0" compat token that would otherwise match Quest.
+ * The UA does not expose the specific Quest/Pico model, so this returns the family only.
+ * `ua` is injectable for testing; defaults to the live navigator user-agent.
+ */
+export function detectHeadset(ua: string = navigator.userAgent): HeadsetFamily {
+  if (/PicoBrowser\//.test(ua)) return 'pico';
+  if (/OculusBrowser\//.test(ua)) return 'quest';
+  return 'other';
+}
+
 // Returns a warning message if the current browser is below the documented minimum
 // version, or null if the version is acceptable or cannot be determined.
 // Pass emulated=true when running under an XR emulator (e.g. IWER) to skip the check.
@@ -31,10 +46,9 @@ export function checkBrowserVersion(emulated = false): string | null {
   }
 
   const ua = navigator.userAgent;
+  const headset = detectHeadset(ua);
 
-  // Detect Pico first — Pico UAs also include "OculusBrowser/7.0" as a compat token
-  // which would otherwise match the Quest check below.
-  if (/PicoBrowser\//.test(ua)) {
+  if (headset === 'pico') {
     const chromeMatch = ua.match(/Chrome\/(\d+)\./);
     if (chromeMatch) {
       const major = parseInt(chromeMatch[1], 10);
@@ -49,7 +63,7 @@ export function checkBrowserVersion(emulated = false): string | null {
     return null;
   }
 
-  const questMatch = ua.match(/OculusBrowser\/(\d+)\./);
+  const questMatch = headset === 'quest' ? ua.match(/OculusBrowser\/(\d+)\./) : null;
   if (questMatch) {
     const major = parseInt(questMatch[1], 10);
     if (major < MIN_OCULUS_BROWSER_MAJOR) {

--- a/deps/cloudxr/webxr_client/helpers/DeviceProfiles.ts
+++ b/deps/cloudxr/webxr_client/helpers/DeviceProfiles.ts
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+import { detectHeadset } from './BrowserCapabilities';
+
 // Device profiles provide per-device defaults used by the example UIs.
 // These are not hard requirements; they are applied as suggested values and remain user-editable.
 export type DeviceProfileId = 'custom' | 'quest2' | 'quest3' | 'quest3s' | 'pico4ultra';
@@ -175,4 +177,26 @@ export function resolveDeviceProfileId(value: string | null | undefined): Device
 
 export function getDeviceProfile(id: DeviceProfileId): DeviceProfile {
   return DEVICE_PROFILES[id] ?? CUSTOM_PROFILE;
+}
+
+/**
+ * Best-effort default profile from the headset user-agent, reusing the same UA detection
+ * as the browser capability check ({@link detectHeadset}).
+ *
+ * Per Meta's Browser Specs the UA platform token carries the model — "Quest 2", "Quest 3",
+ * "Quest Pro", "Quest" — but Quest 3, Quest 3S and Quest 3S Xbox Edition all report
+ * "Quest 3", so 3-vs-3S is not distinguishable (and our quest3/quest3s profiles are
+ * identical anyway). The only split that matters is hardware AV1 support: Quest 3/3S have
+ * it (→ quest3, AV1); Quest 2 / Quest 1 / Quest Pro do not (→ quest2, H.265). Pico →
+ * pico4ultra; non-headset (desktop/emulator) → custom. `ua` is injectable for testing.
+ */
+export function detectDeviceProfileId(ua: string = navigator.userAgent): DeviceProfileId {
+  switch (detectHeadset(ua)) {
+    case 'quest':
+      return /\bQuest 3\b/.test(ua) ? 'quest3' : 'quest2';
+    case 'pico':
+      return 'pico4ultra';
+    default:
+      return 'custom';
+  }
 }

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -59,6 +59,7 @@
     "ts-jest": "^29",
     "ts-loader": "^9.5.7",
     "typescript": "^5.8.2",
+    "webpack": "5.105.4",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.3"
   }

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -58,7 +58,7 @@ import type { XRDevice } from 'iwer';
 import { useState, useMemo, useEffect, useRef } from 'react';
 
 import { v5 } from 'uuid';
-import { CloudXR2DUI } from './CloudXR2DUI';
+import { CloudXR2DUI, COUNTDOWN_STORAGE_KEY } from './CloudXR2DUI';
 import { readUrlParam } from './config/resolve';
 import CloudXR3DUI from './CloudXRUI';
 import { HeadsetControlChannel } from '@helpers/controlChannel';
@@ -136,7 +136,6 @@ function buildOobHubWsUrlFromQuery(searchParams: URLSearchParams): string | null
 
 function App() {
   const COUNTDOWN_MAX_SECONDS = 9;
-  const COUNTDOWN_STORAGE_KEY = 'cxr.react.countdownSeconds';
   // 2D UI management
   const [cloudXR2DUI, setCloudXR2DUI] = useState<CloudXR2DUI | null>(null);
   // IWER loading state

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -162,6 +162,10 @@ export class CloudXR2DUI {
   private headlessInput!: HTMLInputElement;
   /** When to reload the page after the XR session ends (never / clean / any) */
   private autoRefreshModeSelect!: HTMLSelectElement;
+  /** Button that clears stored settings and reloads to defaults. */
+  private resetSettingsButton!: HTMLButtonElement;
+  /** Container for the runtime-generated URL-parameter help list (optional in markup). */
+  private urlParamsHelpList: HTMLElement | null = null;
   /** Breadcrumb subtitle in header (e.g. "for Real Robot › GEAR › Dexmate"). */
   private teleopModeSubtitle!: HTMLElement;
   /** Hierarchical project selector in header */
@@ -215,6 +219,7 @@ export class CloudXR2DUI {
 
       this.applyUrlSeeds();
       this.setupProxyConfiguration();
+      this.renderUrlParamsHelp();
       this.setupEventListeners();
       // Set initial display value
       this.posePredictionFactorValue.textContent = this.posePredictionFactorInput.value;
@@ -416,6 +421,9 @@ export class CloudXR2DUI {
     this.autoRefreshModeSelect = this.getElement<HTMLSelectElement>('cloudxrAutoRefreshMode');
     this.teleopModeSubtitle = this.getElement<HTMLElement>('teleopModeSubtitle');
     this.teleopProjectSelect = this.getElement<HTMLSelectElement>('teleopProjectSelect');
+    this.resetSettingsButton = this.getElement<HTMLButtonElement>('resetSettingsButton');
+    // Optional: absent in trimmed builds; renderUrlParamsHelp() no-ops when null.
+    this.urlParamsHelpList = document.getElementById('urlParamsHelpList');
   }
 
   /**
@@ -470,37 +478,111 @@ export class CloudXR2DUI {
   }
 
   /**
+   * Single source of truth for the global (non-per-project-path) localStorage-backed
+   * controls: maps each form control to its storage key. Used both to wire persistence
+   * ({@link CloudXR2DUI.setupLocalStorage}) and to clear it ({@link CloudXR2DUI.resetToDefaults}),
+   * so adding a setting in one place can't leave the reset path stale.
+   */
+  private localStorageBindings(): Array<{
+    el: HTMLInputElement | HTMLSelectElement;
+    key: string;
+  }> {
+    return [
+      { el: this.serverTypeSelect, key: 'serverType' },
+      { el: this.serverIpInput, key: 'serverIp' },
+      { el: this.portInput, key: 'port' },
+      { el: this.perEyeWidthInput, key: 'perEyeWidth' },
+      { el: this.perEyeHeightInput, key: 'perEyeHeight' },
+      { el: this.reprojectionGridColsInput, key: 'reprojectionGridCols' },
+      { el: this.reprojectionGridRowsInput, key: 'reprojectionGridRows' },
+      { el: this.proxyUrlInput, key: 'proxyUrl' },
+      { el: this.deviceFrameRateSelect, key: 'deviceFrameRate' },
+      { el: this.maxStreamingBitrateMbpsSelect, key: 'maxStreamingBitrateMbps' },
+      { el: this.codecSelect, key: 'codec' },
+      { el: this.enablePoseSmoothingSelect, key: 'enablePoseSmoothing' },
+      { el: this.posePredictionFactorInput, key: 'posePredictionFactor' },
+      { el: this.enableTexSubImage2DSelect, key: 'enableTexSubImage2D' },
+      { el: this.useQuestColorWorkaroundSelect, key: 'useQuestColorWorkaround' },
+      { el: this.immersiveSelect, key: 'immersiveMode' },
+      { el: this.deviceProfileSelect, key: 'deviceProfile' },
+      { el: this.controlPanelPositionSelect, key: 'controlPanelPosition' },
+      { el: this.referenceSpaceSelect, key: 'referenceSpace' },
+      { el: this.xrOffsetXInput, key: 'xrOffsetX' },
+      { el: this.xrOffsetYInput, key: 'xrOffsetY' },
+      { el: this.xrOffsetZInput, key: 'xrOffsetZ' },
+      { el: this.mediaAddressInput, key: 'mediaAddress' },
+      { el: this.mediaPortInput, key: 'mediaPort' },
+      { el: this.controllerModelVisibilitySelect, key: 'controllerModelVisibility' },
+      { el: this.autoRefreshModeSelect, key: 'autoRefreshMode' },
+    ];
+  }
+
+  /**
    * Wires up localStorage persistence for global (non-per-project-path) form
    * inputs. Per-project-path fields are handled separately via
    * loadPerProject/savePerProject around their own change listeners.
    */
   private setupLocalStorage(): void {
-    enableLocalStorage(this.serverTypeSelect, 'serverType');
-    enableLocalStorage(this.serverIpInput, 'serverIp');
-    enableLocalStorage(this.portInput, 'port');
-    enableLocalStorage(this.perEyeWidthInput, 'perEyeWidth');
-    enableLocalStorage(this.perEyeHeightInput, 'perEyeHeight');
-    enableLocalStorage(this.reprojectionGridColsInput, 'reprojectionGridCols');
-    enableLocalStorage(this.reprojectionGridRowsInput, 'reprojectionGridRows');
-    enableLocalStorage(this.proxyUrlInput, 'proxyUrl');
-    enableLocalStorage(this.deviceFrameRateSelect, 'deviceFrameRate');
-    enableLocalStorage(this.maxStreamingBitrateMbpsSelect, 'maxStreamingBitrateMbps');
-    enableLocalStorage(this.codecSelect, 'codec');
-    enableLocalStorage(this.enablePoseSmoothingSelect, 'enablePoseSmoothing');
-    enableLocalStorage(this.posePredictionFactorInput, 'posePredictionFactor');
-    enableLocalStorage(this.enableTexSubImage2DSelect, 'enableTexSubImage2D');
-    enableLocalStorage(this.useQuestColorWorkaroundSelect, 'useQuestColorWorkaround');
-    enableLocalStorage(this.immersiveSelect, 'immersiveMode');
-    enableLocalStorage(this.deviceProfileSelect, 'deviceProfile');
-    enableLocalStorage(this.controlPanelPositionSelect, 'controlPanelPosition');
-    enableLocalStorage(this.referenceSpaceSelect, 'referenceSpace');
-    enableLocalStorage(this.xrOffsetXInput, 'xrOffsetX');
-    enableLocalStorage(this.xrOffsetYInput, 'xrOffsetY');
-    enableLocalStorage(this.xrOffsetZInput, 'xrOffsetZ');
-    enableLocalStorage(this.mediaAddressInput, 'mediaAddress');
-    enableLocalStorage(this.mediaPortInput, 'mediaPort');
-    enableLocalStorage(this.controllerModelVisibilitySelect, 'controllerModelVisibility');
-    enableLocalStorage(this.autoRefreshModeSelect, 'autoRefreshMode');
+    for (const { el, key } of this.localStorageBindings()) {
+      enableLocalStorage(el, key);
+    }
+  }
+
+  /**
+   * Clears stored settings and reloads to a clean default state. Removes the global
+   * localStorage keys, the per-project debug settings for the active teleop application,
+   * and the teleop-start countdown preference. URL params are handled below.
+   */
+  public resetToDefaults(): void {
+    try {
+      for (const { key } of this.localStorageBindings()) {
+        localStorage.removeItem(key);
+      }
+      // Per-project debug settings persist under `cxr.isaac.<key>|<teleopPath>`
+      // (see helpers/react/utils savePerProject); reset only the active application's.
+      for (const key of ['panelHiddenAtStart', 'headless']) {
+        localStorage.removeItem(`cxr.isaac.${key}|${this.teleopPath}`);
+      }
+      // Teleop-start countdown is owned by App.tsx (COUNTDOWN_STORAGE_KEY); keep this in sync.
+      localStorage.removeItem('cxr.react.countdownSeconds');
+    } catch (error) {
+      console.warn('Failed to clear stored settings:', error);
+    }
+
+    // applyUrlSeeds() runs after setupLocalStorage() on load, so a form-backed query
+    // param would immediately re-override the cleared value and the reset would look
+    // like it did nothing. Strip those params from the address bar, but keep the direct
+    // transport/OOB params (turnServer, controlToken, …, set by oob_teleop_env.py) and
+    // the teleop path hash. Then reload explicitly: replaceState followed by reload()
+    // always re-reads cleared storage, even when no params were present (a same-URL
+    // location.replace can be a no-op in some browsers, which would leave the stale form).
+    const url = new URL(window.location.href);
+    for (const param of URL_PARAMS) {
+      if (param.elementId) {
+        url.searchParams.delete(param.url ?? param.key);
+      }
+    }
+    window.history.replaceState(null, '', url.toString());
+    window.location.reload();
+  }
+
+  /**
+   * Populates the "URL parameters" help list from the param registry, listing only
+   * params that opted in with a `description` (keeps secrets/transport internals out).
+   * Reads from URL_PARAMS so the list can never drift from what the client accepts.
+   */
+  private renderUrlParamsHelp(): void {
+    if (!this.urlParamsHelpList) return;
+    this.urlParamsHelpList.replaceChildren();
+    for (const param of URL_PARAMS) {
+      if (!param.description) continue;
+      const li = document.createElement('li');
+      const code = document.createElement('code');
+      code.textContent = param.url ?? param.key;
+      li.appendChild(code);
+      li.appendChild(document.createTextNode(` — ${param.description}`));
+      this.urlParamsHelpList.appendChild(li);
+    }
   }
 
   /**
@@ -636,6 +718,12 @@ export class CloudXR2DUI {
       this.updateConfiguration();
     });
     addListener(this.autoRefreshModeSelect, 'change', updateConfig);
+
+    addListener(this.resetSettingsButton, 'click', () => {
+      if (window.confirm('Reset all settings to their defaults? This reloads the page.')) {
+        this.resetToDefaults();
+      }
+    });
 
     addListener(this.deviceProfileSelect, 'change', () => {
       this.applyDeviceProfileToForm(resolveDeviceProfileId(this.deviceProfileSelect.value));

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -32,6 +32,7 @@
  */
 
 import {
+  detectDeviceProfileId,
   getDeviceProfile,
   resolveDeviceProfileId,
   type DeviceProfileId,
@@ -217,6 +218,9 @@ export class CloudXR2DUI {
       }
       this.applyTeleopPath();
 
+      // Before URL seeds so explicit params still win: on a fresh load, default the
+      // device profile from the headset UA and apply its values.
+      this.applyDefaultDeviceProfileFromUserAgent();
       this.applyUrlSeeds();
       this.setupProxyConfiguration();
       this.renderUrlParamsHelp();
@@ -328,6 +332,26 @@ export class CloudXR2DUI {
     }
 
     select.selectedIndex = 0;
+  }
+
+  /**
+   * On a fresh load (no stored device-profile choice), default the Device Profile from the
+   * headset user-agent and apply its values to the form. A stored 'deviceProfile' suppresses
+   * this — it is written whenever the user picks a profile or edits any profile-linked field
+   * (setProfileToCustomIfNeeded), so we never override an explicit choice. Not persisted, so
+   * detection re-runs each fresh load until the user makes a choice. Runs before applyUrlSeeds()
+   * so URL params still win.
+   */
+  private applyDefaultDeviceProfileFromUserAgent(): void {
+    let stored: string | null = null;
+    try {
+      stored = localStorage.getItem('deviceProfile');
+    } catch (_) {}
+    if (stored != null) return;
+    const detected = detectDeviceProfileId();
+    if (detected === 'custom') return;
+    this.deviceProfileSelect.value = detected;
+    this.applyDeviceProfileToForm(detected);
   }
 
   /**
@@ -724,6 +748,23 @@ export class CloudXR2DUI {
         this.resetToDefaults();
       }
     });
+
+    // Headset on-screen keyboards sometimes lack a minus key, so offsets can't be typed
+    // negative. Each ± button (data-target = input id) flips its field's sign. Dispatch
+    // 'change' so the existing offset listeners (updateConfiguration + localStorage) run.
+    for (const btn of Array.from(
+      document.querySelectorAll<HTMLButtonElement>('.input-sign-btn')
+    )) {
+      const targetId = btn.dataset.target;
+      if (!targetId) continue;
+      const input = document.getElementById(targetId) as HTMLInputElement | null;
+      if (!input) continue;
+      addListener(btn, 'click', () => {
+        const value = parseFloat(input.value);
+        input.value = String(Number.isFinite(value) ? -value : 0);
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+    }
 
     addListener(this.deviceProfileSelect, 'change', () => {
       this.applyDeviceProfileToForm(resolveDeviceProfileId(this.deviceProfileSelect.value));

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -341,6 +341,9 @@ export class CloudXR2DUI {
    * (setProfileToCustomIfNeeded), so we never override an explicit choice. Not persisted, so
    * detection re-runs each fresh load until the user makes a choice. Runs before applyUrlSeeds()
    * so URL params still win.
+   *
+   * Note: the IWER emulator emulates a headset via the WebXR API but does NOT change
+   * navigator.userAgent, so under the emulator this resolves to 'custom' (no flip).
    */
   private applyDefaultDeviceProfileFromUserAgent(): void {
     let stored: string | null = null;

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -74,6 +74,13 @@ import {
 type AppConfig = CloudXRConfig & ReactUIConfig;
 
 /**
+ * localStorage key for the teleop-start countdown. Owned by the countdown feature in
+ * App.tsx but defined here with the other storage keys so reset clears the same key the
+ * feature writes. (Imported by App.tsx; App already depends on this module, so no cycle.)
+ */
+export const COUNTDOWN_STORAGE_KEY = 'cxr.react.countdownSeconds';
+
+/**
  * 2D UI Management for CloudXR React Example
  * Handles the main user interface for CloudXR streaming, including form management,
  * localStorage persistence, and user interaction controls.
@@ -568,11 +575,11 @@ export class CloudXR2DUI {
       }
       // Per-project debug settings persist under `cxr.isaac.<key>|<teleopPath>`
       // (see helpers/react/utils savePerProject); reset only the active application's.
-      for (const key of ['panelHiddenAtStart', 'headless']) {
+      for (const key of CloudXR2DUI.PER_PROJECT_SETTING_KEYS) {
         localStorage.removeItem(`cxr.isaac.${key}|${this.teleopPath}`);
       }
-      // Teleop-start countdown is owned by App.tsx (COUNTDOWN_STORAGE_KEY); keep this in sync.
-      localStorage.removeItem('cxr.react.countdownSeconds');
+      // Teleop-start countdown (owned by App.tsx's countdown feature).
+      localStorage.removeItem(COUNTDOWN_STORAGE_KEY);
       // Advanced groups' expanded/collapsed state (cxr.group.<id>).
       for (let i = localStorage.length - 1; i >= 0; i--) {
         const k = localStorage.key(i);
@@ -622,6 +629,13 @@ export class CloudXR2DUI {
 
   /** localStorage key prefix for each collapsible advanced group's open/closed state. */
   private static readonly GROUP_STATE_PREFIX = 'cxr.group.';
+
+  /**
+   * Settings persisted per teleop application under `cxr.isaac.<key>|<teleopPath>`
+   * (see {@link applyPerProjectSettings} and helpers/react/utils savePerProject).
+   * Centralized so resetToDefaults clears exactly the keys the per-project handlers write.
+   */
+  private static readonly PER_PROJECT_SETTING_KEYS = ['panelHiddenAtStart', 'headless'];
 
   /**
    * Restore each advanced group's expanded/collapsed state from localStorage and persist it on
@@ -797,8 +811,10 @@ export class CloudXR2DUI {
       const input = document.getElementById(targetId) as HTMLInputElement | null;
       if (!input) continue;
       addListener(btn, 'click', () => {
+        // Pure sign flip: a no-op on an empty/non-numeric field rather than inserting 0.
         const value = parseFloat(input.value);
-        input.value = String(Number.isFinite(value) ? -value : 0);
+        if (!Number.isFinite(value)) return;
+        input.value = String(-value);
         input.dispatchEvent(new Event('change', { bubbles: true }));
       });
     }

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -225,6 +225,7 @@ export class CloudXR2DUI {
       this.setupProxyConfiguration();
       this.renderUrlParamsHelp();
       this.setupEventListeners();
+      this.restoreGroupExpandedState();
       // Set initial display value
       this.posePredictionFactorValue.textContent = this.posePredictionFactorInput.value;
       this.updateConfiguration();
@@ -572,6 +573,13 @@ export class CloudXR2DUI {
       }
       // Teleop-start countdown is owned by App.tsx (COUNTDOWN_STORAGE_KEY); keep this in sync.
       localStorage.removeItem('cxr.react.countdownSeconds');
+      // Advanced groups' expanded/collapsed state (cxr.group.<id>).
+      for (let i = localStorage.length - 1; i >= 0; i--) {
+        const k = localStorage.key(i);
+        if (k && k.startsWith(CloudXR2DUI.GROUP_STATE_PREFIX)) {
+          localStorage.removeItem(k);
+        }
+      }
     } catch (error) {
       console.warn('Failed to clear stored settings:', error);
     }
@@ -609,6 +617,32 @@ export class CloudXR2DUI {
       li.appendChild(code);
       li.appendChild(document.createTextNode(` — ${param.description}`));
       this.urlParamsHelpList.appendChild(li);
+    }
+  }
+
+  /** localStorage key prefix for each collapsible advanced group's open/closed state. */
+  private static readonly GROUP_STATE_PREFIX = 'cxr.group.';
+
+  /**
+   * Restore each advanced group's expanded/collapsed state from localStorage and persist it on
+   * toggle, so a user's "open" sections stay open across reloads. Keyed by the group's element id.
+   */
+  private restoreGroupExpandedState(): void {
+    const groups = document.querySelectorAll<HTMLDetailsElement>('details.settings-group[id]');
+    for (const group of Array.from(groups)) {
+      const key = `${CloudXR2DUI.GROUP_STATE_PREFIX}${group.id}`;
+      try {
+        const saved = localStorage.getItem(key);
+        if (saved === 'true') group.open = true;
+        else if (saved === 'false') group.open = false;
+      } catch (_) {}
+      const handler = () => {
+        try {
+          localStorage.setItem(key, String(group.open));
+        } catch (_) {}
+      };
+      group.addEventListener('toggle', handler);
+      this.eventListeners.push({ element: group, event: 'toggle', handler });
     }
   }
 

--- a/deps/cloudxr/webxr_client/src/config/params.ts
+++ b/deps/cloudxr/webxr_client/src/config/params.ts
@@ -37,6 +37,12 @@ export interface UrlParam {
   kind?: 'value' | 'checked';
   /** Optional check for the raw URL string; invalid values are ignored. */
   isValid?: (raw: string) => boolean;
+  /**
+   * One-line, user-facing description. Opt-in: only params with a `description`
+   * are listed in the in-app "URL parameters" help panel, so secrets/transport
+   * internals (tokens, ICE credentials) stay out by simply omitting it.
+   */
+  description?: string;
 }
 
 const oneOf =
@@ -48,39 +54,41 @@ const isNumber = (raw: string): boolean => raw.trim() !== '' && Number.isFinite(
 
 export const URL_PARAMS: UrlParam[] = [
   // --- Form-backed settings (seeded into a control, then read through the form) ---
-  { key: 'serverIP', elementId: 'serverIpInput' },
-  { key: 'port', elementId: 'portInput', isValid: isNumber },
-  { key: 'serverType', elementId: 'serverType', isValid: oneOf('manual', 'nvcf') },
-  { key: 'codec', elementId: 'codec', isValid: oneOf('h264', 'h265', 'av1') },
-  { key: 'immersiveMode', elementId: 'immersive', isValid: oneOf('ar', 'vr') },
+  { key: 'serverIP', elementId: 'serverIpInput', description: 'CloudXR server IP/hostname (default: page URL hostname).' },
+  { key: 'port', elementId: 'portInput', isValid: isNumber, description: 'CloudXR server port.' },
+  { key: 'serverType', elementId: 'serverType', isValid: oneOf('manual', 'nvcf'), description: 'Server backend: manual or nvcf.' },
+  { key: 'codec', elementId: 'codec', isValid: oneOf('h264', 'h265', 'av1'), description: 'Preferred video codec: h264, h265, or av1.' },
+  { key: 'immersiveMode', elementId: 'immersive', isValid: oneOf('ar', 'vr'), description: 'WebXR session mode: ar or vr.' },
   // deviceProfile is intentionally omitted: it is a preset that bulk-fills the fields below via a
   // change handler, which programmatic seeding does not trigger. Set the individual fields instead.
-  { key: 'deviceFrameRate', elementId: 'deviceFrameRate', isValid: isNumber },
-  { key: 'maxStreamingBitrateMbps', elementId: 'maxStreamingBitrateMbps', isValid: isNumber },
-  { key: 'perEyeWidth', elementId: 'perEyeWidth', isValid: isNumber },
-  { key: 'perEyeHeight', elementId: 'perEyeHeight', isValid: isNumber },
-  { key: 'reprojectionGridCols', elementId: 'reprojectionGridCols', isValid: isNumber },
-  { key: 'reprojectionGridRows', elementId: 'reprojectionGridRows', isValid: isNumber },
-  { key: 'enablePoseSmoothing', elementId: 'enablePoseSmoothing', isValid: isBool },
-  { key: 'posePredictionFactor', elementId: 'posePredictionFactor', isValid: isNumber },
-  { key: 'enableTexSubImage2D', elementId: 'enableTexSubImage2D', isValid: isBool },
-  { key: 'useQuestColorWorkaround', elementId: 'useQuestColorWorkaround', isValid: isBool },
-  { key: 'referenceSpace', elementId: 'referenceSpace', isValid: oneOf('auto', 'local-floor', 'local', 'viewer', 'unbounded') },
-  { key: 'xrOffsetX', elementId: 'xrOffsetX', isValid: isNumber },
-  { key: 'xrOffsetY', elementId: 'xrOffsetY', isValid: isNumber },
-  { key: 'xrOffsetZ', elementId: 'xrOffsetZ', isValid: isNumber },
-  { key: 'controlPanelPosition', elementId: 'controlPanelPosition', isValid: oneOf('left', 'center', 'right') },
-  { key: 'controllerModelVisibility', elementId: 'controllerModelVisibility', isValid: oneOf('show', 'hide') },
-  { key: 'panelHiddenAtStart', elementId: 'panelHiddenAtStart', isValid: isBool },
-  { key: 'headless', elementId: 'cloudxrHeadless', kind: 'checked', isValid: isBool },
-  { key: 'autoRefreshMode', elementId: 'cloudxrAutoRefreshMode', isValid: oneOf('never', 'clean', 'any') },
-  { key: 'proxyUrl', elementId: 'proxyUrl' },
-  { key: 'mediaAddress', elementId: 'mediaAddress' },
-  { key: 'mediaPort', elementId: 'mediaPort', isValid: isNumber },
+  { key: 'deviceFrameRate', elementId: 'deviceFrameRate', isValid: isNumber, description: 'Target device frame rate in FPS (e.g. 72, 90, 120).' },
+  { key: 'maxStreamingBitrateMbps', elementId: 'maxStreamingBitrateMbps', isValid: isNumber, description: 'Maximum streaming bitrate in Mbps.' },
+  { key: 'perEyeWidth', elementId: 'perEyeWidth', isValid: isNumber, description: 'Per-eye render width in pixels (multiple of 16, min 128).' },
+  { key: 'perEyeHeight', elementId: 'perEyeHeight', isValid: isNumber, description: 'Per-eye render height in pixels (multiple of 64, min 128).' },
+  { key: 'reprojectionGridCols', elementId: 'reprojectionGridCols', isValid: isNumber, description: 'Depth reprojection mesh columns (>= 2, with rows; blank = factor mode).' },
+  { key: 'reprojectionGridRows', elementId: 'reprojectionGridRows', isValid: isNumber, description: 'Depth reprojection mesh rows (>= 2, with columns; blank = factor mode).' },
+  { key: 'enablePoseSmoothing', elementId: 'enablePoseSmoothing', isValid: isBool, description: 'Smooth predicted positions to reduce jitter (true/false).' },
+  { key: 'posePredictionFactor', elementId: 'posePredictionFactor', isValid: isNumber, description: 'Pose prediction horizon scale, 0.0 (off) to 1.0 (full).' },
+  { key: 'enableTexSubImage2D', elementId: 'enableTexSubImage2D', isValid: isBool, description: 'Use texSubImage2D texture updates; faster on Quest (true/false).' },
+  { key: 'useQuestColorWorkaround', elementId: 'useQuestColorWorkaround', isValid: isBool, description: 'Display P3 color workaround for Quest 3 Browser (true/false).' },
+  { key: 'referenceSpace', elementId: 'referenceSpace', isValid: oneOf('auto', 'local-floor', 'local', 'viewer', 'unbounded'), description: 'XR reference space: auto, local-floor, local, viewer, or unbounded.' },
+  { key: 'xrOffsetX', elementId: 'xrOffsetX', isValid: isNumber, description: 'Reference-space X offset (horizontal) in centimeters.' },
+  { key: 'xrOffsetY', elementId: 'xrOffsetY', isValid: isNumber, description: 'Reference-space Y offset (vertical) in centimeters.' },
+  { key: 'xrOffsetZ', elementId: 'xrOffsetZ', isValid: isNumber, description: 'Reference-space Z offset (depth) in centimeters.' },
+  { key: 'controlPanelPosition', elementId: 'controlPanelPosition', isValid: oneOf('left', 'center', 'right'), description: 'In-XR control panel start position: left, center, or right.' },
+  { key: 'controllerModelVisibility', elementId: 'controllerModelVisibility', isValid: oneOf('show', 'hide'), description: 'Show or hide controller model meshes in XR.' },
+  { key: 'panelHiddenAtStart', elementId: 'panelHiddenAtStart', isValid: isBool, description: 'Start with the in-XR control panel hidden (true/false).' },
+  { key: 'headless', elementId: 'cloudxrHeadless', kind: 'checked', isValid: isBool, description: 'Headless: skip all client render code, keep tracking (true/false).' },
+  { key: 'autoRefreshMode', elementId: 'cloudxrAutoRefreshMode', isValid: oneOf('never', 'clean', 'any'), description: 'Reload page after session ends: never, clean, or any.' },
+  { key: 'proxyUrl', elementId: 'proxyUrl', description: 'Proxy URL for routing (HTTPS); leave empty for direct WSS.' },
+  { key: 'mediaAddress', elementId: 'mediaAddress', description: 'WebRTC media server address for NAT traversal (optional).' },
+  { key: 'mediaPort', elementId: 'mediaPort', isValid: isNumber, description: 'WebRTC media server port (0 = auto).' },
 
   // --- Direct params: read straight from the URL by app logic (no control, never stored) ---
   // TURN/ICE for NAT traversal and OOB hub, typically set in USB-local mode by oob_teleop_env.py.
   // No `isValid` here: the consumers apply their own interpretation (exact matching, regex, etc.).
+  // No `description`: these are set by tooling, not hand-edited, and some are secrets — keep them
+  // out of the user-facing help panel.
   { key: 'turnServer' },
   { key: 'turnUsername' },
   { key: 'turnCredential' },

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -186,6 +186,42 @@ limitations under the License.
             box-shadow: 0 0 0 3px rgba(118, 185, 0, 0.2);
         }
 
+        /* Offset field paired with a ± button: lets the value go negative on headset
+           keyboards that have no minus key (the button flips the current value's sign). */
+        .input-with-sign {
+            display: flex;
+            align-items: stretch;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .input-with-sign .ui-input {
+            /* grow to fill the row and override the global 300px min-width so it can shrink */
+            flex: 1 1 auto;
+            min-width: 0;
+            margin-bottom: 0;
+        }
+
+        .input-sign-btn {
+            flex: 0 0 auto;
+            width: 52px;
+            min-height: 48px;
+            padding: 0;
+            border: var(--input-border);
+            border-radius: var(--input-radius);
+            background: var(--background-main);
+            color: #444;
+            font-size: 1.3rem;
+            font-weight: 700;
+            text-transform: none;
+            letter-spacing: 0;
+            cursor: pointer;
+        }
+
+        .input-sign-btn:hover {
+            background: #f0f0f0;
+        }
+
         .settings-table {
             width: 100%;
             margin-bottom: 24px;
@@ -817,14 +853,15 @@ limitations under the License.
 
             <section>
                 <div class="debug-header">
-                    <h3 class="debug-title">Debug Settings</h3>
+                    <h3 class="debug-title">Setup &amp; Advanced</h3>
                     <button id="resetSettingsButton" class="reset-button" type="button"
                         aria-label="Reset all settings to defaults">Reset to defaults</button>
                 </div>
                 <p class="debug-intro">
-                    For first-time setup, pick your headset below to load good defaults — that is usually all
-                    you need. The advanced groups stay folded; open one only to fine-tune. Any setting can also
-                    be preset with a URL query parameter (see "URL parameters" at the bottom).
+                    To get going: pick your headset to load good defaults, then set the reference space and
+                    offsets so your view lines up. The advanced groups below stay folded — open one only to
+                    tune the picture or troubleshoot. Any setting can also be preset with a URL query
+                    parameter (see "URL parameters" at the bottom).
                 </p>
 
                 <!-- Basic, always-visible step: device profile bulk-fills the advanced groups below with
@@ -859,10 +896,52 @@ limitations under the License.
                     </div>
                 </div>
 
+                <!-- Reference space + operator offsets position the teleoperator relative to the
+                     robot, so they stay visible. The ± buttons flip an offset's sign for headset
+                     keyboards that have no minus key. -->
+                <div class="config-section">
+                    <label for="referenceSpace" class="input-label">Reference Space</label>
+                    <select id="referenceSpace" name="referenceSpace" class="ui-input" aria-label="Select reference space">
+                        <option value="auto">Auto (local-floor preferred)</option>
+                        <option value="local-floor">local-floor</option>
+                        <option value="local" selected>local</option>
+                        <option value="unbounded">unbounded</option>
+                        <option value="viewer">viewer</option>
+                    </select>
+                    <div class="config-text">
+                        Select the preferred reference space for XR tracking. "Auto" uses fallback logic (local-floor → local → viewer). Other options will attempt to use the specified space only.
+                    </div>
+                    <label class="input-label">XR Reference Space Offset</label>
+                    <label for="xrOffsetX" class="input-label">X Offset (centimeters): Horizontal</label>
+                    <div class="input-with-sign">
+                        <input id="xrOffsetX" class="ui-input config-input" type="number" placeholder="X offset in centimeters"
+                            spellcheck="false" value="0" step="1" min="-1000" max="1000">
+                        <button type="button" class="input-sign-btn" data-target="xrOffsetX"
+                            aria-label="Toggle sign of X offset" title="Toggle positive/negative">±</button>
+                    </div>
+                    <label for="xrOffsetY" class="input-label">Y Offset (centimeters): Vertical</label>
+                    <div class="input-with-sign">
+                        <input id="xrOffsetY" class="ui-input config-input" type="number" placeholder="Y offset in centimeters"
+                            spellcheck="false" value="-155" step="1" min="-1000" max="1000">
+                        <button type="button" class="input-sign-btn" data-target="xrOffsetY"
+                            aria-label="Toggle sign of Y offset" title="Toggle positive/negative">±</button>
+                    </div>
+                    <label for="xrOffsetZ" class="input-label">Z Offset (centimeters): Depth (forward/backward)</label>
+                    <div class="input-with-sign">
+                        <input id="xrOffsetZ" class="ui-input config-input" type="number" placeholder="Z offset in centimeters"
+                            spellcheck="false" value="10" step="1" min="-1000" max="1000">
+                        <button type="button" class="input-sign-btn" data-target="xrOffsetZ"
+                            aria-label="Toggle sign of Z offset" title="Toggle positive/negative">±</button>
+                    </div>
+                    <div class="config-text">
+                        Offsets shift the XR origin (in centimeters) to position the operator. On headsets whose keyboard has no minus key, type the number and tap ± to make it negative.
+                    </div>
+                </div>
+
                 <h4 class="advanced-divider">Advanced settings</h4>
 
                 <details class="settings-group">
-                    <summary>Video &amp; Streaming</summary>
+                    <summary>Image quality</summary>
                     <div class="settings-group-body">
                         <div class="config-section">
                             <label class="input-label">Maximum Streaming Bitrate</label>
@@ -922,60 +1001,7 @@ limitations under the License.
                 </details>
 
                 <details class="settings-group">
-                    <summary>Tracking &amp; Pose</summary>
-                    <div class="settings-group-body">
-                        <div class="config-section">
-                            <label for="referenceSpace" class="input-label">Reference Space</label>
-                            <select id="referenceSpace" name="referenceSpace" class="ui-input" aria-label="Select reference space">
-                                <option value="auto">Auto (local-floor preferred)</option>
-                                <option value="local-floor">local-floor</option>
-                                <option value="local" selected>local</option>
-                                <option value="unbounded">unbounded</option>
-                                <option value="viewer">viewer</option>
-                            </select>
-                            <div class="config-text">
-                                Select the preferred reference space for XR tracking. "Auto" uses fallback logic (local-floor → local → viewer). Other options will attempt to use the specified space only.
-                            </div>
-                            <label class="input-label">XR Reference Space Offset</label>
-                            <label for="xrOffsetX" class="input-label">X Offset (centimeters): Horizontal</label>
-                            <input id="xrOffsetX" class="ui-input config-input" type="number" placeholder="X offset in centimeters"
-                                spellcheck="false" value="0" step="1" min="-1000" max="1000">
-                            <label for="xrOffsetY" class="input-label">Y Offset (centimeters): Vertical</label>
-                            <input id="xrOffsetY" class="ui-input config-input" type="number" placeholder="Y offset in centimeters"
-                                spellcheck="false" value="-155" step="1" min="-1000" max="1000">
-                            <label for="xrOffsetZ" class="input-label">Z Offset (centimeters): Depth (forward/backward)</label>
-                            <input id="xrOffsetZ" class="ui-input config-input" type="number" placeholder="Z offset in centimeters"
-                                spellcheck="false" value="10" step="1" min="-1000" max="1000">
-                            <div class="config-text">
-                                Configure the XR reference space offset in centimeters. These values will be applied to the reference space transform to adjust the origin position of the XR experience.
-                            </div>
-                        </div>
-
-                        <div class="config-section">
-                            <label for="enablePoseSmoothing" class="input-label">Pose Smoothing</label>
-                            <select id="enablePoseSmoothing" class="ui-input config-input">
-                                <option value="true" selected>Enabled</option>
-                                <option value="false">Disabled</option>
-                            </select>
-                            <div class="config-text">
-                                Enable or disable secondary smoothing on predicted positions to reduce jitter. This only affects position, not orientation.
-                            </div>
-                        </div>
-
-                        <div class="config-section">
-                            <label for="posePredictionFactor" class="input-label">Pose Prediction Factor: <span id="posePredictionFactorValue">1.0</span></label>
-                            <input id="posePredictionFactor" class="ui-input config-input" type="range"
-                                min="0" max="1" step="0.1" value="1.0"
-                                style="padding: 8px 12px;">
-                            <div class="config-text">
-                                Scale the pose prediction horizon (0.0 = no prediction, 1.0 = full prediction). This multiplier affects both position and orientation prediction strength.
-                            </div>
-                        </div>
-                    </div>
-                </details>
-
-                <details class="settings-group">
-                    <summary>In-XR Controls &amp; Display</summary>
+                    <summary>In-XR comfort</summary>
                     <div class="settings-group-body">
                         <div class="config-section">
                             <label for="controllerModelVisibility" class="input-label">Controller Model</label>
@@ -1015,33 +1041,29 @@ limitations under the License.
                 </details>
 
                 <details class="settings-group">
-                    <summary>Network</summary>
+                    <summary>Advanced / troubleshooting</summary>
                     <div class="settings-group-body">
                         <div class="config-section">
-                            <label class="input-label">Proxy Configuration</label>
-                            <label for="proxyUrl" class="input-label">Proxy URL</label>
-                            <input id="proxyUrl" class="ui-input config-input" type="text" placeholder="" spellcheck="false">
+                            <label for="enablePoseSmoothing" class="input-label">Pose Smoothing</label>
+                            <select id="enablePoseSmoothing" class="ui-input config-input">
+                                <option value="true" selected>Enabled</option>
+                                <option value="false">Disabled</option>
+                            </select>
                             <div class="config-text">
-                                <span id="proxyDefaultText"></span>
+                                Enable or disable secondary smoothing on predicted positions to reduce jitter. This only affects position, not orientation.
                             </div>
                         </div>
 
                         <div class="config-section">
-                            <label class="input-label">Media Server Configuration (Optional)</label>
-                            <label for="mediaAddress" class="input-label">Media Address</label>
-                            <input id="mediaAddress" class="ui-input config-input" type="text" placeholder="e.g., 192.168.1.100" spellcheck="false" autocapitalize="off">
-                            <label for="mediaPort" class="input-label">Media Port</label>
-                            <input id="mediaPort" class="ui-input config-input" type="number" placeholder="Port (use 0 for auto)" spellcheck="false" min="0" max="65535">
+                            <label for="posePredictionFactor" class="input-label">Pose Prediction Factor: <span id="posePredictionFactorValue">1.0</span></label>
+                            <input id="posePredictionFactor" class="ui-input config-input" type="range"
+                                min="0" max="1" step="0.1" value="1.0"
+                                style="padding: 8px 12px;">
                             <div class="config-text">
-                                Configure WebRTC media server address and port for NAT traversal. Only needed when the streaming server is behind NAT. Leave empty to use server-provided ICE information.
+                                Scale the pose prediction horizon (0.0 = no prediction, 1.0 = full prediction). This multiplier affects both position and orientation prediction strength.
                             </div>
                         </div>
-                    </div>
-                </details>
 
-                <details class="settings-group">
-                    <summary>Device Workarounds</summary>
-                    <div class="settings-group-body">
                         <div class="config-section">
                             <label for="enableTexSubImage2D" class="input-label">Quest Texture Optimization</label>
                             <select id="enableTexSubImage2D" class="ui-input config-input">
@@ -1063,12 +1085,27 @@ limitations under the License.
                                 Enable Display P3 color space workaround. Recommended for Quest 3 Browser.
                             </div>
                         </div>
-                    </div>
-                </details>
 
-                <details class="settings-group">
-                    <summary>Developer &amp; Session</summary>
-                    <div class="settings-group-body">
+                        <div class="config-section">
+                            <label class="input-label">Proxy Configuration</label>
+                            <label for="proxyUrl" class="input-label">Proxy URL</label>
+                            <input id="proxyUrl" class="ui-input config-input" type="text" placeholder="" spellcheck="false">
+                            <div class="config-text">
+                                <span id="proxyDefaultText"></span>
+                            </div>
+                        </div>
+
+                        <div class="config-section">
+                            <label class="input-label">Media Server Configuration (Optional)</label>
+                            <label for="mediaAddress" class="input-label">Media Address</label>
+                            <input id="mediaAddress" class="ui-input config-input" type="text" placeholder="e.g., 192.168.1.100" spellcheck="false" autocapitalize="off">
+                            <label for="mediaPort" class="input-label">Media Port</label>
+                            <input id="mediaPort" class="ui-input config-input" type="number" placeholder="Port (use 0 for auto)" spellcheck="false" min="0" max="65535">
+                            <div class="config-text">
+                                Configure WebRTC media server address and port for NAT traversal. Only needed when the streaming server is behind NAT. Leave empty to use server-provided ICE information.
+                            </div>
+                        </div>
+
                         <div class="config-section">
                             <label for="cloudxrHeadless" class="input-label">Headless</label>
                             <div class="config-text">

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -418,6 +418,140 @@ limitations under the License.
             line-height: 1.4;
         }
 
+        /* Debug Settings header row: title + reset action share a line. */
+        .debug-header {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 8px 16px;
+            margin-bottom: 8px;
+        }
+
+        .debug-header .debug-title {
+            margin-bottom: 0;
+        }
+
+        .debug-intro {
+            font-size: 0.9rem;
+            color: #666;
+            margin: 0 0 16px;
+            line-height: 1.4;
+        }
+
+        /* Divider that fences the always-visible basic setup from the folded advanced groups. */
+        .advanced-divider {
+            font-size: 0.8rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: #888;
+            margin: 24px 0 12px;
+            padding-bottom: 6px;
+            border-bottom: 1px solid var(--border-color);
+        }
+
+        /* Secondary button styling for the reset action (distinct from the green CONNECT). */
+        .reset-button {
+            background: var(--background-main);
+            color: #444;
+            border: var(--input-border);
+            min-height: 40px;
+            padding: 8px 16px;
+            font-size: 0.85rem;
+            font-weight: 600;
+            text-transform: none;
+            letter-spacing: 0;
+        }
+
+        .reset-button:hover {
+            background: #f0f0f0;
+        }
+
+        /* Collapsible setting groups (accordion) — tames the long flat debug list. */
+        .settings-group {
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            background: var(--background-main);
+            margin-bottom: 12px;
+        }
+
+        .settings-group > summary {
+            list-style: none;
+            cursor: pointer;
+            padding: 14px 16px;
+            font-weight: 600;
+            font-size: 1rem;
+            display: flex;
+            align-items: center;
+            gap: 10px;
+        }
+
+        .settings-group > summary::-webkit-details-marker {
+            display: none;
+        }
+
+        /* Disclosure triangle that rotates when the group is open. */
+        .settings-group > summary::before {
+            content: '\25B6';
+            font-size: 0.7rem;
+            color: #888;
+            transition: transform 0.15s ease;
+        }
+
+        .settings-group[open] > summary::before {
+            transform: rotate(90deg);
+        }
+
+        .settings-group > summary:focus-visible {
+            outline: 3px solid var(--primary-green);
+            outline-offset: -3px;
+        }
+
+        .settings-group-body {
+            padding: 0 16px 8px;
+        }
+
+        /* First config-section in a group has a redundant top margin against the summary. */
+        .settings-group-body .config-section:first-child {
+            margin-top: 8px;
+        }
+
+        /* URL parameters help (collapsed reference, populated from the param registry). */
+        .url-params-help {
+            margin-top: 24px;
+            font-size: 0.9rem;
+        }
+
+        .url-params-help > summary {
+            cursor: pointer;
+            color: #444;
+            font-weight: 600;
+        }
+
+        .url-params-help-list {
+            list-style: none;
+            margin: 12px 0 0;
+            padding: 0;
+            color: #666;
+        }
+
+        .url-params-help-list li {
+            padding: 6px 0;
+            border-bottom: 1px solid var(--border-color);
+            line-height: 1.4;
+        }
+
+        .url-params-help-list li:last-child {
+            border-bottom: none;
+        }
+
+        .url-params-help-list code {
+            font-family: 'Courier New', monospace;
+            font-weight: 700;
+            color: #333;
+        }
+
         /* Exit Button */
         .exit-button {
             position: fixed;
@@ -682,11 +816,22 @@ limitations under the License.
             </aside>
 
             <section>
-                <h3 class="debug-title">Debug Settings</h3>
+                <div class="debug-header">
+                    <h3 class="debug-title">Debug Settings</h3>
+                    <button id="resetSettingsButton" class="reset-button" type="button"
+                        aria-label="Reset all settings to defaults">Reset to defaults</button>
+                </div>
+                <p class="debug-intro">
+                    For first-time setup, pick your headset below to load good defaults — that is usually all
+                    you need. The advanced groups stay folded; open one only to fine-tune. Any setting can also
+                    be preset with a URL query parameter (see "URL parameters" at the bottom).
+                </p>
 
+                <!-- Basic, always-visible step: device profile bulk-fills the advanced groups below with
+                     headset-appropriate defaults, so it is the one control a first-time operator needs. -->
                 <div class="config-section">
                     <label class="input-label">Device Profile</label>
-                    <label for="deviceProfile" class="input-label">Load defaults</label>
+                    <label for="deviceProfile" class="input-label">Load defaults for your headset</label>
                     <select id="deviceProfile" class="ui-input config-input">
                         <option value="custom" selected>Custom</option>
                         <option value="quest3">Quest 3</option>
@@ -700,220 +845,264 @@ limitations under the License.
                     <div id="deviceProfileWarning" class="profile-warning"></div>
                 </div>
 
-                <div class="config-section">
-                    <label for="controllerModelVisibility" class="input-label">Controller Model</label>
-                    <select id="controllerModelVisibility" class="ui-input config-input">
-                        <option value="show" selected>Show</option>
-                        <option value="hide">Hide</option>
-                    </select>
-                    <div class="config-text">
-                        Show or hide WebXR controller model meshes in XR. Input remains active either way.
-                    </div>
-                </div>
+                <h4 class="advanced-divider">Advanced settings</h4>
 
-                <div class="config-section">
-                    <label for="controlPanelPosition" class="input-label">Control Panel Start Position</label>
-                    <select id="controlPanelPosition" class="ui-input config-input" aria-label="Control panel start position">
-                        <option value="left">Left</option>
-                        <option value="center" selected>Center</option>
-                        <option value="right">Right</option>
-                    </select>
-                    <div class="config-text">
-                        Where the in-XR control panel appears when you enter the session: left, center, or right.
-                    </div>
-                </div>
+                <details class="settings-group">
+                    <summary>Video &amp; Streaming</summary>
+                    <div class="settings-group-body">
+                        <div class="config-section">
+                            <label for="codec" class="input-label">Video Codec</label>
+                            <select id="codec" class="ui-input config-input">
+                                <option value="h264">H.264</option>
+                                <option value="h265">H.265 (HEVC)</option>
+                                <option value="av1" selected>AV1</option>
+                            </select>
+                            <div class="config-text">
+                                Select the preferred streaming codec. Availability depends on browser and server support.
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label for="panelHiddenAtStart" class="input-label">Control panel when entering XR</label>
-                    <select id="panelHiddenAtStart" name="panelHiddenAtStart" class="ui-input config-input"
-                        aria-label="Show or hide control panel when entering immersive XR">
-                        <option value="false" selected>Show control panel</option>
-                        <option value="true">Hide control panel</option>
-                    </select>
-                    <div class="config-text">
-                        If you hide the control panel, only a small control stays visible so you can show it again.
-                    </div>
-                </div>
+                        <div class="config-section">
+                            <label class="input-label">Maximum Streaming Bitrate</label>
+                            <label for="maxStreamingBitrateMbps" class="input-label">Megabits per second</label>
+                            <select id="maxStreamingBitrateMbps" class="ui-input config-input">
+                                <option value="80">80 Mbps</option>
+                                <option value="100">100 Mbps</option>
+                                <option value="120">120 Mbps</option>
+                                <option value="150" selected>150 Mbps</option>
+                                <option value="180">180 Mbps</option>
+                                <option value="200">200 Mbps</option>
+                            </select>
+                            <div class="config-text">
+                                Select the maximum streaming bitrate (in Megabits per second) for the XR session
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label for="cloudxrHeadless" class="input-label">Headless</label>
-                    <div class="config-text">
-                        <input type="checkbox" id="cloudxrHeadless" class="config-input" style="width: auto; margin-right: 0.5em" aria-label="Headless: skip per-frame CloudXR and canvas render">
-                        <span>Per frame: skip all render code in WebXR client.</span>
-                    </div>
-                </div>
+                        <div class="config-section">
+                            <label class="input-label">Frame Rate Configuration</label>
+                            <label for="deviceFrameRate" class="input-label">Device Frame Rate</label>
+                            <select id="deviceFrameRate" class="ui-input config-input">
+                                <option value="72">72 FPS</option>
+                                <option value="90" selected>90 FPS</option>
+                                <option value="120">120 FPS</option>
+                            </select>
+                            <div class="config-text">
+                                Select the target device frame rate for the XR session
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label for="cloudxrAutoRefreshMode" class="input-label">Auto Refresh on Session End</label>
-                    <select id="cloudxrAutoRefreshMode" name="cloudxrAutoRefreshMode" class="ui-input config-input"
-                        aria-label="When to reload the page after the XR session ends">
-                        <option value="never">Never refresh</option>
-                        <option value="clean" selected>Refresh on clean session end</option>
-                        <option value="any">Refresh on any session end (including errors)</option>
-                    </select>
-                    <div class="config-text">
-                        Reload the page after the XR session ends to return to a fresh state. Choose to refresh
-                        only on a clean end (Disconnect, headset exit, server stop), on any end including a
-                        streaming error, or never.
+                        <div class="config-section">
+                            <label class="input-label">Stream Resolution Configuration</label>
+                            <label for="perEyeWidth" class="input-label">Per-Eye Width (default: 2048)</label>
+                            <input id="perEyeWidth" class="ui-input config-input" type="number"
+                                placeholder="Per-eye width in pixels" spellcheck="false" value="2048">
+                            <div id="resolutionWidthValidationMessage" class="config-text" aria-live="polite"></div>
+                            <label for="perEyeHeight" class="input-label">Per-Eye Height (default: 1792)</label>
+                            <input id="perEyeHeight" class="ui-input config-input" type="number"
+                                placeholder="Per-eye height in pixels" spellcheck="false" value="1792">
+                            <div id="resolutionHeightValidationMessage" class="config-text" aria-live="polite"></div>
+                            <div class="config-text">
+                                Configure the per-eye resolution. Width must be a multiple of 16 (min 128); height must be a multiple of 64 (min 128).
+                            </div>
+                            <label for="reprojectionGridCols" class="input-label">Depth Reprojection Grid Columns (optional)</label>
+                            <input id="reprojectionGridCols" class="ui-input config-input" type="number"
+                                placeholder="Leave blank for factor mode, or set >= 2" spellcheck="false" value="">
+                            <div id="reprojectionGridColsValidationMessage" class="config-text" aria-live="polite"></div>
+                            <label for="reprojectionGridRows" class="input-label">Depth Reprojection Grid Rows (optional)</label>
+                            <input id="reprojectionGridRows" class="ui-input config-input" type="number"
+                                placeholder="Leave blank for factor mode, or set >= 2" spellcheck="false" value="">
+                            <div id="reprojectionGridRowsValidationMessage" class="config-text" aria-live="polite"></div>
+                            <div class="config-text">
+                                Grid rules: leave either field blank to use factor mode, or set both to integers >= 2 for explicit mesh resolution.
+                            </div>
+                        </div>
                     </div>
-                </div>
+                </details>
 
-                <div class="config-section">
-                    <label class="input-label">Proxy Configuration</label>
-                    <label for="proxyUrl" class="input-label">Proxy URL</label>
-                    <input id="proxyUrl" class="ui-input config-input" type="text" placeholder="" spellcheck="false">
-                    <div class="config-text">
-                        <span id="proxyDefaultText"></span>
-                    </div>
-                </div>
+                <details class="settings-group">
+                    <summary>Tracking &amp; Pose</summary>
+                    <div class="settings-group-body">
+                        <div class="config-section">
+                            <label for="referenceSpace" class="input-label">Reference Space</label>
+                            <select id="referenceSpace" name="referenceSpace" class="ui-input" aria-label="Select reference space">
+                                <option value="auto">Auto (local-floor preferred)</option>
+                                <option value="local-floor">local-floor</option>
+                                <option value="local" selected>local</option>
+                                <option value="unbounded">unbounded</option>
+                                <option value="viewer">viewer</option>
+                            </select>
+                            <div class="config-text">
+                                Select the preferred reference space for XR tracking. "Auto" uses fallback logic (local-floor → local → viewer). Other options will attempt to use the specified space only.
+                            </div>
+                            <label class="input-label">XR Reference Space Offset</label>
+                            <label for="xrOffsetX" class="input-label">X Offset (centimeters): Horizontal</label>
+                            <input id="xrOffsetX" class="ui-input config-input" type="number" placeholder="X offset in centimeters"
+                                spellcheck="false" value="0" step="1" min="-1000" max="1000">
+                            <label for="xrOffsetY" class="input-label">Y Offset (centimeters): Vertical</label>
+                            <input id="xrOffsetY" class="ui-input config-input" type="number" placeholder="Y offset in centimeters"
+                                spellcheck="false" value="-155" step="1" min="-1000" max="1000">
+                            <label for="xrOffsetZ" class="input-label">Z Offset (centimeters): Depth (forward/backward)</label>
+                            <input id="xrOffsetZ" class="ui-input config-input" type="number" placeholder="Z offset in centimeters"
+                                spellcheck="false" value="10" step="1" min="-1000" max="1000">
+                            <div class="config-text">
+                                Configure the XR reference space offset in centimeters. These values will be applied to the reference space transform to adjust the origin position of the XR experience.
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label class="input-label">Media Server Configuration (Optional)</label>
-                    <label for="mediaAddress" class="input-label">Media Address</label>
-                    <input id="mediaAddress" class="ui-input config-input" type="text" placeholder="e.g., 192.168.1.100" spellcheck="false" autocapitalize="off">
-                    <label for="mediaPort" class="input-label">Media Port</label>
-                    <input id="mediaPort" class="ui-input config-input" type="number" placeholder="Port (use 0 for auto)" spellcheck="false" min="0" max="65535">
-                    <div class="config-text">
-                        Configure WebRTC media server address and port for NAT traversal. Only needed when the streaming server is behind NAT. Leave empty to use server-provided ICE information.
-                    </div>
-                </div>
+                        <div class="config-section">
+                            <label for="enablePoseSmoothing" class="input-label">Pose Smoothing</label>
+                            <select id="enablePoseSmoothing" class="ui-input config-input">
+                                <option value="true" selected>Enabled</option>
+                                <option value="false">Disabled</option>
+                            </select>
+                            <div class="config-text">
+                                Enable or disable secondary smoothing on predicted positions to reduce jitter. This only affects position, not orientation.
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label class="input-label">Frame Rate Configuration</label>
-                    <label for="deviceFrameRate" class="input-label">Device Frame Rate</label>
-                    <select id="deviceFrameRate" class="ui-input config-input">
-                        <option value="72">72 FPS</option>
-                        <option value="90" selected>90 FPS</option>
-                        <option value="120">120 FPS</option>
-                    </select>
-                    <div class="config-text">
-                        Select the target device frame rate for the XR session
+                        <div class="config-section">
+                            <label for="posePredictionFactor" class="input-label">Pose Prediction Factor: <span id="posePredictionFactorValue">1.0</span></label>
+                            <input id="posePredictionFactor" class="ui-input config-input" type="range"
+                                min="0" max="1" step="0.1" value="1.0"
+                                style="padding: 8px 12px;">
+                            <div class="config-text">
+                                Scale the pose prediction horizon (0.0 = no prediction, 1.0 = full prediction). This multiplier affects both position and orientation prediction strength.
+                            </div>
+                        </div>
                     </div>
-                </div>
+                </details>
 
-                <div class="config-section">
-                    <label class="input-label">Maximum Streaming Bitrate</label>
-                    <label for="maxStreamingBitrateMbps" class="input-label">Megabits per second</label>
-                    <select id="maxStreamingBitrateMbps" class="ui-input config-input">
-                        <option value="80">80 Mbps</option>
-                        <option value="100">100 Mbps</option>
-                        <option value="120">120 Mbps</option>
-                        <option value="150" selected>150 Mbps</option>
-                        <option value="180">180 Mbps</option>
-                        <option value="200">200 Mbps</option>
-                    </select>
-                    <div class="config-text">
-                        Select the maximum streaming bitrate (in Megabits per second) for the XR session
-                    </div>
-                </div>
+                <details class="settings-group">
+                    <summary>In-XR Controls &amp; Display</summary>
+                    <div class="settings-group-body">
+                        <div class="config-section">
+                            <label for="controllerModelVisibility" class="input-label">Controller Model</label>
+                            <select id="controllerModelVisibility" class="ui-input config-input">
+                                <option value="show" selected>Show</option>
+                                <option value="hide">Hide</option>
+                            </select>
+                            <div class="config-text">
+                                Show or hide WebXR controller model meshes in XR. Input remains active either way.
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label for="codec" class="input-label">Video Codec</label>
-                    <select id="codec" class="ui-input config-input">
-                        <option value="h264">H.264</option>
-                        <option value="h265">H.265 (HEVC)</option>
-                        <option value="av1" selected>AV1</option>
-                    </select>
-                    <div class="config-text">
-                        Select the preferred streaming codec. Availability depends on browser and server support.
-                    </div>
-                </div>
+                        <div class="config-section">
+                            <label for="controlPanelPosition" class="input-label">Control Panel Start Position</label>
+                            <select id="controlPanelPosition" class="ui-input config-input" aria-label="Control panel start position">
+                                <option value="left">Left</option>
+                                <option value="center" selected>Center</option>
+                                <option value="right">Right</option>
+                            </select>
+                            <div class="config-text">
+                                Where the in-XR control panel appears when you enter the session: left, center, or right.
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label class="input-label">Stream Resolution Configuration</label>
-                    <label for="perEyeWidth" class="input-label">Per-Eye Width (default: 2048)</label>
-                    <input id="perEyeWidth" class="ui-input config-input" type="number"
-                        placeholder="Per-eye width in pixels" spellcheck="false" value="2048">
-                    <div id="resolutionWidthValidationMessage" class="config-text" aria-live="polite"></div>
-                    <label for="perEyeHeight" class="input-label">Per-Eye Height (default: 1792)</label>
-                    <input id="perEyeHeight" class="ui-input config-input" type="number"
-                        placeholder="Per-eye height in pixels" spellcheck="false" value="1792">
-                    <div id="resolutionHeightValidationMessage" class="config-text" aria-live="polite"></div>
-                    <div class="config-text">
-                        Configure the per-eye resolution. Width must be a multiple of 16 (min 128); height must be a multiple of 64 (min 128).
+                        <div class="config-section">
+                            <label for="panelHiddenAtStart" class="input-label">Control panel when entering XR</label>
+                            <select id="panelHiddenAtStart" name="panelHiddenAtStart" class="ui-input config-input"
+                                aria-label="Show or hide control panel when entering immersive XR">
+                                <option value="false" selected>Show control panel</option>
+                                <option value="true">Hide control panel</option>
+                            </select>
+                            <div class="config-text">
+                                If you hide the control panel, only a small control stays visible so you can show it again.
+                            </div>
+                        </div>
                     </div>
-                    <label for="reprojectionGridCols" class="input-label">Depth Reprojection Grid Columns (optional)</label>
-                    <input id="reprojectionGridCols" class="ui-input config-input" type="number"
-                        placeholder="Leave blank for factor mode, or set >= 2" spellcheck="false" value="">
-                    <div id="reprojectionGridColsValidationMessage" class="config-text" aria-live="polite"></div>
-                    <label for="reprojectionGridRows" class="input-label">Depth Reprojection Grid Rows (optional)</label>
-                    <input id="reprojectionGridRows" class="ui-input config-input" type="number"
-                        placeholder="Leave blank for factor mode, or set >= 2" spellcheck="false" value="">
-                    <div id="reprojectionGridRowsValidationMessage" class="config-text" aria-live="polite"></div>
-                    <div class="config-text">
-                        Grid rules: leave either field blank to use factor mode, or set both to integers >= 2 for explicit mesh resolution.
-                    </div>
-                </div>
+                </details>
 
-                <div class="config-section">
-                    <label for="referenceSpace" class="input-label">Reference Space</label>
-                    <select id="referenceSpace" name="referenceSpace" class="ui-input" aria-label="Select reference space">
-                        <option value="auto">Auto (local-floor preferred)</option>
-                        <option value="local-floor">local-floor</option>
-                        <option value="local" selected>local</option>
-                        <option value="unbounded">unbounded</option>
-                        <option value="viewer">viewer</option>
-                    </select>
-                    <div class="config-text">
-                        Select the preferred reference space for XR tracking. "Auto" uses fallback logic (local-floor → local → viewer). Other options will attempt to use the specified space only.
-                    </div>
-                    <label class="input-label">XR Reference Space Offset</label>
-                    <label for="xrOffsetX" class="input-label">X Offset (centimeters): Horizontal</label>
-                    <input id="xrOffsetX" class="ui-input config-input" type="number" placeholder="X offset in centimeters"
-                        spellcheck="false" value="0" step="1" min="-1000" max="1000">
-                    <label for="xrOffsetY" class="input-label">Y Offset (centimeters): Vertical</label>
-                    <input id="xrOffsetY" class="ui-input config-input" type="number" placeholder="Y offset in centimeters"
-                        spellcheck="false" value="-155" step="1" min="-1000" max="1000">
-                    <label for="xrOffsetZ" class="input-label">Z Offset (centimeters): Depth (forward/backward)</label>
-                    <input id="xrOffsetZ" class="ui-input config-input" type="number" placeholder="Z offset in centimeters"
-                        spellcheck="false" value="10" step="1" min="-1000" max="1000">
-                    <div class="config-text">
-                        Configure the XR reference space offset in centimeters. These values will be applied to the reference space transform to adjust the origin position of the XR experience.
-                    </div>
-                </div>
+                <details class="settings-group">
+                    <summary>Network</summary>
+                    <div class="settings-group-body">
+                        <div class="config-section">
+                            <label class="input-label">Proxy Configuration</label>
+                            <label for="proxyUrl" class="input-label">Proxy URL</label>
+                            <input id="proxyUrl" class="ui-input config-input" type="text" placeholder="" spellcheck="false">
+                            <div class="config-text">
+                                <span id="proxyDefaultText"></span>
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label for="enablePoseSmoothing" class="input-label">Pose Smoothing</label>
-                    <select id="enablePoseSmoothing" class="ui-input config-input">
-                        <option value="true" selected>Enabled</option>
-                        <option value="false">Disabled</option>
-                    </select>
-                    <div class="config-text">
-                        Enable or disable secondary smoothing on predicted positions to reduce jitter. This only affects position, not orientation.
+                        <div class="config-section">
+                            <label class="input-label">Media Server Configuration (Optional)</label>
+                            <label for="mediaAddress" class="input-label">Media Address</label>
+                            <input id="mediaAddress" class="ui-input config-input" type="text" placeholder="e.g., 192.168.1.100" spellcheck="false" autocapitalize="off">
+                            <label for="mediaPort" class="input-label">Media Port</label>
+                            <input id="mediaPort" class="ui-input config-input" type="number" placeholder="Port (use 0 for auto)" spellcheck="false" min="0" max="65535">
+                            <div class="config-text">
+                                Configure WebRTC media server address and port for NAT traversal. Only needed when the streaming server is behind NAT. Leave empty to use server-provided ICE information.
+                            </div>
+                        </div>
                     </div>
-                </div>
+                </details>
 
-                <div class="config-section">
-                    <label for="posePredictionFactor" class="input-label">Pose Prediction Factor: <span id="posePredictionFactorValue">1.0</span></label>
-                    <input id="posePredictionFactor" class="ui-input config-input" type="range"
-                        min="0" max="1" step="0.1" value="1.0"
-                        style="padding: 8px 12px;">
-                    <div class="config-text">
-                        Scale the pose prediction horizon (0.0 = no prediction, 1.0 = full prediction). This multiplier affects both position and orientation prediction strength.
-                    </div>
-                </div>
+                <details class="settings-group">
+                    <summary>Device Workarounds</summary>
+                    <div class="settings-group-body">
+                        <div class="config-section">
+                            <label for="enableTexSubImage2D" class="input-label">Quest Texture Optimization</label>
+                            <select id="enableTexSubImage2D" class="ui-input config-input">
+                                <option value="false" selected>Disabled</option>
+                                <option value="true">Enabled</option>
+                            </select>
+                            <div class="config-text">
+                                Enable texSubImage2D for texture updates. Improves performance on Meta Quest devices but may cause issues on headsets with older Chromium forks.
+                            </div>
+                        </div>
 
-                <div class="config-section">
-                    <label for="enableTexSubImage2D" class="input-label">Quest Texture Optimization</label>
-                    <select id="enableTexSubImage2D" class="ui-input config-input">
-                        <option value="false" selected>Disabled</option>
-                        <option value="true">Enabled</option>
-                    </select>
-                    <div class="config-text">
-                        Enable texSubImage2D for texture updates. Improves performance on Meta Quest devices but may cause issues on headsets with older Chromium forks.
+                        <div class="config-section">
+                            <label for="useQuestColorWorkaround" class="input-label">Quest Color Workaround</label>
+                            <select id="useQuestColorWorkaround" class="ui-input config-input">
+                                <option value="false" selected>Disabled</option>
+                                <option value="true">Enabled</option>
+                            </select>
+                            <div class="config-text">
+                                Enable Display P3 color space workaround. Recommended for Quest 3 Browser.
+                            </div>
+                        </div>
                     </div>
-                </div>
+                </details>
 
-                <div class="config-section">
-                    <label for="useQuestColorWorkaround" class="input-label">Quest Color Workaround</label>
-                    <select id="useQuestColorWorkaround" class="ui-input config-input">
-                        <option value="false" selected>Disabled</option>
-                        <option value="true">Enabled</option>
-                    </select>
-                    <div class="config-text">
-                        Enable Display P3 color space workaround. Recommended for Quest 3 Browser.
+                <details class="settings-group">
+                    <summary>Developer &amp; Session</summary>
+                    <div class="settings-group-body">
+                        <div class="config-section">
+                            <label for="cloudxrHeadless" class="input-label">Headless</label>
+                            <div class="config-text">
+                                <input type="checkbox" id="cloudxrHeadless" class="config-input" style="width: auto; margin-right: 0.5em" aria-label="Headless: skip per-frame CloudXR and canvas render">
+                                <span>Per frame: skip all render code in WebXR client.</span>
+                            </div>
+                        </div>
+
+                        <div class="config-section">
+                            <label for="cloudxrAutoRefreshMode" class="input-label">Auto Refresh on Session End</label>
+                            <select id="cloudxrAutoRefreshMode" name="cloudxrAutoRefreshMode" class="ui-input config-input"
+                                aria-label="When to reload the page after the XR session ends">
+                                <option value="never">Never refresh</option>
+                                <option value="clean" selected>Refresh on clean session end</option>
+                                <option value="any">Refresh on any session end (including errors)</option>
+                            </select>
+                            <div class="config-text">
+                                Reload the page after the XR session ends to return to a fresh state. Choose to refresh
+                                only on a clean end (Disconnect, headset exit, server stop), on any end including a
+                                streaming error, or never.
+                            </div>
+                        </div>
                     </div>
-                </div>
+                </details>
+
+                <!-- Reference list of URL query parameters, populated at runtime from the param
+                     registry (CloudXR2DUI.renderUrlParamsHelp) so it can never drift from params.ts. -->
+                <details class="url-params-help">
+                    <summary>URL parameters</summary>
+                    <p class="config-text">
+                        Append any of these to the page URL to preset a setting, e.g.
+                        <code>?codec=h264&amp;perEyeWidth=1920</code>. URL values apply for that load only
+                        and are not saved.
+                    </p>
+                    <ul id="urlParamsHelpList" class="url-params-help-list"></ul>
+                </details>
             </section>
         </main>
     </div>

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -817,7 +817,7 @@ limitations under the License.
                     <span id="errorMessageText"></span>
                 </div>
 
-                <h2 class="settings-title">Settings</h2>
+                <h2 class="settings-title">Connectivity Settings</h2>
 
                 <form id="settingsForm">
                     <label for="serverType" class="input-label">Select Server Backend</label>
@@ -842,12 +842,6 @@ limitations under the License.
                             <a id="certLink" href="#" target="_blank" rel="noopener noreferrer"></a>
                         </div>
                     </div>
-
-                    <label for="immersive" class="input-label">Immersive Mode</label>
-                    <select id="immersive" name="immersive" class="ui-input" aria-label="Select immersive mode">
-                        <option value="ar" selected>AR Immersive</option>
-                        <option value="vr">VR Immersive</option>
-                    </select>
                 </form>
             </aside>
 
@@ -858,14 +852,37 @@ limitations under the License.
                         aria-label="Reset all settings to defaults">Reset to defaults</button>
                 </div>
                 <p class="debug-intro">
-                    To get going: pick your headset to load good defaults, then set the reference space and
-                    offsets so your view lines up. The advanced groups below stay folded — open one only to
-                    tune the picture or troubleshoot. Any setting can also be preset with a URL query
-                    parameter (see "URL parameters" at the bottom).
+                    Pick your immersive mode and codec, then connect. Everything else is grouped and folded
+                    below — open a section only when you need it. Any setting can also be preset with a URL
+                    query parameter (see "URL parameters" at the bottom).
                 </p>
 
-                <!-- Basic, always-visible step: device profile bulk-fills the advanced groups below with
-                     headset-appropriate defaults, so it is the one control a first-time operator needs. -->
+                <!-- Immersive mode and codec are the session settings operators change most, so they stay
+                     visible here alongside the connectivity settings. -->
+                <div class="config-section">
+                    <label for="immersive" class="input-label">Immersive Mode</label>
+                    <select id="immersive" name="immersive" class="ui-input config-input" aria-label="Select immersive mode">
+                        <option value="ar" selected>AR Immersive</option>
+                        <option value="vr">VR Immersive</option>
+                    </select>
+                </div>
+
+                <div class="config-section">
+                    <label for="codec" class="input-label">Video Codec</label>
+                    <select id="codec" class="ui-input config-input">
+                        <option value="h264">H.264</option>
+                        <option value="h265">H.265 (HEVC)</option>
+                        <option value="av1" selected>AV1</option>
+                    </select>
+                    <div class="config-text">
+                        Select the preferred streaming codec. Availability depends on browser and server support.
+                    </div>
+                </div>
+
+                <h4 class="advanced-divider">Advanced settings</h4>
+
+                <!-- Device Profile auto-detects from the headset user-agent and bulk-fills the groups
+                     below, so it lives under Advanced; change it only to override the detected defaults. -->
                 <div class="config-section">
                     <label class="input-label">Device Profile</label>
                     <label for="deviceProfile" class="input-label">Load defaults for your headset</label>
@@ -882,65 +899,7 @@ limitations under the License.
                     <div id="deviceProfileWarning" class="profile-warning"></div>
                 </div>
 
-                <!-- Video Codec is a basic, commonly-changed setting, so it stays visible
-                     alongside Device Profile rather than folded into the advanced groups. -->
-                <div class="config-section">
-                    <label for="codec" class="input-label">Video Codec</label>
-                    <select id="codec" class="ui-input config-input">
-                        <option value="h264">H.264</option>
-                        <option value="h265">H.265 (HEVC)</option>
-                        <option value="av1" selected>AV1</option>
-                    </select>
-                    <div class="config-text">
-                        Select the preferred streaming codec. Availability depends on browser and server support.
-                    </div>
-                </div>
-
-                <!-- Reference space + operator offsets position the teleoperator relative to the
-                     robot, so they stay visible. The ± buttons flip an offset's sign for headset
-                     keyboards that have no minus key. -->
-                <div class="config-section">
-                    <label for="referenceSpace" class="input-label">Reference Space</label>
-                    <select id="referenceSpace" name="referenceSpace" class="ui-input" aria-label="Select reference space">
-                        <option value="auto">Auto (local-floor preferred)</option>
-                        <option value="local-floor">local-floor</option>
-                        <option value="local" selected>local</option>
-                        <option value="unbounded">unbounded</option>
-                        <option value="viewer">viewer</option>
-                    </select>
-                    <div class="config-text">
-                        Select the preferred reference space for XR tracking. "Auto" uses fallback logic (local-floor → local → viewer). Other options will attempt to use the specified space only.
-                    </div>
-                    <label class="input-label">XR Reference Space Offset</label>
-                    <label for="xrOffsetX" class="input-label">X Offset (centimeters): Horizontal</label>
-                    <div class="input-with-sign">
-                        <input id="xrOffsetX" class="ui-input config-input" type="number" placeholder="X offset in centimeters"
-                            spellcheck="false" value="0" step="1" min="-1000" max="1000">
-                        <button type="button" class="input-sign-btn" data-target="xrOffsetX"
-                            aria-label="Toggle sign of X offset" title="Toggle positive/negative">±</button>
-                    </div>
-                    <label for="xrOffsetY" class="input-label">Y Offset (centimeters): Vertical</label>
-                    <div class="input-with-sign">
-                        <input id="xrOffsetY" class="ui-input config-input" type="number" placeholder="Y offset in centimeters"
-                            spellcheck="false" value="-155" step="1" min="-1000" max="1000">
-                        <button type="button" class="input-sign-btn" data-target="xrOffsetY"
-                            aria-label="Toggle sign of Y offset" title="Toggle positive/negative">±</button>
-                    </div>
-                    <label for="xrOffsetZ" class="input-label">Z Offset (centimeters): Depth (forward/backward)</label>
-                    <div class="input-with-sign">
-                        <input id="xrOffsetZ" class="ui-input config-input" type="number" placeholder="Z offset in centimeters"
-                            spellcheck="false" value="10" step="1" min="-1000" max="1000">
-                        <button type="button" class="input-sign-btn" data-target="xrOffsetZ"
-                            aria-label="Toggle sign of Z offset" title="Toggle positive/negative">±</button>
-                    </div>
-                    <div class="config-text">
-                        Offsets shift the XR origin (in centimeters) to position the operator. On headsets whose keyboard has no minus key, type the number and tap ± to make it negative.
-                    </div>
-                </div>
-
-                <h4 class="advanced-divider">Advanced settings</h4>
-
-                <details class="settings-group">
+                <details class="settings-group" id="group-image-quality">
                     <summary>Image quality</summary>
                     <div class="settings-group-body">
                         <div class="config-section">
@@ -984,7 +943,7 @@ limitations under the License.
                     </div>
                 </details>
 
-                <details class="settings-group">
+                <details class="settings-group" id="group-networking">
                     <summary>Networking</summary>
                     <div class="settings-group-body">
                         <div class="config-section">
@@ -1025,7 +984,7 @@ limitations under the License.
                     </div>
                 </details>
 
-                <details class="settings-group">
+                <details class="settings-group" id="group-in-xr-comfort">
                     <summary>In-XR comfort</summary>
                     <div class="settings-group-body">
                         <div class="config-section">
@@ -1065,7 +1024,53 @@ limitations under the License.
                     </div>
                 </details>
 
-                <details class="settings-group">
+                <details class="settings-group" id="group-teleop-adjustment">
+                    <summary>Teleoperator adjustment</summary>
+                    <div class="settings-group-body">
+                        <!-- Reference space + offsets position the operator relative to the robot.
+                             The ± buttons flip an offset's sign for headset keyboards with no minus key. -->
+                        <div class="config-section">
+                            <label for="referenceSpace" class="input-label">Reference Space</label>
+                            <select id="referenceSpace" name="referenceSpace" class="ui-input config-input" aria-label="Select reference space">
+                                <option value="auto">Auto (local-floor preferred)</option>
+                                <option value="local-floor">local-floor</option>
+                                <option value="local" selected>local</option>
+                                <option value="unbounded">unbounded</option>
+                                <option value="viewer">viewer</option>
+                            </select>
+                            <div class="config-text">
+                                Select the preferred reference space for XR tracking. "Auto" uses fallback logic (local-floor → local → viewer). Other options will attempt to use the specified space only.
+                            </div>
+                            <label class="input-label">XR Reference Space Offset</label>
+                            <label for="xrOffsetX" class="input-label">X Offset (centimeters): Horizontal</label>
+                            <div class="input-with-sign">
+                                <input id="xrOffsetX" class="ui-input config-input" type="number" placeholder="X offset in centimeters"
+                                    spellcheck="false" value="0" step="1" min="-1000" max="1000">
+                                <button type="button" class="input-sign-btn" data-target="xrOffsetX"
+                                    aria-label="Toggle sign of X offset" title="Toggle positive/negative">±</button>
+                            </div>
+                            <label for="xrOffsetY" class="input-label">Y Offset (centimeters): Vertical</label>
+                            <div class="input-with-sign">
+                                <input id="xrOffsetY" class="ui-input config-input" type="number" placeholder="Y offset in centimeters"
+                                    spellcheck="false" value="-155" step="1" min="-1000" max="1000">
+                                <button type="button" class="input-sign-btn" data-target="xrOffsetY"
+                                    aria-label="Toggle sign of Y offset" title="Toggle positive/negative">±</button>
+                            </div>
+                            <label for="xrOffsetZ" class="input-label">Z Offset (centimeters): Depth (forward/backward)</label>
+                            <div class="input-with-sign">
+                                <input id="xrOffsetZ" class="ui-input config-input" type="number" placeholder="Z offset in centimeters"
+                                    spellcheck="false" value="10" step="1" min="-1000" max="1000">
+                                <button type="button" class="input-sign-btn" data-target="xrOffsetZ"
+                                    aria-label="Toggle sign of Z offset" title="Toggle positive/negative">±</button>
+                            </div>
+                            <div class="config-text">
+                                Offsets shift the XR origin (in centimeters) to position the operator. On headsets whose keyboard has no minus key, type the number and tap ± to make it negative.
+                            </div>
+                        </div>
+                    </div>
+                </details>
+
+                <details class="settings-group" id="group-troubleshooting">
                     <summary>Troubleshooting</summary>
                     <div class="settings-group-body">
                         <div class="config-section">

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -888,8 +888,7 @@ limitations under the License.
                     <label for="deviceProfile" class="input-label">Load defaults for your headset</label>
                     <select id="deviceProfile" class="ui-input config-input">
                         <option value="custom" selected>Custom</option>
-                        <option value="quest3">Quest 3</option>
-                        <option value="quest3s">Quest 3S</option>
+                        <option value="quest3">Quest 3 / 3S</option>
                         <option value="quest2">Quest 2</option>
                         <option value="pico4ultra">Pico 4 Ultra</option>
                     </select>

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -944,22 +944,6 @@ limitations under the License.
                     <summary>Image quality</summary>
                     <div class="settings-group-body">
                         <div class="config-section">
-                            <label class="input-label">Maximum Streaming Bitrate</label>
-                            <label for="maxStreamingBitrateMbps" class="input-label">Megabits per second</label>
-                            <select id="maxStreamingBitrateMbps" class="ui-input config-input">
-                                <option value="80">80 Mbps</option>
-                                <option value="100">100 Mbps</option>
-                                <option value="120">120 Mbps</option>
-                                <option value="150" selected>150 Mbps</option>
-                                <option value="180">180 Mbps</option>
-                                <option value="200">200 Mbps</option>
-                            </select>
-                            <div class="config-text">
-                                Select the maximum streaming bitrate (in Megabits per second) for the XR session
-                            </div>
-                        </div>
-
-                        <div class="config-section">
                             <label class="input-label">Frame Rate Configuration</label>
                             <label for="deviceFrameRate" class="input-label">Device Frame Rate</label>
                             <select id="deviceFrameRate" class="ui-input config-input">
@@ -995,6 +979,47 @@ limitations under the License.
                             <div id="reprojectionGridRowsValidationMessage" class="config-text" aria-live="polite"></div>
                             <div class="config-text">
                                 Grid rules: leave either field blank to use factor mode, or set both to integers >= 2 for explicit mesh resolution.
+                            </div>
+                        </div>
+                    </div>
+                </details>
+
+                <details class="settings-group">
+                    <summary>Networking</summary>
+                    <div class="settings-group-body">
+                        <div class="config-section">
+                            <label class="input-label">Maximum Streaming Bitrate</label>
+                            <label for="maxStreamingBitrateMbps" class="input-label">Megabits per second</label>
+                            <select id="maxStreamingBitrateMbps" class="ui-input config-input">
+                                <option value="80">80 Mbps</option>
+                                <option value="100">100 Mbps</option>
+                                <option value="120">120 Mbps</option>
+                                <option value="150" selected>150 Mbps</option>
+                                <option value="180">180 Mbps</option>
+                                <option value="200">200 Mbps</option>
+                            </select>
+                            <div class="config-text">
+                                Maximum streaming bitrate (Megabits per second). Lower it on constrained networks.
+                            </div>
+                        </div>
+
+                        <div class="config-section">
+                            <label class="input-label">Proxy Configuration</label>
+                            <label for="proxyUrl" class="input-label">Proxy URL</label>
+                            <input id="proxyUrl" class="ui-input config-input" type="text" placeholder="" spellcheck="false">
+                            <div class="config-text">
+                                <span id="proxyDefaultText"></span>
+                            </div>
+                        </div>
+
+                        <div class="config-section">
+                            <label class="input-label">Media Server Configuration (Optional)</label>
+                            <label for="mediaAddress" class="input-label">Media Address</label>
+                            <input id="mediaAddress" class="ui-input config-input" type="text" placeholder="e.g., 192.168.1.100" spellcheck="false" autocapitalize="off">
+                            <label for="mediaPort" class="input-label">Media Port</label>
+                            <input id="mediaPort" class="ui-input config-input" type="number" placeholder="Port (use 0 for auto)" spellcheck="false" min="0" max="65535">
+                            <div class="config-text">
+                                Configure WebRTC media server address and port for NAT traversal. Only needed when the streaming server is behind NAT. Leave empty to use server-provided ICE information.
                             </div>
                         </div>
                     </div>
@@ -1041,7 +1066,7 @@ limitations under the License.
                 </details>
 
                 <details class="settings-group">
-                    <summary>Advanced / troubleshooting</summary>
+                    <summary>Troubleshooting</summary>
                     <div class="settings-group-body">
                         <div class="config-section">
                             <label for="enablePoseSmoothing" class="input-label">Pose Smoothing</label>
@@ -1083,26 +1108,6 @@ limitations under the License.
                             </select>
                             <div class="config-text">
                                 Enable Display P3 color space workaround. Recommended for Quest 3 Browser.
-                            </div>
-                        </div>
-
-                        <div class="config-section">
-                            <label class="input-label">Proxy Configuration</label>
-                            <label for="proxyUrl" class="input-label">Proxy URL</label>
-                            <input id="proxyUrl" class="ui-input config-input" type="text" placeholder="" spellcheck="false">
-                            <div class="config-text">
-                                <span id="proxyDefaultText"></span>
-                            </div>
-                        </div>
-
-                        <div class="config-section">
-                            <label class="input-label">Media Server Configuration (Optional)</label>
-                            <label for="mediaAddress" class="input-label">Media Address</label>
-                            <input id="mediaAddress" class="ui-input config-input" type="text" placeholder="e.g., 192.168.1.100" spellcheck="false" autocapitalize="off">
-                            <label for="mediaPort" class="input-label">Media Port</label>
-                            <input id="mediaPort" class="ui-input config-input" type="number" placeholder="Port (use 0 for auto)" spellcheck="false" min="0" max="65535">
-                            <div class="config-text">
-                                Configure WebRTC media server address and port for NAT traversal. Only needed when the streaming server is behind NAT. Leave empty to use server-provided ICE information.
                             </div>
                         </div>
 

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -845,23 +845,25 @@ limitations under the License.
                     <div id="deviceProfileWarning" class="profile-warning"></div>
                 </div>
 
+                <!-- Video Codec is a basic, commonly-changed setting, so it stays visible
+                     alongside Device Profile rather than folded into the advanced groups. -->
+                <div class="config-section">
+                    <label for="codec" class="input-label">Video Codec</label>
+                    <select id="codec" class="ui-input config-input">
+                        <option value="h264">H.264</option>
+                        <option value="h265">H.265 (HEVC)</option>
+                        <option value="av1" selected>AV1</option>
+                    </select>
+                    <div class="config-text">
+                        Select the preferred streaming codec. Availability depends on browser and server support.
+                    </div>
+                </div>
+
                 <h4 class="advanced-divider">Advanced settings</h4>
 
                 <details class="settings-group">
                     <summary>Video &amp; Streaming</summary>
                     <div class="settings-group-body">
-                        <div class="config-section">
-                            <label for="codec" class="input-label">Video Codec</label>
-                            <select id="codec" class="ui-input config-input">
-                                <option value="h264">H.264</option>
-                                <option value="h265">H.265 (HEVC)</option>
-                                <option value="av1" selected>AV1</option>
-                            </select>
-                            <div class="config-text">
-                                Select the preferred streaming codec. Availability depends on browser and server support.
-                            </div>
-                        </div>
-
                         <div class="config-section">
                             <label class="input-label">Maximum Streaming Bitrate</label>
                             <label for="maxStreamingBitrateMbps" class="input-label">Megabits per second</label>

--- a/deps/cloudxr/webxr_client/webpack.common.js
+++ b/deps/cloudxr/webxr_client/webpack.common.js
@@ -102,11 +102,6 @@ module.exports = {
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
     alias: {
-      // Force a single `three` instance. stats-gl (pulled in via @react-three/drei)
-      // nests its own three (0.170) beside the top-level one (0.172); two three copies
-      // in the bundle make React-Three-Fiber throw "Cannot read properties of undefined"
-      // at ACESFilmicToneMapping. Pinning all `three` imports to the top-level copy dedupes.
-      three: path.resolve(__dirname, 'node_modules/three'),
       // @helpers can be used instead of relative paths to the helpers directory
       '@helpers': path.resolve(__dirname, './helpers'),
     },

--- a/deps/cloudxr/webxr_client/webpack.common.js
+++ b/deps/cloudxr/webxr_client/webpack.common.js
@@ -102,6 +102,11 @@ module.exports = {
   resolve: {
     extensions: ['.tsx', '.ts', '.js'],
     alias: {
+      // Force a single `three` instance. stats-gl (pulled in via @react-three/drei)
+      // nests its own three (0.170) beside the top-level one (0.172); two three copies
+      // in the bundle make React-Three-Fiber throw "Cannot read properties of undefined"
+      // at ACESFilmicToneMapping. Pinning all `three` imports to the top-level copy dedupes.
+      three: path.resolve(__dirname, 'node_modules/three'),
       // @helpers can be used instead of relative paths to the helpers directory
       '@helpers': path.resolve(__dirname, './helpers'),
     },


### PR DESCRIPTION
The web client's Debug Settings were a flat list of ~16 controls with no categorization, and accepted URL query params were undocumented (visible only in source). This reworks the panel for first-time setup:

- Keep Device Profile as the always-visible basic step; fold the rest under an "Advanced settings" divider into 6 collapsed <details> groups (Video & Streaming, Tracking & Pose, In-XR Controls & Display, Network, Device Workarounds, Developer & Session). All element IDs unchanged.
- Add a "Reset to defaults" button: clears global + per-project localStorage and the countdown, strips form-backed URL params (keeps direct transport/OOB params + teleop hash), then replaceState + reload. localStorage keys are centralized in localStorageBindings() so setup and reset can't drift.
- Add an opt-in `description` to UrlParam and render a collapsed "URL parameters" help list from URL_PARAMS, so it can never drift from the registry; secrets/transport internals stay out by omitting a description.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Reset to defaults** button for quickly restoring settings.
  * Added collapsible **Setup & Advanced** sections and an optional **URL parameters** help panel.
  * Numeric offset fields now include a **± toggle** for reversing values.

* **Improvements**
  * The app now better detects headset type on first load and applies the right default profile automatically.
  * URL-based settings and saved preferences are now restored more reliably, with advanced section state preserved.

* **Bug Fixes**
  * Improved browser/device compatibility checks to avoid incorrect warnings on some headset browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->