### PR TITLE
chore(cloudxr): bump runtime SDK version to 6.2.1

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.2.0
+CXR_RUNTIME_SDK_VERSION=6.2.1
 CXR_WEB_SDK_VERSION=6.2.0
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 


### PR DESCRIPTION
## Summary
Bumps the CloudXR **runtime** SDK version from `6.2.0` to `6.2.1` in `deps/cloudxr/.env.default` (`CXR_RUNTIME_SDK_VERSION`).

The web SDK version (`CXR_WEB_SDK_VERSION`) is left unchanged at `6.2.0`.

This enabled SFE for supported GPUs on Linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CloudXR runtime SDK to version 6.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->