### PR TITLE
ROS: Publish EE poses in separate topics

### DIFF
--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -60,9 +60,10 @@ Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
 
 - `xr_teleop/hand` (`geometry_msgs/PoseArray`)
   - `poses`: Hand joint poses (all joints except palm, left then right); published by `hand_teleop` and by `controller_teleop` when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`
-- `xr_teleop/ee_poses` (`geometry_msgs/PoseArray`)
-  - `poses[0]`: Left hand/controller EE pose (if active)
-  - `poses[1]`: Right hand/controller EE pose (if active)
+- `xr_teleop/ee_pose_left` (`geometry_msgs/PoseStamped`)
+  - Left hand/controller EE pose; published when the left EE source is active
+- `xr_teleop/ee_pose_right` (`geometry_msgs/PoseStamped`)
+  - Right hand/controller EE pose; published when the right EE source is active
 - `xr_teleop/root_twist` (`geometry_msgs/TwistStamped`)
 - `xr_teleop/root_pose` (`geometry_msgs/PoseStamped`)
 - `xr_teleop/head_pose` (`geometry_msgs/PoseStamped`)
@@ -119,14 +120,16 @@ docker run --rm --gpus all --net=host --ipc=host \
   --name teleop_ros2_ref \
   teleop_ros2_ref --ros-args -p cloudxr_accept_eula:=true \
   -p world_frame:=odom -p rate_hz:=30.0 \
-  -r xr_teleop/hand:=my_robot/hand -r xr_teleop/ee_poses:=my_robot/ee_poses
+  -r xr_teleop/hand:=my_robot/hand \
+  -r xr_teleop/ee_pose_left:=my_robot/ee_pose_left \
+  -r xr_teleop/ee_pose_right:=my_robot/ee_pose_right
 ```
 
 Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 
-Available topics for remapping: `xr_teleop/hand`, `xr_teleop/ee_poses`, `xr_teleop/root_twist`, `xr_teleop/root_pose`, `xr_teleop/head_pose`, `xr_teleop/controller_data`, `xr_teleop/full_body`, `xr_teleop/finger_joints`. Active remaps can be inspected with `ros2 node info /teleop_ros2_node`.
+Available topics for remapping: `xr_teleop/hand`, `xr_teleop/ee_pose_left`, `xr_teleop/ee_pose_right`, `xr_teleop/root_twist`, `xr_teleop/root_pose`, `xr_teleop/head_pose`, `xr_teleop/controller_data`, `xr_teleop/full_body`, `xr_teleop/finger_joints`. Active remaps can be inspected with `ros2 node info /teleop_ros2_node`.
 
 ### Mode
 
@@ -134,8 +137,8 @@ The `mode` parameter selects the teleoperation scenario and which topics are pub
 
 | Mode | Topics published |
 |------|------------------|
-| `controller_teleop` (default) | `ee_poses` (from controller aim pose), `root_twist`, `root_pose`, `head_pose`, `finger_joints` (TriHand by default; Sharpa from Manus/OpenXR hands when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`), `controller_data`, `tf` (from controller aim pose and head pose), and `hand` only for the explicit Sharpa retargeter path |
-| `hand_teleop` | `ee_poses` (from hand tracking wrist), `hand` (finger joints in pose space), `finger_joints` (finger joints in joint space), `root_twist`, `root_pose`, `head_pose`, `tf` (from hand tracking wrist and head pose); locomotion comes from the configured foot pedal collection |
+| `controller_teleop` (default) | `ee_pose_left`, `ee_pose_right` (from controller aim pose), `root_twist`, `root_pose`, `head_pose`, `finger_joints` (TriHand by default; Sharpa from Manus/OpenXR hands when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`), `controller_data`, `tf` (from controller aim pose and head pose), and `hand` only for the explicit Sharpa retargeter path |
+| `hand_teleop` | `ee_pose_left`, `ee_pose_right` (from hand tracking wrist), `hand` (finger joints in pose space), `finger_joints` (finger joints in joint space), `root_twist`, `root_pose`, `head_pose`, `tf` (from hand tracking wrist and head pose); locomotion comes from the configured foot pedal collection |
 | `controller_raw` | `controller_data` only |
 | `full_body` | `full_body` and `controller_data` |
 
