### PR TITLE
Add an option to disable the wss proxy

### DIFF
--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -81,12 +81,13 @@ class CloudXRLauncher:
         setup_oob: bool = False,
         usb_local: bool = False,
         host_client: bool = False,
+        start_wss_proxy: bool = True,
     ) -> None:
-        """Launch the CloudXR runtime and WSS proxy.
+        """Launch the CloudXR runtime and optionally the WSS proxy.
 
         Configures the environment, spawns the runtime subprocess, and
-        starts the WSS TLS proxy.  Blocks until the runtime signals
-        readiness (up to
+        optionally starts the WSS TLS proxy.  Blocks until the runtime
+        signals readiness (up to
         :data:`~isaacteleop.cloudxr.runtime.RUNTIME_STARTUP_TIMEOUT_SEC`)
         or raises :class:`RuntimeError` on failure.
 
@@ -111,10 +112,16 @@ class CloudXRLauncher:
             host_client: Serve the web client at ``/client/`` on the WSS
                 proxy port.  Assets are fetched once from GitHub Pages into
                 ``TELEOP_WEB_CLIENT_STATIC_DIR`` or ``~/.cloudxr/static-client``.
+            start_wss_proxy: Start the in-process WSS TLS proxy after the
+                runtime is ready (default: ``True``).  Pass ``False`` when
+                an external proxy is already running or only the runtime
+                subprocess is needed.
 
         Raises:
             RuntimeError: If the EULA is not accepted or the runtime
                 fails to start within the timeout.
+            ValueError: If *start_wss_proxy* is ``False`` while any WSS-only
+                option (*setup_oob*, *usb_local*, or *host_client*) is set.
         """
         self._install_dir = install_dir
         self._env_config = str(env_config) if env_config is not None else None
@@ -123,6 +130,15 @@ class CloudXRLauncher:
         self._setup_oob = setup_oob
         self._usb_local = usb_local
         self._host_client = host_client
+        self._start_wss_proxy = start_wss_proxy
+
+        if not self._start_wss_proxy and (
+            self._setup_oob or self._usb_local or self._host_client
+        ):
+            raise ValueError(
+                "start_wss_proxy=False is incompatible with setup_oob, "
+                "usb_local, and host_client (those features require the WSS proxy)"
+            )
 
         if self._usb_local or self._host_client:
             from .oob_teleop_env import require_web_client_static_dir  # noqa: PLC0415
@@ -189,11 +205,14 @@ class CloudXRLauncher:
             atexit.register(self.stop)
             self._atexit_registered = True
 
-        wss_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
-        wss_log_path = logs_dir_path / f"wss.{wss_ts}.log"
-        self._wss_log_path = wss_log_path
-        self._start_wss_proxy(wss_log_path)
-        logger.info("CloudXR WSS proxy started (log=%s)", wss_log_path)
+        if self._start_wss_proxy:
+            wss_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+            wss_log_path = logs_dir_path / f"wss.{wss_ts}.log"
+            self._wss_log_path = wss_log_path
+            self._start_wss_proxy_thread(wss_log_path)
+            logger.info("CloudXR WSS proxy started (log=%s)", wss_log_path)
+        else:
+            logger.info("CloudXR WSS proxy disabled; runtime only")
 
     # ------------------------------------------------------------------
     # CLI helpers for embedding applications and examples
@@ -281,6 +300,25 @@ class CloudXRLauncher:
         )
 
     @staticmethod
+    def add_launch_wss_proxy_argument(parser: argparse.ArgumentParser) -> None:
+        """Register ``--launch-wss-proxy`` on ``parser``.
+
+        Uses :class:`argparse.BooleanOptionalAction`, so callers may pass
+        ``--no-launch-wss-proxy`` when an external WSS proxy is already
+        running or only the runtime subprocess is needed.
+        """
+        parser.add_argument(
+            "--launch-wss-proxy",
+            action=argparse.BooleanOptionalAction,
+            default=True,
+            help=(
+                "Start the in-process WSS TLS proxy after the runtime is ready "
+                "(default: true). Pass --no-launch-wss-proxy when an external proxy "
+                "is already running or only the runtime subprocess is needed."
+            ),
+        )
+
+    @staticmethod
     def add_launcher_arguments(parser: argparse.ArgumentParser) -> None:
         """Register CloudXR launcher CLI arguments on ``parser``."""
         CloudXRLauncher.add_cloudxr_install_dir_argument(parser)
@@ -288,6 +326,7 @@ class CloudXRLauncher:
         CloudXRLauncher.add_cloudxr_env_config_argument(parser)
         CloudXRLauncher.add_accept_eula_argument(parser)
         CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
+        CloudXRLauncher.add_launch_wss_proxy_argument(parser)
 
     @staticmethod
     def _resolve_install_dir(
@@ -330,6 +369,16 @@ class CloudXRLauncher:
         return bool(getattr(args, "accept_eula", False))
 
     @staticmethod
+    def _resolve_start_wss_proxy(
+        args: argparse.Namespace,
+        start_wss_proxy: bool | None = None,
+    ) -> bool:
+        """Return ``start_wss_proxy`` or ``args.launch_wss_proxy`` when registered."""
+        if start_wss_proxy is not None:
+            return start_wss_proxy
+        return bool(getattr(args, "launch_wss_proxy", True))
+
+    @staticmethod
     def launch_context(
         args: argparse.Namespace,
         *,
@@ -340,16 +389,17 @@ class CloudXRLauncher:
         setup_oob: bool = False,
         usb_local: bool = False,
         host_client: bool = False,
+        start_wss_proxy: bool | None = None,
     ) -> contextlib.AbstractContextManager[CloudXRLauncher | None]:
         """Start :class:`CloudXRLauncher` when ``args.launch_cloudxr_runtime`` is true.
 
         Returns :func:`contextlib.nullcontext` when ``args.launch_cloudxr_runtime`` is
         false so callers can always use ``with CloudXRLauncher.launch_context(args):``.
 
-        ``install_dir``, ``env_config``, ``device_profile`` and ``accept_eula``
-        default to the values registered by :meth:`add_launcher_arguments`
-        (``args.cloudxr_install_dir`` etc.); pass an explicit keyword only to
-        override what came in on the command line.
+        ``install_dir``, ``env_config``, ``device_profile``, ``accept_eula``, and
+        ``start_wss_proxy`` default to the values registered by
+        :meth:`add_launcher_arguments` (``args.cloudxr_install_dir`` etc.); pass an
+        explicit keyword only to override what came in on the command line.
         """
         if not args.launch_cloudxr_runtime:
             return contextlib.nullcontext(None)
@@ -363,6 +413,9 @@ class CloudXRLauncher:
             setup_oob=setup_oob,
             usb_local=usb_local,
             host_client=host_client,
+            start_wss_proxy=CloudXRLauncher._resolve_start_wss_proxy(
+                args, start_wss_proxy
+            ),
         )
 
     # ------------------------------------------------------------------
@@ -405,14 +458,15 @@ class CloudXRLauncher:
     def health_check(self) -> None:
         """Verify that the runtime process and WSS proxy are healthy.
 
-        Returns immediately when both components are running.  Raises
-        :class:`RuntimeError` with diagnostic details when any component
-        has stopped unexpectedly, allowing embedding applications to
-        perform a controlled teardown.
+        Returns immediately when the runtime is running and, when the WSS
+        proxy was started, its background thread is alive.  Raises
+        :class:`RuntimeError` with diagnostic details when any monitored
+        component has stopped unexpectedly, allowing embedding applications
+        to perform a controlled teardown.
 
         Raises:
             RuntimeError: If the launcher has not been started, or if
-                the runtime process or WSS proxy has stopped.
+                the runtime process or (when enabled) the WSS proxy has stopped.
         """
         if self._runtime_proc is None:
             raise RuntimeError("CloudXR launcher is not running")
@@ -423,7 +477,11 @@ class CloudXRLauncher:
                 f"CloudXR runtime process exited unexpectedly (exit code {exit_code})"
             )
 
-        if self._wss_thread is not None and not self._wss_thread.is_alive():
+        if (
+            self._start_wss_proxy
+            and self._wss_thread is not None
+            and not self._wss_thread.is_alive()
+        ):
             raise RuntimeError("CloudXR WSS proxy thread stopped unexpectedly")
 
     @property
@@ -589,7 +647,7 @@ class CloudXRLauncher:
     # WSS proxy (background thread with its own event loop)
     # ------------------------------------------------------------------
 
-    def _start_wss_proxy(self, log_path: Path) -> None:
+    def _start_wss_proxy_thread(self, log_path: Path) -> None:
         """Launch the WSS proxy in a daemon thread."""
         from .wss import run as wss_run
 

--- a/src/core/cloudxr_tests/python/test_launcher.py
+++ b/src/core/cloudxr_tests/python/test_launcher.py
@@ -105,7 +105,7 @@ def mock_launcher_deps(tmp_path, ready=True):
         ) as m_popen,
         patch.object(
             CloudXRLauncher,
-            "_start_wss_proxy",
+            "_start_wss_proxy_thread",
         ) as m_wss,
         patch.object(
             CloudXRLauncher,
@@ -187,6 +187,22 @@ class TestLauncherConstruction:
             assert launcher.wss_log_path is not None
             assert isinstance(launcher.wss_log_path, Path)
             assert "wss." in str(launcher.wss_log_path)
+
+    def test_construction_skips_wss_when_disabled(self, tmp_path):
+        """start_wss_proxy=False launches runtime only."""
+        with mock_launcher_deps(tmp_path, ready=True) as mocks:
+            launcher = CloudXRLauncher(start_wss_proxy=False)
+
+            mocks["popen"].assert_called_once()
+            mocks["wss"].assert_not_called()
+            assert launcher.wss_log_path is None
+            assert launcher._start_wss_proxy is False
+
+    def test_construction_rejects_wss_options_without_proxy(self, tmp_path):
+        """WSS-only options require start_wss_proxy=True."""
+        with mock_launcher_deps(tmp_path, ready=True):
+            with pytest.raises(ValueError, match="start_wss_proxy=False"):
+                CloudXRLauncher(start_wss_proxy=False, host_client=True)
 
 
 # ============================================================================
@@ -367,6 +383,7 @@ class TestLaunchArgumentHelpers:
                 "/etc/cloudxr.env",
                 "--accept-eula",
                 "--no-launch-cloudxr-runtime",
+                "--no-launch-wss-proxy",
             ]
         )
         assert args.cloudxr_install_dir == "/opt/cloudxr"
@@ -374,6 +391,7 @@ class TestLaunchArgumentHelpers:
         assert args.cloudxr_env_config == "/etc/cloudxr.env"
         assert args.accept_eula is True
         assert args.launch_cloudxr_runtime is False
+        assert args.launch_wss_proxy is False
 
     def test_add_launcher_arguments_defaults(self) -> None:
         parser = argparse.ArgumentParser()
@@ -381,6 +399,7 @@ class TestLaunchArgumentHelpers:
         args = parser.parse_args([])
         assert args.cloudxr_env_config is None
         assert args.accept_eula is False
+        assert args.launch_wss_proxy is True
 
     def test_add_cloudxr_device_profile_argument_default(self) -> None:
         parser = argparse.ArgumentParser()
@@ -405,6 +424,18 @@ class TestLaunchArgumentHelpers:
         CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
         args = parser.parse_args(["--no-launch-cloudxr-runtime"])
         assert args.launch_cloudxr_runtime is False
+
+    def test_add_launch_wss_proxy_argument_defaults_true(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_launch_wss_proxy_argument(parser)
+        args = parser.parse_args([])
+        assert args.launch_wss_proxy is True
+
+    def test_add_launch_wss_proxy_argument_no_launch(self) -> None:
+        parser = argparse.ArgumentParser()
+        CloudXRLauncher.add_launch_wss_proxy_argument(parser)
+        args = parser.parse_args(["--no-launch-wss-proxy"])
+        assert args.launch_wss_proxy is False
 
     def test_launch_context_skips_when_disabled(self) -> None:
         args = argparse.Namespace(launch_cloudxr_runtime=False)
@@ -439,6 +470,23 @@ class TestLaunchArgumentHelpers:
             ) as launcher:
                 assert launcher is not None
                 assert launcher._device_profile == "auto-native"
+            mocks["proc"].poll.return_value = 0
+
+    @_windows_skip
+    def test_launch_context_passes_start_wss_proxy_kwarg(self, tmp_path) -> None:
+        args = argparse.Namespace(
+            launch_cloudxr_runtime=True,
+            cloudxr_install_dir="/opt/cloudxr",
+            cloudxr_device_profile="Quest3",
+            launch_wss_proxy=True,
+        )
+        with mock_launcher_deps(tmp_path) as mocks:
+            with CloudXRLauncher.launch_context(
+                args, start_wss_proxy=False
+            ) as launcher:
+                assert launcher is not None
+                assert launcher._start_wss_proxy is False
+                mocks["wss"].assert_not_called()
             mocks["proc"].poll.return_value = 0
 
     def test_stop_on_windows_raises_unsupported(self, tmp_path) -> None:


### PR DESCRIPTION
This lets users use their own without getting errors about ports being used when launching the examples.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to disable the WSS proxy when starting CloudXR, with matching command-line support.
  * Launcher behavior now respects a per-launch setting for whether WSS starts.

* **Bug Fixes**
  * Improved validation so WSS-only features can’t be enabled when the WSS proxy is turned off.
  * Health checks now only require WSS-related checks when WSS startup is requested.

* **Tests**
  * Expanded coverage for WSS proxy defaults, overrides, and disabled-mode behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->