### PR TITLE
docs: rework quick start around auto-launched CloudXR

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -60,7 +60,7 @@ _smv_name = os.environ.get("SPHINX_MULTIVERSION_NAME", "")
 _DEFAULT_ICONS = {
     "teleop_version": "main",
     "teleop_url": "https://github.com/NVIDIA/IsaacTeleop",
-    "cloudxr_version": "6.1",
+    "cloudxr_version": "6.2",
     "cloudxr_url": "https://docs.nvidia.com/cloudxr-sdk",
     "lab_version": "3.0",
     "lab_url": "https://isaac-sim.github.io/IsaacLab",

--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -140,7 +140,7 @@ that the runtime writes on startup. This points the OpenXR loader at CloudXR:
 
    source ~/.cloudxr/run/cloudxr.env
 
-See :ref:`run-cloudxr-server` and :ref:`load-cloudxr-environment-variables`
+See :ref:`run-cloudxr-server` and :ref:`whitelist-firewall-ports`
 in the Quick Start for the full CloudXR runtime setup, including EULA
 acceptance and firewall configuration.
 

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -91,6 +91,13 @@ To inspect the resolved settings after startup:
 
    cat ~/.cloudxr/run/cloudxr.env
 
+.. note::
+
+   If you prefer to run the runtime yourself in its own terminal — e.g. to keep
+   the headset connection alive across example restarts, or to use launch modes
+   like ``--host-client`` and ``--setup-oob`` — see
+   :doc:`/references/cloudxr`.
+
 .. list-table:: Environment variables
    :header-rows: 1
    :widths: 25 15 35 25

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -15,8 +15,8 @@ commands to the terminal.
 
 .. _check-out-code-base:
 
-1. Check out code base (Optional)
-----------------------------------
+1. Check out code base (for examples)
+-------------------------------------
 
 Clone the repository and enter the project directory:
 
@@ -60,106 +60,57 @@ See :doc:`build_from_source/index` for more details.
 
 .. _run-cloudxr-server:
 
-3. Run CloudXR Server
----------------------
+3. Configure CloudXR (optional)
+-------------------------------
 
-Start the CloudXR runtime. The first run downloads the CloudXR Web Client SDK
-and asks you to review and accept the EULA:
+The teleop examples in this guide auto-launch the CloudXR runtime and its WSS
+proxy for you through ``CloudXRLauncher`` when they connect — you do **not**
+need to start the runtime in a separate terminal or source any environment file.
+The first launch downloads the CloudXR Web Client SDK and asks you to review and
+accept the EULA on the terminal; answer the prompt once and the acceptance is
+remembered for subsequent runs.
+
+The CloudXR runtime uses the ``auto-webrtc`` device profile by default
+(Pico & Quest). For Apple Vision Pro it defaults to ``auto-native``. To
+override settings, write a ``KEY=value`` env file and pass it to the example
+with ``--cloudxr-env-config``:
 
 .. code-block:: bash
 
-   python -m isaacteleop.cloudxr
+   echo 'NV_DEVICE_PROFILE=auto-native' > custom.env
+   python examples/teleop/python/gripper_retargeting_example_simple.py \
+         --cloudxr-env-config ./custom.env
 
-To bypass the interactive EULA prompt (e.g. for CI or headless runs), pass the flag:
+The teleop examples under ``examples/teleop/python/`` all register CloudXR's
+launcher arguments through ``CloudXRLauncher.add_launcher_arguments()``, so
+the same ``--cloudxr-env-config`` flag is available on each of them. (The ROS 2
+example takes the equivalent ``cloudxr_env_config`` ROS parameter instead.)
+To inspect the resolved settings after startup:
 
 .. code-block:: bash
 
-   python -m isaacteleop.cloudxr --accept-eula
+   cat ~/.cloudxr/run/cloudxr.env
 
-.. dropdown:: Optional launch modes
+.. list-table:: Environment variables
+   :header-rows: 1
+   :widths: 25 15 35 25
 
-   The launcher supports three optional flags that can be combined to control
-   how the headset connects and how the web client is delivered.
-
-   .. list-table::
-      :header-rows: 1
-      :widths: 45 55
-
-      * - Command
-        - What it does
-      * - ``python -m isaacteleop.cloudxr``
-        - Plain: headset navigates to GitHub Pages URL over WiFi.
-      * - ``python -m isaacteleop.cloudxr --host-client``
-        - Serves the web client at ``https://<ip>:48322/client/`` via the WSS
-          proxy. No separate port, no USB or TURN relay required. Useful when
-          GitHub Pages is unreachable.
-      * - ``python -m isaacteleop.cloudxr --setup-oob``
-        - OOB hub + CDP automation: opens the browser on the headset and
-          auto-clicks CONNECT over USB adb. Client URL is GitHub Pages.
-      * - ``python -m isaacteleop.cloudxr --setup-oob --host-client``
-        - OOB hub + CDP with client at ``/client/`` on the WSS proxy
-          (air-gapped / proxy use).
-      * - ``python -m isaacteleop.cloudxr --setup-oob --usb-local``
-        - All traffic over USB: adb-reverse + coturn TURN relay + loopback
-          HTTPS. Requires ``coturn`` and a WiFi-associated headset.
-
-   ``--usb-local`` requires ``--setup-oob``.  See
-   :doc:`/references/oob_teleop_control` for full OOB documentation.
-
-You should see output similar to:
-
-.. figure:: ../_static/cloudxr-run-output.png
-   :alt: CloudXR run output
-   :align: center
-
-   **Figure:** CloudXR run output
-
-.. important::
-
-   Keep this terminal open — CloudXR must stay running for the duration of the session. Open a
-   **new terminal** for the remaining steps.
-
-   Also take note of the ``source /home/dev/.cloudxr/run/cloudxr.env`` path it mentioned in the
-   output. You will need to source it in step :ref:`load-cloudxr-environment-variables`.
-
-.. dropdown:: CloudXR configurations (optional)
-
-   The CloudXR runtime uses the ``auto-webrtc`` device profile by default (Pico & Quest). For
-   Apple Vision Pro it defaults to ``auto-native``.
-
-   To inspect the active settings after startup:
-
-   .. code-block:: bash
-
-      cat ~/.cloudxr/run/cloudxr.env
-
-   To override settings, create an env file and pass it at startup:
-
-   .. code-block:: bash
-
-      echo 'NV_DEVICE_PROFILE=auto-native' > custom.env
-      python -m isaacteleop.cloudxr --cloudxr-env-config=./custom.env
-
-   .. list-table:: Environment variables
-      :header-rows: 1
-      :widths: 25 15 35 25
-
-      * - Variable
-        - Default
-        - Description
-        - Values
-      * - ``NV_DEVICE_PROFILE``
-        - ``auto-webrtc``
-        - Device profile
-        - ``auto-webrtc``, ``auto-native``, ``Quest3``, ``AppleVisionPro``
-      * - ``NV_CXR_ENABLE_PUSH_DEVICES``
-        - ``true``
-        - Push device overseer for hand tracking
-        - ``true``, ``false``
-      * - ``NV_CXR_FILE_LOGGING``
-        - ``true``
-        - File-based logging (disable to print to console)
-        - ``true``, ``false``
+   * - Variable
+     - Default
+     - Description
+     - Values
+   * - ``NV_DEVICE_PROFILE``
+     - ``auto-webrtc``
+     - Device profile
+     - ``auto-webrtc``, ``auto-native``, ``Quest3``, ``AppleVisionPro``
+   * - ``NV_CXR_ENABLE_PUSH_DEVICES``
+     - ``true``
+     - Push device overseer for hand tracking
+     - ``true``, ``false``
+   * - ``NV_CXR_FILE_LOGGING``
+     - ``true``
+     - File-based logging (disable to print to console)
+     - ``true``, ``false``
 
 .. _whitelist-firewall-ports:
 
@@ -237,10 +188,11 @@ running the CloudXR runtime and wss proxy in containerized environment; or using
 
    .. note::
 
-      If GitHub Pages is unreachable (corporate network, air-gapped machine), start the server with
-      ``--host-client`` in step :ref:`run-cloudxr-server` and open
-      ``https://<your-ip>:48322/client/`` instead of the GitHub Pages URL. Port 48322 is already
-      whitelisted in step :ref:`whitelist-firewall-ports`.
+      If GitHub Pages is unreachable (corporate network, air-gapped machine), you can serve the web
+      client locally from the CloudXR proxy and open ``https://<your-ip>:48322/client/`` instead of
+      the GitHub Pages URL. Port 48322 is already whitelisted in step
+      :ref:`whitelist-firewall-ports`. See :doc:`/references/oob_teleop_control` for how to serve the
+      client from the proxy.
 
    .. tab-set::
       .. tab-item:: CloudXR web client
@@ -307,28 +259,9 @@ running the CloudXR runtime and wss proxy in containerized environment; or using
       to connect to Isaac Teleop.
 
 
-.. _load-cloudxr-environment-variables:
-
-6. Load CloudXR environment variables
---------------------------------------
-
-Open a new terminal and source the CloudXR environment variables posted from the CloudXR runtime in
-:ref:`run-cloudxr-server`:
-
-Source the setup script so that the OpenXR runtime points to CloudXR:
-
-.. code-block:: bash
-
-   source ~/.cloudxr/run/cloudxr.env
-
-.. important::
-
-   Make sure to run the rest of the commands in the same terminal. Or if have to open a new
-   terminal, source the CloudXR environment variables again.
-
 .. _run-teleop-example:
 
-7. Run a teleop example
+6. Run a teleop example
 ------------------------
 
 Run the simplified gripper retargeting example. This demonstrates the full
@@ -392,11 +325,10 @@ Next steps
 
       **Teleoperation with Isaac ROS**
 
-      Check out the :code-dir:`examples/teleop_ros2/` directory for an example on how to make a
-      ROS 2 message publisher using Isaac Teleop.
-
-      We are also working on a Unitree G1-based end-to-end teleoperation, data collection, and
-      imitation learning solution for ROS2 in an upcoming `Isaac ROS`_ release. Stay tuned!
+      For a complete `Isaac ROS`_ pipeline, follow `Teleoperation with Isaac GR00T and Unitree G1`_
+      — an end-to-end workflow that combines Isaac Teleop, CloudXR, and ROS 2 to teleoperate a
+      Unitree G1 humanoid. You validate the setup in MuJoCo, then deploy on real hardware over a
+      Jetson AGX Thor, as a precursor to data collection and imitation learning.
 
       .. rst-class:: trademark-notice
 
@@ -420,3 +352,4 @@ More Information
 .. _`Teleoperation and Imitation Learning with Isaac Lab Mimic`: https://isaac-sim.github.io/IsaacLab/develop/source/overview/imitation-learning/teleop_imitation.html#teleoperation-imitation-learning
 .. _`CloudXR network setup`: https://docs.nvidia.com/cloudxr-sdk/latest/requirement/network_setup.html#ports-and-firewalls
 .. _`Isaac ROS`: https://nvidia-isaac-ros.github.io
+.. _`Teleoperation with Isaac GR00T and Unitree G1`: https://docs.nvidia.com/learning/physical-ai/gr00t-e2e-workflow/latest/real-robot-workflow/real-teleop.html

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,6 +66,7 @@ Table of Contents
    references/retargeting/index
    references/camera_streaming
    references/mcap_record_replay
+   references/cloudxr
    references/oob_teleop_control
    references/egocentric_hand_reconstruction
    references/license

--- a/docs/source/references/cloudxr.rst
+++ b/docs/source/references/cloudxr.rst
@@ -1,0 +1,150 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+.. _dedicated-cloudxr-runtime:
+
+Dedicated CloudXR Runtime
+=========================
+
+The teleop examples auto-launch the CloudXR runtime and its WSS proxy through
+``CloudXRLauncher`` when they connect, so for the common workflow you never
+start the runtime yourself (see :ref:`run-cloudxr-server` in the quick start).
+Sometimes, though, you want the runtime running **standalone in its own
+terminal**:
+
+- keep the runtime — and the headset connection — alive while you restart your
+  teleop application repeatedly during development,
+- point OpenXR applications that do not embed ``CloudXRLauncher`` at CloudXR,
+- use launch modes that only the standalone launcher exposes, such as serving
+  the web client locally (``--host-client``) or the out-of-band automation
+  flags (``--setup-oob``, ``--usb-local``).
+
+This page describes that dedicated workflow.
+
+.. contents:: Sections
+   :local:
+   :depth: 1
+   :backlinks: none
+
+Start the runtime
+-----------------
+
+With the ``isaacteleop`` package installed (including the ``cloudxr`` extra,
+see :ref:`install-isaacteleop-pip-package`), start the CloudXR runtime and WSS
+proxy. The first run downloads the CloudXR Web Client SDK and asks you to
+review and accept the EULA:
+
+.. code-block:: bash
+
+   python -m isaacteleop.cloudxr
+
+To bypass the interactive EULA prompt (e.g. for CI or headless runs), pass the
+flag:
+
+.. code-block:: bash
+
+   python -m isaacteleop.cloudxr --accept-eula
+
+You should see output similar to:
+
+.. figure:: ../_static/cloudxr-run-output.png
+   :alt: CloudXR run output
+   :align: center
+
+   **Figure:** CloudXR run output
+
+.. important::
+
+   Keep this terminal open — CloudXR must stay running for the duration of the
+   session (``Ctrl+C`` terminates it). Open a **new terminal** for the
+   remaining steps.
+
+   Also take note of the ``source ~/.cloudxr/run/cloudxr.env`` path mentioned
+   in the output. You will need to source it in
+   :ref:`load-cloudxr-environment-variables`.
+
+Optional launch modes
+---------------------
+
+The launcher supports optional flags that can be combined to control how the
+headset connects and how the web client is delivered.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 45 55
+
+   * - Command
+     - What it does
+   * - ``python -m isaacteleop.cloudxr``
+     - Plain: headset navigates to GitHub Pages URL over WiFi.
+   * - ``python -m isaacteleop.cloudxr --host-client``
+     - Serves the web client at ``https://<ip>:48322/client/`` via the WSS
+       proxy. No separate port, no USB or TURN relay required. Useful when
+       GitHub Pages is unreachable.
+   * - ``python -m isaacteleop.cloudxr --setup-oob``
+     - OOB hub + CDP automation: opens the browser on the headset and
+       auto-clicks CONNECT over USB adb. Client URL is GitHub Pages.
+   * - ``python -m isaacteleop.cloudxr --setup-oob --host-client``
+     - OOB hub + CDP with client at ``/client/`` on the WSS proxy
+       (air-gapped / proxy use).
+   * - ``python -m isaacteleop.cloudxr --setup-oob --usb-local``
+     - All traffic over USB: adb-reverse + coturn TURN relay + loopback
+       HTTPS. Requires ``coturn`` and a WiFi-associated headset.
+
+``--usb-local`` requires ``--setup-oob``. See
+:doc:`/references/oob_teleop_control` for full OOB documentation.
+
+.. _load-cloudxr-environment-variables:
+
+Load CloudXR environment variables
+----------------------------------
+
+On every start the runtime writes its resolved environment to
+``~/.cloudxr/run/cloudxr.env`` (the exact path is printed in the startup
+output). Sourcing it points the OpenXR loader at CloudXR — it sets
+``XR_RUNTIME_JSON`` along with the ``NV_CXR_*`` variables — so any OpenXR
+application started from that terminal connects to the dedicated runtime.
+
+Open a new terminal and source the setup script:
+
+.. code-block:: bash
+
+   source ~/.cloudxr/run/cloudxr.env
+
+.. important::
+
+   Make sure to run the rest of the commands in the same terminal. If you have
+   to open a new terminal, source the CloudXR environment variables again.
+
+Run teleop examples against the dedicated runtime
+-------------------------------------------------
+
+The teleop examples under ``examples/teleop/python/`` launch their own runtime
+by default. When a dedicated runtime is already running, source the env file
+(previous section) and pass ``--no-launch-cloudxr-runtime`` so the example
+uses the running runtime instead of starting another one:
+
+.. code-block:: bash
+
+   source ~/.cloudxr/run/cloudxr.env
+   python examples/teleop/python/gripper_retargeting_example_simple.py \
+         --no-launch-cloudxr-runtime
+
+Configuration
+-------------
+
+The standalone launcher accepts the same configuration flags as the embedded
+one:
+
+- ``--cloudxr-env-config <PATH>`` — a ``KEY=value`` env file of CloudXR
+  runtime overrides, e.g. ``NV_DEVICE_PROFILE=auto-native``. See
+  :ref:`run-cloudxr-server` in the quick start for the list of supported
+  environment variables.
+- ``--cloudxr-install-dir <PATH>`` — CloudXR install directory
+  (default: ``~/.cloudxr``).
+
+To inspect the active settings after startup:
+
+.. code-block:: bash
+
+   cat ~/.cloudxr/run/cloudxr.env


### PR DESCRIPTION
Reflect that the teleop examples auto-launch the CloudXR runtime and WSS proxy via CloudXRLauncher, so users no longer start the runtime or source cloudxr.env by hand for the common path. Reframe the CloudXR section as optional configuration (--cloudxr-env-config), move the standalone-runtime workflow into dropdowns, mark the 'load environment variables' step as standalone-only, and fix the environment-variables list-table indentation.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start guide with clearer checkout instructions.
  * Consolidated optional CloudXR configuration guidance, including environment overrides and standalone runtime setup.
  * Clarified auto-launch behavior, launch modes, required terminal usage, and relevant command-line options.
  * Revised environment variable instructions to explain when they can be skipped and how to configure standalone runtime sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->