### PR TITLE
docs: add LeRobot and SO-101 getting-started guide

### DIFF
--- a/docs/source/_static/lerobot/sim-teleop-example-huggingface.gif
+++ b/docs/source/_static/lerobot/sim-teleop-example-huggingface.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:19e19886b0faa181f5cfc04624cb1a581cef8e4ad2c21c2b1f66adeb34624f31
+size 5152490

--- a/docs/source/_static/lerobot/so-101-isaac-teleop-real.gif
+++ b/docs/source/_static/lerobot/so-101-isaac-teleop-real.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0b4d491a490c232b28c4c8613fd38f33713e1803f111f097c3b5319d30adcb5
+size 2125305

--- a/docs/source/_static/lerobot/so-101-isaac-teleop-sim.gif
+++ b/docs/source/_static/lerobot/so-101-isaac-teleop-sim.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:324e251b145d7b566d1e2e2f5737d78ce5e8d282f5253023d867a6e73859a143
+size 2975110

--- a/docs/source/_static/lerobot/so101_vial_to_rack_task.gif
+++ b/docs/source/_static/lerobot/so101_vial_to_rack_task.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8b7c2e8569b7072a53635463531a666423f186342529a6b1fdbe8bb91de4d7a8
+size 11676445

--- a/docs/source/device/joint_space.rst
+++ b/docs/source/device/joint_space.rst
@@ -69,6 +69,8 @@ The gripper is just another named DOF (conventionally ``"gripper"``). ``velocity
 and ``ee_pose`` are optional/reserved: the reference plugin and ``JointStateSource`` populate and
 surface joint **positions** only.
 
+.. _so101-leader-plugin:
+
 The SO-101 leader plugin
 ------------------------
 

