### PR TITLE
Serve CloudXR client from ROS2 example

### DIFF
--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -390,6 +390,7 @@ class TeleopRos2Node(Node):
             accept_eula=self._params.cloudxr_params.accept_eula,
             setup_oob=self._params.cloudxr_params.setup_oob,
             usb_local=self._params.cloudxr_params.usb_local,
+            host_client=True,
         ) as launcher:
             self.get_logger().info(
                 "CloudXR runtime and WSS proxy started "


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Ensure live teleop_ros2 sessions host the WebXR client on the CloudXR proxy so headset clients can load it locally.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Manual test

## Checklist

- [ X ] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ X ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ X ] I have made corresponding changes to the documentation
- [ X ] I have added tests that prove my fix/feature works (or explained why not)
- [ X ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the teleoperation startup flow so the client launches in host mode, improving connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->