### PR TITLE
docs: require DCO Signed-off-by for AI-drafted commits

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,11 @@ repos:
   # Copyright year: ensure SPDX-FileCopyrightText includes current year (--fix updates in place)
   - repo: local
     hooks:
+      - id: check-dco-signoff
+        name: Require DCO Signed-off-by in commit message
+        entry: python3 scripts/check_dco_signoff.py
+        language: system
+        stages: [commit-msg]
       - id: check-copyright-year
         name: Check copyright year (include current year)
         entry: python3 scripts/check_copyright_year.py --fix

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,26 @@ only point here — edit the rules in the doc, not the shims.
   must keep `[ ... ]`. Check the shebang (and, for sourced files, who sources
   them) first.
 
+## Commits — DCO sign-off for AI-drafted commits
+
+Any commit whose message is drafted or edited by an AI agent **must** include
+a `Signed-off-by:` line (Developer Certificate of Origin). Pass `-s` /
+`--signoff` to `git commit`, or add the line manually:
+
+```
+Signed-off-by: Your Name <your@email.com>
+```
+
+The name and e-mail must match the committer's git identity
+(`git config user.name` / `git config user.email`).
+
+A `commit-msg` pre-commit hook enforces this. Install it **once per clone**
+(in addition to the usual `pre-commit install`):
+
+```bash
+pre-commit install --hook-type commit-msg
+```
+
 ## Pre-commit — match CI before you stop
 
 - From the **IsaacTeleop repo root** (this directory), run pre-commit and **fix all failures** before you treat a change as finished (do not only rely on “should pass” reasoning).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 
@@ -32,7 +32,7 @@ tools and hooks as follows:
 ```bash
 uv tool install ruff
 uv tool install pre-commit
-pre-commit install
+pre-commit install --hook-type pre-commit --hook-type commit-msg
 ```
 
 After that, pre-commit runs automatically on `git commit`. To run on all files manually:

--- a/scripts/check_dco_signoff.py
+++ b/scripts/check_dco_signoff.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Commit-msg hook: reject commits that lack a DCO Signed-off-by line."""
+
+import re
+import sys
+
+# Matches a real git trailer line: "Signed-off-by: Name <email>" at the start
+# of a line, with at least one non-whitespace character before the angle bracket.
+_TRAILER_RE = re.compile(r"^Signed-off-by: \S.*<\S+>", re.MULTILINE)
+
+
+def main() -> None:
+    commit_msg_file = sys.argv[1]
+    with open(commit_msg_file) as f:
+        msg = f.read()
+
+    # Strip comment lines that git inserts (e.g. with --verbose)
+    body = "\n".join(line for line in msg.splitlines() if not line.startswith("#"))
+
+    if _TRAILER_RE.search(body):
+        sys.exit(0)
+
+    print(
+        "ERROR: commit message is missing a DCO Signed-off-by line.\n"
+        "\n"
+        "  Add it automatically:  git commit -s  (or --signoff)\n"
+        "  Or append manually:\n"
+        "\n"
+        "    Signed-off-by: Your Name <your@email.com>\n"
+        "\n"
+        "  Name/email must match: git config user.name / user.email\n"
+        "  See AGENTS.md § Commits for details.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **AGENTS.md**: new §Commits section documenting that AI-drafted commits must include a `Signed-off-by:` line, with example and the one-time hook install step
- **scripts/check_dco_signoff.py**: `commit-msg` hook script — fails with a clear error when `Signed-off-by:` is absent (strips git comment lines before checking)
- **.pre-commit-config.yaml**: wires the hook in at the `commit-msg` stage

## Usage

Install the hook once per clone (in addition to the normal `pre-commit install`):

```bash
pre-commit install --hook-type commit-msg
```

After that, any commit without `-s`/`--signoff` is rejected before it lands.

## Test plan

- [ ] `pre-commit install --hook-type commit-msg` on a fresh clone
- [ ] `git commit` without `-s` → hook rejects with clear error
- [ ] `git commit -s` → hook passes
- [ ] Commit with `Signed-off-by:` already in message body → hook passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a commit-message check that helps ensure commits include a required sign-off line.
  * Introduced guidance for using sign-off on AI-drafted or edited commits.
* **Documentation**
  * Updated contributor instructions with how to install and use the commit-message hook.
  * Clarified the sign-off requirement and how it must match your Git identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->