--- a/docs/source/getting_started/lerobot/data_collection_real.rst
+++ b/docs/source/getting_started/lerobot/data_collection_real.rst
@@ -1,0 +1,185 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Data Collection in Real
+=======================
+
+Record demonstrations on a physical SO-101 into a `LeRobot dataset
+<https://huggingface.co/docs/lerobot/en/index>`_, driving the follower with either teleop device
+(see :doc:`devices`). The example scripts live in ``examples/isaac_teleop_to_so101/`` in the
+`LeRobot <https://github.com/huggingface/lerobot>`_ repository: ``teleoperate.py`` drives the arm
+live, and ``record.py`` does the same while saving a dataset. Both take the same
+``--robot.*`` / ``--teleop.*`` flags; ``--teleop.type`` selects the device
+(``xr_controller`` | ``so101_leader``).
+
+Before you start
+----------------
+
+#. A working **SO-101 follower** — assembled, motors set up, and calibrated. See
+   `SO-101 support in LeRobot`_.
+
+#. The **isaac-teleop extra** installed (``isaacteleop`` ships on public PyPI; its
+   ``[cloudxr,retargeters]`` extras pull the CloudXR runtime bindings and the retargeter library):
+
+   .. code-block:: bash
+
+      uv pip install -e '.[isaac-teleop]'
+
+#. Run the scripts from the example directory, and log in to the Hugging Face Hub — recorded
+   datasets are pushed to the Hub by default (pass ``--dataset.push_to_hub=false`` to keep them
+   local):
+
+   .. code-block:: bash
+
+      cd examples/isaac_teleop_to_so101
+      huggingface-cli login
+
+Then follow the steps for your teleop device:
+
+.. tab-set::
+
+   .. tab-item:: XR controller
+
+      The controller pose drives the follower's end-effector through the clutch + IK pipeline,
+      streamed over CloudXR.
+
+      #. **Fetch the robot model.** The XR path solves inverse kinematics, so it needs the SO-101
+         URDF and meshes (downloaded into ``./SO101/``):
+
+         .. code-block:: bash
+
+            python download_assets.py
+
+      #. **Connect a headset.** Bring up CloudXR and connect your XR headset — follow the
+         :doc:`/getting_started/quick_start`.
+
+      #. **(Optional) Try teleoperation without recording.** A good way to check the setup before
+         committing to a dataset:
+
+         .. code-block:: bash
+
+            python teleoperate.py \
+                --robot.type=so101_follower \
+                --robot.port=/dev/ttyACM0 \
+                --robot.id=so101_follower_arm \
+                --teleop.type=xr_controller
+
+         Squeeze and hold the grip to engage the clutch and move the arm; the trigger controls the
+         gripper. Release the grip to pause.
+
+      #. **Record a dataset.** Add cameras and the dataset parameters:
+
+         .. code-block:: bash
+
+            python record.py \
+                --robot.type=so101_follower \
+                --robot.port=/dev/ttyACM0 \
+                --robot.id=so101_follower_arm \
+                --teleop.type=xr_controller \
+                --robot.cameras="{ front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}" \
+                --dataset.repo_id=<hf_user>/<dataset_name> \
+                --dataset.single_task="Pick up vial from rack on the left side" \
+                --dataset.num_episodes=3 \
+                --dataset.episode_time_s=20 \
+                --dataset.reset_time_s=5
+
+      .. note::
+
+         **Customizing the reset pose.** On startup the XR path slews the arm to a built-in default
+         reset pose (a comfortable mid-range pose) before handing control to the clutch — you do
+         **not** need to record anything. To tailor it to your setup, back-drive the arm to the
+         pose you want and run ``python override_reset_pose.py``; it writes ``reset_pose.json``
+         (git-ignored, user-local), which takes priority over the default on the next run. Pass
+         ``--reset_to_origin=false`` to skip the slew and keep the arm where it is.
+
+   .. tab-item:: SO-101 Leader
+
+      A back-drivable SO-101 leader arm mirrored 1:1 to the follower. Its joints are streamed by
+      Isaac Teleop's ``so101_leader`` plugin, which the script launches for you.
+
+      #. **Build the so101_leader plugin.** It is part of Isaac Teleop's C++ source, not the
+         ``isaacteleop`` pip package, so build it from an Isaac Teleop checkout:
+
+         .. code-block:: bash
+
+            cmake -B build && cmake --build build --parallel && cmake --install build
+
+         The binary lands at ``install/plugins/so101_leader/so101_leader_plugin``. For details see
+         :ref:`so101-leader-plugin` and :doc:`/getting_started/build_from_source/index`.
+
+      #. **Calibrate the leader** so the leader and follower agree on each joint's zero and range.
+         This reuses the serial SO-101 leader's calibration (stored under ``so_leader/<id>.json``
+         and reused on every run):
+
+         .. code-block:: bash
+
+            lerobot-calibrate \
+                --teleop.type=so101_leader \
+                --teleop.port=/dev/ttyACM1 \
+                --teleop.id=so101_leader_arm
+
+      #. **(Optional) Try teleoperation without recording.** ``--launch_plugin`` spawns the plugin
+         after CloudXR is up; ``--teleop.port`` is the leader's serial port:
+
+         .. code-block:: bash
+
+            python teleoperate.py \
+                --robot.type=so101_follower \
+                --robot.port=/dev/ttyACM0 \
+                --robot.id=so101_follower_arm \
+                --teleop.type=so101_leader \
+                --teleop.port=/dev/ttyACM1 \
+                --teleop.id=so101_leader_arm \
+                --launch_plugin=/path/to/IsaacTeleop/install/plugins/so101_leader/so101_leader_plugin
+
+         Back-drive the leader arm by hand to move the follower.
+
+      #. **Record a dataset.** Same flags as teleoperation, plus the cameras and dataset parameters
+         (keep ``--launch_plugin`` so the plugin is started):
+
+         .. code-block:: bash
+
+            python record.py \
+                --robot.type=so101_follower \
+                --robot.port=/dev/ttyACM0 \
+                --robot.id=so101_follower_arm \
+                --teleop.type=so101_leader \
+                --teleop.port=/dev/ttyACM1 \
+                --teleop.id=so101_leader_arm \
+                --launch_plugin=/path/to/IsaacTeleop/install/plugins/so101_leader/so101_leader_plugin \
+                --robot.cameras="{ front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}" \
+                --dataset.repo_id=<hf_user>/<dataset_name> \
+                --dataset.single_task="Pick up vial from rack on the left side" \
+                --dataset.num_episodes=3 \
+                --dataset.episode_time_s=20 \
+                --dataset.reset_time_s=5
+
+Recording controls
+------------------
+
+``record.py`` records ``--dataset.num_episodes`` episodes of ``--dataset.episode_time_s`` seconds
+each, with a ``--dataset.reset_time_s`` window between episodes to reposition the scene. While
+it is running, **press** these keys in the terminal where ``record.py`` is running — the example
+reads them from that terminal, so they work over SSH and in a plain terminal (Linux/macOS), with
+no desktop session required:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 78
+
+   * - Key
+     - Action
+   * - Right arrow →
+     - End the current episode early and save it.
+   * - Left arrow ←
+     - Discard the current take and re-record it.
+   * - Escape
+     - Stop after the current episode (already-saved episodes are kept).
+
+Set ``LEROBOT_KEYBOARD_BACKEND`` to override how keys are read — ``auto`` (the default; uses the
+terminal when one is attached, otherwise a global listener), ``stdin``, ``pynput``, or ``none``.
+The dataset is written under ``$HF_LEROBOT_HOME/<repo_id>`` and pushed to the Hub when recording
+finishes (unless ``--dataset.push_to_hub=false``). Next, train a policy on it:
+:doc:`training_groot`.
+
+.. _SO-101 support in LeRobot: https://huggingface.co/docs/lerobot/en/so101

