### PR TITLE
Use CloudXRLauncher CLI helpers in mcap examples.

### DIFF
--- a/examples/mcap_record_replay/python/live_controller.py
+++ b/examples/mcap_record_replay/python/live_controller.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from pathlib import Path
@@ -51,22 +50,11 @@ def main(argv: list[str]) -> int:
         help="Accept the NVIDIA CloudXR EULA non-interactively",
     )
     parser.add_argument(
-        "--install-dir",
-        default="~/.cloudxr",
-        help="CloudXR install directory (default: ~/.cloudxr)",
-    )
-    parser.add_argument(
         "--env-file",
         default=str(Path(__file__).parent / "default.env"),
         help="Path to a KEY=value env file for CloudXR overrides (default: default.env)",
     )
-    parser.add_argument(
-        "--launch-cloudxr-runtime",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Launch the CloudXR runtime automatically (default: true; pass "
-        "--no-launch-cloudxr-runtime to connect to the system runtime instead)",
-    )
+    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -78,16 +66,9 @@ def main(argv: list[str]) -> int:
         pipeline=build_controller_pipeline(),
     )
 
-    launcher_ctx = (
-        contextlib.nullcontext()
-        if not args.launch_cloudxr_runtime
-        else CloudXRLauncher(
-            install_dir=args.install_dir,
-            env_config=args.env_file,
-            accept_eula=args.accept_eula,
-        )
-    )
-    with launcher_ctx as launcher:
+    with CloudXRLauncher.launch_context(
+        args, env_config=args.env_file, accept_eula=args.accept_eula
+    ) as launcher:
         if launcher is not None:
             print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")

--- a/examples/mcap_record_replay/python/live_full_body.py
+++ b/examples/mcap_record_replay/python/live_full_body.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from pathlib import Path
@@ -47,22 +46,11 @@ def main(argv: list[str]) -> int:
         help="Accept the NVIDIA CloudXR EULA non-interactively",
     )
     parser.add_argument(
-        "--install-dir",
-        default="~/.cloudxr",
-        help="CloudXR install directory (default: ~/.cloudxr)",
-    )
-    parser.add_argument(
         "--env-file",
         default=str(Path(__file__).parent / "default.env"),
         help="Path to a KEY=value env file for CloudXR overrides (default: default.env)",
     )
-    parser.add_argument(
-        "--launch-cloudxr-runtime",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Launch the CloudXR runtime automatically (default: true; pass "
-        "--no-launch-cloudxr-runtime to connect to the system runtime instead)",
-    )
+    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -74,16 +62,9 @@ def main(argv: list[str]) -> int:
         pipeline=build_full_body_pipeline(),
     )
 
-    launcher_ctx = (
-        contextlib.nullcontext()
-        if not args.launch_cloudxr_runtime
-        else CloudXRLauncher(
-            install_dir=args.install_dir,
-            env_config=args.env_file,
-            accept_eula=args.accept_eula,
-        )
-    )
-    with launcher_ctx as launcher:
+    with CloudXRLauncher.launch_context(
+        args, env_config=args.env_file, accept_eula=args.accept_eula
+    ) as launcher:
         if launcher is not None:
             print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")

--- a/examples/mcap_record_replay/python/live_hand.py
+++ b/examples/mcap_record_replay/python/live_hand.py
@@ -17,7 +17,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from pathlib import Path
@@ -45,22 +44,11 @@ def main(argv: list[str]) -> int:
         help="Accept the NVIDIA CloudXR EULA non-interactively",
     )
     parser.add_argument(
-        "--install-dir",
-        default="~/.cloudxr",
-        help="CloudXR install directory (default: ~/.cloudxr)",
-    )
-    parser.add_argument(
         "--env-file",
         default=str(Path(__file__).parent / "default.env"),
         help="Path to a KEY=value env file for CloudXR overrides (default: default.env)",
     )
-    parser.add_argument(
-        "--launch-cloudxr-runtime",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Launch the CloudXR runtime automatically (default: true; pass "
-        "--no-launch-cloudxr-runtime to connect to the system runtime instead)",
-    )
+    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -72,16 +60,9 @@ def main(argv: list[str]) -> int:
         pipeline=build_hand_pipeline(),
     )
 
-    launcher_ctx = (
-        contextlib.nullcontext()
-        if not args.launch_cloudxr_runtime
-        else CloudXRLauncher(
-            install_dir=args.install_dir,
-            env_config=args.env_file,
-            accept_eula=args.accept_eula,
-        )
-    )
-    with launcher_ctx as launcher:
+    with CloudXRLauncher.launch_context(
+        args, env_config=args.env_file, accept_eula=args.accept_eula
+    ) as launcher:
         if launcher is not None:
             print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")

--- a/examples/mcap_record_replay/python/record_controller.py
+++ b/examples/mcap_record_replay/python/record_controller.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from datetime import datetime
@@ -44,22 +43,11 @@ def main(argv: list[str]) -> int:
         help="Accept the NVIDIA CloudXR EULA non-interactively",
     )
     parser.add_argument(
-        "--install-dir",
-        default="~/.cloudxr",
-        help="CloudXR install directory (default: ~/.cloudxr)",
-    )
-    parser.add_argument(
         "--env-file",
         default=str(Path(__file__).parent / "default.env"),
         help="Path to a KEY=value env file for CloudXR overrides (default: default.env)",
     )
