### PR TITLE
🍒 enable Televiz by default + pip-install path for camera_viz/docs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,24 @@ option(BUILD_PLUGIN_OAK_CAMERA "Build OAK camera plugin (requires vcpkg for Dept
 option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_EXAMPLE_TELEOP_ROS2 "Build only the teleop_ros2 example (e.g. for Docker)" OFF)
 option(BUILD_TESTING "Build unit tests" ON)
-option(BUILD_VIZ "Build Televiz visualization module (requires Vulkan)" OFF)
+# Televiz (src/viz) needs Vulkan, the CUDA Toolkit, and glslangValidator.
+# Default BUILD_VIZ ON when all three are present (so it builds out of the box)
+# and OFF otherwise (so a core-only source build still configures on machines
+# without them). Override explicitly with -DBUILD_VIZ=ON/OFF.
+find_package(Vulkan QUIET)
+find_package(CUDAToolkit QUIET)
+find_program(_viz_glslang NAMES glslangValidator)
+if(Vulkan_FOUND AND CUDAToolkit_FOUND AND _viz_glslang)
+    set(_viz_default ON)
+else()
+    set(_viz_default OFF)
+endif()
+option(BUILD_VIZ "Build Televiz visualization module (auto-ON when Vulkan + CUDA + glslang are found)" ${_viz_default})
+if(BUILD_VIZ AND NOT (Vulkan_FOUND AND CUDAToolkit_FOUND AND _viz_glslang))
+    message(WARNING "BUILD_VIZ=ON but not all of Vulkan / CUDA Toolkit / glslangValidator were detected; "
+                    "the viz build may fail. Install the deps or pass -DBUILD_VIZ=OFF.")
+endif()
+message(STATUS "BUILD_VIZ: ${BUILD_VIZ} (Vulkan=${Vulkan_FOUND} CUDAToolkit=${CUDAToolkit_FOUND} glslang=${_viz_glslang})")
 option(ENABLE_EXPERIMENTAL_WINDOWS_BUILD "Enable experimental Windows build support (source code only)" OFF)
 
 # Note: This is used to check if the CloudXR bundle is available to be bundled with Isaac Teleop.