--- a/docs/source/getting_started/lerobot/data_collection_sim.rst
+++ b/docs/source/getting_started/lerobot/data_collection_sim.rst
@@ -1,0 +1,108 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Data Collection in Sim
+======================
+
+Collect SO-101 demonstrations in simulation with `NVIDIA Isaac Lab
+<https://isaac-sim.github.io/IsaacLab>`_, on the cube-stacking task. You drive the simulated
+follower through Isaac Teleop (see :doc:`devices`) and record episodes to an HDF5 dataset.
+
+Two SO-101 stack tasks are registered in Isaac Lab:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Task id
+     - Use
+   * - ``IsaacContrib-Stack-Cube-SO101-IK-Abs-v0``
+     - Absolute-pose IK + Isaac Teleop teleoperation (use this for data collection).
+   * - ``IsaacContrib-Stack-Cube-SO101-v0``
+     - Joint-position control baseline (no teleop).
+
+Before you start
+----------------
+
+.. important::
+
+   Both steps below are **required** — complete them first. The teleoperation and recording
+   commands later on will not work until you have.
+
+**Step 1 — Install Isaac Lab.** Follow the `Isaac Lab installation guide`_ to set up the ``Lab``
+repository, then run every script through its launcher: ``./isaaclab.sh -p <script> ...`` (or
+plain ``python`` inside the activated Isaac Lab environment). The SO-101 USD assets stream from
+the NVIDIA Nucleus server, so there is no manual asset download.
+
+**Step 2 — Set up CloudXR and connect a headset.** XR teleoperation needs CloudXR and a headset,
+the same as the real flow — follow the :doc:`/getting_started/quick_start` and the
+`CloudXR teleoperation in Isaac Lab`_ guide. CloudXR auto-launches by default; pick the profile
+with ``--cloudxr_env`` (``cloudxrjs`` for Quest/Pico, ``avp`` for Apple Vision Pro, ``none`` to
+disable). No physical headset? Open the CloudXR web client in a desktop browser, which emulates a
+headset.
+
+Collect Teleop Data
+-------------------
+
+.. tab-set::
+
+   .. tab-item:: XR controller
+
+      The controller pose drives the simulated follower's end-effector through the clutch + IK
+      pipeline, streamed over CloudXR — the same controls as on real hardware.
+
+      #. **(Optional) Try teleoperation without recording.** A good way to check the setup first:
+
+         .. code-block:: bash
+
+            ./isaaclab.sh -p scripts/environments/teleoperation/teleop_se3_agent.py \
+                --task IsaacContrib-Stack-Cube-SO101-IK-Abs-v0 \
+                --xr \
+                --viz kit
+
+         ``--xr`` enables the XR/CloudXR path and ``--viz kit`` opens the Omniverse Kit viewport.
+         Squeeze and hold the grip to engage the clutch and move the arm; the trigger controls the
+         gripper.
+
+      #. **Record a dataset.** ``record_demos.py`` runs the same teleoperation while saving
+         episodes to HDF5. It records ``--num_demos`` demonstrations, marking one successful after
+         ``--num_success_steps`` consecutive success frames:
+
+         .. code-block:: bash
+
+            ./isaaclab.sh -p scripts/tools/record_demos.py \
+                --task IsaacContrib-Stack-Cube-SO101-IK-Abs-v0 \
+                --dataset_file ./datasets/so101_stack_demos.hdf5 \
+                --num_demos 10 \
+                --step_hz 30 \
+                --xr \
+                --viz kit
+
+         The demos are written to the ``--dataset_file`` path in HDF5 format.
+
+   .. tab-item:: SO-101 Leader
+
+      .. admonition:: 🚧 Work in progress
+         :class: caution
+
+         Driving the simulated follower from an **SO-101 Leader** arm is **not yet supported in
+         Isaac Lab** — Isaac Lab has no joint-space leader device, and the SO-101 stack task is
+         wired only for the XR controller. Sim leader support is planned; until then, use the
+         leader arm on the real robot (:doc:`data_collection_real`).
+
+Convert to LeRobot Dataset
+--------------------------
+
+.. admonition:: 🚧 Work in progress
+   :class: caution
+
+   **Export to a LeRobot dataset.** Converting these sim HDF5 demos to the
+   :doc:`LeRobot dataset format <training_groot>` is **not yet provided** for the stack task. The
+   closest reference is the locomanipulation converter `convert_dataset.py`_ from the ``develop``
+   branch in Isaac Lab, which targets a different task and must be adapted.
+
+..
+   References
+.. _Isaac Lab installation guide: https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html#isaaclab-installation-root
+.. _CloudXR teleoperation in Isaac Lab: https://isaac-sim.github.io/IsaacLab/develop/source/how-to/cloudxr_teleoperation.html
+.. _convert_dataset.py: https://github.com/isaac-sim/IsaacLab/blob/develop/scripts/imitation_learning/locomanipulation_sdg/gr00t/convert_dataset.py

