### PR TITLE
fix: Make sure to use the right python version when building wheel

### DIFF
--- a/src/core/python/CMakeLists.txt
+++ b/src/core/python/CMakeLists.txt
@@ -163,8 +163,10 @@ add_custom_target(python_stubs
 add_custom_target(python_wheel ALL
     COMMAND ${CMAKE_COMMAND} -E echo "Building Python wheel with uv..."
     COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/wheels"
-    COMMAND uv build --wheel --out-dir "${CMAKE_BINARY_DIR}/wheels" "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>" ||
-            python3 -m build --wheel --outdir "${CMAKE_BINARY_DIR}/wheels" "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
+    COMMAND uv build --wheel --python ${ISAAC_TELEOP_PYTHON_VERSION}
+            --out-dir "${CMAKE_BINARY_DIR}/wheels" "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>" ||
+            "${Python3_EXECUTABLE}" -m build --wheel
+            --outdir "${CMAKE_BINARY_DIR}/wheels" "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
     DEPENDS python_stubs
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
     COMMENT "Building Python wheel with uv (fallback to python -m build)"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the Python wheel build process to use the configured Python version more consistently.
  * Updated the fallback build step to use the detected Python executable, helping make builds more reliable across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->