### PR TITLE
fix(webxr): ship safe Quest profile defaults (72 FPS, 25 Mbps)

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/DeviceProfiles.test.ts
+++ b/deps/cloudxr/webxr_client/helpers/DeviceProfiles.test.ts
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DEVICE_PROFILES } from './DeviceProfiles';
+
+describe('device profile defaults', () => {
+  it('keeps every profile bitrate within the 100 Mbps StreamSDK ceiling', () => {
+    for (const profile of Object.values(DEVICE_PROFILES)) {
+      const kbps = profile.cloudxr?.maxStreamingBitrateKbps;
+      if (kbps !== undefined) {
+        expect(kbps).toBeLessThanOrEqual(100000);
+      }
+    }
+  });
+});

--- a/deps/cloudxr/webxr_client/helpers/DeviceProfiles.ts
+++ b/deps/cloudxr/webxr_client/helpers/DeviceProfiles.ts
@@ -88,8 +88,12 @@ const QUEST3_PROFILE: DeviceProfile = {
   cloudxr: {
     perEyeWidth: 2048,
     perEyeHeight: 1792,
-    deviceFrameRate: 90,
-    maxStreamingBitrateKbps: 150000,
+    // 72 FPS / 25 Mbps: measured stable on a wireless Quest 3 production deployment.
+    // The previous 90 FPS left sessions paced against a rate the stream did not hold
+    // there (frames landing out of phase), and 150 Mbps saturated the link while
+    // exceeding the 100 Mbps ceiling StreamSDK guidance warns about.
+    deviceFrameRate: 72,
+    maxStreamingBitrateKbps: 25000,
     codec: 'av1',
     enablePoseSmoothing: true,
     posePredictionFactor: 1.0,

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -24,7 +24,8 @@
     "preset": "ts-jest",
     "testEnvironment": "node",
     "roots": [
-      "<rootDir>/src"
+      "<rootDir>/src",
+      "<rootDir>/helpers"
     ]
   },
   "dependencies": {

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -228,6 +228,15 @@ export class CloudXR2DUI {
       // Before URL seeds so explicit params still win: on a fresh load, default the
       // device profile from the headset UA and apply its values.
       this.applyDefaultDeviceProfileFromUserAgent();
+      // Re-apply a persisted non-custom profile so profile updates reach returning
+      // clients: localStorage restores the values saved when the profile was picked,
+      // which otherwise pins them forever. Safe because any manual edit of a
+      // profile-bound field switches the persisted profile to 'custom'.
+      const persistedProfileId = resolveDeviceProfileId(this.deviceProfileSelect.value);
+      if (persistedProfileId !== 'custom') {
+        this.applyDeviceProfileToForm(persistedProfileId);
+        this.persistProfileFieldsToLocalStorage();
+      }
       this.applyUrlSeeds();
       this.setupProxyConfiguration();
       this.renderUrlParamsHelp();
@@ -491,8 +500,10 @@ export class CloudXR2DUI {
       perEyeHeight: 1792,
       reprojectionGridCols: 0,
       reprojectionGridRows: 0,
-      deviceFrameRate: 90,
-      maxStreamingBitrateMbps: 150,
+      // Keep in sync with the Quest profile defaults (helpers/DeviceProfiles.ts)
+      // and the 'selected' options in index.html.
+      deviceFrameRate: 72,
+      maxStreamingBitrateMbps: 25,
       codec: 'av1',
       immersiveMode: 'ar',
       deviceProfileId: 'custom',

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -905,8 +905,8 @@ limitations under the License.
                             <label class="input-label">Frame Rate Configuration</label>
                             <label for="deviceFrameRate" class="input-label">Device Frame Rate</label>
                             <select id="deviceFrameRate" class="ui-input config-input">
-                                <option value="72">72 FPS</option>
-                                <option value="90" selected>90 FPS</option>
+                                <option value="72" selected>72 FPS</option>
+                                <option value="90">90 FPS</option>
                                 <option value="120">120 FPS</option>
                             </select>
                             <div class="config-text">
@@ -949,10 +949,12 @@ limitations under the License.
                             <label class="input-label">Maximum Streaming Bitrate</label>
                             <label for="maxStreamingBitrateMbps" class="input-label">Megabits per second</label>
                             <select id="maxStreamingBitrateMbps" class="ui-input config-input">
+                                <option value="25" selected>25 Mbps</option>
+                                <option value="50">50 Mbps</option>
                                 <option value="80">80 Mbps</option>
                                 <option value="100">100 Mbps</option>
                                 <option value="120">120 Mbps</option>
-                                <option value="150" selected>150 Mbps</option>
+                                <option value="150">150 Mbps</option>
                                 <option value="180">180 Mbps</option>
                                 <option value="200">200 Mbps</option>
                             </select>

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -224,6 +224,19 @@ running the CloudXR runtime and wss proxy in containerized environment; or using
 
    .. note::
 
+      Out of the box, Quest headsets stream at 72 FPS and 25 Mbps (Pico 4 Ultra at 90 FPS
+      and 100 Mbps). You can raise both under **Advanced settings** in the control panel,
+      up to 120 FPS and 200 Mbps, but on a typical 5 GHz Wi-Fi link the higher bitrates
+      saturate the connection and you get reprojection judder within a few minutes. The
+      defaults are the values that held stable over long sessions in our testing.
+
+      The client remembers your settings between sessions. A saved profile other than
+      ``Custom`` picks up the current recommended values on the next load, so updated
+      defaults reach you without clearing browser storage. Switch the profile to
+      ``Custom`` if you want your manual values to stick.
+
+   .. note::
+
       If GitHub Pages is unreachable (corporate network, air-gapped machine), start the server with
       ``--host-client`` in step :ref:`run-cloudxr-server` and open
       ``https://<your-ip>:48322/client/`` instead of the GitHub Pages URL. Port 48322 is already

--- a/docs/source/references/oob_teleop_control.rst
+++ b/docs/source/references/oob_teleop_control.rst
@@ -332,6 +332,11 @@ previously saved settings:
 - ``codec`` video codec
 - ``panelHiddenAtStart`` hide the control panel on load
 
+When no URL override is present, form fields restore from ``localStorage``, with one
+exception: a saved device profile other than ``Custom`` is re-applied from the current
+profile table at startup, so profile default updates (frame rate, bitrate, codec)
+reach returning clients. Only ``Custom`` keeps manually edited values.
+
 Environment variables
 ---------------------
 


### PR DESCRIPTION
# Description

Out of the box, a Quest connecting to the web client gets the 90 FPS / 150 Mbps profile, which on most Wi-Fi setups means reprojection judder and freezes within a few minutes. This ships Quest defaults that just work.

What changed:

- `DeviceProfiles.ts`: the Quest profile now defaults to 72 FPS and 25 Mbps. 4K per eye at 90 Hz over 150 Mbps saturates a typical 5 GHz link; 72/25 held stable over long real sessions in our testing.
- `index.html`: the bitrate select gains 25 and 50 Mbps options so the new defaults are actually selectable in the UI.
- `CloudXR2DUI.tsx`: on initialize, a persisted non-custom profile is re-applied from the current profile table, so users who stored the old defaults in localStorage pick up the safe ones without clearing storage.
- `DeviceProfiles.test.ts`: new unit test asserting no device profile ships a bitrate above 100 Mbps.
- `package.json`: the jest roots now include `helpers/` so the new test runs with `npm test`.

How tested: jest unit tests, plus real Quest 3 sessions over CloudXR with the new defaults (72 FPS negotiated end to end, no freezes at 25 Mbps where 150 Mbps froze within minutes).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated coverage to verify streaming bitrate settings stay within supported limits.

* **Bug Fixes**
  * Updated default device streaming settings to use 72 FPS and 25 Mbps for more stable behavior.
  * Restored saved device profile selections more reliably after initialization, helping prevent outdated settings from sticking.
  * Updated the UI defaults so the frame rate and streaming bitrate controls now start at the new recommended values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->