### PR TITLE
ci: scope check-lfs-pointers hook to the pre-commit stage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,3 +55,7 @@ repos:
         language: system
         types: [file]
         pass_filenames: true
+        # pre-commit stage only: in the commit-msg stage pre-commit passes the
+        # COMMIT_EDITMSG path (outside the work tree), which makes the script's
+        # `git check-attr` fail with "outside repository" (exit 128).
+        stages: [pre-commit]


### PR DESCRIPTION
## Problem

Every `git commit` fails in the `commit-msg` stage with:

```
Ensure Git LFS-marked files are LFS pointers.............................Failed
...
subprocess.CalledProcessError: Command '['git', 'check-attr', 'filter', '-z', '--stdin']' returned non-zero exit status 128
```

## Root cause

The `check-lfs-pointers` hook has no `stages:` restriction, so pre-commit also runs it in the **`commit-msg`** stage. There it is handed the commit-message file (`$GIT_DIR/COMMIT_EDITMSG`) as a "changed file" — an absolute path **outside** the work tree. The script's `git check-attr filter -z --stdin` then rejects it:

```
fatal: '.../COMMIT_EDITMSG' is outside repository
```

exiting 128 and failing the commit. (`check-copyright-year` has the same latent gap but is masked by its `files:` regex not matching `COMMIT_EDITMSG`.)

## Fix

Scope the hook to the `pre-commit` stage, where it belongs and where it already passes.

## Verification

- `pre-commit run check-lfs-pointers` still passes.
- A real `git commit` now succeeds: the LFS hook runs only in the `pre-commit` stage and no longer appears in the `commit-msg` stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository checks to run at the appropriate commit stage.
  * Added guidance explaining the stage-specific behavior of the check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->