--- a/docs/source/getting_started/lerobot/devices.rst
+++ b/docs/source/getting_started/lerobot/devices.rst
@@ -1,0 +1,109 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Supported Teleop devices
+========================
+
+Isaac Teleop drives the SO-101 from two input devices today. Both command the same SO-101 follower
+arm and produce the same LeRobot-format demonstrations — pick the one that matches the hardware you
+have and the control feel you want.
+
+XR controller
+-------------
+
+A VR controller — from a Meta Quest, PICO, or Apple Vision Pro headset — streamed to your
+workstation over `NVIDIA CloudXR <https://docs.nvidia.com/cloudxr-sdk>`_. The controller pose drives
+the SO-101 **end-effector** target, which inverse kinematics turns into arm joint commands, so you
+steer the gripper through space rather than posing each joint.
+
+A **clutch** (deadman) keeps teleoperation safe: the arm only moves while you hold the grip engaged.
+Releasing pauses motion, and re-engaging re-centers on the arm's current pose, so the arm never
+jumps when you reposition your hand.
+
+**Controls**
+
+- **Squeeze / grip** — the clutch. Hold to engage teleoperation; release to pause.
+- **Trigger** — the gripper, controlled proportionally (analog).
+- **Controller orientation** — the wrist. On the 5-DOF SO-101 the wrist follows your hand only
+  partially, by design.
+
+The XR controller is **self-calibrating** — there is no leader arm and no manual calibration step —
+and it works in both simulation and on real hardware. You will need a CloudXR-connected headset; see
+the :doc:`Quick Start </getting_started/quick_start>` for headset setup.
+
+SO-101 Leader
+-------------
+
+A second, back-drivable SO-101 arm used as a **leader**: you move the leader by hand and the SO-101
+follower mirrors it. Because the leader and follower share the same kinematics, the mapping is a
+**direct joint-space mirror** — there is no inverse kinematics and no clutch; the follower tracks the
+leader's joints one-to-one.
+
+The leader's joint stream is published by Isaac Teleop's native ``so101_leader`` plugin, which the
+teleoperation example launches for you.
+
+This path needs the physical leader arm and a one-time **calibration** so the leader and follower
+agree on each joint's zero and range. Calibrate with ``lerobot-calibrate`` (or the plugin's own
+calibration step); the result is reused on every run.
+
+The SO-101 Leader gives the most direct, intuitive feel for SO-101 teleoperation, at the cost of
+needing a second arm.
+
+The SO-101 Leader is the first :doc:`joint-space device </device/joint_space>` in Isaac Teleop — one
+that streams joint positions directly instead of an end-effector pose. The interface is general, so
+the SO-101 Leader is just the starting point; feature requests and/or contributions that add more
+joint-space devices are highly welcome.
+
+Choosing a device
+-----------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 39 39
+
+   * -
+     - XR controller
+     - SO-101 Leader
+   * - Hardware
+     - XR headset (CloudXR) that can be reused to teleoperate other robots
+     - A leader arm dedicated to SO-101
+   * - Mapping
+     - End-effector pose → IK, with a clutch
+     - Direct joint-space mirror (1:1)
+   * - Extra Features
+     - - No dedicated space needed for setting up a second arm
+       - Haptics support (coming soon)
+     - - No clutch or IK weights to tune
+
+Prerequisites and calibration
+-----------------------------
+
+Both devices share the same high-level setup — see the per-flow steps in
+:doc:`data_collection_real` and :doc:`data_collection_sim`. Calibration differs by device:
+
+- **XR controller** — **self-calibrating**: the clutch re-centers on every engage, so there is no
+  manual calibration step. It just needs a CloudXR-connected headset
+  (:doc:`/getting_started/quick_start`).
+- **SO-101 Leader** — needs a **one-time calibration** so the leader and follower agree on each
+  joint's zero and range:
+
+  .. code-block:: bash
+
+     lerobot-calibrate \
+         --teleop.type=so101_leader \
+         --teleop.port=/dev/ttyACM1 \
+         --teleop.id=so101_leader_arm
+
+  The result is stored under ``so_leader/<id>.json`` and reused on every run.
+
+Learn more
+----------
+
+For the device and retargeting internals behind these flows, see the Isaac Teleop references:
+
+- :doc:`/device/index` — the device interface and plugin model.
+- :doc:`/device/joint_space` — the SO-101 leader (joint-space) device and its plugin.
+- :doc:`/references/retargeting/index` — the retargeting interface.
+- :doc:`/references/retargeting/so101` — the SO-101 (5-DOF arm) retargeters used by the XR
+  controller.
+- :doc:`/references/retargeting/joint_space` — the joint-space retargeter used by the leader.