-    parser.add_argument(
-        "--launch-cloudxr-runtime",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Launch the CloudXR runtime automatically (default: true; pass "
-        "--no-launch-cloudxr-runtime to connect to the system runtime instead)",
-    )
+    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -80,16 +68,9 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    launcher_ctx = (
-        contextlib.nullcontext()
-        if not args.launch_cloudxr_runtime
-        else CloudXRLauncher(
-            install_dir=args.install_dir,
-            env_config=args.env_file,
-            accept_eula=args.accept_eula,
-        )
-    )
-    with launcher_ctx as launcher:
+    with CloudXRLauncher.launch_context(
+        args, env_config=args.env_file, accept_eula=args.accept_eula
+    ) as launcher:
         if launcher is not None:
             print(
                 f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"

--- a/examples/mcap_record_replay/python/record_full_body.py
+++ b/examples/mcap_record_replay/python/record_full_body.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from datetime import datetime
@@ -46,22 +45,11 @@ def main(argv: list[str]) -> int:
         help="Accept the NVIDIA CloudXR EULA non-interactively",
     )
     parser.add_argument(
-        "--install-dir",
-        default="~/.cloudxr",
-        help="CloudXR install directory (default: ~/.cloudxr)",
-    )
-    parser.add_argument(
         "--env-file",
         default=str(Path(__file__).parent / "default.env"),
         help="Path to a KEY=value env file for CloudXR overrides (default: default.env)",
     )
-    parser.add_argument(
-        "--launch-cloudxr-runtime",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Launch the CloudXR runtime automatically (default: true; pass "
-        "--no-launch-cloudxr-runtime to connect to the system runtime instead)",
-    )
+    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -82,16 +70,9 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    launcher_ctx = (
-        contextlib.nullcontext()
-        if not args.launch_cloudxr_runtime
-        else CloudXRLauncher(
-            install_dir=args.install_dir,
-            env_config=args.env_file,
-            accept_eula=args.accept_eula,
-        )
-    )
-    with launcher_ctx as launcher:
+    with CloudXRLauncher.launch_context(
+        args, env_config=args.env_file, accept_eula=args.accept_eula
+    ) as launcher:
         if launcher is not None:
             print(
                 f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"

--- a/examples/mcap_record_replay/python/record_hand.py
+++ b/examples/mcap_record_replay/python/record_hand.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from datetime import datetime
@@ -43,22 +42,11 @@ def main(argv: list[str]) -> int:
         help="Accept the NVIDIA CloudXR EULA non-interactively",
     )
     parser.add_argument(
-        "--install-dir",
-        default="~/.cloudxr",
-        help="CloudXR install directory (default: ~/.cloudxr)",
-    )
-    parser.add_argument(
         "--env-file",
         default=str(Path(__file__).parent / "default.env"),
         help="Path to a KEY=value env file for CloudXR overrides (default: default.env)",
     )
-    parser.add_argument(
-        "--launch-cloudxr-runtime",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Launch the CloudXR runtime automatically (default: true; pass "
-        "--no-launch-cloudxr-runtime to connect to the system runtime instead)",
-    )
+    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -79,16 +67,9 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    launcher_ctx = (
-        contextlib.nullcontext()
-        if not args.launch_cloudxr_runtime
-        else CloudXRLauncher(
-            install_dir=args.install_dir,
-            env_config=args.env_file,
-            accept_eula=args.accept_eula,
-        )
-    )
-    with launcher_ctx as launcher:
+    with CloudXRLauncher.launch_context(
+        args, env_config=args.env_file, accept_eula=args.accept_eula
+    ) as launcher:
         if launcher is not None:
             print(
                 f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"


### PR DESCRIPTION
Short term: the six mcap record/live scripts (record_hand, record_controller, record_full_body, live_hand, live_controller, live_full_body) hand-rolled the --launch-cloudxr-runtime flag and the nullcontext()/CloudXRLauncher(...) branching. Replace that duplication with the shared CloudXRLauncher.add_launcher_arguments(parser) and CloudXRLauncher.launch_context(...) helpers, forwarding --env-file and --accept-eula as keyword arguments, and drop the now-unused contextlib import. This standardizes these examples on the same launcher wiring the teleop examples already use.

Behavior note: --install-dir is now --cloudxr-install-dir, and a --cloudxr-device-profile flag is now available (both from the shared helper).

Long term: the goal is to unify all examples onto a single launcher/session setup (e.g. a shared ExampleSession helper) so each example carries only its teaching-specific code.


<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading CloudXR override settings from an environment file.
  * Expanded the example scripts’ command-line options to include additional CloudXR launcher settings.

* **Improvements**
  * Simplified CloudXR startup across record and live replay examples for more consistent behavior.
  * Removed several script-specific CloudXR options in favor of shared launcher handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->