### PR TITLE
fix(web): unpin webpack now that 5.108.1 fixes the bundle corruption

### DIFF
--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -59,7 +59,6 @@
     "ts-jest": "^29",
     "ts-loader": "^9.5.7",
     "typescript": "^5.8.2",
-    "webpack": "5.105.4",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.3"
   }

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -59,6 +59,7 @@
     "ts-jest": "^29",
     "ts-loader": "^9.5.7",
     "typescript": "^5.8.2",
+    "webpack": "5.108.0",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.3"
   }

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -59,7 +59,6 @@
     "ts-jest": "^29",
     "ts-loader": "^9.5.7",
     "typescript": "^5.8.2",
-    "webpack": "5.108.0",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.3"
   }


### PR DESCRIPTION
## What

Removes the `webpack: 5.105.4` pin added in #705 (one line in `deps/cloudxr/webxr_client/package.json`), letting a fresh install float to the latest 5.x.

## Why

The pin worked around **webpack 5.108.0**, which mis-emitted re-export property chains (e.g. `s.A.C.E.S…`) and crashed React-Three-Fiber at Canvas init — the client failed to load.

Verified on this branch:
- **5.108.0** → reproduced the crash.
- **5.108.1** → builds and loads clean. ✅

So the pin is no longer needed.

## Note

Install is still floating (lockfile is gitignored, CI does a fresh install), so a future webpack minor could regress the same way. The durable fix is committing a lockfile + `npm ci` — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an explicit build tool dependency from the project manifest.
  * No user-facing functionality changes were included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->