### PR TITLE
docs: link GR00T-WholeBodyControl SONIC setup guide in ecosystem

### DIFF
--- a/docs/source/overview/ecosystem.rst
+++ b/docs/source/overview/ecosystem.rst
@@ -142,6 +142,8 @@ Targeted Robotics Embodiments
   including popular embodiments such as Unitree G1.
 - `Retargeter tuning UI <https://github.com/NVIDIA/IsaacTeleop/tree/main/src/core/retargeting_engine_ui/python>`_ to facilitate
   live retargeter tuning.
+- GR00T-WholeBodyControl SONIC whole-body control on Unitree G1 (Thor backpack); see
+  `GR00T-WholeBodyControl: Isaac Teleop Publisher Setup`_ to get started.
 
 Device Acquisition
 ------------------
@@ -261,3 +263,4 @@ WeChat app** (Discover → Scan) to join. Scanning with your phone's built-in ca
 .. _`Generic 3-axis Pedal Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/generic_3axis_pedal
 .. _`OAK-D Camera Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/oak
 .. _`Haptikos Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/haptikos
+.. _`GR00T-WholeBodyControl: Isaac Teleop Publisher Setup`: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/isaac_teleop_publisher_setup.html


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Adds a link to the GR00T-WholeBodyControl SONIC setup guide in the ecosystem docs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new ecosystem entry for **GR00T-WholeBodyControl** on Unitree G1.
  * Included a direct link to setup instructions for the new teleoperation publisher guidance.
  * Added the required reference so the new documentation link resolves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->