### PR TITLE
ROS: Centralize teleop runtime profiles

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -643,7 +643,7 @@ jobs:
             if docker exec \
               -e PYTHONUNBUFFERED=1 \
               "$RUN_NAME" bash -c \
-              "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync integration_tests/teleop_ros2_topic_verifier.py --mode $mode"; then
+              "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync python -m integration_tests.teleop_ros2_topic_verifier --mode $mode"; then
               verifier_rc=0
             else
               verifier_rc=$?

--- a/examples/teleop_ros2/AGENTS.md
+++ b/examples/teleop_ros2/AGENTS.md
@@ -16,3 +16,9 @@ SPDX-License-Identifier: Apache-2.0
 
 - In source code files under this example, preserve the existing grouped/sorted organization for helpers, message builders, classes, and member functions: scan the surrounding order before inserting, and do not place helpers near call sites when the existing section is sorted.
 - In Python integration test verifier code, do not use bare `assert` for runtime validation; Python optimization can disable it, so raise explicit exceptions from validators.
+
+## Rename consistency
+
+- When renaming a symbol or concept, update semantically coupled type names,
+  fields, variables, constructor keywords, consumers, and tests in the same pass
+  so old and new vocabulary do not coexist.

--- a/examples/teleop_ros2/python/constants.py
+++ b/examples/teleop_ros2/python/constants.py
@@ -27,6 +27,13 @@ class HandRetargeter(StrEnum):
     DEXPILOT = "dexpilot"
 
 
