### PR TITLE
Retry transient Artifactory failures in publish-wheel curls

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -859,6 +859,7 @@ jobs:
           echo "Resolving Artifactory URL for ${wheel_name}"
 
           search_json="$(curl --fail-with-body --show-error --silent --location --get --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-delay 5 --retry-all-errors \
             -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_API_KEY}" \
             --data-urlencode "name=${wheel_name}" \
             --data-urlencode "repos=${ARTIFACTORY_REPO}" \
@@ -879,6 +880,7 @@ jobs:
           fi
 
           metadata_json="$(curl --fail-with-body --show-error --silent --location --connect-timeout 10 --max-time 60 \
+            --retry 3 --retry-delay 5 --retry-all-errors \
             -u "${ARTIFACTORY_USERNAME}:${ARTIFACTORY_API_KEY}" \
             "${storage_uri}")"
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Deal with intermittent failures like [this](https://github.com/NVIDIA/IsaacTeleop/actions/runs/29016973935/job/86117974464):
```
Resolving Artifactory URL for isaacteleop-1.4.35a1-cp310-cp310-manylinux_2_35_aarch64.whl
curl: (28) Operation timed out after 60000 milliseconds with 0 bytes received
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of wheel publishing by automatically retrying failed network requests during artifact lookup and metadata retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->