@@ -191,7 +194,8 @@ coverage.
 docker exec -it teleop_ros2_ref /bin/bash
 
 ros2 topic echo /xr_teleop/hand geometry_msgs/msg/PoseArray
-ros2 topic echo /xr_teleop/ee_poses geometry_msgs/msg/PoseArray
+ros2 topic echo /xr_teleop/ee_pose_left geometry_msgs/msg/PoseStamped
+ros2 topic echo /xr_teleop/ee_pose_right geometry_msgs/msg/PoseStamped
 ros2 topic echo /xr_teleop/root_twist geometry_msgs/msg/TwistStamped
 ros2 topic echo /xr_teleop/root_pose geometry_msgs/msg/PoseStamped
 ros2 topic echo /xr_teleop/head_pose geometry_msgs/msg/PoseStamped

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -69,6 +69,26 @@ def _assert_pose_array(msg: PoseArray, *, expected_count: int) -> None:
         raise ValueError("pose array positions are all zero")
 
 
+def _assert_pose_stamped(
+    msg: PoseStamped, *, require_nonzero_position: bool = False
+) -> None:
+    if msg.header.frame_id != "world":
+        raise ValueError(f"unexpected frame_id {msg.header.frame_id!r}")
+    position = (msg.pose.position.x, msg.pose.position.y, msg.pose.position.z)
+    orientation = (
+        msg.pose.orientation.x,
+        msg.pose.orientation.y,
+        msg.pose.orientation.z,
+        msg.pose.orientation.w,
+    )
+    if not _is_finite_sequence(position):
+        raise ValueError("PoseStamped position contains non-finite values")
+    if not _is_finite_sequence(orientation):
+        raise ValueError("PoseStamped orientation contains non-finite values")
+    if require_nonzero_position and not any(abs(value) > 1e-6 for value in position):
+        raise ValueError("PoseStamped position is all zero")
+
+
 def _assert_joint_state(msg: JointState) -> None:
     if msg.header.frame_id != "world":
         raise ValueError(f"unexpected frame_id {msg.header.frame_id!r}")
@@ -93,22 +113,6 @@ def _assert_twist(msg: TwistStamped) -> None:
     )
     if not _is_finite_sequence(values):
         raise ValueError("TwistStamped contains non-finite values")
-
-
-def _assert_root_pose(msg: PoseStamped) -> None:
-    if msg.header.frame_id != "world":
-        raise ValueError(f"unexpected frame_id {msg.header.frame_id!r}")
-    position = (msg.pose.position.x, msg.pose.position.y, msg.pose.position.z)
-    orientation = (
-        msg.pose.orientation.x,
-        msg.pose.orientation.y,
-        msg.pose.orientation.z,
-        msg.pose.orientation.w,
-    )
-    if not _is_finite_sequence(position):
-        raise ValueError("PoseStamped position contains non-finite values")
-    if not _is_finite_sequence(orientation):
-        raise ValueError("PoseStamped orientation contains non-finite values")
 
 
 def _assert_controller_payload(msg: ByteMultiArray) -> None:
