### PR TITLE
fix(cloudxr): Honor explicit accept_eula=False in launch_context

### DIFF
--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -361,11 +361,15 @@ class CloudXRLauncher:
     @staticmethod
     def _resolve_accept_eula(
         args: argparse.Namespace,
-        accept_eula: bool = False,
+        accept_eula: bool | None = None,
     ) -> bool:
-        """Return ``accept_eula`` or ``args.accept_eula`` when registered."""
-        if accept_eula:
-            return True
+        """Return ``accept_eula`` or ``args.accept_eula`` when registered.
+
+        ``None`` means no override (fall back to ``args``); an explicit ``False``
+        disables EULA acceptance even when ``args.accept_eula`` is true.
+        """
+        if accept_eula is not None:
+            return accept_eula
         return bool(getattr(args, "accept_eula", False))
 
     @staticmethod
@@ -385,7 +389,7 @@ class CloudXRLauncher:
         install_dir: str | None = None,
         env_config: str | Path | None = None,
         device_profile: str | None = None,
-        accept_eula: bool = False,
+        accept_eula: bool | None = None,
         setup_oob: bool = False,
         usb_local: bool = False,
         host_client: bool = False,
@@ -399,7 +403,9 @@ class CloudXRLauncher:
         ``install_dir``, ``env_config``, ``device_profile``, ``accept_eula``, and
         ``start_wss_proxy`` default to the values registered by
         :meth:`add_launcher_arguments` (``args.cloudxr_install_dir`` etc.); pass an
-        explicit keyword only to override what came in on the command line.
+        explicit keyword only to override what came in on the command line. For
+        ``accept_eula``, pass ``False`` to force-disable even when the CLI flag
+        is set.
         """
         if not args.launch_cloudxr_runtime:
             return contextlib.nullcontext(None)

--- a/src/core/cloudxr_tests/python/test_launcher.py
+++ b/src/core/cloudxr_tests/python/test_launcher.py
@@ -489,6 +489,19 @@ class TestLaunchArgumentHelpers:
                 mocks["wss"].assert_not_called()
             mocks["proc"].poll.return_value = 0
 
+    def test_resolve_accept_eula_none_falls_back_to_args(self) -> None:
+        args = argparse.Namespace(accept_eula=True)
+        assert CloudXRLauncher._resolve_accept_eula(args) is True
+        assert CloudXRLauncher._resolve_accept_eula(args, None) is True
+        args.accept_eula = False
+        assert CloudXRLauncher._resolve_accept_eula(args) is False
+
+    def test_resolve_accept_eula_explicit_override(self) -> None:
+        args = argparse.Namespace(accept_eula=True)
+        assert CloudXRLauncher._resolve_accept_eula(args, False) is False
+        args.accept_eula = False
+        assert CloudXRLauncher._resolve_accept_eula(args, True) is True
+
     def test_stop_on_windows_raises_unsupported(self, tmp_path) -> None:
         """Simulated win32 platform raises instead of calling POSIX APIs."""
         with mock_launcher_deps(tmp_path, ready=True) as mocks:


### PR DESCRIPTION
Use Optional[bool] None sentinel so callers can force-disable EULA acceptance instead of always falling back to args.accept_eula.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved EULA handling so an explicit on/off choice now takes precedence when launching CloudXR.
  * You can now reliably override the CLI EULA setting, including forcing it off when needed.
* **Tests**
  * Added coverage for both default behavior and explicit override behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->