+class TeleopMode(StrEnum):
+    CONTROLLER_TELEOP = "controller_teleop"
+    HAND_TELEOP = "hand_teleop"
+    CONTROLLER_RAW = "controller_raw"
+    FULL_BODY = "full_body"
+
+
 BODY_JOINT_NAMES = [e.name for e in BodyJointPicoIndex]
 HAND_POSE_JOINT_INDICES = tuple(
     HandJointIndex(i)
@@ -35,7 +42,7 @@ HAND_POSE_JOINT_INDICES = tuple(
 HAND_POSE_NAMES = [joint.name for joint in HAND_POSE_JOINT_INDICES]
 HAND_RETARGETERS = tuple(retargeter.value for retargeter in HandRetargeter)
 SHARPA_HAND_RETARGETERS = (HandRetargeter.PINK_IK, HandRetargeter.DEXPILOT)
-TELEOP_MODES = ("controller_teleop", "hand_teleop", "controller_raw", "full_body")
+TELEOP_MODES = tuple(mode.value for mode in TeleopMode)
 
 TRIHAND_JOINT_NAMES = [
     "thumb_rotation",
@@ -81,16 +88,16 @@ DEX_HANDTRACKING_TO_BASELINK_FRAME_TRANSFORM = (0, -1, 0, -1, 0, 0, 0, 0, -1)
 
 
 def resolve_hand_retargeter(
-    mode: str, hand_retargeter: HandRetargeter
+    mode: TeleopMode, hand_retargeter: HandRetargeter
 ) -> HandRetargeter:
     if hand_retargeter == HandRetargeter.MODE_DEFAULT:
-        if mode == "controller_teleop":
+        if mode == TeleopMode.CONTROLLER_TELEOP:
             return HandRetargeter.TRIHAND
-        if mode == "hand_teleop":
+        if mode == TeleopMode.HAND_TELEOP:
             return HandRetargeter.DEXPILOT
         return hand_retargeter
 
-    if mode == "hand_teleop" and hand_retargeter == HandRetargeter.TRIHAND:
+    if mode == TeleopMode.HAND_TELEOP and hand_retargeter == HandRetargeter.TRIHAND:
         raise ValueError(
             "Parameter 'hand_retargeter:=trihand' is only valid with "
             "mode:=controller_teleop"
@@ -100,6 +107,9 @@ def resolve_hand_retargeter(
 
 
 def uses_hands_source_for_controller(
-    mode: str, hand_retargeter: HandRetargeter
+    mode: TeleopMode, hand_retargeter: HandRetargeter
 ) -> bool:
-    return mode == "controller_teleop" and hand_retargeter in SHARPA_HAND_RETARGETERS
+    return (
+        mode == TeleopMode.CONTROLLER_TELEOP
+        and hand_retargeter in SHARPA_HAND_RETARGETERS
+    )

--- a/examples/teleop_ros2/python/geometry.py
+++ b/examples/teleop_ros2/python/geometry.py
@@ -10,26 +10,6 @@ import numpy as np
 from geometry_msgs.msg import Pose, TransformStamped
 from scipy.spatial.transform import Rotation
 
-from isaacteleop.retargeting_engine.tensor_types.indices import HandJointIndex
-
-
-def append_hand_poses(
-    poses: list[Pose],
-    joint_positions: np.ndarray,
-    joint_orientations: np.ndarray,
-    joint_valid: np.ndarray,
-    transform_rot: Rotation | None = None,
-    transform_trans: Sequence[float] | None = None,
-) -> None:
-    for joint_idx in range(HandJointIndex.WRIST, HandJointIndex.LITTLE_TIP + 1):
-        if joint_valid[joint_idx]:
-            pose = to_pose(joint_positions[joint_idx], joint_orientations[joint_idx])
-            if transform_rot is not None or transform_trans is not None:
-                pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
-        else:
-            pose = to_pose([0.0, 0.0, 0.0])
-        poses.append(pose)
-
 
 def apply_manus_controller_to_hand_pose(pose: Pose, side: str) -> Pose:
     """

--- a/examples/teleop_ros2/python/integration_tests/__init__.py
+++ b/examples/teleop_ros2/python/integration_tests/__init__.py
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Integration tests for the Teleop ROS 2 example."""

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -15,8 +15,9 @@ from typing import Callable
 
 import msgpack
 import rclpy
-from constants import HAND_POSE_NAMES, TELEOP_MODES
+from constants import TELEOP_MODES
 from geometry_msgs.msg import PoseStamped, TwistStamped
+from isaacteleop.retargeting_engine.tensor_types.indices import HandJointIndex
 from rclpy.node import Node
 from sensor_msgs.msg import JointState
 from std_msgs.msg import ByteMultiArray
@@ -25,8 +26,12 @@ from tf2_msgs.msg import TFMessage
 
 
 _EXPECTED_TF_FRAMES = {"right_wrist", "left_wrist", "head"}
+_HAND_POSE_NAMES = [
+    HandJointIndex(i).name
+    for i in range(HandJointIndex.WRIST, HandJointIndex.LITTLE_TIP + 1)
+]
 _EXPECTED_HAND_POSE_NAMES = [
-    f"{side}_{name}" for side in ("left", "right") for name in HAND_POSE_NAMES
+    f"{side}_{name}" for side in ("left", "right") for name in _HAND_POSE_NAMES
 ]
 
 

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -15,8 +15,8 @@ from typing import Callable
 
 import msgpack
 import rclpy
+from constants import HAND_POSE_NAMES, TELEOP_MODES
 from geometry_msgs.msg import PoseStamped, TwistStamped
-from isaacteleop.retargeting_engine.tensor_types.indices import HandJointIndex
 from rclpy.node import Node
 from sensor_msgs.msg import JointState
 from std_msgs.msg import ByteMultiArray
@@ -24,14 +24,9 @@ from teleop_ros2_interfaces.msg import NamedPoseArray
 from tf2_msgs.msg import TFMessage
 
 
-_MODES = ("controller_teleop", "hand_teleop", "controller_raw", "full_body")
 _EXPECTED_TF_FRAMES = {"right_wrist", "left_wrist", "head"}
-_HAND_POSE_NAMES = [
-    HandJointIndex(i).name
-    for i in range(HandJointIndex.WRIST, HandJointIndex.LITTLE_TIP + 1)
-]
 _EXPECTED_HAND_POSE_NAMES = [
-    f"{side}_{name}" for side in ("left", "right") for name in _HAND_POSE_NAMES
+    f"{side}_{name}" for side in ("left", "right") for name in HAND_POSE_NAMES
 ]
 
 
@@ -337,7 +332,7 @@ class TopicVerifier(Node):
 
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--mode", choices=_MODES, required=True)
+    parser.add_argument("--mode", choices=TELEOP_MODES, required=True)
     parser.add_argument("--timeout", type=float, default=20.0)
     return parser.parse_args()
 

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -33,6 +33,7 @@ from constants import (
     HAND_RETARGETERS,
     TELEOP_MODES,
     HandRetargeter,
+    TeleopMode,
     resolve_hand_retargeter,
     uses_hands_source_for_controller,
 )
@@ -57,7 +58,7 @@ class CloudXRParams:
 class NodeParameters:
     """Resolved snapshot of every ROS parameter consumed by TeleopRos2Node."""
 
-    mode: str
+    mode: TeleopMode
     sleep_period_s: float
     hand_retargeter: HandRetargeter
     resolved_hand_retargeter: HandRetargeter
@@ -283,7 +284,7 @@ def _load_frames(node: Node) -> tuple[str, str, str, str]:
 
 
 def _load_hand_retargeter(
-    node: Node, mode: str
+    node: Node, mode: TeleopMode
 ) -> tuple[HandRetargeter, HandRetargeter, bool]:
     node.declare_parameter(
         "hand_retargeter",
@@ -311,7 +312,7 @@ def _load_hand_retargeter(
     controller_uses_hands_source = uses_hands_source_for_controller(
         mode, resolved_hand_retargeter
     )
-    if mode in ("hand_teleop", "controller_teleop"):
+    if mode in (TeleopMode.HAND_TELEOP, TeleopMode.CONTROLLER_TELEOP):
         node.get_logger().info(f"Hand retargeter: {resolved_hand_retargeter}")
     if controller_uses_hands_source:
         node.get_logger().info(
@@ -349,13 +350,15 @@ def _load_mcap_replay(
     return SessionMode.REPLAY, McapReplayConfig(str(replay_path))
 
 
-def _load_mode(node: Node) -> str:
-    node.declare_parameter("mode", "controller_teleop")
-    mode = node.get_parameter("mode").get_parameter_value().string_value
-    if mode not in TELEOP_MODES:
+def _load_mode(node: Node) -> TeleopMode:
+    node.declare_parameter("mode", TeleopMode.CONTROLLER_TELEOP.value)
+    raw_mode = node.get_parameter("mode").get_parameter_value().string_value
+    try:
+        mode = TeleopMode(raw_mode)
+    except ValueError as exc:
         raise ValueError(
-            f"Parameter 'mode' must be one of {TELEOP_MODES}, got {mode!r}"
-        )
+            f"Parameter 'mode' must be one of {TELEOP_MODES}, got {raw_mode!r}"
+        ) from exc
     node.get_logger().info(f"Mode: {mode}")
     return mode
 

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -14,3 +14,12 @@ dependencies = [
     # dex-retargeting resolves to 0.5.x, keeping the env on NumPy 2 / Pinocchio 3.
     "nlopt>=2.8.0",
 ]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]
+
+[tool.pytest.ini_options]
+pythonpath = ["."]
+testpaths = ["tests"]

--- a/examples/teleop_ros2/python/session_config.py
+++ b/examples/teleop_ros2/python/session_config.py
@@ -41,6 +41,7 @@ from constants import (
     RIGHT_SHARPA_WAVE_JOINT_NAMES,
     SHARPA_FINGER_JOINT_COUNT,
     SHARPA_HAND_RETARGETERS,
+    TeleopMode,
 )
 from node_parameters import NodeParameters
 from tensor_group_helpers import joint_names_from_group_type
@@ -142,7 +143,7 @@ def build_controller_teleop_config(params: NodeParameters) -> TeleopSessionConfi
         )
         hands = HandsSource(name="hands")
         left_finger_joints, right_finger_joints = build_sharpa_finger_joint_outputs(
-            hands, params, "controller_teleop"
+            hands, params, TeleopMode.CONTROLLER_TELEOP.value
         )
         pipeline_outputs.update(
             {
@@ -211,7 +212,7 @@ def build_hand_teleop_config(params: NodeParameters) -> TeleopSessionConfig:
     )
     locomotion_connected = locomotion.connect({"pedals": pedals.output("pedals")})
     left_finger_joints, right_finger_joints = build_sharpa_finger_joint_outputs(
-        hands, params, "hand_teleop"
+        hands, params, TeleopMode.HAND_TELEOP.value
     )
 
     pipeline = OutputCombiner(
@@ -234,13 +235,13 @@ def build_hand_teleop_config(params: NodeParameters) -> TeleopSessionConfig:
 
 
 def build_session_config(params: NodeParameters) -> TeleopSessionConfig:
-    if params.mode == "controller_teleop":
+    if params.mode == TeleopMode.CONTROLLER_TELEOP:
         return build_controller_teleop_config(params)
-    if params.mode == "hand_teleop":
+    if params.mode == TeleopMode.HAND_TELEOP:
         return build_hand_teleop_config(params)
-    if params.mode == "controller_raw":
+    if params.mode == TeleopMode.CONTROLLER_RAW:
         return build_controller_raw_config(params)
-    if params.mode == "full_body":
+    if params.mode == TeleopMode.FULL_BODY:
         return build_full_body_config(params)
     raise ValueError(f"Unsupported mode {params.mode!r}")
 

--- a/examples/teleop_ros2/python/teleop_profiles.py
+++ b/examples/teleop_ros2/python/teleop_profiles.py
@@ -12,7 +12,7 @@ from isaacteleop.retargeting_engine.interface import OptionalTensorGroup
 from constants import SHARPA_HAND_RETARGETERS, HandRetargeter, StrEnum, TeleopMode
 
 
-class FramePublication(StrEnum):
+class PublishType(StrEnum):
     CONTROLLER_PAYLOAD = "controller_payload"
     EE_FROM_CONTROLLERS = "ee_from_controllers"
     EE_FROM_HANDS = "ee_from_hands"
@@ -49,7 +49,7 @@ class TeleopProfileSpec:
 
     mode: TeleopMode
     required_result_keys: frozenset[str]
-    publications: frozenset[FramePublication]
+    publish_types: frozenset[PublishType]
 
 
 TELEOP_PROFILE_SPECS = {
@@ -65,13 +65,13 @@ TELEOP_PROFILE_SPECS = {
                 "root_command",
             }
         ),
-        publications=frozenset(
+        publish_types=frozenset(
             {
-                FramePublication.CONTROLLER_PAYLOAD,
-                FramePublication.EE_FROM_CONTROLLERS,
-                FramePublication.FINGER_JOINTS,
-                FramePublication.HEAD,
-                FramePublication.ROOT_COMMAND,
+                PublishType.CONTROLLER_PAYLOAD,
+                PublishType.EE_FROM_CONTROLLERS,
+                PublishType.FINGER_JOINTS,
+                PublishType.HEAD,
+                PublishType.ROOT_COMMAND,
             }
         ),
     ),
@@ -89,14 +89,14 @@ TELEOP_PROFILE_SPECS = {
                 "root_command",
             }
         ),
-        publications=frozenset(
+        publish_types=frozenset(
             {
-                FramePublication.CONTROLLER_PAYLOAD,
-                FramePublication.EE_FROM_CONTROLLERS,
-                FramePublication.FINGER_JOINTS,
-                FramePublication.HAND_POSES,
-                FramePublication.HEAD,
-                FramePublication.ROOT_COMMAND,
+                PublishType.CONTROLLER_PAYLOAD,
+                PublishType.EE_FROM_CONTROLLERS,
+                PublishType.FINGER_JOINTS,
+                PublishType.HAND_POSES,
+                PublishType.HEAD,
+                PublishType.ROOT_COMMAND,
             }
         ),
     ),
@@ -112,30 +112,30 @@ TELEOP_PROFILE_SPECS = {
                 "root_command",
             }
         ),
-        publications=frozenset(
+        publish_types=frozenset(
             {
-                FramePublication.EE_FROM_HANDS,
-                FramePublication.FINGER_JOINTS,
-                FramePublication.HAND_POSES,
-                FramePublication.HEAD,
-                FramePublication.ROOT_COMMAND,
+                PublishType.EE_FROM_HANDS,
+                PublishType.FINGER_JOINTS,
+                PublishType.HAND_POSES,
+                PublishType.HEAD,
+                PublishType.ROOT_COMMAND,
             }
         ),
     ),
     TeleopProfile.CONTROLLER_RAW: TeleopProfileSpec(
         mode=TeleopMode.CONTROLLER_RAW,
         required_result_keys=frozenset({"controller_left", "controller_right"}),
-        publications=frozenset({FramePublication.CONTROLLER_PAYLOAD}),
+        publish_types=frozenset({PublishType.CONTROLLER_PAYLOAD}),
     ),
     TeleopProfile.FULL_BODY: TeleopProfileSpec(
         mode=TeleopMode.FULL_BODY,
         required_result_keys=frozenset(
             {"controller_left", "controller_right", "full_body"}
         ),
-        publications=frozenset(
+        publish_types=frozenset(
             {
-                FramePublication.CONTROLLER_PAYLOAD,
-                FramePublication.FULL_BODY_PAYLOAD,
+                PublishType.CONTROLLER_PAYLOAD,
+                PublishType.FULL_BODY_PAYLOAD,
             }
         ),
     ),

--- a/examples/teleop_ros2/python/teleop_profiles.py
+++ b/examples/teleop_ros2/python/teleop_profiles.py
@@ -1,0 +1,178 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolved runtime profiles for teleoperation session results and publishing."""
+
+from dataclasses import dataclass
+from typing import Mapping, TypedDict, cast
+
+from isaacteleop.retargeting_engine.interface import OptionalTensorGroup
+
+from constants import SHARPA_HAND_RETARGETERS, HandRetargeter, StrEnum, TeleopMode
+
+
+class FramePublication(StrEnum):
+    CONTROLLER_PAYLOAD = "controller_payload"
+    EE_FROM_CONTROLLERS = "ee_from_controllers"
+    EE_FROM_HANDS = "ee_from_hands"
+    FINGER_JOINTS = "finger_joints"
+    FULL_BODY_PAYLOAD = "full_body_payload"
+    HAND_POSES = "hand_poses"
+    HEAD = "head"
+    ROOT_COMMAND = "root_command"
+
+
+class TeleopProfile(StrEnum):
+    CONTROLLER_TELEOP = "controller_teleop"
+    CONTROLLER_TELEOP_WITH_HANDS = "controller_teleop_with_hands"
+    HAND_TELEOP = "hand_teleop"
+    CONTROLLER_RAW = "controller_raw"
+    FULL_BODY = "full_body"
+
+
+class SessionResult(TypedDict, total=False):
+    controller_left: OptionalTensorGroup
+    controller_right: OptionalTensorGroup
+    finger_joints_left: OptionalTensorGroup
+    finger_joints_right: OptionalTensorGroup
+    full_body: OptionalTensorGroup
+    hand_left: OptionalTensorGroup
+    hand_right: OptionalTensorGroup
+    head: OptionalTensorGroup
+    root_command: OptionalTensorGroup
+
+
+@dataclass(frozen=True)
+class TeleopProfileSpec:
+    """Describe the frame inputs and publish paths for one resolved profile."""
+
+    mode: TeleopMode
+    required_result_keys: frozenset[str]
+    publications: frozenset[FramePublication]
+
+
+TELEOP_PROFILE_SPECS = {
+    TeleopProfile.CONTROLLER_TELEOP: TeleopProfileSpec(
+        mode=TeleopMode.CONTROLLER_TELEOP,
+        required_result_keys=frozenset(
+            {
+                "controller_left",
+                "controller_right",
+                "finger_joints_left",
+                "finger_joints_right",
+                "head",
+                "root_command",
+            }
+        ),
+        publications=frozenset(
+            {
+                FramePublication.CONTROLLER_PAYLOAD,
+                FramePublication.EE_FROM_CONTROLLERS,
+                FramePublication.FINGER_JOINTS,
+                FramePublication.HEAD,
+                FramePublication.ROOT_COMMAND,
+            }
+        ),
+    ),
+    TeleopProfile.CONTROLLER_TELEOP_WITH_HANDS: TeleopProfileSpec(
+        mode=TeleopMode.CONTROLLER_TELEOP,
+        required_result_keys=frozenset(
+            {
+                "controller_left",
+                "controller_right",
+                "finger_joints_left",
+                "finger_joints_right",
+                "hand_left",
+                "hand_right",
+                "head",
+                "root_command",
+            }
+        ),
+        publications=frozenset(
+            {
+                FramePublication.CONTROLLER_PAYLOAD,
+                FramePublication.EE_FROM_CONTROLLERS,
+                FramePublication.FINGER_JOINTS,
+                FramePublication.HAND_POSES,
+                FramePublication.HEAD,
+                FramePublication.ROOT_COMMAND,
+            }
+        ),
+    ),
+    TeleopProfile.HAND_TELEOP: TeleopProfileSpec(
+        mode=TeleopMode.HAND_TELEOP,
+        required_result_keys=frozenset(
+            {
+                "finger_joints_left",
+                "finger_joints_right",
+                "hand_left",
+                "hand_right",
+                "head",
+                "root_command",
+            }
+        ),
+        publications=frozenset(
+            {
+                FramePublication.EE_FROM_HANDS,
+                FramePublication.FINGER_JOINTS,
+                FramePublication.HAND_POSES,
+                FramePublication.HEAD,
+                FramePublication.ROOT_COMMAND,
+            }
+        ),
+    ),
+    TeleopProfile.CONTROLLER_RAW: TeleopProfileSpec(
+        mode=TeleopMode.CONTROLLER_RAW,
+        required_result_keys=frozenset({"controller_left", "controller_right"}),
+        publications=frozenset({FramePublication.CONTROLLER_PAYLOAD}),
+    ),
+    TeleopProfile.FULL_BODY: TeleopProfileSpec(
+        mode=TeleopMode.FULL_BODY,
+        required_result_keys=frozenset(
+            {"controller_left", "controller_right", "full_body"}
+        ),
+        publications=frozenset(
+            {
+                FramePublication.CONTROLLER_PAYLOAD,
+                FramePublication.FULL_BODY_PAYLOAD,
+            }
+        ),
+    ),
+}
+
+
+def resolve_teleop_profile_spec(
+    mode: TeleopMode, resolved_hand_retargeter: HandRetargeter
+) -> TeleopProfileSpec:
+    """Resolve user-facing settings to one complete immutable runtime profile."""
+    if (
+        mode == TeleopMode.CONTROLLER_TELEOP
+        and resolved_hand_retargeter in SHARPA_HAND_RETARGETERS
+    ):
+        profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HANDS
+    else:
+        profile = TeleopProfile(mode.value)
+    return TELEOP_PROFILE_SPECS[profile]
+
+
+def validate_session_result(
+    result: Mapping[str, OptionalTensorGroup],
+    profile_spec: TeleopProfileSpec,
+) -> SessionResult:
+    """Validate and type-narrow a session frame against its profile contract."""
+    expected_keys = profile_spec.required_result_keys
+    actual_keys = frozenset(result)
+    missing_keys = expected_keys - actual_keys
+    unexpected_keys = actual_keys - expected_keys
+    if missing_keys or unexpected_keys:
+        details = []
+        if missing_keys:
+            details.append(f"missing keys: {sorted(missing_keys)}")
+        if unexpected_keys:
+            details.append(f"unexpected keys: {sorted(unexpected_keys)}")
+        raise ValueError(
+            f"Invalid session result for mode {profile_spec.mode.value!r}: "
+            f"{'; '.join(details)}"
+        )
+    return cast(SessionResult, result)

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -70,7 +70,7 @@ from messages import (
     build_head_msg,
 )
 from teleop_profiles import (
-    FramePublication,
+    PublishType,
     SessionResult,
     resolve_teleop_profile_spec,
     validate_session_result,
@@ -314,40 +314,34 @@ class TeleopRos2Node(Node):
                         now = self.get_clock().now().to_msg()
 
                         if (
-                            FramePublication.EE_FROM_HANDS
-                            in self._profile_spec.publications
+                            PublishType.EE_FROM_HANDS
+                            in self._profile_spec.publish_types
                         ):
                             self._publish_ee_pose_from_hands(result, now)
                         if (
-                            FramePublication.EE_FROM_CONTROLLERS
-                            in self._profile_spec.publications
+                            PublishType.EE_FROM_CONTROLLERS
+                            in self._profile_spec.publish_types
                         ):
                             self._publish_ee_pose_from_controllers(result, now)
-                        if (
-                            FramePublication.HAND_POSES
-                            in self._profile_spec.publications
-                        ):
+                        if PublishType.HAND_POSES in self._profile_spec.publish_types:
                             self._publish_hand_poses(result, now)
-                        if (
-                            FramePublication.ROOT_COMMAND
-                            in self._profile_spec.publications
-                        ):
+                        if PublishType.ROOT_COMMAND in self._profile_spec.publish_types:
                             self._publish_root_command(result, now)
                         if (
-                            FramePublication.FINGER_JOINTS
-                            in self._profile_spec.publications
+                            PublishType.FINGER_JOINTS
+                            in self._profile_spec.publish_types
                         ):
                             self._publish_finger_joints(result, now)
-                        if FramePublication.HEAD in self._profile_spec.publications:
+                        if PublishType.HEAD in self._profile_spec.publish_types:
                             self._publish_head(result, now)
                         if (
-                            FramePublication.CONTROLLER_PAYLOAD
-                            in self._profile_spec.publications
+                            PublishType.CONTROLLER_PAYLOAD
+                            in self._profile_spec.publish_types
                         ):
                             self._publish_controller_payload(result)
                         if (
-                            FramePublication.FULL_BODY_PAYLOAD
-                            in self._profile_spec.publications
+                            PublishType.FULL_BODY_PAYLOAD
+                            in self._profile_spec.publish_types
                         ):
                             self._publish_full_body_payload(result)
 

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -69,6 +69,12 @@ from messages import (
     build_hand_msg,
     build_head_msg,
 )
+from teleop_profiles import (
+    FramePublication,
+    SessionResult,
+    resolve_teleop_profile_spec,
+    validate_session_result,
+)
 from node_parameters import (
     NodeParameters,
     create_node_parameters,
@@ -85,6 +91,9 @@ class TeleopRos2Node(Node):
     def __init__(self) -> None:
         super().__init__("teleop_ros2_node")
         self._params: NodeParameters = create_node_parameters(self)
+        self._profile_spec = resolve_teleop_profile_spec(
+            self._params.mode, self._params.resolved_hand_retargeter
+        )
         self._tf_broadcaster = TransformBroadcaster(self)
         self._create_publishers()
         self._config = build_session_config(self._params)
@@ -144,7 +153,7 @@ class TeleopRos2Node(Node):
         )
         self._pub_head = self.create_publisher(PoseStamped, "xr_teleop/head_pose", 10)
 
-    def _publish_ee_pose_from_controllers(self, result: dict, now) -> None:
+    def _publish_ee_pose_from_controllers(self, result: SessionResult, now) -> None:
         left_ctrl = result["controller_left"]
         right_ctrl = result["controller_right"]
         ee_pose_msg = build_ee_msg_from_controllers(
@@ -161,14 +170,7 @@ class TeleopRos2Node(Node):
         if wrist_tfs:
             self._tf_broadcaster.sendTransform(wrist_tfs)
 
-    def _publish_controller_payload(self, result: dict) -> None:
-        if self._params.mode not in (
-            "controller_raw",
-            "controller_teleop",
-            "full_body",
-        ):
-            return
-
+    def _publish_controller_payload(self, result: SessionResult) -> None:
         left_ctrl = result["controller_left"]
         right_ctrl = result["controller_right"]
         if left_ctrl.is_none and right_ctrl.is_none:
@@ -180,10 +182,7 @@ class TeleopRos2Node(Node):
         controller_msg.data = tuple(bytes([a]) for a in payload)
         self._pub_controller.publish(controller_msg)
 
-    def _publish_finger_joints(self, result: dict, now) -> None:
-        if self._params.mode not in ("controller_teleop", "hand_teleop"):
-            return
-
+    def _publish_finger_joints(self, result: SessionResult, now) -> None:
         finger_joints_msg = build_finger_joints_msg(
             result["finger_joints_left"],
             result["finger_joints_right"],
@@ -193,10 +192,7 @@ class TeleopRos2Node(Node):
         if finger_joints_msg is not None:
             self._pub_finger_joints.publish(finger_joints_msg)
 
-    def _publish_full_body_payload(self, result: dict) -> None:
-        if self._params.mode != "full_body":
-            return
-
+    def _publish_full_body_payload(self, result: SessionResult) -> None:
         full_body_data = result["full_body"]
         if full_body_data.is_none:
             return
@@ -207,7 +203,7 @@ class TeleopRos2Node(Node):
         body_msg.data = tuple(bytes([a]) for a in payload)
         self._pub_full_body.publish(body_msg)
 
-    def _publish_hand_poses(self, result: dict, now) -> None:
+    def _publish_hand_poses(self, result: SessionResult, now) -> None:
         hand_msg = build_hand_msg(
             result["hand_left"],
             result["hand_right"],
@@ -218,7 +214,7 @@ class TeleopRos2Node(Node):
         )
         self._pub_hand.publish(hand_msg)
 
-    def _publish_ee_pose_from_hands(self, result: dict, now) -> None:
+    def _publish_ee_pose_from_hands(self, result: SessionResult, now) -> None:
         left_hand = result["hand_left"]
         right_hand = result["hand_right"]
         ee_pose_msg = build_ee_msg_from_hands(
@@ -234,10 +230,7 @@ class TeleopRos2Node(Node):
         if wrist_tfs:
             self._tf_broadcaster.sendTransform(wrist_tfs)
 
-    def _publish_head(self, result: dict, now) -> None:
-        if self._params.mode not in ("controller_teleop", "hand_teleop"):
-            return
-
+    def _publish_head(self, result: SessionResult, now) -> None:
         head = result["head"]
         if not head_is_valid(head):
             return
@@ -268,10 +261,7 @@ class TeleopRos2Node(Node):
         )
         self._tf_broadcaster.sendTransform(head_tf)
 
-    def _publish_root_command(self, result: dict, now) -> None:
-        if self._params.mode not in ("hand_teleop", "controller_teleop"):
-            return
-
+    def _publish_root_command(self, result: SessionResult, now) -> None:
         root_command = result["root_command"]
         if root_command.is_none:
             return
@@ -312,7 +302,10 @@ class TeleopRos2Node(Node):
                         if launcher is not None:
                             launcher.health_check()
 
-                        result = session.step()
+                        result = validate_session_result(
+                            session.step(),
+                            self._profile_spec,
+                        )
 
                         # Keep ROS time and other callbacks updated in this
                         # manual loop so stamped messages progress with /clock.
@@ -320,21 +313,43 @@ class TeleopRos2Node(Node):
 
                         now = self.get_clock().now().to_msg()
 
-                        if self._params.mode == "hand_teleop":
+                        if (
+                            FramePublication.EE_FROM_HANDS
+                            in self._profile_spec.publications
+                        ):
                             self._publish_ee_pose_from_hands(result, now)
-                        elif self._params.mode == "controller_teleop":
+                        if (
+                            FramePublication.EE_FROM_CONTROLLERS
+                            in self._profile_spec.publications
+                        ):
                             self._publish_ee_pose_from_controllers(result, now)
                         if (
-                            self._params.mode == "hand_teleop"
-                            or self._params.controller_uses_hands_source
+                            FramePublication.HAND_POSES
+                            in self._profile_spec.publications
                         ):
                             self._publish_hand_poses(result, now)
-
-                        self._publish_root_command(result, now)
-                        self._publish_finger_joints(result, now)
-                        self._publish_head(result, now)
-                        self._publish_controller_payload(result)
-                        self._publish_full_body_payload(result)
+                        if (
+                            FramePublication.ROOT_COMMAND
+                            in self._profile_spec.publications
+                        ):
+                            self._publish_root_command(result, now)
+                        if (
+                            FramePublication.FINGER_JOINTS
+                            in self._profile_spec.publications
+                        ):
+                            self._publish_finger_joints(result, now)
+                        if FramePublication.HEAD in self._profile_spec.publications:
+                            self._publish_head(result, now)
+                        if (
+                            FramePublication.CONTROLLER_PAYLOAD
+                            in self._profile_spec.publications
+                        ):
+                            self._publish_controller_payload(result)
+                        if (
+                            FramePublication.FULL_BODY_PAYLOAD
+                            in self._profile_spec.publications
+                        ):
+                            self._publish_full_body_payload(result)
 
                         time.sleep(self._params.sleep_period_s)
             except RuntimeError as e:

--- a/examples/teleop_ros2/python/tests/test_geometry.py
+++ b/examples/teleop_ros2/python/tests/test_geometry.py
@@ -1,0 +1,82 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ROS pose geometry helpers."""
+
+import numpy as np
+import pytest
+from scipy.spatial.transform import Rotation
+
+from geometry import (
+    apply_manus_controller_to_hand_pose,
+    apply_transform_to_pose,
+    to_pose,
+)
+
+
+def _orientation(pose) -> np.ndarray:
+    return np.array(
+        [
+            pose.orientation.x,
+            pose.orientation.y,
+            pose.orientation.z,
+            pose.orientation.w,
+        ]
+    )
+
+
+def _position(pose) -> np.ndarray:
+    return np.array([pose.position.x, pose.position.y, pose.position.z])
+
+
+def test_apply_transform_rotates_translates_and_changes_orientation_basis() -> None:
+    pose = to_pose(
+        [1.0, 0.0, 0.0],
+        Rotation.from_euler("x", 30.0, degrees=True).as_quat(),
+    )
+    basis_rotation = Rotation.from_euler("z", 90.0, degrees=True)
+
+    transformed = apply_transform_to_pose(
+        pose,
+        rotation=basis_rotation,
+        translation=[1.0, 2.0, 3.0],
+    )
+
+    np.testing.assert_allclose(_position(transformed), [1.0, 3.0, 3.0], atol=1e-7)
+    expected_orientation = (
+        basis_rotation * Rotation.from_quat(_orientation(pose)) * basis_rotation.inv()
+    )
+    np.testing.assert_allclose(
+        Rotation.from_quat(_orientation(transformed)).as_matrix(),
+        expected_orientation.as_matrix(),
+        atol=1e-7,
+    )
+
+
+def test_apply_transform_returns_a_new_pose_without_mutating_input() -> None:
+    pose = to_pose([1.0, 2.0, 3.0], [0.0, 0.0, 0.0, 1.0])
+
+    transformed = apply_transform_to_pose(pose, translation=[4.0, 5.0, 6.0])
+
+    assert transformed is not pose
+    np.testing.assert_allclose(_position(pose), [1.0, 2.0, 3.0])
+    np.testing.assert_allclose(_position(transformed), [5.0, 7.0, 9.0])
+
+
+def test_manus_calibration_is_side_specific_and_finite() -> None:
+    controller_pose = to_pose([0.1, 0.2, 0.3], [0.0, 0.0, 0.0, 1.0])
+
+    left_hand = apply_manus_controller_to_hand_pose(controller_pose, "left")
+    right_hand = apply_manus_controller_to_hand_pose(controller_pose, "right")
+
+    assert np.isfinite(_position(left_hand)).all()
+    assert np.isfinite(_orientation(left_hand)).all()
+    assert np.isfinite(_position(right_hand)).all()
+    assert np.isfinite(_orientation(right_hand)).all()
+    assert not np.allclose(_orientation(left_hand), _orientation(right_hand))
+
+
+def test_manus_calibration_rejects_unknown_side() -> None:
+    with pytest.raises(ValueError, match="side must be 'left' or 'right'"):
+        apply_manus_controller_to_hand_pose(to_pose([0.0, 0.0, 0.0]), "center")

--- a/examples/teleop_ros2/python/tests/test_messages.py
+++ b/examples/teleop_ros2/python/tests/test_messages.py
@@ -1,0 +1,135 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for tensor-group to ROS-message conversion."""
+
+import numpy as np
+from builtin_interfaces.msg import Time
+
+from isaacteleop.retargeting_engine.interface import OptionalTensorGroup, TensorGroup
+from isaacteleop.retargeting_engine.tensor_types import (
+    NUM_HAND_JOINTS,
+    ControllerInput,
+    ControllerInputIndex,
+    HandInput,
+    HandInputIndex,
+)
+
+from constants import HAND_POSE_NAMES
+from messages import (
+    build_controller_payload,
+    build_ee_msg_from_controllers,
+    build_hand_msg,
+)
+
+
+def _active_controller() -> TensorGroup:
+    controller = TensorGroup(ControllerInput())
+    controller[ControllerInputIndex.GRIP_POSITION] = np.array(
+        [1.0, 2.0, 3.0], dtype=np.float32
+    )
+    controller[ControllerInputIndex.GRIP_ORIENTATION] = np.array(
+        [0.0, 0.0, 0.0, 1.0], dtype=np.float32
+    )
+    controller[ControllerInputIndex.GRIP_IS_VALID] = True
+    controller[ControllerInputIndex.AIM_POSITION] = np.array(
+        [4.0, 5.0, 6.0], dtype=np.float32
+    )
+    controller[ControllerInputIndex.AIM_ORIENTATION] = np.array(
+        [0.0, 0.0, 0.0, 1.0], dtype=np.float32
+    )
+    controller[ControllerInputIndex.AIM_IS_VALID] = True
+    controller[ControllerInputIndex.PRIMARY_CLICK] = 1.0
+    controller[ControllerInputIndex.SECONDARY_CLICK] = 0.0
+    controller[ControllerInputIndex.THUMBSTICK_CLICK] = 1.0
+    controller[ControllerInputIndex.MENU_CLICK] = 0.0
+    controller[ControllerInputIndex.THUMBSTICK_X] = 0.25
+    controller[ControllerInputIndex.THUMBSTICK_Y] = -0.5
+    controller[ControllerInputIndex.SQUEEZE_VALUE] = 0.75
+    controller[ControllerInputIndex.TRIGGER_VALUE] = 0.5
+    return controller
+
+
+def _active_hand() -> TensorGroup:
+    hand = TensorGroup(HandInput())
+    positions = np.zeros((NUM_HAND_JOINTS, 3), dtype=np.float32)
+    positions[:, 0] = np.arange(NUM_HAND_JOINTS, dtype=np.float32)
+    orientations = np.zeros((NUM_HAND_JOINTS, 4), dtype=np.float32)
+    orientations[:, 3] = 1.0
+    valid = np.ones(NUM_HAND_JOINTS, dtype=np.uint8)
+
+    hand[HandInputIndex.JOINT_POSITIONS] = positions
+    hand[HandInputIndex.JOINT_ORIENTATIONS] = orientations
+    hand[HandInputIndex.JOINT_RADII] = np.ones(NUM_HAND_JOINTS, dtype=np.float32)
+    hand[HandInputIndex.JOINT_VALID] = valid
+    return hand
+
+
+def test_ee_message_has_fixed_entries_and_invalid_placeholder() -> None:
+    left = _active_controller()
+    right = OptionalTensorGroup(ControllerInput())
+
+    msg = build_ee_msg_from_controllers(left, right, Time(), "world")
+
+    assert list(msg.name) == ["left", "right"]
+    assert list(msg.is_valid) == [True, False]
+    assert msg.pose[0].position.x == 4.0
+    assert msg.pose[1].position.x == 0.0
+    assert msg.pose[1].orientation.w == 1.0
+
+
+def test_hand_message_has_stable_names_and_absent_side_placeholders() -> None:
+    left = _active_hand()
+    right = OptionalTensorGroup(HandInput())
+
+    msg = build_hand_msg(left, right, Time(), "world")
+
+    expected_names = [
+        f"{side}_{name}" for side in ("left", "right") for name in HAND_POSE_NAMES
+    ]
+    assert list(msg.name) == expected_names
+    assert len(msg.pose) == len(expected_names)
+    assert all(msg.is_valid[: len(HAND_POSE_NAMES)])
+    assert not any(msg.is_valid[len(HAND_POSE_NAMES) :])
+    assert "left_PALM" not in msg.name
+
+
+def test_controller_payload_schema_and_absent_side_defaults() -> None:
+    payload = build_controller_payload(
+        _active_controller(), OptionalTensorGroup(ControllerInput())
+    )
+
+    assert set(payload) == {
+        "timestamp",
+        "left_thumbstick",
+        "right_thumbstick",
+        "left_trigger_value",
+        "right_trigger_value",
+        "left_squeeze_value",
+        "right_squeeze_value",
+        "left_aim_position",
+        "right_aim_position",
+        "left_grip_position",
+        "right_grip_position",
+        "left_aim_orientation",
+        "right_aim_orientation",
+        "left_grip_orientation",
+        "right_grip_orientation",
+        "left_primary_click",
+        "right_primary_click",
+        "left_secondary_click",
+        "right_secondary_click",
+        "left_thumbstick_click",
+        "right_thumbstick_click",
+        "left_menu_click",
+        "right_menu_click",
+        "left_is_active",
+        "right_is_active",
+    }
+    assert isinstance(payload["timestamp"], int)
+    assert payload["left_is_active"] is True
+    assert payload["right_is_active"] is False
+    assert payload["left_thumbstick"] == [0.25, -0.5]
+    assert payload["right_aim_position"] == [0.0, 0.0, 0.0]
+    assert payload["right_aim_orientation"] == [0.0, 0.0, 0.0, 1.0]

--- a/examples/teleop_ros2/python/tests/test_teleop_profiles.py
+++ b/examples/teleop_ros2/python/tests/test_teleop_profiles.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for resolved teleoperation runtime profiles."""
+
+from types import SimpleNamespace
+
+import pytest
+
+import session_config
+from constants import (
+    TELEOP_MODES,
+    HandRetargeter,
+    TeleopMode,
+    resolve_hand_retargeter,
+)
+from session_config import validate_joint_name_alias_count
+from teleop_profiles import (
+    TELEOP_PROFILE_SPECS,
+    FramePublication,
+    TeleopProfile,
+    TeleopProfileSpec,
+    resolve_teleop_profile_spec,
+    validate_session_result,
+)
+
+
+def _frame_for(profile_spec: TeleopProfileSpec) -> dict:
+    return {key: object() for key in profile_spec.required_result_keys}
+
+
+def test_every_profile_has_a_spec() -> None:
+    assert tuple(mode.value for mode in TeleopMode) == TELEOP_MODES
+    assert set(TELEOP_PROFILE_SPECS) == set(TeleopProfile)
+    assert {spec.mode for spec in TELEOP_PROFILE_SPECS.values()} == set(TeleopMode)
+
+
+@pytest.mark.parametrize(
+    ("mode", "builder_name"),
+    (
+        (TeleopMode.CONTROLLER_TELEOP, "build_controller_teleop_config"),
+        (TeleopMode.HAND_TELEOP, "build_hand_teleop_config"),
+        (TeleopMode.CONTROLLER_RAW, "build_controller_raw_config"),
+        (TeleopMode.FULL_BODY, "build_full_body_config"),
+    ),
+)
+def test_session_config_dispatches_each_mode(
+    monkeypatch, mode: TeleopMode, builder_name: str
+) -> None:
+    expected_config = object()
+    monkeypatch.setattr(
+        session_config,
+        builder_name,
+        lambda _params: expected_config,
+    )
+
+    assert (
+        session_config.build_session_config(SimpleNamespace(mode=mode))
+        is expected_config
+    )
+
+
+def test_controller_profile_spec_is_resolved_for_selected_retargeter() -> None:
+    controller_spec = resolve_teleop_profile_spec(
+        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.TRIHAND
+    )
+    hands_spec = resolve_teleop_profile_spec(
+        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.DEXPILOT
+    )
+
+    assert "hand_left" not in controller_spec.required_result_keys
+    assert "hand_right" not in controller_spec.required_result_keys
+    assert FramePublication.HAND_POSES not in controller_spec.publications
+
+    assert {"hand_left", "hand_right"} <= hands_spec.required_result_keys
+    assert FramePublication.HAND_POSES in hands_spec.publications
+
+
+@pytest.mark.parametrize(
+    ("retargeter", "expected_profile"),
+    (
+        (HandRetargeter.TRIHAND, TeleopProfile.CONTROLLER_TELEOP),
+        (HandRetargeter.DEXPILOT, TeleopProfile.CONTROLLER_TELEOP_WITH_HANDS),
+        (HandRetargeter.PINK_IK, TeleopProfile.CONTROLLER_TELEOP_WITH_HANDS),
+    ),
+)
+def test_controller_profile_spec_resolution(
+    retargeter: HandRetargeter, expected_profile: TeleopProfile
+) -> None:
+    profile_spec = resolve_teleop_profile_spec(TeleopMode.CONTROLLER_TELEOP, retargeter)
+    assert profile_spec is TELEOP_PROFILE_SPECS[expected_profile]
+
+
+@pytest.mark.parametrize("profile", list(TeleopProfile))
+def test_valid_session_result_is_accepted(profile: TeleopProfile) -> None:
+    profile_spec = TELEOP_PROFILE_SPECS[profile]
+    result = _frame_for(profile_spec)
+
+    assert validate_session_result(result, profile_spec) is result
+
+
+def test_session_result_reports_missing_and_unexpected_keys() -> None:
+    profile_spec = TELEOP_PROFILE_SPECS[TeleopProfile.CONTROLLER_RAW]
+    result = _frame_for(profile_spec)
+    result.pop("controller_left")
+    result["head"] = object()
+
+    with pytest.raises(
+        ValueError,
+        match=r"missing keys: \['controller_left'\].*unexpected keys: \['head'\]",
+    ):
+        validate_session_result(result, profile_spec)
+
+
+def test_mode_default_retargeters_are_resolved_centrally() -> None:
+    assert (
+        resolve_hand_retargeter(
+            TeleopMode.CONTROLLER_TELEOP, HandRetargeter.MODE_DEFAULT
+        )
+        == HandRetargeter.TRIHAND
+    )
+    assert (
+        resolve_hand_retargeter(TeleopMode.HAND_TELEOP, HandRetargeter.MODE_DEFAULT)
+        == HandRetargeter.DEXPILOT
+    )
+
+
+def test_trihand_is_rejected_for_hand_teleop() -> None:
+    with pytest.raises(ValueError, match="only valid with mode:=controller_teleop"):
+        resolve_hand_retargeter(TeleopMode.HAND_TELEOP, HandRetargeter.TRIHAND)
+
+
+def test_joint_alias_count_validation() -> None:
+    validate_joint_name_alias_count("left_finger_joint_names", None, 2)
+    validate_joint_name_alias_count("left_finger_joint_names", ["a", "b"], 2)
+
+    with pytest.raises(ValueError, match="must contain exactly 2"):
+        validate_joint_name_alias_count("left_finger_joint_names", ["a"], 2)

--- a/examples/teleop_ros2/python/tests/test_teleop_profiles.py
+++ b/examples/teleop_ros2/python/tests/test_teleop_profiles.py
@@ -18,7 +18,7 @@ from constants import (
 from session_config import validate_joint_name_alias_count
 from teleop_profiles import (
     TELEOP_PROFILE_SPECS,
-    FramePublication,
+    PublishType,
     TeleopProfile,
     TeleopProfileSpec,
     resolve_teleop_profile_spec,
@@ -71,10 +71,10 @@ def test_controller_profile_spec_is_resolved_for_selected_retargeter() -> None:
 
     assert "hand_left" not in controller_spec.required_result_keys
     assert "hand_right" not in controller_spec.required_result_keys
-    assert FramePublication.HAND_POSES not in controller_spec.publications
+    assert PublishType.HAND_POSES not in controller_spec.publish_types
 
     assert {"hand_left", "hand_right"} <= hands_spec.required_result_keys
-    assert FramePublication.HAND_POSES in hands_spec.publications
+    assert PublishType.HAND_POSES in hands_spec.publish_types
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Make mode-specific session and publication contracts explicit, and add focused unit coverage to prevent wiring drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added profile-based teleoperation handling to select required outputs and published telemetry for each operating mode.
  * Added clearer validation for session results, including actionable missing or unexpected output errors.
  * Standardized teleoperation mode handling with named mode values.

* **Bug Fixes**
  * Improved consistency of hand, controller, full-body, head, and root-command output publishing across modes.

* **Tests**
  * Added coverage for geometry transformations, message construction, profile selection, mode validation, and malformed session results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->