### PR TITLE
ci(docs): pull Git LFS assets before building docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -124,6 +124,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Images/GIFs/etc. are stored in Git LFS (see .gitattributes). Without
+          # this, the working tree holds LFS pointer files and Sphinx copies the
+          # pointers verbatim, so the deployed site serves broken images.
+          lfs: true
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -143,6 +148,10 @@ jobs:
         if: needs.check-repo.outputs.is-canonical-repo == 'true' && needs.check-repo.outputs.is-deploy-branch == 'true'
         run: |
           git fetch --prune --unshallow --tags
+          # sphinx-multiversion checks each ref out into its own worktree, which
+          # smudges LFS files from the local object cache. `lfs: true` above only
+          # fetched HEAD's objects, so pull the rest for every built ref here.
+          git lfs fetch --all
           make multi-docs
 
       - name: Upload docs artifact


### PR DESCRIPTION
## Problem

Fixes #756. Docs images broke on the deployed site — most visibly on PR previews such as https://nvidia.github.io/IsaacTeleop/preview/pr-776/ — after #669 moved images into Git LFS (merged 2026-06-12).

The `build-docs` job checks out with `actions/checkout@v6`, which defaults to `lfs: false`. So the working tree holds LFS **pointer files** (~131-byte text stubs), Sphinx copies them verbatim into `_images/`, and `peaceiris/actions-gh-pages` pushes the stubs to `gh-pages`. Browsers then receive `version https://git-lfs.github.com/spec/v1 …` instead of an image.

Verified empirically: `preview/pr-776/_images/isaac-teleop-hero.jpg` is served as a 131-byte pointer, and all 23 LFS-tracked docs images are pointers in the source tree. Production `main/` still renders only because that path is stale (last deployed before the migration, kept by `keep_files: true`); the next `main` docs deploy would overwrite it with pointers.

The muzimuzhi symlink/tarring theory in the issue does not apply here — that failure mode is specific to native GitHub Pages artifact deploys, whereas this repo pushes real files via `actions-gh-pages`.

## Fix

- `lfs: true` on the `build-docs` checkout — materializes the assets for `current-docs`, which is exactly what PR previews deploy.
- `git lfs fetch --all` before `make multi-docs` — `lfs: true` only fetches HEAD's objects, but sphinx-multiversion checks out each ref (`main`, `release/*`, `v*` tags) into its own worktree, so those refs' LFS objects must be in the local cache to smudge real files.

`build-app` is intentionally left unchanged: `git ls-files` finds no LFS-tracked raster images in `webxr_client`, and its SVG icons are explicitly LFS-excluded in `.gitattributes`.

## Verification

Workflow edits are only fully provable via a CI run. Since `docs.yaml`'s `pull_request` trigger runs from the PR branch, this PR itself (which touches `.github/workflows/docs.yaml`) exercises the edited workflow — confirm that `preview/pr-<N>/_images/*.jpg` serves binary rather than a pointer stub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved documentation builds to include the correct media assets across all published documentation versions.
  * Resolved issues where images and other large files could appear as missing or invalid placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->