@@ -225,14 +229,24 @@ class TopicVerifier(Node):
         if mode == "controller_teleop":
             return [
                 (
-                    "ee_poses",
-                    "xr_teleop/ee_poses",
-                    PoseArray,
-                    lambda msg: _assert_pose_array(msg, expected_count=2),
+                    "ee_pose_left",
+                    "xr_teleop/ee_pose_left",
+                    PoseStamped,
+                    lambda msg: _assert_pose_stamped(
+                        msg, require_nonzero_position=True
+                    ),
+                ),
+                (
+                    "ee_pose_right",
+                    "xr_teleop/ee_pose_right",
+                    PoseStamped,
+                    lambda msg: _assert_pose_stamped(
+                        msg, require_nonzero_position=True
+                    ),
                 ),
                 ("root_twist", "xr_teleop/root_twist", TwistStamped, _assert_twist),
-                ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_root_pose),
-                ("head_pose", "xr_teleop/head_pose", PoseStamped, _assert_root_pose),
+                ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_pose_stamped),
+                ("head_pose", "xr_teleop/head_pose", PoseStamped, _assert_pose_stamped),
                 (
                     "finger_joints",
                     "xr_teleop/finger_joints",
@@ -255,14 +269,24 @@ class TopicVerifier(Node):
                     lambda msg: _assert_pose_array(msg, expected_count=50),
                 ),
                 (
-                    "ee_poses",
-                    "xr_teleop/ee_poses",
-                    PoseArray,
-                    lambda msg: _assert_pose_array(msg, expected_count=2),
+                    "ee_pose_left",
+                    "xr_teleop/ee_pose_left",
+                    PoseStamped,
+                    lambda msg: _assert_pose_stamped(
+                        msg, require_nonzero_position=True
+                    ),
+                ),
+                (
+                    "ee_pose_right",
+                    "xr_teleop/ee_pose_right",
+                    PoseStamped,
+                    lambda msg: _assert_pose_stamped(
+                        msg, require_nonzero_position=True
+                    ),
                 ),
                 ("root_twist", "xr_teleop/root_twist", TwistStamped, _assert_twist),