--- a/docs/source/getting_started/lerobot/index.rst
+++ b/docs/source/getting_started/lerobot/index.rst
@@ -1,0 +1,107 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+LeRobot and SO-101
+==================
+
+With Isaac Teleop, we got an end-to-end data collection and training pipeline for SO-101 in both sim and real teleoperation.
+
+The `SO-101 <https://github.com/TheRobotStudio/SO-ARM100>`_ is a low-cost, open-source robot arm
+that has become a popular platform in the `LeRobot <https://github.com/huggingface/lerobot>`_
+community. Isaac Teleop lets you drive an SO-101 from more than one teleoperation device to collect
+demonstrations — in simulation with `Isaac Lab <https://isaac-sim.github.io/IsaacLab>`_ and on real
+hardware with `SO-101 support in LeRobot <https://huggingface.co/docs/lerobot/en/so101>`_ — then train a GR00T N1.7
+manipulation policy on the result and close the loop from sim to real.
+
+The same SO-101 task runs in Isaac Lab and on the real arm, each recording a LeRobot dataset. The two
+panels below stack on narrow screens and sit side by side on wider ones, and can be replaced
+independently:
+
+.. grid:: 1 1 2 2
+   :gutter: 3
+
+   .. grid-item::
+
+      .. figure:: ../../_static/lerobot/so-101-isaac-teleop-sim.gif
+         :alt: SO-101 task teleoperated in Isaac Lab (simulation)
+         :width: 100%
+
+         In Isaac Lab (simulation)
+
+   .. grid-item::
+
+      .. figure:: ../../_static/lerobot/so-101-isaac-teleop-real.gif
+         :alt: SO-101 task teleoperated on the real arm
+         :width: 100%
+
+         On the real arm
+
+End-to-end workflow
+-------------------
+
+The same SO-101 embodiment runs in simulation and on real hardware, so a single workflow carries
+you from teleoperation to a deployed policy:
+
+#. **Teleoperate and collect.** Drive the SO-101 with the :doc:`XR controller or the SO-101 Leader
+   <devices>` and record demonstrations — in :doc:`real <data_collection_real>` and in
+   :doc:`simulation <data_collection_sim>`. Both produce datasets in the LeRobot format.
+
+.. Source: https://docs.nvidia.com/learning/physical-ai/sim-to-real-so-101/latest/_images/sim-teleop-example-huggingface.gif
+.. figure:: ../../_static/lerobot/sim-teleop-example-huggingface.gif
+   :alt: Data collection with LeRobot
+   :width: 600px
+   :align: center
+
+   Data Collection with LeRobot.
+
+#. **Train.** Fine-tune a :doc:`GR00T N1.7 <training_groot>` policy on the collected dataset.
+
+.. Source: https://docs.nvidia.com/learning/physical-ai/sim-to-real-so-101/latest/_images/so101_vial_to_rack_task.gif
+.. figure:: ../../_static/lerobot/so101_vial_to_rack_task.gif
+   :alt: Trained GR00T N1.7 policy running on the SO-101
+   :width: 600px
+   :align: center
+
+   The trained GR00T N1.7 policy running autonomously on the SO-101.
+
+#. **Deploy.** Take the policy from sim to real — see the `Sim-to-Real SO-101 learning path`_ —
+   addressing the sim-to-real gap with domain randomization, sim/real co-training, and
+   actuator-gap compensation.
+
+In this section
+---------------
+
+- :doc:`devices` — the supported teleop devices: the XR controller and the SO-101 Leader.
+- :doc:`data_collection_real` — record demonstrations on a physical SO-101.
+- :doc:`data_collection_sim` — record demonstrations in Isaac Lab.
+- :doc:`training_groot` — fine-tune a GR00T N1.7 policy on the collected data.
+
+New to XR teleoperation? Start with the :doc:`Isaac Teleop Quick Start </getting_started/quick_start>`
+to set up CloudXR and connect a headset.
+
+Pending Tasks
+-------------
+
+The guides below are still being written:
+
+| ☑ Implement teleop devices: XR controller and SO-101 Leader
+| ☑ Data collection in real
+| ☑ Data collection in sim (XR controller)
+| ☐ Data collection in sim (SO-101 Leader)
+| ☐ Export sim demos to the LeRobot dataset format
+| ☐ Model training with GR00T N1.7
+| ☐ Sim-to-Real — update the `Sim-to-Real SO-101 learning path`_ to use Isaac Teleop
+
+See also: the `Sim-to-Real SO-101 learning path`_.
+
+.. toctree::
+   :hidden:
+
+   devices
+   data_collection_real
+   data_collection_sim
+   training_groot
+
+..
+   References
+.. _Sim-to-Real SO-101 learning path: https://docs.nvidia.com/learning/physical-ai/sim-to-real-so-101/latest/index.html

--- a/docs/source/getting_started/lerobot/training_groot.rst
+++ b/docs/source/getting_started/lerobot/training_groot.rst
@@ -1,0 +1,20 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+Model Training with GR00T
+=========================
+
+With a LeRobot dataset collected on real hardware (:doc:`data_collection_real`) or in simulation
+(:doc:`data_collection_sim`), the next step is to fine-tune a GR00T N1.7 manipulation policy on it
+and evaluate the trained policy on the SO-101.
+
+.. admonition:: 🚧 Work in progress
+   :class: caution
+
+   This training guide is still being written. In the meantime, the
+   `Sim-to-Real SO-101 learning path`_ walks through GR00T N1.6 training and evaluation for the
+   SO-101 end to end, while the GR00T N1.7 model is still being finalized.
+
+..
+   References
+.. _Sim-to-Real SO-101 learning path: https://docs.nvidia.com/learning/physical-ai/sim-to-real-so-101/latest/index.html

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -53,6 +53,7 @@ Table of Contents
    getting_started/teleop_session
    getting_started/teleop_control_state_machine
    getting_started/televiz
+   getting_started/lerobot/index
    getting_started/contributing
 
 .. toctree::


### PR DESCRIPTION
New multi-page section under docs/source/getting_started/lerobot/ for the end-to-end SO-101 pipeline on Isaac Teleop, LeRobot, and Isaac Lab:

- index: overview, end-to-end workflow, and teleop/policy figures
- devices: the XR controller and SO-101 Leader teleop devices
- data_collection_real: record LeRobot datasets on hardware with either device, via the isaac_teleop_to_so101 example
- data_collection_sim: record in Isaac Lab with the XR controller (the SO-101 Leader and LeRobot export are work-in-progress)
- training_groot: GR00T N1.7 training (work-in-progress)

Also wires the landing page into the Getting Started toctree and adds a so101-leader-plugin ref label in device/joint_space.rst. Builds clean under sphinx-build -W.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [ ] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new getting-started documentation for SO-101, covering supported teleoperation devices, real-robot data collection, simulation data collection, and model training.
  * Introduced an overview page that links the full SO-101 workflow from teleoperation through dataset creation and policy training.
  * Added navigation links and reference anchors to make the new guides easier to find and cross-reference.

* **Documentation**
  * Expanded setup, recording, and workflow instructions, including prerequisites, controls, and notes on current limitations and work-in-progress guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->