### PR TITLE
Add CloudXRLauncher to remaining TeleopSession examples

### DIFF
--- a/examples/teleop/python/g1_trihand_retargeting_example.py
+++ b/examples/teleop/python/g1_trihand_retargeting_example.py
@@ -11,10 +11,12 @@ This example shows:
 1. TriHandMotionControllerRetargeter - Simple VR controller-based hand control for G1 TriHand
 """
 
+import argparse
 import sys
 import time
 from pathlib import Path
 
+from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.retargeting_engine.deviceio_source_nodes import ControllersSource
 from isaacteleop.retargeters import (
     TriHandMotionControllerRetargeter,
@@ -31,6 +33,10 @@ PLUGIN_ROOT_ID = "synthetic_hands"
 
 def example_trihand_motion_controller():
     """Run TriHandMotionControllerRetargeter example with VR controllers."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    CloudXRLauncher.add_launcher_arguments(parser)
+    args = parser.parse_args()
+
     print("\n" + "=" * 80)
     print("  TriHandMotionControllerRetargeter Example")
     print("=" * 80)
@@ -112,7 +118,10 @@ def example_trihand_motion_controller():
         )
     session_config.plugins = plugins
 
-    with TeleopSession(session_config) as session:
+    with (
+        CloudXRLauncher.launch_context(args),
+        TeleopSession(session_config) as session,
+    ):
         # No session injection needed
 
         run_motion_controller_loop(session)

--- a/examples/teleop/python/gripper_retargeting_example.py
+++ b/examples/teleop/python/gripper_retargeting_example.py
@@ -9,11 +9,13 @@ This example manually connects Controller and Hand sources to Gripper and SE3 re
 combining their outputs into a unified action vector (Pose + Gripper) executed via TeleopSession.
 """
 
+import argparse
 import sys
 import time
 from pathlib import Path
 
 import numpy as np
+from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.retargeting_engine.deviceio_source_nodes import (
     ControllersSource,
     HandsSource,
@@ -40,6 +42,10 @@ PLUGIN_ROOT_ID = "synthetic_hands"
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    CloudXRLauncher.add_launcher_arguments(parser)
+    args = parser.parse_args()
+
     # Create controllers source (tracker is internal)
     controllers = ControllersSource(name="controllers")
     hands = HandsSource(name="hands")
@@ -111,7 +117,7 @@ def main():
     )
 
     # Use TeleopSession to manage the loop and data injection
-    with TeleopSession(config) as session:
+    with CloudXRLauncher.launch_context(args), TeleopSession(config) as session:
         run_loop(session)
 
     return 0

--- a/examples/teleop/python/gripper_retargeting_example_simple.py
+++ b/examples/teleop/python/gripper_retargeting_example_simple.py
@@ -8,11 +8,13 @@ Demonstrates using TeleopSession with the new retargeting engine.
 Minimal boilerplate - just configure and run!
 """
 
+import argparse
 import sys
 import time
 from pathlib import Path
 import isaacteleop.deviceio as deviceio
 
+from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.retargeters import (
     GripperRetargeter,
     GripperRetargeterConfig,
@@ -31,6 +33,10 @@ PLUGIN_ROOT_ID = "synthetic_hands"
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    CloudXRLauncher.add_launcher_arguments(parser)
+    args = parser.parse_args()
+
     # ==================================================================
     # Setup: Create standard inputs (trackers + sources)
     # ==================================================================
@@ -80,7 +86,7 @@ def main():
         plugins=plugins,
     )
 
-    with TeleopSession(config) as session:
+    with CloudXRLauncher.launch_context(args), TeleopSession(config) as session:
         # No session injection needed
 
         print("\n" + "=" * 60)

--- a/examples/teleop/python/locomotion_retargeting_example.py
+++ b/examples/teleop/python/locomotion_retargeting_example.py
@@ -8,11 +8,13 @@ Demonstrates using LocomotionRootCmdRetargeter to generate robot base commands
 from VR controller inputs.
 """
 
+import argparse
 import sys
 import time
 from pathlib import Path
 import isaacteleop.deviceio as deviceio
 
+from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.retargeters import (
     LocomotionRootCmdRetargeter,
     LocomotionRootCmdRetargeterConfig,
@@ -31,6 +33,10 @@ PLUGIN_ROOT_ID = "synthetic_hands"
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    CloudXRLauncher.add_launcher_arguments(parser)
+    args = parser.parse_args()
+
     print("\n" + "=" * 80)
     print("  Locomotion Retargeting Example")
     print("=" * 80)
@@ -93,7 +99,10 @@ def main():
         plugins=plugins,
     )
 
-    with TeleopSession(session_config) as session:
+    with (
+        CloudXRLauncher.launch_context(args),
+        TeleopSession(session_config) as session,
+    ):
         # No need to inject session anymore
 
         start_time = time.time()

--- a/examples/teleop_session_manager/python/external_inputs_example.py
+++ b/examples/teleop_session_manager/python/external_inputs_example.py
@@ -44,11 +44,13 @@ Scenario:
     so they both use ValueInput rather than custom subclasses.
 """
 
+import argparse
 import sys
 import time
 import numpy as np
 from pathlib import Path
 
+from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.retargeting_engine.deviceio_source_nodes import ControllersSource
 from isaacteleop.retargeting_engine.interface import (
     BaseRetargeter,
@@ -172,6 +174,10 @@ class DeltaPositionRetargeter(BaseRetargeter):
 
 
 def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    CloudXRLauncher.add_launcher_arguments(parser)
+    args = parser.parse_args()
+
     # ==================================================================
     # 1. Build Pipeline
     # ==================================================================
@@ -282,7 +288,7 @@ def main() -> int:
         ],
     )
 
-    with TeleopSession(config) as session:
+    with CloudXRLauncher.launch_context(args), TeleopSession(config) as session:
         # ==============================================================
         # 3. Discover what external inputs the pipeline expects
         # ==============================================================

--- a/examples/teleop_session_manager/python/teleop_session_example.py
+++ b/examples/teleop_session_manager/python/teleop_session_example.py
@@ -12,12 +12,14 @@ This example shows:
 3. Displaying velocity data
 """
 
+import argparse
 import sys
 import time
 import numpy as np
 from pathlib import Path
 from typing import Optional
 
+from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.retargeting_engine.deviceio_source_nodes import (
     HandsSource,
     ControllersSource,
@@ -163,6 +165,10 @@ class VelocityTracker(BaseRetargeter):
 
 
 def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    CloudXRLauncher.add_launcher_arguments(parser)
+    args = parser.parse_args()
+
     # ==================================================================
     # Build Pipeline
     # ==================================================================
@@ -196,7 +202,7 @@ def main():
         ],
     )
 
-    with TeleopSession(config) as session:
+    with CloudXRLauncher.launch_context(args), TeleopSession(config) as session:
         print("\n" + "=" * 70)
         print("Velocity Tracker - Move your hands and controllers")
         print("Press Ctrl+C to exit")


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Teleoperation examples now accept command-line options for CloudXR setup.
  * Updated example startup flow so sessions run inside a CloudXR-enabled launch context.

* **Bug Fixes**
  * Improved example execution consistency by ensuring the CloudXR environment is active throughout teleop and retargeting loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->