### PR TITLE
ci: pin actions/cache to v6.1.0 hash across workflows

### DIFF
--- a/.github/actions/setup-v2d-src/action.yml
+++ b/.github/actions/setup-v2d-src/action.yml
@@ -58,7 +58,7 @@ runs:
     - name: Cache robotic_grounding source bundle
       id: cache
       if: inputs.github-token != ''
-      uses: actions/cache@v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: deps/v2d/src
         # Source bundle is pure files; cache key only depends on V2D SHA.

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -81,7 +81,7 @@ jobs:
 
     # vcpkg - required when BUILD_PLUGIN_OAK_CAMERA=ON for DepthAI v3.x deps
     - name: Cache vcpkg
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: |
           ~/vcpkg
@@ -99,7 +99,7 @@ jobs:
         echo "VCPKG_ROOT=$HOME/vcpkg" >> $GITHUB_ENV
 
     - name: Cache ccache
-      uses: actions/cache@v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/.cache/ccache
         key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build_type }}-py${{ matrix.python_version }}-${{ hashFiles('**/CMakeLists.txt') }}
@@ -366,7 +366,7 @@ jobs:
       uses: ./.github/actions/setup-cuda
 
     - name: Cache ccache
-      uses: actions/cache@v5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/.cache/ccache
         key: ccache-${{ runner.os }}-${{ runner.arch }}-sanitizers-${{ hashFiles('**/CMakeLists.txt') }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -49,7 +49,7 @@ jobs:
 
     # vcpkg - required when BUILD_PLUGIN_OAK_CAMERA=ON for DepthAI v3.x deps
     - name: Cache vcpkg
-      uses: actions/cache@v4
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: |
           C:\vcpkg


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

This fixes Node deprecation warnings in the build log

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated caching steps in build and setup workflows to use pinned action revisions instead of version tags.
  * Kept all cache targets and workflow behavior the same while tightening the referenced action versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->