--- a/docs/source/_static/televiz_2d.gif
+++ b/docs/source/_static/televiz_2d.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0724094f3d50039e84f93ab773c3b77b9ffffaac15f74a9ea50d333e63497fc6
+size 2928224

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -180,6 +180,9 @@ The CMake options (defined in root :code-file:`CMakeLists.txt`, :code-file:`cmak
    * - **Clang-format check**
      - ``ENABLE_CLANG_FORMAT_CHECK``
      - ``ON`` on Linux
+   * - **Televiz visualization**
+     - ``BUILD_VIZ``
+     - Auto: ``ON`` when Vulkan, the CUDA Toolkit, and ``glslangValidator`` are detected, else ``OFF``. Force with ``-DBUILD_VIZ=ON`` / ``-DBUILD_VIZ=OFF``. (Most users don't need this — ``pip install isaacteleop`` already ships the compiled ``isaacteleop.viz`` module.)
 
 .. list-table:: Plugin Specific Options
    :widths: 26 34 40

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -21,6 +21,26 @@ directly.
    :local:
    :depth: 2
 
+Installation
+------------
+
+Televiz ships inside the ``isaacteleop`` wheel — install it from PyPI:
+
+.. code-block:: bash
+
+   pip install isaacteleop
+
+The published wheels (Linux x86_64 / aarch64, CPython 3.10–3.13) bundle the compiled
+``isaacteleop.viz`` module, so **no source build is required**. Verify with:
+
+.. code-block:: python
+
+   import isaacteleop.viz as televiz
+
+You only need to :doc:`build from source </getting_started/build_from_source/index>` when
+developing Isaac Teleop itself — that build enables Televiz automatically when Vulkan, the CUDA
+Toolkit, and ``glslangValidator`` are present.
+
 Overview
 --------
 
@@ -374,8 +394,8 @@ symbols live in ``namespace viz``, and headers use nested include paths::
    #include <viz/layers/quad_layer.hpp>
    #include <viz/core/viz_buffer.hpp>
 
-Enable ``BUILD_VIZ`` (default ``OFF``; requires Vulkan, the CUDA toolkit, and ``glslangValidator``)
-and link the relevant CMake target:
+``BUILD_VIZ`` auto-enables when Vulkan, the CUDA toolkit, and ``glslangValidator`` are detected
+(force it with ``-DBUILD_VIZ=ON`` / ``-DBUILD_VIZ=OFF``); link the relevant CMake target:
 
 .. list-table::
    :header-rows: 1

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -13,6 +13,13 @@ The sample lives at :code-dir:`examples/camera_viz/ <examples/camera_viz>`; this
 it works. For the exact command surface and flags, see the
 :code-file:`README <examples/camera_viz/README.md>`.
 
+.. figure:: ../_static/televiz_2d.gif
+   :alt: camera_viz in window mode with synthetic multi-camera feeds
+   :width: 420px
+   :class: no-image-zoom
+
+   ``camera_viz`` in XR mode — one plane per camera.
+
 .. contents:: On this page
    :local:
    :depth: 2
@@ -93,22 +100,23 @@ Televiz as the compositor at the end of the chain:
 Setup
 -----
 
-One-time setup builds the Televiz wheel and installs the sample's Python environment:
+One-time setup installs the sample's Python environment — no source build required:
 
 .. code-block:: bash
 
-   cmake -B build -DBUILD_VIZ=ON
-   cmake --build build --target python_wheel --parallel
    examples/camera_viz/camera_viz.sh setup
    source examples/camera_viz/.venv/bin/activate
 
-``setup`` installs every Python dependency into ``.venv/`` via ``uv``, builds the native NVENC/NVDEC
-codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack
-``cuda-nvrtc`` + ``ld.so`` wiring). When something is missing it prints the exact ``apt-get`` line
-and prompts ``[y/N]`` — answering ``n`` or running non-interactively aborts.
+``setup`` installs ``isaacteleop`` (which bundles Televiz) and every other Python dependency from
+PyPI into ``.venv/`` via ``uv``, builds the native NVENC/NVDEC codec, and probes system packages
+(GStreamer plugins, cairo / girepository headers, JetPack ``cuda-nvrtc`` + ``ld.so`` wiring). When
+something is missing it prints the exact ``apt-get`` line and prompts ``[y/N]`` — answering ``n`` or
+running non-interactively aborts.
 
 Useful flags: ``--no-{v4l2,oakd,rtp}``, ``--with-zed``, ``--sender-only``, ``--jetson``. Pass
-``--venv PATH`` to install into an existing virtual environment.
+``--venv PATH`` to install into an existing virtual environment. To develop against a locally built
+wheel instead of the PyPI release, pass ``--wheel <path>`` (see
+:doc:`/getting_started/build_from_source/index`).
 
 Running
 -------

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -28,15 +28,15 @@ Output: window or XR headset; one plane per camera, aspect-fit. Stereo cameras r
 ## Setup (one-time)
 
 ```bash
-cmake -B build -DBUILD_VIZ=ON
-cmake --build build --target python_wheel --parallel
 examples/camera_viz/camera_viz.sh setup
 source examples/camera_viz/.venv/bin/activate
 ```
 
-`setup` installs every Python dep into `.venv/` via `uv` (no `--system-site-packages`), builds the native NVENC/NVDEC codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts.
+`setup` installs `isaacteleop` (which bundles Televiz) and every other Python dep from PyPI into `.venv/` via `uv` (no `--system-site-packages`), builds the native NVENC/NVDEC codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts. No need to build IsaacTeleop from source.
 
 Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`. Pass `--venv PATH` to install into an existing venv (symlinks `.venv` → PATH so `run` / `loopback` pick it up too).
+
+> **Developing against a local build?** Pass `--wheel <path>` (e.g. `camera_viz.sh setup --wheel build/wheels/isaacteleop-*.whl`) to install a locally built wheel instead of the PyPI release. See the [build-from-source guide](../../docs/source/getting_started/build_from_source/index.rst).
 
 ---
 

--- a/examples/camera_viz/camera_viz.sh
+++ b/examples/camera_viz/camera_viz.sh
@@ -393,8 +393,8 @@ LOCAL
                           PATH instead of creating one in-place.
                           examples/camera_viz/.venv is symlinked → PATH
                           so run / loopback pick it up too.
-                          --sender-only skips the isaacteleop wheel + vulkan
-                          deps (use on Jetson sender hosts).
+                          --sender-only skips isaacteleop + vulkan deps
+                          (use on Jetson sender hosts).
                           --jetson adds JetPack-only checks: unversioned
                           CUDA lib symlinks + ld.so wiring that JetPack
                           skips. Off on desktop.

--- a/examples/camera_viz/pyproject.toml
+++ b/examples/camera_viz/pyproject.toml
@@ -3,8 +3,9 @@
 #
 # Standalone pyproject for camera_viz so `uv run` resolves the example's
 # deps without polluting the IsaacTeleop wheel's runtime requirements.
-# isaacteleop is consumed from the locally built wheel (./build/wheels/)
-# or from PyPI — point uv at it via --find-links / --with as needed.
+# isaacteleop (which bundles Televiz) is installed from PyPI by default by
+# ``camera_viz.sh setup``; pass ``setup --wheel <path>`` to use a locally
+# built wheel instead.
 
 [project]
 name = "camera-viz"

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -6,8 +6,9 @@
 # ``camera_viz.sh setup`` (local) and ``camera_viz.sh deploy`` (over SSH).
 #
 # Modes:
-#   --full         viewer + sender (workstation). Installs isaacteleop wheel.
-#   --sender-only  sender path only. No wheel, no vulkan deps.
+#   --full         viewer + sender (workstation). Installs isaacteleop from PyPI
+#                  (or a local --wheel).
+#   --sender-only  sender path only. No isaacteleop, no vulkan deps.
 #
 # Flags: --venv, --wheel, --python, --no-v4l2, --no-oakd, --no-rtp,
 #        --with-zed, --zed-sdk.
@@ -255,25 +256,23 @@ if ! command -v uv >/dev/null 2>&1; then
     fi
 fi
 
-# Resolve the wheel only in --full mode.
-if [[ "$MODE" == full ]]; then
-    if [[ -z "$WHEEL" ]]; then
-        if [[ -n "$REPO_ROOT" ]]; then
-            WHEEL=$(ls -1 "$REPO_ROOT"/build/wheels/isaacteleop-*.whl 2>/dev/null | head -1 || true)
-        fi
-    fi
-    [[ -n "$WHEEL" && -f "$WHEEL" ]] || {
-        echo "_install_deps.sh: no isaacteleop wheel found." >&2
-        echo "  Build one with: cmake --build build --target python_wheel" >&2
-        echo "  Or pass --wheel <path>. Or use --sender-only if this is a sender host." >&2
+# isaacteleop comes from PyPI by default (the published wheel includes the
+# viz module). --wheel <path> installs a locally built wheel instead — only
+# needed when developing against an unreleased build (see the build-from-source
+# docs). Sender-only deploys don't install isaacteleop at all.
+ISAACTELEOP_PKG="isaacteleop"
+if [[ "$MODE" == full && -n "$WHEEL" ]]; then
+    [[ -f "$WHEEL" ]] || {
+        echo "_install_deps.sh: --wheel '$WHEEL' not found." >&2
         exit 1
     }
+    ISAACTELEOP_PKG="$WHEEL"
 fi
 
 echo "==> mode:   $MODE"
 echo "==> venv:   $VENV_DIR"
 echo "==> python: $PYTHON_VERSION"
-[[ "$MODE" == full ]] && echo "==> wheel:  $WHEEL"
+[[ "$MODE" == full ]] && echo "==> isaacteleop: $ISAACTELEOP_PKG"
 
 if [[ ! -d "$VENV_DIR" ]]; then
     # Strict venv isolation: no --system-site-packages. PyGObject + every
@@ -321,7 +320,7 @@ fi
 # (libgirepository1.0-dev). 3.50.x supports both. Source-builds against
 # the C deps installed in ensure_apt_deps(); pycairo is a transitive dep.
 PKGS=("pyyaml>=6.0" "$target_cupy" "numpy>=1.23" "scipy>=1.15")
-[[ "$MODE" == full ]] && PKGS=("$WHEEL" "${PKGS[@]}")
+[[ "$MODE" == full ]] && PKGS=("$ISAACTELEOP_PKG" "${PKGS[@]}")
 $WITH_V4L2 && PKGS+=("opencv-python>=4.5")
 $WITH_OAKD && PKGS+=("depthai>=3.0")
 $WITH_RTP  && PKGS+=("pybind11>=2.11" "PyGObject>=3.42,<3.52")


### PR DESCRIPTION
- BUILD_VIZ now auto-detects: defaults ON when Vulkan, the CUDA Toolkit, and glslangValidator are present, OFF otherwise (so a core-only source build still configures). Override with -DBUILD_VIZ=ON/OFF.
- camera_viz setup installs isaacteleop from PyPI (the published wheel bundles the viz module) instead of requiring a local source build; --wheel <path> remains for developing against a locally built wheel.
- Docs: televiz gains a pip-install Installation section; camera_streaming Setup drops the cmake/python_wheel steps; build-from-source documents the BUILD_VIZ auto-default. Source builds are now opt-in for development only.

(cherry picked from commit 92e8cae47e3650f6697fcc0dd54fc4005656f987)