-                ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_root_pose),
-                ("head_pose", "xr_teleop/head_pose", PoseStamped, _assert_root_pose),
+                ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_pose_stamped),
+                ("head_pose", "xr_teleop/head_pose", PoseStamped, _assert_pose_stamped),
                 (
                     "finger_joints",
                     "xr_teleop/finger_joints",

--- a/examples/teleop_ros2/python/messages.py
+++ b/examples/teleop_ros2/python/messages.py
@@ -8,7 +8,7 @@ import time
 from typing import Dict, Sequence
 
 import numpy as np
-from geometry_msgs.msg import PoseArray, PoseStamped
+from geometry_msgs.msg import Pose, PoseArray, PoseStamped
 from scipy.spatial.transform import Rotation
 from sensor_msgs.msg import JointState
 
@@ -34,6 +34,14 @@ from tensor_group_helpers import (
     head_is_valid,
     joint_names_from_group_type,
 )
+
+
+def _to_pose_stamped(pose: Pose, now, frame_id: str) -> PoseStamped:
+    msg = PoseStamped()
+    msg.header.stamp = now
+    msg.header.frame_id = frame_id
+    msg.pose = pose
+    return msg
 
 
 def build_controller_payload(
@@ -111,93 +119,50 @@ def build_controller_payload(
     }
 
 
-def build_ee_msg_from_controllers(
-    left_ctrl: OptionalTensorGroup,
-    right_ctrl: OptionalTensorGroup,
+def build_ee_msg_from_controller(
+    ctrl: OptionalTensorGroup,
+    side: str,
     now,
     frame_id: str,
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
     controller_uses_hands_source: bool = False,
-) -> PoseArray:
-    """Build a PoseArray with left then right controller/hand wrist poses."""
-    msg = PoseArray()
-    msg.header.stamp = now
-    msg.header.frame_id = frame_id
+) -> PoseStamped | None:
+    if not controller_aim_is_valid(ctrl):
+        return None
 
-    if controller_aim_is_valid(left_ctrl):
-        pos = [float(x) for x in left_ctrl[ControllerInputIndex.AIM_POSITION]]
-        ori = [float(x) for x in left_ctrl[ControllerInputIndex.AIM_ORIENTATION]]
-        pose = to_pose(pos, ori)
+    pos = [float(x) for x in ctrl[ControllerInputIndex.AIM_POSITION]]
+    ori = [float(x) for x in ctrl[ControllerInputIndex.AIM_ORIENTATION]]
+    pose = to_pose(pos, ori)
 
-        if transform_rot is not None or transform_trans is not None:
-            pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
+    if transform_rot is not None or transform_trans is not None:
+        pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
 
-        if controller_uses_hands_source:
-            pose = apply_manus_controller_to_hand_pose(pose, "left")
+    if controller_uses_hands_source:
+        pose = apply_manus_controller_to_hand_pose(pose, side)
 
-        msg.poses.append(pose)
-    else:
-        msg.poses.append(to_pose([0.0, 0.0, 0.0]))
-
-    if controller_aim_is_valid(right_ctrl):
-        pos = [float(x) for x in right_ctrl[ControllerInputIndex.AIM_POSITION]]
-        ori = [float(x) for x in right_ctrl[ControllerInputIndex.AIM_ORIENTATION]]
-        pose = to_pose(pos, ori)
-
-        if transform_rot is not None or transform_trans is not None:
-            pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
-
-        if controller_uses_hands_source:
-            pose = apply_manus_controller_to_hand_pose(pose, "right")
-
-        msg.poses.append(pose)
-    else:
-        msg.poses.append(to_pose([0.0, 0.0, 0.0]))
-
-    return msg
+    return _to_pose_stamped(pose, now, frame_id)
 
 
-def build_ee_msg_from_hands(
-    left_hand: OptionalTensorGroup,
-    right_hand: OptionalTensorGroup,
+def build_ee_msg_from_hand(
+    hand: OptionalTensorGroup,
     now,
     frame_id: str,
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
-) -> PoseArray:
-    """Build a PoseArray with left then right hand wrist poses (EE proxy)."""
-    msg = PoseArray()
-    msg.header.stamp = now
-    msg.header.frame_id = frame_id
+) -> PoseStamped | None:
+    if not hand_wrist_is_valid(hand):
+        return None
 
-    if hand_wrist_is_valid(left_hand):
-        left_positions = np.asarray(left_hand[HandInputIndex.JOINT_POSITIONS])
-        left_orientations = np.asarray(left_hand[HandInputIndex.JOINT_ORIENTATIONS])
-        pose = to_pose(
-            left_positions[HandJointIndex.WRIST],
-            left_orientations[HandJointIndex.WRIST],
-        )
-        if transform_rot is not None or transform_trans is not None:
-            pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
-        msg.poses.append(pose)
-    else:
-        msg.poses.append(to_pose([0.0, 0.0, 0.0]))
-
-    if hand_wrist_is_valid(right_hand):
-        right_positions = np.asarray(right_hand[HandInputIndex.JOINT_POSITIONS])
-        right_orientations = np.asarray(right_hand[HandInputIndex.JOINT_ORIENTATIONS])
-        pose = to_pose(
-            right_positions[HandJointIndex.WRIST],
-            right_orientations[HandJointIndex.WRIST],
-        )
-        if transform_rot is not None or transform_trans is not None:
-            pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
-        msg.poses.append(pose)
-    else:
-        msg.poses.append(to_pose([0.0, 0.0, 0.0]))
-
-    return msg
+    positions = np.asarray(hand[HandInputIndex.JOINT_POSITIONS])
+    orientations = np.asarray(hand[HandInputIndex.JOINT_ORIENTATIONS])
+    pose = to_pose(
+        positions[HandJointIndex.WRIST],
+        orientations[HandJointIndex.WRIST],
+    )
+    if transform_rot is not None or transform_trans is not None:
+        pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
+    return _to_pose_stamped(pose, now, frame_id)
 
 
 def build_finger_joints_msg(
@@ -314,8 +279,4 @@ def build_head_msg(
     if transform_rot is not None or transform_trans is not None:
         pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
 
-    msg = PoseStamped()
-    msg.header.stamp = now
-    msg.header.frame_id = frame_id
-    msg.pose = pose
-    return msg
+    return _to_pose_stamped(pose, now, frame_id)

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -10,20 +10,21 @@ Publishes teleoperation data over ROS2 topics using isaacteleop TeleopSession.
 The `mode` parameter selects the teleoperation scenario and which topics are
 published:
 
-  - controller_teleop (default): ee_poses (from controller aim pose), root_twist,
-                       root_pose, finger_joints (retargeted TriHand angles),
-                       controller_data, head_pose, and TF transforms for
-                       left/right wrists and head
-  - hand_teleop: ee_poses (from hand tracking wrist), hand (finger joint poses),
-                 finger_joints (retargeted Sharpa joint angles),
-                 root_twist/root_pose (from foot pedal locomotion), head_pose,
-                 and TF transforms for left/right wrists and head
+  - controller_teleop (default): ee_pose_left/ee_pose_right (from controller
+                       aim pose), root_twist, root_pose, finger_joints
+                       (retargeted TriHand angles), controller_data, head_pose,
+                       and TF transforms for left/right wrists and head
+  - hand_teleop: ee_pose_left/ee_pose_right (from hand tracking wrist), hand
+                 (finger joint poses), finger_joints (retargeted Sharpa joint
+                 angles), root_twist/root_pose (from foot pedal locomotion),
+                 head_pose, and TF transforms for left/right wrists and head
   - controller_raw: controller_data only
   - full_body: full_body and controller_data
 
 Topic names (remappable via ROS 2 remapping):
   - xr_teleop/hand (PoseArray): [finger_joint_poses...]
-  - xr_teleop/ee_poses (PoseArray): [left_ee, right_ee]
+  - xr_teleop/ee_pose_left (PoseStamped): left hand/controller EE pose
+  - xr_teleop/ee_pose_right (PoseStamped): right hand/controller EE pose
   - xr_teleop/root_twist (TwistStamped): root velocity command
   - xr_teleop/root_pose (PoseStamped): root pose command (height only)
   - xr_teleop/head_pose (PoseStamped): head pose
@@ -61,8 +62,8 @@ from isaacteleop.teleop_session_manager import SessionMode, TeleopSession
 from geometry import make_transform
 from messages import (
     build_controller_payload,
-    build_ee_msg_from_controllers,
-    build_ee_msg_from_hands,
+    build_ee_msg_from_controller,
+    build_ee_msg_from_hand,
     build_finger_joints_msg,
     build_full_body_payload,
     build_hand_msg_from_hands,
@@ -74,8 +75,6 @@ from node_parameters import (
 )
 from session_config import build_session_config
 from tensor_group_helpers import (
-    controller_aim_is_valid,
-    hand_wrist_is_valid,
     head_is_valid,
 )
 
@@ -92,13 +91,12 @@ class TeleopRos2Node(Node):
 
     def _build_wrist_tfs(
         self,
-        ee_msg: PoseArray,
+        left_ee_msg: PoseStamped | None,
+        right_ee_msg: PoseStamped | None,
         *,
-        right_available: bool,
-        left_available: bool,
         now,
     ) -> List[TransformStamped]:
-        """Build wrist TF transforms from a pre-built ee_poses PoseArray (left pose at index 0, right at index 1)."""
+        """Build wrist TF transforms from side-specific EE pose messages."""
         tfs = []
 
         def _get_orientation(pose: Pose) -> List[float]:
@@ -109,8 +107,8 @@ class TeleopRos2Node(Node):
                 pose.orientation.w,
             ]
 
-        if left_available:
-            pose = ee_msg.poses[0]
+        if left_ee_msg is not None:
+            pose = left_ee_msg.pose
             tfs.append(
                 make_transform(
                     now,
@@ -120,8 +118,8 @@ class TeleopRos2Node(Node):
                     _get_orientation(pose),
                 )
             )
-        if right_available:
-            pose = ee_msg.poses[1]
+        if right_ee_msg is not None:
+            pose = right_ee_msg.pose
             tfs.append(
                 make_transform(
                     now,
@@ -135,7 +133,12 @@ class TeleopRos2Node(Node):
 
     def _create_publishers(self) -> None:
         self._pub_hand = self.create_publisher(PoseArray, "xr_teleop/hand", 10)
-        self._pub_ee_pose = self.create_publisher(PoseArray, "xr_teleop/ee_poses", 10)
+        self._pub_ee_pose_left = self.create_publisher(
+            PoseStamped, "xr_teleop/ee_pose_left", 10
+        )
+        self._pub_ee_pose_right = self.create_publisher(
+            PoseStamped, "xr_teleop/ee_pose_right", 10
+        )
         self._pub_root_twist = self.create_publisher(
             TwistStamped, "xr_teleop/root_twist", 10
         )
@@ -156,21 +159,31 @@ class TeleopRos2Node(Node):
     def _publish_controller_outputs(self, result: dict, now) -> None:
         left_ctrl = result["controller_left"]
         right_ctrl = result["controller_right"]
-        ee_msg = build_ee_msg_from_controllers(
+        left_ee_msg = build_ee_msg_from_controller(
             left_ctrl,
-            right_ctrl,
+            "left",
             now,
             self._params.world_frame,
             self._params.transform_rotation,
             self._params.transform_translation,
             self._params.controller_uses_hands_source,
         )
-        if ee_msg.poses:
-            self._pub_ee_pose.publish(ee_msg)
+        right_ee_msg = build_ee_msg_from_controller(
+            right_ctrl,
+            "right",
+            now,
+            self._params.world_frame,
+            self._params.transform_rotation,
+            self._params.transform_translation,
+            self._params.controller_uses_hands_source,
+        )
+        if left_ee_msg is not None:
+            self._pub_ee_pose_left.publish(left_ee_msg)
+        if right_ee_msg is not None:
+            self._pub_ee_pose_right.publish(right_ee_msg)
         wrist_tfs = self._build_wrist_tfs(
-            ee_msg,
-            right_available=controller_aim_is_valid(right_ctrl),
-            left_available=controller_aim_is_valid(left_ctrl),
+            left_ee_msg,
+            right_ee_msg,
             now=now,
         )
         if wrist_tfs:
@@ -247,20 +260,27 @@ class TeleopRos2Node(Node):
         if hand_msg.poses:
             self._pub_hand.publish(hand_msg)
 
-        ee_msg = build_ee_msg_from_hands(
+        left_ee_msg = build_ee_msg_from_hand(
             left_hand,
+            now,
+            self._params.world_frame,
+            self._params.transform_rotation,
+            self._params.transform_translation,
+        )
+        right_ee_msg = build_ee_msg_from_hand(
             right_hand,
             now,
             self._params.world_frame,
             self._params.transform_rotation,
             self._params.transform_translation,
         )
-        if ee_msg.poses:
-            self._pub_ee_pose.publish(ee_msg)
+        if left_ee_msg is not None:
+            self._pub_ee_pose_left.publish(left_ee_msg)
+        if right_ee_msg is not None:
+            self._pub_ee_pose_right.publish(right_ee_msg)
         wrist_tfs = self._build_wrist_tfs(
-            ee_msg,
-            right_available=hand_wrist_is_valid(right_hand),
-            left_available=hand_wrist_is_valid(left_hand),
+            left_ee_msg,
+            right_ee_msg,
             now=now,
         )
         if wrist_tfs:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Currently EE poses are published in an unannotated Pose Array, which makes it hard for consumers to distinguish left from right. Switch to two PoseStamped topics with clear frame ids

Fixes #538 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Verified published topics

## Checklist

- [X] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [X] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix/feature works (or explained why not)
- [X] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * End-effector pose outputs now use separate left and right topics.
  * Updated ROS 2 teleop examples and remapping guidance to reflect the new topic names.

* **Bug Fixes**
  * Improved pose handling and validation for teleop outputs.
  * End-effector, head, and root pose messages now include consistent stamped pose data and frame information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->