### PR TITLE
fix: extract _load_libcloudxr() so runtime_version() uses RTLD_DEEPBIND

### DIFF
--- a/src/core/cloudxr/python/runtime.py
+++ b/src/core/cloudxr/python/runtime.py
@@ -145,10 +145,16 @@ def wait_for_runtime_ready_sync(
     return False
 
 
+def _load_libcloudxr(sdk_path: str) -> ctypes.CDLL:
+    """Load libcloudxr.so with RTLD_DEEPBIND so the native stack resolves symbols from its own packaged libraries."""
+    deepbind = getattr(os, "RTLD_DEEPBIND", 0)
+    return ctypes.CDLL(os.path.join(sdk_path, "libcloudxr.so"), mode=deepbind)
+
+
 def runtime_version() -> str:
     """Query the CloudXR runtime version from the native library (major.minor.patch)."""
     sdk_path = _get_sdk_path()
-    lib = ctypes.CDLL(os.path.join(sdk_path, "libcloudxr.so"))
+    lib = _load_libcloudxr(sdk_path)
     if not hasattr(lib, "nv_cxr_get_runtime_version"):
         return "unknown"
     major, minor, patch = ctypes.c_uint32(), ctypes.c_uint32(), ctypes.c_uint32()
@@ -247,9 +253,7 @@ def run() -> None:
         os.close(devnull_fd)
         os.close(stderr_fd)
 
-    lib_path = os.path.join(sdk_path, "libcloudxr.so")
-    deepbind = getattr(os, "RTLD_DEEPBIND", 0)
-    lib = ctypes.CDLL(lib_path, mode=deepbind)
+    lib = _load_libcloudxr(sdk_path)
     svc = ctypes.c_void_p()
     # Signal handler must only call stop() after create() has run; avoid calling with null svc.
     state = {"service_created": False, "interrupted": False}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Standardize libcloudxr.so loading with a helper.

Related to: https://github.com/NVIDIA/IsaacTeleop/pull/254

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native library loading to be more reliable across environments.
  * Version checks and runtime startup now use a consistent loading path, which may reduce loading-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->