### PR TITLE
Add SE3 tracker device type with example controller plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ if(BUILD_PLUGINS)
     # Build plugin utilities
     add_subdirectory(src/plugins/plugin_utils)
 
+    add_subdirectory(src/plugins/controller_se3_tracker)
     add_subdirectory(src/plugins/controller_synthetic_hands)
     add_subdirectory(src/plugins/generic_3axis_pedal)
     add_subdirectory(src/plugins/so101_leader)

--- a/docs/source/device/add_device.rst
+++ b/docs/source/device/add_device.rst
@@ -16,7 +16,7 @@ The reference implementation is the **generic 3-axis foot pedal**:
      - :code-dir:`src/plugins/generic_3axis_pedal`
    * - Tracker facade (``Generic3AxisPedalTracker``)
      - :code-file:`src/core/deviceio_trackers/cpp/generic_3axis_pedal_tracker.cpp` and
-       :code-file:`src/core/deviceio_trackers/cpp/inc/deviceio/generic_3axis_pedal_tracker.hpp`
+       :code-file:`src/core/deviceio_trackers/cpp/inc/deviceio_trackers/generic_3axis_pedal_tracker.hpp`
    * - Live backend (``LiveGeneric3AxisPedalTrackerImpl``)
      - :code-file:`src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.cpp` and
        :code-file:`src/core/live_trackers/cpp/live_generic_3axis_pedal_tracker_impl.hpp`

--- a/docs/source/device/trackers.rst
+++ b/docs/source/device/trackers.rst
@@ -2,7 +2,7 @@ Device Trackers
 ===============
 
 Trackers (defined in :code-dir:`src/core/deviceio_trackers`) are the consumer-side API for reading device
-data from an active :code-file:`DeviceIOSession <src/core/deviceio_session/cpp/inc/deviceio/deviceio_session.hpp>`.
+data from an active :code-file:`DeviceIOSession <src/core/deviceio_session/cpp/inc/deviceio_session/deviceio_session.hpp>`.
 Each tracker manages one logical device, queries the OpenXR runtime every frame,
 and exposes the latest sample through typed ``get_*()`` accessors.
 
@@ -11,17 +11,17 @@ There are two categories of trackers:
 **OpenXR-direct trackers** -- read pose and input data through standard OpenXR
 APIs (``xrLocateSpace``, ``xrSyncActions``, etc.):
 
-- :code-file:`HeadTracker <src/core/deviceio_trackers/cpp/inc/deviceio/head_tracker.hpp>` -- HMD head pose
-- :code-file:`HandTracker <src/core/deviceio_trackers/cpp/inc/deviceio/hand_tracker.hpp>` -- articulated hand joints (left and right)
-- :code-file:`ControllerTracker <src/core/deviceio_trackers/cpp/inc/deviceio/controller_tracker.hpp>` -- controller poses and button/axis inputs (left and right)
-- :code-file:`FullBodyTrackerPico <src/core/deviceio_trackers/cpp/inc/deviceio/full_body_tracker_pico.hpp>` -- 24-joint full body pose (PICO ``XR_BD_body_tracking``)
+- :code-file:`HeadTracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/head_tracker.hpp>` -- HMD head pose
+- :code-file:`HandTracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/hand_tracker.hpp>` -- articulated hand joints (left and right)
+- :code-file:`ControllerTracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/controller_tracker.hpp>` -- controller poses and button/axis inputs (left and right)
+- :code-file:`FullBodyTrackerPico <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/full_body_tracker_pico.hpp>` -- 24-joint full body pose (PICO ``XR_BD_body_tracking``)
 
 **SchemaTracker-based trackers** -- create new device type by defining a FlatBuffer schema and
 reading it from OpenXR tensor collections via the
 :code-file:`SchemaTracker <src/core/live_trackers/cpp/inc/live_trackers/schema_tracker.hpp>` utility.
 
-- :code-file:`FrameMetadataTrackerOak <src/core/deviceio_trackers/cpp/inc/deviceio/frame_metadata_tracker_oak.hpp>` -- per-stream frame metadata from OAK cameras
-- :code-file:`Generic3AxisPedalTracker <src/core/deviceio_trackers/cpp/inc/deviceio/generic_3axis_pedal_tracker.hpp>` -- foot pedal axis values
+- :code-file:`FrameMetadataTrackerOak <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/frame_metadata_tracker_oak.hpp>` -- per-stream frame metadata from OAK cameras
+- :code-file:`Generic3AxisPedalTracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/generic_3axis_pedal_tracker.hpp>` -- foot pedal axis values
 
 All trackers follow the same lifecycle:
 

--- a/docs/source/device/trackers.rst
+++ b/docs/source/device/trackers.rst
@@ -22,6 +22,8 @@ reading it from OpenXR tensor collections via the
 
 - :code-file:`FrameMetadataTrackerOak <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/frame_metadata_tracker_oak.hpp>` -- per-stream frame metadata from OAK cameras
 - :code-file:`Generic3AxisPedalTracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/generic_3axis_pedal_tracker.hpp>` -- foot pedal axis values
+- :code-file:`JointStateTracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/joint_state_tracker.hpp>` -- named joint-space device state (leader arms, exoskeletons, gloves, ...)
+- :code-file:`Se3Tracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/se3_tracker.hpp>` -- generic SE3 (6-DoF) pose sources (tracker pucks, mocap rigid bodies, logical trackers)
 
 All trackers follow the same lifecycle:
 

--- a/examples/schemaio/CMakeLists.txt
+++ b/examples/schemaio/CMakeLists.txt
@@ -33,6 +33,20 @@ target_link_libraries(pedal_printer PRIVATE
     Threads::Threads
 )
 
+# Create SE3 tracker printer executable
+add_executable(se3_printer
+    se3_printer.cpp
+)
+
+target_link_libraries(se3_printer PRIVATE
+    deviceio::deviceio_session
+    deviceio::deviceio_trackers
+    oxr::oxr_core
+    isaacteleop_schema
+    ${CMAKE_DL_LIBS}
+    Threads::Threads
+)
+
 # Create frame metadata printer executable
 add_executable(frame_metadata_printer
     frame_metadata_printer.cpp
@@ -48,6 +62,6 @@ target_link_libraries(frame_metadata_printer PRIVATE
 )
 
 # Install
-install(TARGETS pedal_pusher pedal_printer frame_metadata_printer
+install(TARGETS pedal_pusher pedal_printer se3_printer frame_metadata_printer
     RUNTIME DESTINATION examples/schemaio
 )

--- a/examples/schemaio/se3_printer.cpp
+++ b/examples/schemaio/se3_printer.cpp
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/*!
+ * @file se3_printer.cpp
+ * @brief Standalone application that reads and prints SE3 tracker poses from the OpenXR runtime.
+ *
+ * This application demonstrates using Se3Tracker to read Se3TrackerPose FlatBuffer samples
+ * pushed by an SE3 producer plugin (e.g. controller_se3_tracker). The application creates
+ * the OpenXR session with required extensions and uses DeviceIOSession to manage the tracker.
+ *
+ * Note: Both pusher and reader agree on the schema (Se3TrackerPose from se3_tracker.fbs), so the
+ * schema does not need to be sent over the wire. The collection ID must match the producer's;
+ * pass it as the first argument to read a non-default stream (multiple SE3 trackers stream on
+ * distinct collection IDs).
+ */
+
+#include "common_utils.hpp"
+
+#include <deviceio_session/deviceio_session.hpp>
+#include <deviceio_trackers/se3_tracker.hpp>
+#include <oxr/oxr_session.hpp>
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace schemaio_example;
+
+void print_se3_data(const core::Se3TrackerPoseT& data, size_t sample_count)
+{
+    std::cout << "Sample " << sample_count;
+
+    if (!data.is_valid)
+    {
+        // Pose contents are unspecified while tracking is lost (see se3_tracker.fbs) —
+        // gate on is_valid, never on pose values.
+        std::cout << " [tracking lost]" << std::endl;
+        return;
+    }
+
+    const auto& position = data.pose->position();
+    const auto& orientation = data.pose->orientation();
+    std::cout << std::fixed << std::setprecision(3) << " pos=[" << position.x() << ", " << position.y() << ", "
+              << position.z() << "] quat(xyzw)=[" << orientation.x() << ", " << orientation.y() << ", "
+              << orientation.z() << ", " << orientation.w() << "]";
+
+    std::cout << std::endl;
+}
+
+int main(int argc, char** argv)
+try
+{
+    const std::string collection_id = (argc > 1) ? argv[1] : std::string(core::Se3Tracker::TENSOR_IDENTIFIER);
+
+    std::cout << "SE3 Printer (collection: " << collection_id << ")" << std::endl;
+
+    // Step 1: Create the tracker
+    std::cout << "[Step 1] Creating Se3Tracker..." << std::endl;
+    auto tracker = std::make_shared<core::Se3Tracker>(collection_id);
+
+    // Step 2: Get required extensions and create OpenXR session
+    std::cout << "[Step 2] Creating OpenXR session with required extensions..." << std::endl;
+
+    std::vector<std::shared_ptr<core::ITracker>> trackers = { tracker };
+    auto required_extensions = core::DeviceIOSession::get_required_extensions(trackers);
+
+    auto oxr_session = std::make_shared<core::OpenXRSession>("Se3Printer", required_extensions);
+
+    std::cout << "  OpenXR session created" << std::endl;
+
+    // Step 3: Create DeviceIOSession with the tracker
+    std::cout << "[Step 3] Creating DeviceIOSession..." << std::endl;
+
+    std::unique_ptr<core::DeviceIOSession> session;
+    session = core::DeviceIOSession::run(trackers, oxr_session->get_handles());
+
+    // Step 4: Read samples by updating the session
+    std::cout << "[Step 4] Reading samples..." << std::endl;
+
+    size_t received_count = 0;
+    while (received_count < MAX_SAMPLES)
+    {
+        // Update session (this calls update on all trackers). Each update drains ALL
+        // samples pending in the tensor collection, so the first tick consumes any
+        // backlog and get_data() below always exposes the latest pose.
+        session->update();
+
+        // Print current data if available. Note: the live backend retains the
+        // last-known sample between pushes, so without the fixed-rate sleep below this
+        // loop would spin and reprint stale data as fast as the CPU allows.
+        const auto& tracked = tracker->get_data(*session);
+        if (tracked.data)
+        {
+            print_se3_data(*tracked.data, received_count++);
+        }
+
+        // Tick at ~90 Hz to match the controller_se3_tracker plugin's push rate.
+        std::this_thread::sleep_for(std::chrono::milliseconds(33));
+    }
+
+    std::cout << "\nDone. Received " << received_count << " samples." << std::endl;
+    return 0;
+}
+catch (const std::exception& e)
+{
+    std::cerr << argv[0] << ": " << e.what() << std::endl;
+    return 1;
+}
+catch (...)
+{
+    std::cerr << argv[0] << ": Unknown error occurred" << std::endl;
+    return 1;
+}

--- a/examples/schemaio/se3_printer.cpp
+++ b/examples/schemaio/se3_printer.cpp
@@ -98,7 +98,8 @@ try
             print_se3_data(*tracked.data, received_count++);
         }
 
-        // Tick at ~90 Hz to match the controller_se3_tracker plugin's push rate.
+        // Tick at ~30 Hz. Each update drains all pending samples, so the printer keeps up
+        // even when a producer (e.g. controller_se3_tracker) pushes faster, at ~90 Hz.
         std::this_thread::sleep_for(std::chrono::milliseconds(33));
     }
 

--- a/src/core/deviceio_base/cpp/inc/deviceio_base/se3_tracker_base.hpp
+++ b/src/core/deviceio_base/cpp/inc/deviceio_base/se3_tracker_base.hpp
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "tracker.hpp"
+
+namespace core
+{
+
+struct Se3TrackerPoseTrackedT;
+
+// Abstract base interface for Se3Tracker implementations.
+//
+// Backs a generic SE3 (6-DoF pose) tracker device (tracker puck, mocap rigid body, logical
+// tracker derived from another device, ...): the implementation keeps the last-known
+// Se3TrackerPose snapshot, which the Se3Tracker facade exposes.
+class ISe3TrackerImpl : public ITrackerImpl
+{
+public:
+    virtual const Se3TrackerPoseTrackedT& get_data() const = 0;
+};
+
+} // namespace core

--- a/src/core/deviceio_trackers/cpp/CMakeLists.txt
+++ b/src/core/deviceio_trackers/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ add_library(deviceio_trackers STATIC
     tensor_push_tracker.cpp
     haptic_command_reader_tracker.cpp
     joint_state_tracker.cpp
+    se3_tracker.cpp
     frame_metadata_tracker_oak.cpp
     full_body_tracker_pico.cpp
     inc/deviceio_trackers/head_tracker.hpp
@@ -24,6 +25,7 @@ add_library(deviceio_trackers STATIC
     inc/deviceio_trackers/tensor_push_tracker.hpp
     inc/deviceio_trackers/haptic_command_reader_tracker.hpp
     inc/deviceio_trackers/joint_state_tracker.hpp
+    inc/deviceio_trackers/se3_tracker.hpp
     inc/deviceio_trackers/frame_metadata_tracker_oak.hpp
 )
 

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/se3_tracker.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/se3_tracker.hpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_base/se3_tracker_base.hpp>
+#include <schema/se3_tracker_generated.h>
+
+#include <cstddef>
+#include <string>
+#include <string_view>
+
+namespace core
+{
+
+/*!
+ * @brief Facade for a generic SE3 (6-DoF pose) tracker device exposed as ``Se3TrackerPoseTrackedT``.
+ *
+ * Generic across rigid-body pose sources (tracker pucks, mocap rigid bodies, logical trackers
+ * derived from other devices, ...): the payload is a single pose plus a validity flag. The
+ * reference frame is defined by the data producer (see ``se3_tracker.fbs`` for the normative
+ * conventions). A distinct ``collection_id`` per device allows several SE3 trackers to stream
+ * simultaneously.
+ *
+ * After each ``ITrackerSession::update()`` that includes this tracker, ``get_data(session)``
+ * reflects the implementation's tracked snapshot. As with other ``SchemaTracker``-backed trackers,
+ * the live backend may retain the last-known sample when a tick has no new samples while the
+ * collection remains available (``data`` stays non-null but may be stale); ``data`` is null only
+ * when no sample has arrived yet or the collection is unavailable. Independently,
+ * ``data->is_valid == false`` means the producer is streaming but tracking is lost — the pose
+ * contents are then unspecified.
+ *
+ * Note: ``collection_id`` (stream instance), ``TENSOR_IDENTIFIER`` (tensor name within the
+ * collection), and the MCAP channel names are independent identifiers that happen to share the
+ * default spelling ``se3_tracker``.
+ *
+ * Usage:
+ * @code
+ * auto tracker = std::make_shared<Se3Tracker>("se3_tracker");
+ * // ... register the tracker with a session, then each tick: ...
+ * session->update();
+ * const auto& data = tracker->get_data(*session);
+ * @endcode
+ */
+class Se3Tracker : public ITracker
+{
+public:
+    //! Default maximum FlatBuffer size for Se3TrackerPose messages. Pusher and tracker must agree
+    //! on this value (it sizes the fixed tensor buffer).
+    static constexpr size_t DEFAULT_MAX_FLATBUFFER_SIZE = 256;
+
+    //! Tensor name within the collection. Single source of truth for the pusher/reader wire
+    //! rendezvous: both LiveSe3TrackerImpl and producer plugins reference this symbol (a mismatch
+    //! is silent no-data).
+    static constexpr std::string_view TENSOR_IDENTIFIER = "se3_tracker";
+
+    /*!
+     * @brief Constructs an Se3Tracker.
+     * @param collection_id Logical stream identifier; must match the device plugin / pusher.
+     * @param max_flatbuffer_size Upper bound for serialized ``Se3TrackerPose`` / record payloads.
+     */
+    explicit Se3Tracker(const std::string& collection_id, size_t max_flatbuffer_size = DEFAULT_MAX_FLATBUFFER_SIZE);
+
+    std::string_view get_name() const override
+    {
+        return TRACKER_NAME;
+    }
+
+    /*!
+     * @brief SE3 tracker snapshot from the session's implementation.
+     *
+     * ``tracked.data`` is null when no sample has arrived yet or the collection is unavailable.
+     * When non-null, gate on ``data->is_valid`` before consuming ``data->pose`` — the pose is
+     * unspecified while tracking is lost.
+     */
+    const Se3TrackerPoseTrackedT& get_data(const ITrackerSession& session) const;
+
+    const std::string& collection_id() const
+    {
+        return collection_id_;
+    }
+
+    size_t max_flatbuffer_size() const
+    {
+        return max_flatbuffer_size_;
+    }
+
+private:
+    static constexpr const char* TRACKER_NAME = "Se3Tracker";
+
+    std::string collection_id_;
+    size_t max_flatbuffer_size_;
+};
+
+} // namespace core

--- a/src/core/deviceio_trackers/cpp/se3_tracker.cpp
+++ b/src/core/deviceio_trackers/cpp/se3_tracker.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "inc/deviceio_trackers/se3_tracker.hpp"
+
+namespace core
+{
+
+// ============================================================================
+// Se3Tracker
+// ============================================================================
+
+Se3Tracker::Se3Tracker(const std::string& collection_id, size_t max_flatbuffer_size)
+    : collection_id_(collection_id), max_flatbuffer_size_(max_flatbuffer_size)
+{
+}
+
+const Se3TrackerPoseTrackedT& Se3Tracker::get_data(const ITrackerSession& session) const
+{
+    return static_cast<const ISe3TrackerImpl&>(session.get_tracker_impl(*this)).get_data();
+}
+
+} // namespace core

--- a/src/core/deviceio_trackers/python/deviceio_trackers_init.py
+++ b/src/core/deviceio_trackers/python/deviceio_trackers_init.py
@@ -14,6 +14,7 @@ from ._deviceio_trackers import (
     Generic3AxisPedalTracker,
     TensorPushTracker,
     JointStateTracker,
+    Se3Tracker,
     FullBodyTrackerPico,
     ITrackerSession,
     NUM_JOINTS,
@@ -40,5 +41,6 @@ __all__ = [
     "JOINT_THUMB_TIP",
     "JOINT_WRIST",
     "NUM_JOINTS",
+    "Se3Tracker",
     "ITrackerSession",
 ]

--- a/src/core/deviceio_trackers/python/tracker_bindings.cpp
+++ b/src/core/deviceio_trackers/python/tracker_bindings.cpp
@@ -9,6 +9,7 @@
 #include <deviceio_trackers/head_tracker.hpp>
 #include <deviceio_trackers/joint_state_tracker.hpp>
 #include <deviceio_trackers/message_channel_tracker.hpp>
+#include <deviceio_trackers/se3_tracker.hpp>
 #include <deviceio_trackers/tensor_push_tracker.hpp>
 #include <pybind11/numpy.h>
 #include <pybind11/stl.h>
@@ -181,6 +182,19 @@ PYBIND11_MODULE(_deviceio_trackers, m)
             [](const core::JointStateTracker& self, const core::ITrackerSession& session) -> core::JointStateOutputTrackedT
             { return self.get_data(session); },
             py::arg("session"), "Get the current joint-state tracked snapshot (data is None when no data available)");
+
+    py::class_<core::Se3Tracker, core::ITracker, std::shared_ptr<core::Se3Tracker>>(m, "Se3Tracker")
+        .def(py::init<const std::string&, size_t>(), py::arg("collection_id"),
+             py::arg("max_flatbuffer_size") = core::Se3Tracker::DEFAULT_MAX_FLATBUFFER_SIZE,
+             "Construct an Se3Tracker for the given tensor collection ID (one generic SE3 "
+             "6-DoF pose source: tracker puck, mocap rigid body, logical tracker, ...)")
+        .def(
+            "get_data",
+            [](const core::Se3Tracker& self, const core::ITrackerSession& session) -> core::Se3TrackerPoseTrackedT
+            { return self.get_data(session); },
+            py::arg("session"),
+            "Get the current SE3 tracked snapshot (data is None when no data available; gate on "
+            "data.is_valid before consuming the pose)");
 
     py::class_<core::FullBodyTrackerPico, core::ITracker, std::shared_ptr<core::FullBodyTrackerPico>>(
         m, "FullBodyTrackerPico")

--- a/src/core/live_trackers/cpp/CMakeLists.txt
+++ b/src/core/live_trackers/cpp/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(live_trackers STATIC
     live_tensor_push_tracker_impl.cpp
     live_haptic_command_reader_tracker_impl.cpp
     live_joint_state_tracker_impl.cpp
+    live_se3_tracker_impl.cpp
     live_frame_metadata_tracker_oak_impl.cpp
     inc/live_trackers/schema_tracker_base.hpp
     inc/live_trackers/schema_tracker.hpp
@@ -28,6 +29,7 @@ add_library(live_trackers STATIC
     live_tensor_push_tracker_impl.hpp
     live_haptic_command_reader_tracker_impl.hpp
     live_joint_state_tracker_impl.hpp
+    live_se3_tracker_impl.hpp
     live_frame_metadata_tracker_oak_impl.hpp
 )
 

--- a/src/core/live_trackers/cpp/inc/live_trackers/live_deviceio_factory.hpp
+++ b/src/core/live_trackers/cpp/inc/live_trackers/live_deviceio_factory.hpp
@@ -36,6 +36,8 @@ class HapticCommandReaderTracker;
 class IHapticCommandReaderTrackerImpl;
 class JointStateTracker;
 class IJointStateTrackerImpl;
+class Se3Tracker;
+class ISe3TrackerImpl;
 class HandTracker;
 class IHandTrackerImpl;
 class HeadTracker;
@@ -72,6 +74,7 @@ public:
     std::unique_ptr<IHapticCommandReaderTrackerImpl> create_haptic_command_reader_tracker_impl(
         const HapticCommandReaderTracker* tracker);
     std::unique_ptr<IJointStateTrackerImpl> create_joint_state_tracker_impl(const JointStateTracker* tracker);
+    std::unique_ptr<ISe3TrackerImpl> create_se3_tracker_impl(const Se3Tracker* tracker);
     std::unique_ptr<IFrameMetadataTrackerOakImpl> create_frame_metadata_tracker_oak_impl(
         const FrameMetadataTrackerOak* tracker);
 

--- a/src/core/live_trackers/cpp/live_deviceio_factory.cpp
+++ b/src/core/live_trackers/cpp/live_deviceio_factory.cpp
@@ -12,6 +12,7 @@
 #include "live_head_tracker_impl.hpp"
 #include "live_joint_state_tracker_impl.hpp"
 #include "live_message_channel_tracker_impl.hpp"
+#include "live_se3_tracker_impl.hpp"
 #include "live_tensor_push_tracker_impl.hpp"
 
 #include <deviceio_trackers/controller_tracker.hpp>
@@ -23,6 +24,7 @@
 #include <deviceio_trackers/head_tracker.hpp>
 #include <deviceio_trackers/joint_state_tracker.hpp>
 #include <deviceio_trackers/message_channel_tracker.hpp>
+#include <deviceio_trackers/se3_tracker.hpp>
 #include <deviceio_trackers/tensor_push_tracker.hpp>
 #include <oxr_utils/oxr_time.hpp>
 
@@ -103,6 +105,12 @@ std::unique_ptr<ITrackerImpl> try_create_joint_state_impl(LiveDeviceIOFactory& f
     return typed ? factory.create_joint_state_tracker_impl(typed) : nullptr;
 }
 
+std::unique_ptr<ITrackerImpl> try_create_se3_tracker_impl(LiveDeviceIOFactory& factory, const ITracker& tracker)
+{
+    auto* typed = dynamic_cast<const Se3Tracker*>(&tracker);
+    return typed ? factory.create_se3_tracker_impl(typed) : nullptr;
+}
+
 std::unique_ptr<ITrackerImpl> try_create_oak_impl(LiveDeviceIOFactory& factory, const ITracker& tracker)
 {
     auto* typed = dynamic_cast<const FrameMetadataTrackerOak*>(&tracker);
@@ -130,6 +138,7 @@ inline const TrackerDispatchEntry k_tracker_dispatch[] = {
     { &try_add_extensions<HapticCommandReaderTracker, LiveHapticCommandReaderTrackerImpl>,
       &try_create_haptic_command_reader_impl },
     { &try_add_extensions<JointStateTracker, LiveJointStateTrackerImpl>, &try_create_joint_state_impl },
+    { &try_add_extensions<Se3Tracker, LiveSe3TrackerImpl>, &try_create_se3_tracker_impl },
     { &try_add_extensions<FrameMetadataTrackerOak, LiveFrameMetadataTrackerOakImpl>, &try_create_oak_impl },
 };
 
@@ -291,6 +300,16 @@ std::unique_ptr<IJointStateTrackerImpl> LiveDeviceIOFactory::create_joint_state_
         channels = LiveJointStateTrackerImpl::create_mcap_channels(*writer_, get_name(tracker));
     }
     return std::make_unique<LiveJointStateTrackerImpl>(handles_, tracker, std::move(channels));
+}
+
+std::unique_ptr<ISe3TrackerImpl> LiveDeviceIOFactory::create_se3_tracker_impl(const Se3Tracker* tracker)
+{
+    std::unique_ptr<Se3TrackerMcapChannels> channels;
+    if (should_record(tracker))
+    {
+        channels = LiveSe3TrackerImpl::create_mcap_channels(*writer_, get_name(tracker));
+    }
+    return std::make_unique<LiveSe3TrackerImpl>(handles_, tracker, std::move(channels));
 }
 
 std::unique_ptr<IFrameMetadataTrackerOakImpl> LiveDeviceIOFactory::create_frame_metadata_tracker_oak_impl(

--- a/src/core/live_trackers/cpp/live_se3_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_se3_tracker_impl.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "live_se3_tracker_impl.hpp"
+
+#include <mcap/recording_traits.hpp>
+#include <schema/se3_tracker_bfbs_generated.h>
+
+namespace core
+{
+
+namespace
+{
+
+SchemaTrackerConfig make_se3_tracker_tensor_config(const Se3Tracker* tracker)
+{
+    SchemaTrackerConfig cfg;
+    cfg.collection_id = tracker->collection_id();
+    cfg.max_flatbuffer_size = tracker->max_flatbuffer_size();
+    // Wire rendezvous with producer plugins; single source of truth on the facade.
+    cfg.tensor_identifier = std::string(Se3Tracker::TENSOR_IDENTIFIER);
+    cfg.localized_name = "Se3Tracker";
+    return cfg;
+}
+
+} // namespace
+
+// ============================================================================
+// LiveSe3TrackerImpl
+// ============================================================================
+
+std::unique_ptr<Se3TrackerMcapChannels> LiveSe3TrackerImpl::create_mcap_channels(mcap::McapWriter& writer,
+                                                                                 std::string_view base_name)
+{
+    return std::make_unique<Se3TrackerMcapChannels>(
+        writer, base_name, Se3TrackerRecordingTraits::schema_name,
+        std::vector<std::string>(Se3TrackerRecordingTraits::recording_channels.begin(),
+                                 Se3TrackerRecordingTraits::recording_channels.end()));
+}
+
+LiveSe3TrackerImpl::LiveSe3TrackerImpl(const OpenXRSessionHandles& handles,
+                                       const Se3Tracker* tracker,
+                                       std::unique_ptr<Se3TrackerMcapChannels> mcap_channels)
+    : mcap_channels_(std::move(mcap_channels)),
+      // Channel indices follow Se3TrackerRecordingTraits::recording_channels order:
+      // 0 = per-sample "se3_tracker", 1 = per-tick "se3_tracker_tracked".
+      m_schema_reader(handles,
+                      make_se3_tracker_tensor_config(tracker),
+                      mcap_channels_.get(),
+                      /*mcap_channel_index=*/0,
+                      /*mcap_channel_tracked_index=*/1)
+{
+}
+
+void LiveSe3TrackerImpl::update(int64_t /*monotonic_time_ns*/)
+{
+    // Policy: SchemaTracker throws on critical OpenXR/tensor API failures.
+    // Missing collection/no new data are treated as common non-fatal cases.
+    m_schema_reader.update(m_tracked.data);
+}
+
+const Se3TrackerPoseTrackedT& LiveSe3TrackerImpl::get_data() const
+{
+    return m_tracked;
+}
+
+} // namespace core

--- a/src/core/live_trackers/cpp/live_se3_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_se3_tracker_impl.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "inc/live_trackers/schema_tracker.hpp"
+
+#include <deviceio_trackers/se3_tracker.hpp>
+#include <oxr_utils/oxr_session_handles.hpp>
+#include <schema/se3_tracker_generated.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace core
+{
+
+using Se3TrackerMcapChannels = McapTrackerChannels<Se3TrackerPoseRecord, Se3TrackerPose>;
+using Se3TrackerSchemaTracker = SchemaTracker<Se3TrackerPoseRecord, Se3TrackerPose>;
+
+class LiveSe3TrackerImpl : public ISe3TrackerImpl
+{
+public:
+    static std::vector<std::string> required_extensions()
+    {
+        return SchemaTrackerBase::get_required_extensions();
+    }
+    static std::unique_ptr<Se3TrackerMcapChannels> create_mcap_channels(mcap::McapWriter& writer,
+                                                                        std::string_view base_name);
+
+    LiveSe3TrackerImpl(const OpenXRSessionHandles& handles,
+                       const Se3Tracker* tracker,
+                       std::unique_ptr<Se3TrackerMcapChannels> mcap_channels);
+
+    LiveSe3TrackerImpl(const LiveSe3TrackerImpl&) = delete;
+    LiveSe3TrackerImpl& operator=(const LiveSe3TrackerImpl&) = delete;
+    LiveSe3TrackerImpl(LiveSe3TrackerImpl&&) = delete;
+    LiveSe3TrackerImpl& operator=(LiveSe3TrackerImpl&&) = delete;
+
+    void update(int64_t monotonic_time_ns) override;
+    const Se3TrackerPoseTrackedT& get_data() const override;
+
+private:
+    std::unique_ptr<Se3TrackerMcapChannels> mcap_channels_;
+    Se3TrackerSchemaTracker m_schema_reader;
+    Se3TrackerPoseTrackedT m_tracked;
+};
+
+} // namespace core

--- a/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
+++ b/src/core/mcap/cpp/inc/mcap/recording_traits.hpp
@@ -59,6 +59,13 @@ struct JointStateRecordingTraits
     static constexpr std::array replay_channels = { "joint_state_tracked" };
 };
 
+struct Se3TrackerRecordingTraits
+{
+    static constexpr std::string_view schema_name = "core.Se3TrackerPoseRecord";
+    static constexpr std::array recording_channels = { "se3_tracker", "se3_tracker_tracked" };
+    static constexpr std::array replay_channels = { "se3_tracker_tracked" };
+};
+
 struct OakRecordingTraits
 {
     static constexpr std::string_view schema_name = "core.FrameMetadataOakRecord";

--- a/src/core/replay_deviceio_session_tests/cpp/test_replay_session.cpp
+++ b/src/core/replay_deviceio_session_tests/cpp/test_replay_session.cpp
@@ -10,11 +10,13 @@
 #include <deviceio_trackers/hand_tracker.hpp>
 #include <deviceio_trackers/head_tracker.hpp>
 #include <deviceio_trackers/message_channel_tracker.hpp>
+#include <deviceio_trackers/se3_tracker.hpp>
 #include <mcap/recording_traits.hpp>
 #include <mcap/tracker_channels.hpp>
 #include <schema/hand_generated.h>
 #include <schema/head_generated.h>
 #include <schema/message_channel_generated.h>
+#include <schema/se3_tracker_generated.h>
 
 #include <array>
 #include <atomic>
@@ -86,6 +88,7 @@ using HeadChannels = core::McapTrackerChannels<core::HeadPoseRecord, core::HeadP
 using HandChannels = core::McapTrackerChannels<core::HandPoseRecord, core::HandPose>;
 using MessageChannelChannels =
     core::McapTrackerChannels<core::MessageChannelMessagesRecord, core::MessageChannelMessages>;
+using Se3TrackerChannels = core::McapTrackerChannels<core::Se3TrackerPoseRecord, core::Se3TrackerPose>;
 
 // ============================================================================
 // Write helpers
@@ -102,6 +105,18 @@ void write_head_frame(HeadChannels& ch, int64_t time_ns, float x, float y, float
 void write_hand_frame(HandChannels& ch, int64_t time_ns, size_t channel_index, std::shared_ptr<core::HandPoseT> data)
 {
     ch.write(channel_index, core::DeviceDataTimestamp(time_ns, time_ns, time_ns), data);
+}
+
+// Mirror LiveSe3TrackerImpl's channel usage: per-sample writes go to index 0
+// ("se3_tracker"), the per-tick snapshot to index 1 ("se3_tracker_tracked").
+// Replay reads only the tracked channel.
+void write_se3_tracker_frame(Se3TrackerChannels& ch, int64_t time_ns, float x, float y, float z)
+{
+    auto data = std::make_shared<core::Se3TrackerPoseT>();
+    data->is_valid = true;
+    data->pose = std::make_shared<core::Pose>(make_pose(x, y, z));
+    ch.write(0, core::DeviceDataTimestamp(time_ns, time_ns, time_ns), data);
+    ch.write(1, core::DeviceDataTimestamp(time_ns, time_ns, time_ns), data);
 }
 
 void write_message_record(MessageChannelChannels& ch, int64_t time_ns, const std::string& payload)
@@ -180,6 +195,64 @@ TEST_CASE("ReplaySession: head tracker round-trip with multiple frames", "[repla
 
     session->update();
     CHECK_FALSE(head_tracker.get_head(*session).data);
+}
+
+// =============================================================================
+// Single tracker — Se3Tracker (pusher-fed; replay reads the *_tracked channel)
+// =============================================================================
+
+TEST_CASE("ReplaySession: se3 tracker round-trip and null at EOF", "[replay][session][se3_tracker]")
+{
+    // Frozen wire strings — these must never change once an MCAP has been recorded.
+    CHECK(core::Se3TrackerRecordingTraits::schema_name == "core.Se3TrackerPoseRecord");
+    REQUIRE(core::Se3TrackerRecordingTraits::recording_channels.size() == 2);
+    CHECK(std::string_view(core::Se3TrackerRecordingTraits::recording_channels[0]) == "se3_tracker");
+    CHECK(std::string_view(core::Se3TrackerRecordingTraits::recording_channels[1]) == "se3_tracker_tracked");
+    REQUIRE(core::Se3TrackerRecordingTraits::replay_channels.size() == 1);
+    CHECK(std::string_view(core::Se3TrackerRecordingTraits::replay_channels[0]) == "se3_tracker_tracked");
+
+    auto path = get_temp_mcap_path();
+    TempFileCleanup cleanup(path);
+    const std::string base_name = "se3";
+
+    constexpr int num_frames = 3;
+    {
+        auto writer = open_writer(path);
+        Se3TrackerChannels ch(*writer, base_name, core::Se3TrackerRecordingTraits::schema_name,
+                              to_string_vec(core::Se3TrackerRecordingTraits::recording_channels));
+        for (int i = 0; i < num_frames; ++i)
+        {
+            float v = static_cast<float>(i + 1);
+            write_se3_tracker_frame(ch, (i + 1) * 1000000, v, v * 10.0f, v * 100.0f);
+        }
+        writer->close();
+    }
+
+    core::Se3Tracker tracker("se3_tracker");
+    core::McapReplayConfig config;
+    config.filename = path;
+    config.tracker_names = { { &tracker, base_name } };
+
+    auto session = core::ReplaySession::run(config);
+    REQUIRE(session != nullptr);
+
+    for (int i = 0; i < num_frames; ++i)
+    {
+        session->update();
+        const auto& tracked = tracker.get_data(*session);
+        REQUIRE(tracked.data);
+        CHECK(tracked.data->is_valid);
+        float v = static_cast<float>(i + 1);
+        CHECK(tracked.data->pose->position().x() == v);
+        CHECK(tracked.data->pose->position().y() == v * 10.0f);
+        CHECK(tracked.data->pose->position().z() == v * 100.0f);
+    }
+
+    // Replay nulls data at gap/EOF — intentionally different from the live impl's
+    // stale-sample retention on sample-less ticks. See the "Record/replay fidelity"
+    // paragraph in docs/se3-tracker-design.md before "fixing" this toward sample-and-hold.
+    session->update();
+    CHECK_FALSE(tracker.get_data(*session).data);
 }
 
 // =============================================================================

--- a/src/core/replay_trackers/cpp/CMakeLists.txt
+++ b/src/core/replay_trackers/cpp/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(replay_trackers STATIC
     replay_full_body_tracker_pico_impl.cpp
     replay_generic_3axis_pedal_tracker_impl.cpp
     replay_joint_state_tracker_impl.cpp
+    replay_se3_tracker_impl.cpp
     replay_message_channel_tracker_impl.cpp
     replay_tensor_push_tracker_impl.cpp
     replay_haptic_command_reader_tracker_impl.cpp
@@ -21,6 +22,7 @@ add_library(replay_trackers STATIC
     replay_full_body_tracker_pico_impl.hpp
     replay_generic_3axis_pedal_tracker_impl.hpp
     replay_joint_state_tracker_impl.hpp
+    replay_se3_tracker_impl.hpp
     replay_message_channel_tracker_impl.hpp
     replay_tensor_push_tracker_impl.hpp
     replay_haptic_command_reader_tracker_impl.hpp

--- a/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
+++ b/src/core/replay_trackers/cpp/inc/replay_trackers/replay_deviceio_factory.hpp
@@ -27,6 +27,8 @@ class HapticCommandReaderTracker;
 class IHapticCommandReaderTrackerImpl;
 class JointStateTracker;
 class IJointStateTrackerImpl;
+class Se3Tracker;
+class ISe3TrackerImpl;
 class HandTracker;
 class IHandTrackerImpl;
 class HeadTracker;
@@ -60,6 +62,7 @@ public:
     std::unique_ptr<IHapticCommandReaderTrackerImpl> create_haptic_command_reader_tracker_impl(
         const HapticCommandReaderTracker* tracker);
     std::unique_ptr<IJointStateTrackerImpl> create_joint_state_tracker_impl(const JointStateTracker* tracker);
+    std::unique_ptr<ISe3TrackerImpl> create_se3_tracker_impl(const Se3Tracker* tracker);
     std::unique_ptr<IMessageChannelTrackerImpl> create_message_channel_tracker_impl(const MessageChannelTracker* tracker);
 
 private:

--- a/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
+++ b/src/core/replay_trackers/cpp/replay_deviceio_factory.cpp
@@ -11,6 +11,7 @@
 #include "replay_head_tracker_impl.hpp"
 #include "replay_joint_state_tracker_impl.hpp"
 #include "replay_message_channel_tracker_impl.hpp"
+#include "replay_se3_tracker_impl.hpp"
 #include "replay_tensor_push_tracker_impl.hpp"
 
 #include <deviceio_trackers/controller_tracker.hpp>
@@ -21,6 +22,7 @@
 #include <deviceio_trackers/head_tracker.hpp>
 #include <deviceio_trackers/joint_state_tracker.hpp>
 #include <deviceio_trackers/message_channel_tracker.hpp>
+#include <deviceio_trackers/se3_tracker.hpp>
 #include <deviceio_trackers/tensor_push_tracker.hpp>
 #include <mcap/reader.hpp>
 
@@ -96,6 +98,12 @@ std::unique_ptr<ITrackerImpl> try_create_joint_state_impl(ReplayDeviceIOFactory&
     return typed ? factory.create_joint_state_tracker_impl(typed) : nullptr;
 }
 
+std::unique_ptr<ITrackerImpl> try_create_se3_tracker_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
+{
+    auto* typed = dynamic_cast<const Se3Tracker*>(&tracker);
+    return typed ? factory.create_se3_tracker_impl(typed) : nullptr;
+}
+
 std::unique_ptr<ITrackerImpl> try_create_message_channel_impl(ReplayDeviceIOFactory& factory, const ITracker& tracker)
 {
     auto* typed = dynamic_cast<const MessageChannelTracker*>(&tracker);
@@ -113,6 +121,7 @@ inline const TryCreateFn k_tracker_dispatch[] = {
     &try_create_tensor_push_impl,
     &try_create_haptic_command_reader_impl,
     &try_create_joint_state_impl,
+    &try_create_se3_tracker_impl,
     &try_create_message_channel_impl,
 };
 
@@ -195,6 +204,11 @@ std::unique_ptr<IHapticCommandReaderTrackerImpl> ReplayDeviceIOFactory::create_h
 std::unique_ptr<IJointStateTrackerImpl> ReplayDeviceIOFactory::create_joint_state_tracker_impl(const JointStateTracker* tracker)
 {
     return std::make_unique<ReplayJointStateTrackerImpl>(open_reader(filename_), get_name(tracker));
+}
+
+std::unique_ptr<ISe3TrackerImpl> ReplayDeviceIOFactory::create_se3_tracker_impl(const Se3Tracker* tracker)
+{
+    return std::make_unique<ReplaySe3TrackerImpl>(open_reader(filename_), get_name(tracker));
 }
 
 std::unique_ptr<IMessageChannelTrackerImpl> ReplayDeviceIOFactory::create_message_channel_tracker_impl(

--- a/src/core/replay_trackers/cpp/replay_se3_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_se3_tracker_impl.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "replay_se3_tracker_impl.hpp"
+
+#include <mcap/recording_traits.hpp>
+#include <schema/se3_tracker_bfbs_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace core
+{
+
+// ============================================================================
+// ReplaySe3TrackerImpl
+// ============================================================================
+
+ReplaySe3TrackerImpl::ReplaySe3TrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name)
+    : mcap_viewers_(std::make_unique<Se3TrackerMcapViewers>(
+          std::move(reader),
+          base_name,
+          std::vector<std::string>(
+              Se3TrackerRecordingTraits::replay_channels.begin(), Se3TrackerRecordingTraits::replay_channels.end()))),
+      no_data_message_("ReplaySe3TrackerImpl[" + std::string(base_name) + "]: no data (EOF or gap)")
+{
+}
+
+const Se3TrackerPoseTrackedT& ReplaySe3TrackerImpl::get_data() const
+{
+    return tracked_;
+}
+
+void ReplaySe3TrackerImpl::update(int64_t /*monotonic_time_ns*/)
+{
+    auto record = mcap_viewers_->read(0);
+    if (record)
+    {
+        tracked_.data = std::move(record->data);
+        warned_no_data_ = false;
+    }
+    else
+    {
+        // EOF / sparse streams call this every frame; log once per gap, not per frame.
+        if (!warned_no_data_)
+        {
+            std::cerr << no_data_message_ << std::endl;
+            warned_no_data_ = true;
+        }
+        tracked_.data.reset();
+    }
+}
+
+} // namespace core

--- a/src/core/replay_trackers/cpp/replay_se3_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_se3_tracker_impl.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_base/se3_tracker_base.hpp>
+#include <mcap/tracker_channels.hpp>
+#include <schema/se3_tracker_generated.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+
+namespace core
+{
+
+using Se3TrackerMcapViewers = McapTrackerViewers<Se3TrackerPoseRecord>;
+
+class ReplaySe3TrackerImpl : public ISe3TrackerImpl
+{
+public:
+    ReplaySe3TrackerImpl(std::unique_ptr<mcap::McapReader> reader, std::string_view base_name);
+
+    ReplaySe3TrackerImpl(const ReplaySe3TrackerImpl&) = delete;
+    ReplaySe3TrackerImpl& operator=(const ReplaySe3TrackerImpl&) = delete;
+    ReplaySe3TrackerImpl(ReplaySe3TrackerImpl&&) = delete;
+    ReplaySe3TrackerImpl& operator=(ReplaySe3TrackerImpl&&) = delete;
+
+    void update(int64_t monotonic_time_ns) override;
+    const Se3TrackerPoseTrackedT& get_data() const override;
+
+private:
+    Se3TrackerPoseTrackedT tracked_;
+    std::unique_ptr<Se3TrackerMcapViewers> mcap_viewers_;
+    // Pre-baked warn-once message including the base_name, so multi-tracker replays are
+    // distinguishable in the log.
+    std::string no_data_message_;
+    // Warn only on the first frame of a no-data gap (EOF / sparse stream) to avoid per-frame spam.
+    bool warned_no_data_ = false;
+};
+
+} // namespace core

--- a/src/core/schema/fbs/se3_tracker.fbs
+++ b/src/core/schema/fbs/se3_tracker.fbs
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+include "pose.fbs";
+include "timestamp.fbs";
+
+namespace core;
+
+// Pose sample from a generic SE3 (6-DoF) tracker device: a rigid-body pose source
+// such as a tracker puck, a mocap rigid body, or a logical tracker derived from
+// another device (e.g. an XR controller grip republished by a plugin).
+//
+// Normative conventions:
+// - Position is in meters; orientation is a unit Hamilton quaternion (x, y, z, w);
+//   frames are right-handed.
+// - The reference frame is defined by the data producer and MUST be documented by it.
+//   XR-sourced producers MUST express the pose in the OpenXR session base reference
+//   space (the XrSpace in OpenXRSessionHandles::space — the same space the head and
+//   controller channels are located in).
+// - Two-level validity: the parent Tracked wrapper's data is null when no sample has
+//   arrived yet or the source collection is unavailable; is_valid is false when the
+//   producer is streaming but tracking is lost. When is_valid is false the pose
+//   contents are UNSPECIFIED (producers may send an identity filler) — consumers must
+//   gate on is_valid and freeze, never act on the pose value.
+//
+// All fields are always present when the parent Tracked/Record wrapper's data is non-null.
+table Se3TrackerPose {
+    // The concrete pose data
+    pose: Pose (id: 0);
+
+    // Whether the pose data is valid (false = producer streaming, tracking lost)
+    is_valid: bool (id: 1);
+}
+
+// Tracked wrapper for the in-memory tracker API (data is null when no sample is available).
+table Se3TrackerPoseTracked {
+    data: Se3TrackerPose (id: 0);
+}
+
+// MCAP recording wrapper for Se3TrackerPose.
+//
+// Record types are the root types written to MCAP channels by the McapRecorder.
+// Trackers serialize into Record types via their serialize() method, but the
+// public query API returns the inner data type directly.
+table Se3TrackerPoseRecord {
+    data: Se3TrackerPose (id: 0);
+    timestamp: DeviceDataTimestamp (id: 1);
+}
+
+root_type Se3TrackerPoseRecord;

--- a/src/core/schema/python/CMakeLists.txt
+++ b/src/core/schema/python/CMakeLists.txt
@@ -12,6 +12,7 @@ pybind11_add_module(schema_py
     message_channel_bindings.h
     pedals_bindings.h
     pose_bindings.h
+    se3_tracker_bindings.h
     schema_module.cpp
 )
 

--- a/src/core/schema/python/schema_init.py
+++ b/src/core/schema/python/schema_init.py
@@ -40,6 +40,11 @@ from ._schema import (
     JointStateOutput,
     JointStateOutputTrackedT,
     JointStateOutputRecord,
+    # SE3 tracker types (generic 6-DoF pose sources: tracker pucks, mocap rigid bodies, ...).
+    # Record classes drop the T suffix in Python by family convention.
+    Se3TrackerPoseT,
+    Se3TrackerPoseTrackedT,
+    Se3TrackerPoseRecord,
     # Message channel types.
     MessageChannelMessages,
     MessageChannelMessagesTrackedT,
@@ -95,6 +100,10 @@ __all__ = [
     "JointStateOutput",
     "JointStateOutputTrackedT",
     "JointStateOutputRecord",
+    # SE3 tracker types (generic 6-DoF pose sources).
+    "Se3TrackerPoseT",
+    "Se3TrackerPoseTrackedT",
+    "Se3TrackerPoseRecord",
     # Message channel types.
     "MessageChannelMessages",
     "MessageChannelMessagesTrackedT",

--- a/src/core/schema/python/schema_module.cpp
+++ b/src/core/schema/python/schema_module.cpp
@@ -16,6 +16,7 @@
 #include "oak_bindings.h"
 #include "pedals_bindings.h"
 #include "pose_bindings.h"
+#include "se3_tracker_bindings.h"
 #include "timestamp_bindings.h"
 
 namespace py = pybind11;
@@ -44,6 +45,9 @@ PYBIND11_MODULE(_schema, m)
 
     // Bind joint-state types (JointState, JointStateOutput tables) for generic joint-space devices.
     core::bind_joint_state(m);
+
+    // Bind SE3 tracker types (Se3TrackerPoseT table) for generic 6-DoF pose sources.
+    core::bind_se3_tracker(m);
 
     // Bind message channel types (MessageChannelMessages table).
     core::bind_message_channel(m);

--- a/src/core/schema/python/se3_tracker_bindings.h
+++ b/src/core/schema/python/se3_tracker_bindings.h
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Python bindings for the Se3TrackerPose FlatBuffer schema.
+// Se3TrackerPoseT is a table type (mutable object-API) with pose and is_valid fields.
+
+#pragma once
+
+#include <pybind11/pybind11.h>
+#include <schema/se3_tracker_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <memory>
+
+namespace py = pybind11;
+
+namespace core
+{
+
+inline void bind_se3_tracker(py::module& m)
+{
+    // Bind Se3TrackerPoseT class (FlatBuffers object API for tables).
+    py::class_<Se3TrackerPoseT, std::shared_ptr<Se3TrackerPoseT>>(m, "Se3TrackerPoseT")
+        .def(py::init(
+            []()
+            {
+                auto obj = std::make_shared<Se3TrackerPoseT>();
+                obj->pose = std::make_shared<Pose>();
+                return obj;
+            }))
+        .def(py::init(
+                 [](const Pose& pose, bool is_valid)
+                 {
+                     auto obj = std::make_shared<Se3TrackerPoseT>();
+                     obj->pose = std::make_shared<Pose>(pose);
+                     obj->is_valid = is_valid;
+                     return obj;
+                 }),
+             py::arg("pose"), py::arg("is_valid"))
+        .def_property_readonly(
+            "pose", [](const Se3TrackerPoseT& self) -> const Pose* { return self.pose.get(); },
+            py::return_value_policy::reference_internal)
+        .def_readonly("is_valid", &Se3TrackerPoseT::is_valid)
+        .def("__repr__",
+             [](const Se3TrackerPoseT& self)
+             {
+                 std::string pose_str = "None";
+                 if (self.pose)
+                 {
+                     pose_str = "Pose(position=Point(x=" + std::to_string(self.pose->position().x()) +
+                                ", y=" + std::to_string(self.pose->position().y()) +
+                                ", z=" + std::to_string(self.pose->position().z()) +
+                                "), orientation=Quaternion(x=" + std::to_string(self.pose->orientation().x()) +
+                                ", y=" + std::to_string(self.pose->orientation().y()) +
+                                ", z=" + std::to_string(self.pose->orientation().z()) +
+                                ", w=" + std::to_string(self.pose->orientation().w()) + "))";
+                 }
+                 return "Se3TrackerPoseT(pose=" + pose_str + ", is_valid=" + (self.is_valid ? "True" : "False") + ")";
+             });
+
+    py::class_<Se3TrackerPoseRecordT, std::shared_ptr<Se3TrackerPoseRecordT>>(m, "Se3TrackerPoseRecord")
+        .def(py::init<>())
+        .def(py::init(
+                 [](const Se3TrackerPoseT& data, const DeviceDataTimestamp& timestamp)
+                 {
+                     auto obj = std::make_shared<Se3TrackerPoseRecordT>();
+                     obj->data = std::make_shared<Se3TrackerPoseT>(data);
+                     obj->timestamp = std::make_shared<core::DeviceDataTimestamp>(timestamp);
+                     return obj;
+                 }),
+             py::arg("data"), py::arg("timestamp"))
+        .def_property_readonly(
+            "data", [](const Se3TrackerPoseRecordT& self) -> std::shared_ptr<Se3TrackerPoseT> { return self.data; })
+        .def_readonly("timestamp", &Se3TrackerPoseRecordT::timestamp)
+        .def("__repr__", [](const Se3TrackerPoseRecordT& self)
+             { return "Se3TrackerPoseRecord(data=" + std::string(self.data ? "Se3TrackerPoseT(...)" : "None") + ")"; });
+
+    py::class_<Se3TrackerPoseTrackedT, std::shared_ptr<Se3TrackerPoseTrackedT>>(m, "Se3TrackerPoseTrackedT")
+        .def(py::init<>())
+        .def(py::init(
+                 [](const Se3TrackerPoseT& data)
+                 {
+                     auto obj = std::make_shared<Se3TrackerPoseTrackedT>();
+                     obj->data = std::make_shared<Se3TrackerPoseT>(data);
+                     return obj;
+                 }),
+             py::arg("data"))
+        .def_property_readonly(
+            "data", [](const Se3TrackerPoseTrackedT& self) -> std::shared_ptr<Se3TrackerPoseT> { return self.data; })
+        .def("__repr__",
+             [](const Se3TrackerPoseTrackedT& self) {
+                 return std::string("Se3TrackerPoseTrackedT(data=") + (self.data ? "Se3TrackerPoseT(...)" : "None") + ")";
+             });
+}
+
+} // namespace core

--- a/src/core/schema_tests/cpp/CMakeLists.txt
+++ b/src/core/schema_tests/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20)
@@ -11,6 +11,7 @@ add_executable(schema_tests
   test_full_body.cpp
   test_controller.cpp
   test_pedals.cpp
+  test_se3_tracker.cpp
 )
 target_link_libraries(schema_tests PRIVATE
   isaacteleop_schema

--- a/src/core/schema_tests/cpp/test_se3_tracker.cpp
+++ b/src/core/schema_tests/cpp/test_se3_tracker.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Unit tests for the generated Se3TrackerPose FlatBuffer message.
+
+#include <catch2/catch_approx.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <flatbuffers/flatbuffers.h>
+
+// Include generated FlatBuffer headers.
+#include <schema/se3_tracker_generated.h>
+#include <schema/timestamp_generated.h>
+
+#include <memory>
+#include <type_traits>
+
+// =============================================================================
+// Compile-time verification of FlatBuffer field IDs.
+// These ensure schema field IDs remain stable across changes.
+// VT values are computed as: (field_id + 2) * 2.
+// =============================================================================
+// Maps an .fbs field id to the generated VT_* vtable offset: VT_<FIELD> == (id + 2) * 2.
+#define VT(field) (field + 2) * 2
+static_assert(core::Se3TrackerPose::VT_POSE == VT(0));
+static_assert(core::Se3TrackerPose::VT_IS_VALID == VT(1));
+
+static_assert(core::Se3TrackerPoseTracked::VT_DATA == VT(0));
+
+static_assert(core::Se3TrackerPoseRecord::VT_DATA == VT(0));
+static_assert(core::Se3TrackerPoseRecord::VT_TIMESTAMP == VT(1));
+
+// =============================================================================
+// Compile-time verification of FlatBuffer field types.
+// These ensure schema field types remain stable across changes.
+// =============================================================================
+#define TYPE(field) decltype(std::declval<core::Se3TrackerPose>().field())
+static_assert(std::is_same_v<TYPE(pose), const core::Pose*>);
+static_assert(std::is_same_v<TYPE(is_valid), bool>);
+
+
+TEST_CASE("Se3TrackerPoseT default construction", "[se3_tracker][native]")
+{
+    auto se3_pose = std::make_unique<core::Se3TrackerPoseT>();
+
+    // Default values.
+    CHECK(se3_pose->pose == nullptr);
+    CHECK(se3_pose->is_valid == false);
+}
+
+TEST_CASE("Se3TrackerPoseT serialization round-trip", "[se3_tracker][flatbuffers]")
+{
+    flatbuffers::FlatBufferBuilder builder(1024);
+
+    // Create Se3TrackerPoseT with all fields set.
+    auto original = std::make_unique<core::Se3TrackerPoseT>();
+    core::Point position(1.5f, 2.5f, 3.5f);
+    core::Quaternion orientation(0.0f, 0.0f, 0.7071068f, 0.7071068f); // 90 deg around Z (x, y, z, w).
+    original->pose = std::make_shared<core::Pose>(position, orientation);
+    original->is_valid = true;
+
+    auto offset = core::Se3TrackerPose::Pack(builder, original.get());
+    builder.Finish(offset);
+
+    // Unpack to a fresh Se3TrackerPoseT and verify.
+    auto fb = flatbuffers::GetRoot<core::Se3TrackerPose>(builder.GetBufferPointer());
+    auto unpacked = std::make_unique<core::Se3TrackerPoseT>();
+    fb->UnPackTo(unpacked.get());
+
+    CHECK(unpacked->pose->position().x() == Catch::Approx(1.5f));
+    CHECK(unpacked->pose->position().y() == Catch::Approx(2.5f));
+    CHECK(unpacked->pose->position().z() == Catch::Approx(3.5f));
+    // x and y must stay zero — guards against quaternion component-order regressions.
+    CHECK(unpacked->pose->orientation().x() == Catch::Approx(0.0f));
+    CHECK(unpacked->pose->orientation().y() == Catch::Approx(0.0f));
+    CHECK(unpacked->pose->orientation().z() == Catch::Approx(0.7071068f).epsilon(0.0001));
+    CHECK(unpacked->pose->orientation().w() == Catch::Approx(0.7071068f).epsilon(0.0001));
+    CHECK(unpacked->is_valid == true);
+}
+
+// =============================================================================
+// Se3TrackerPoseRecord tests (timestamp lives on the Record wrapper)
+// =============================================================================
+TEST_CASE("Se3TrackerPoseRecord round-trip with DeviceDataTimestamp", "[se3_tracker][flatbuffers]")
+{
+    flatbuffers::FlatBufferBuilder builder(1024);
+
+    auto record = std::make_shared<core::Se3TrackerPoseRecordT>();
+    record->data = std::make_shared<core::Se3TrackerPoseT>();
+    core::Point position(1.0f, 2.0f, 3.0f);
+    core::Quaternion orientation(0.0f, 0.0f, 0.0f, 1.0f);
+    record->data->pose = std::make_shared<core::Pose>(position, orientation);
+    record->data->is_valid = true;
+    record->timestamp = std::make_shared<core::DeviceDataTimestamp>(1000000000LL, 2000000000LL, 3000000000LL);
+
+    auto offset = core::Se3TrackerPoseRecord::Pack(builder, record.get());
+    builder.Finish(offset);
+
+    auto fb = flatbuffers::GetRoot<core::Se3TrackerPoseRecord>(builder.GetBufferPointer());
+    auto unpacked = std::make_shared<core::Se3TrackerPoseRecordT>();
+    fb->UnPackTo(unpacked.get());
+
+    CHECK(unpacked->timestamp->available_time_local_common_clock() == 1000000000LL);
+    CHECK(unpacked->timestamp->sample_time_local_common_clock() == 2000000000LL);
+    CHECK(unpacked->timestamp->sample_time_raw_device_clock() == 3000000000LL);
+    CHECK(unpacked->data->pose->position().x() == Catch::Approx(1.0f));
+    CHECK(unpacked->data->is_valid == true);
+}

--- a/src/core/schema_tests/python/test_se3_tracker.py
+++ b/src/core/schema_tests/python/test_se3_tracker.py
@@ -1,0 +1,97 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for Se3TrackerPoseT in isaacteleop.schema.
+
+Se3TrackerPoseT is a FlatBuffers table for a generic SE3 (6-DoF) tracker device:
+- pose: The Pose struct (position and orientation)
+- is_valid: Whether the pose data is valid (False = producer streaming, tracking lost;
+  pose contents are then unspecified)
+
+Timestamps are carried by Se3TrackerPoseRecord, not Se3TrackerPoseT.
+
+Note: Python code should only READ this data (created by C++ trackers), not modify it.
+"""
+
+import pytest
+
+from isaacteleop.schema import (
+    Se3TrackerPoseT,
+    Se3TrackerPoseTrackedT,
+    Se3TrackerPoseRecord,
+    Pose,
+    Point,
+    Quaternion,
+    DeviceDataTimestamp,
+)
+
+
+class TestSe3TrackerPoseTConstruction:
+    """Tests for Se3TrackerPoseT construction and basic properties."""
+
+    def test_default_construction(self):
+        """Default construction creates Se3TrackerPoseT with default-initialized fields."""
+        se3_pose = Se3TrackerPoseT()
+
+        assert se3_pose is not None
+        assert se3_pose.pose is not None
+        assert se3_pose.is_valid is False
+
+    def test_parameterized_construction(self):
+        """Construction with pose and is_valid."""
+        pose = Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0))
+        se3_pose = Se3TrackerPoseT(pose, True)
+
+        assert se3_pose.pose.position.x == pytest.approx(1.0)
+        assert se3_pose.pose.position.y == pytest.approx(2.0)
+        assert se3_pose.pose.position.z == pytest.approx(3.0)
+        assert se3_pose.pose.orientation.w == pytest.approx(1.0)
+        assert se3_pose.is_valid is True
+
+    def test_repr(self):
+        """__repr__ includes the type name and is_valid."""
+        pose = Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0))
+        se3_pose = Se3TrackerPoseT(pose, True)
+
+        repr_str = repr(se3_pose)
+        assert "Se3TrackerPoseT" in repr_str
+        assert "is_valid=True" in repr_str
+
+
+class TestSe3TrackerPoseTracked:
+    """Tests for the Se3TrackerPoseTrackedT wrapper."""
+
+    def test_default_construction_has_no_data(self):
+        """Default Tracked wrapper has no data (no sample yet / collection unavailable)."""
+        tracked = Se3TrackerPoseTrackedT()
+        assert tracked.data is None
+
+    def test_construction_with_data(self):
+        """Tracked wrapper carries the payload."""
+        pose = Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0))
+        tracked = Se3TrackerPoseTrackedT(Se3TrackerPoseT(pose, True))
+
+        assert tracked.data is not None
+        assert tracked.data.is_valid is True
+
+
+class TestSe3TrackerPoseRecordTimestamp:
+    """Tests for Se3TrackerPoseRecord with DeviceDataTimestamp."""
+
+    def test_construction_with_timestamp(self):
+        """Se3TrackerPoseRecord carries DeviceDataTimestamp (positional field order)."""
+        pose = Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0))
+        data = Se3TrackerPoseT(pose, True)
+        ts = DeviceDataTimestamp(1000000000, 2000000000, 3000000000)
+        record = Se3TrackerPoseRecord(data, ts)
+
+        assert record.timestamp.available_time_local_common_clock == 1000000000
+        assert record.timestamp.sample_time_local_common_clock == 2000000000
+        assert record.timestamp.sample_time_raw_device_clock == 3000000000
+        assert record.data.is_valid is True
+
+    def test_default_construction(self):
+        """Default Se3TrackerPoseRecord has no data and no timestamp."""
+        record = Se3TrackerPoseRecord()
+        assert record.data is None
+        assert record.timestamp is None

--- a/src/plugins/controller_se3_tracker/CMakeLists.txt
+++ b/src/plugins/controller_se3_tracker/CMakeLists.txt
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20)
+
+add_executable(controller_se3_tracker_plugin
+    main.cpp
+    controller_se3_tracker_plugin.cpp
+    controller_se3_tracker_plugin.hpp
+)
+
+target_link_libraries(controller_se3_tracker_plugin PRIVATE
+    deviceio::deviceio_session
+    deviceio::deviceio_trackers
+    isaacteleop_schema
+    oxr::oxr_core
+    pusherio::pusherio
+)
+
+install(TARGETS controller_se3_tracker_plugin RUNTIME DESTINATION plugins/controller_se3_tracker)
+install(FILES plugin.yaml README.md DESTINATION plugins/controller_se3_tracker)

--- a/src/plugins/controller_se3_tracker/README.md
+++ b/src/plugins/controller_se3_tracker/README.md
@@ -1,0 +1,30 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Controller SE3 Tracker Plugin
+
+Example producer for the generic SE3 tracker device type: reads an XR controller's **grip
+pose** each tick and republishes it as `Se3TrackerPose` via OpenXR (`SchemaPusher`), in the
+OpenXR session base reference space. Pair with an `Se3Tracker` created with the same
+`collection_id`.
+
+## Usage
+
+```bash
+./controller_se3_tracker_plugin [hand] [collection_id]
+```
+
+- **hand**: `left` or `right`. Default `right`.
+- **collection_id**: Default `se3_tracker`. This default deliberately matches
+  `Se3Tracker::TENSOR_IDENTIFIER` (and `Se3Tracker`'s usual collection id) rather than the
+  plugin name, so plugin and tracker rendezvous out of the box. Run multiple instances with
+  distinct collection ids for multiple simultaneous trackers.
+
+## Behavior
+
+- Pushes at 90 Hz, **every** tick: when the controller is absent or its grip pose is
+  invalid, it pushes `is_valid=false` with an identity filler pose (consumers must gate on
+  `is_valid`, never on pose values — see `se3_tracker.fbs`).
+- Producer-only: it never registers an `Se3Tracker` in its own OpenXR session.

--- a/src/plugins/controller_se3_tracker/controller_se3_tracker_plugin.cpp
+++ b/src/plugins/controller_se3_tracker/controller_se3_tracker_plugin.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "controller_se3_tracker_plugin.hpp"
+
+#include <deviceio_trackers/se3_tracker.hpp>
+#include <flatbuffers/flatbuffers.h>
+#include <oxr_utils/os_time.hpp>
+#include <schema/controller_generated.h>
+#include <schema/se3_tracker_generated.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace plugins
+{
+namespace controller_se3_tracker
+{
+
+namespace
+{
+
+std::vector<std::string> make_required_extensions(const std::vector<std::shared_ptr<core::ITracker>>& trackers)
+{
+    auto extensions = core::DeviceIOSession::get_required_extensions(trackers);
+    for (const auto& ext : core::SchemaPusher::get_required_extensions())
+    {
+        if (std::find(extensions.begin(), extensions.end(), ext) == extensions.end())
+        {
+            extensions.push_back(ext);
+        }
+    }
+    return extensions;
+}
+
+core::SchemaPusherConfig make_pusher_config(const std::string& collection_id)
+{
+    // Wire rendezvous (tensor identifier + buffer size) comes from the Se3Tracker facade —
+    // the single source of truth shared with LiveSe3TrackerImpl; a mismatch is silent no-data.
+    return core::SchemaPusherConfig{ .collection_id = collection_id,
+                                     .max_flatbuffer_size = core::Se3Tracker::DEFAULT_MAX_FLATBUFFER_SIZE,
+                                     .tensor_identifier = std::string(core::Se3Tracker::TENSOR_IDENTIFIER),
+                                     .localized_name = "Controller SE3 Tracker",
+                                     .app_name = "ControllerSe3TrackerPlugin" };
+}
+
+} // namespace
+
+ControllerSe3TrackerPlugin::ControllerSe3TrackerPlugin(bool use_left_hand, const std::string& collection_id)
+    : m_use_left_hand(use_left_hand)
+{
+    m_controller_tracker = std::make_shared<core::ControllerTracker>();
+    std::vector<std::shared_ptr<core::ITracker>> trackers = { m_controller_tracker };
+
+    m_session = std::make_shared<core::OpenXRSession>("ControllerSe3TrackerPlugin", make_required_extensions(trackers));
+    const auto handles = m_session->get_handles();
+
+    m_deviceio_session = core::DeviceIOSession::run(trackers, handles);
+    m_pusher = std::make_unique<core::SchemaPusher>(handles, make_pusher_config(collection_id));
+
+    std::cout << "ControllerSe3TrackerPlugin: republishing " << (m_use_left_hand ? "left" : "right")
+              << " controller grip pose on collection '" << collection_id << "'" << std::endl;
+}
+
+void ControllerSe3TrackerPlugin::update()
+{
+    // Capture the sample time BEFORE update(): DeviceIOSession::update() samples
+    // os_monotonic_now_ns() internally and locates the controller pose at that tick
+    // (deviceio_session.cpp). The pre-update capture approximates that tick time to
+    // microseconds; do not move this to post-update/push time — that would add loop
+    // processing bias to cross-device synchronization.
+    const int64_t sample_time_ns = core::os_monotonic_now_ns();
+
+    m_deviceio_session->update();
+
+    const core::ControllerSnapshotTrackedT& tracked =
+        m_use_left_hand ? m_controller_tracker->get_left_controller(*m_deviceio_session) :
+                          m_controller_tracker->get_right_controller(*m_deviceio_session);
+
+    core::Se3TrackerPoseT out;
+    if (tracked.data && tracked.data->grip_pose && tracked.data->grip_pose->is_valid())
+    {
+        out.pose = std::make_shared<core::Pose>(tracked.data->grip_pose->pose());
+        out.is_valid = true;
+    }
+    else
+    {
+        // Identity pose is a filler consistent with "pose contents unspecified when
+        // is_valid == false" (se3_tracker.fbs) — consumers gate on is_valid, never on
+        // pose values. Pushing explicit invalidity beats silence, which is ambiguous
+        // both live (stale retention) and in recordings.
+        out.pose = std::make_shared<core::Pose>(core::Point(0.0f, 0.0f, 0.0f), core::Quaternion(0.0f, 0.0f, 0.0f, 1.0f));
+        out.is_valid = false;
+    }
+
+    flatbuffers::FlatBufferBuilder builder(core::Se3Tracker::DEFAULT_MAX_FLATBUFFER_SIZE);
+    auto offset = core::Se3TrackerPose::Pack(builder, &out);
+    builder.Finish(offset);
+
+    // A logical device has no raw device clock of its own; pass the local common clock
+    // sample time as the documented best-effort substitute.
+    m_pusher->push_buffer(builder.GetBufferPointer(), builder.GetSize(), sample_time_ns, sample_time_ns);
+}
+
+} // namespace controller_se3_tracker
+} // namespace plugins

--- a/src/plugins/controller_se3_tracker/controller_se3_tracker_plugin.hpp
+++ b/src/plugins/controller_se3_tracker/controller_se3_tracker_plugin.hpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <deviceio_session/deviceio_session.hpp>
+#include <deviceio_trackers/controller_tracker.hpp>
+#include <oxr/oxr_session.hpp>
+#include <pusherio/schema_pusher.hpp>
+
+#include <memory>
+#include <string>
+
+namespace plugins
+{
+namespace controller_se3_tracker
+{
+
+/*!
+ * @brief Logical SE3 tracker driven by an XR controller.
+ *
+ * Reads the configured controller's grip pose (the OpenXR rigid-attachment frame for the
+ * physical device) each tick and republishes it as an ``Se3TrackerPose`` via OpenXR
+ * SchemaPusher, in the same OpenXR session base reference space. Pair with an
+ * ``Se3Tracker`` on the same ``collection_id``.
+ *
+ * Producer-only: this plugin never registers an ``Se3Tracker`` in its own session (it
+ * would read back its own pushes).
+ */
+class ControllerSe3TrackerPlugin
+{
+public:
+    ControllerSe3TrackerPlugin(bool use_left_hand, const std::string& collection_id);
+
+    ControllerSe3TrackerPlugin(const ControllerSe3TrackerPlugin&) = delete;
+    ControllerSe3TrackerPlugin& operator=(const ControllerSe3TrackerPlugin&) = delete;
+    ControllerSe3TrackerPlugin(ControllerSe3TrackerPlugin&&) = delete;
+    ControllerSe3TrackerPlugin& operator=(ControllerSe3TrackerPlugin&&) = delete;
+
+    //! One tick: update the device session, read the controller, push one Se3TrackerPose.
+    //! Pushes EVERY tick — is_valid=false (identity filler pose) when the controller is
+    //! absent or its grip pose is invalid.
+    void update();
+
+private:
+    bool m_use_left_hand;
+
+    std::shared_ptr<core::ControllerTracker> m_controller_tracker;
+    std::shared_ptr<core::OpenXRSession> m_session;
+    std::unique_ptr<core::DeviceIOSession> m_deviceio_session;
+    std::unique_ptr<core::SchemaPusher> m_pusher;
+};
+
+} // namespace controller_se3_tracker
+} // namespace plugins

--- a/src/plugins/controller_se3_tracker/main.cpp
+++ b/src/plugins/controller_se3_tracker/main.cpp
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "controller_se3_tracker_plugin.hpp"
+
+#include <deviceio_trackers/se3_tracker.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <iostream>
+#include <string>
+#include <thread>
+
+using namespace plugins::controller_se3_tracker;
+
+int main(int argc, char** argv)
+try
+{
+    const std::string hand = (argc > 1) ? argv[1] : "right";
+    // The default collection id deliberately matches the tensor identifier so plugin and
+    // Se3Tracker rendezvous out of the box (see README).
+    const std::string collection_id = (argc > 2) ? argv[2] : std::string(core::Se3Tracker::TENSOR_IDENTIFIER);
+
+    if (hand != "left" && hand != "right")
+    {
+        std::cerr << "Usage: " << argv[0] << " [hand(left|right)] [collection_id]" << std::endl;
+        return 1;
+    }
+
+    std::cout << "Controller SE3 Tracker (hand: " << hand << ", collection: " << collection_id << ")" << std::endl;
+
+    ControllerSe3TrackerPlugin plugin(hand == "left", collection_id);
+
+    // Push data at 90 Hz
+    const auto frame_duration = std::chrono::nanoseconds(1000000000 / 90);
+    const auto program_start = std::chrono::steady_clock::now();
+    std::size_t frame_count = 0;
+
+    while (true)
+    {
+        plugin.update();
+        frame_count++;
+        std::this_thread::sleep_until(program_start + frame_duration * frame_count);
+    }
+
+    return 0;
+}
+catch (const std::exception& e)
+{
+    std::cerr << argv[0] << ": " << e.what() << std::endl;
+    return 1;
+}
+catch (...)
+{
+    std::cerr << argv[0] << ": Unknown error" << std::endl;
+    return 1;
+}

--- a/src/plugins/controller_se3_tracker/plugin.yaml
+++ b/src/plugins/controller_se3_tracker/plugin.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: controller_se3_tracker
+description: "Logical SE3 tracker republishing an XR controller grip pose"
+command: "./controller_se3_tracker_plugin"
+version: "1.0.0"
+devices:
+  - path: "/se3_tracker/controller"
+    type: "se3_tracker"
+    description: "SE3 (6-DoF) pose from an XR controller grip"


### PR DESCRIPTION
Add a generic SE3 (6-DoF pose) tracker device type end-to-end:

- se3_tracker.fbs: Se3TrackerPose/Tracked/Record wrapper triple built on core.Pose, with normative conventions (units, Hamilton x,y,z,w quaternion, producer-defined reference frame with the XR session-base-space rule, and two-level validity semantics) documented in the schema itself.
- Tracker stack mirroring the joint_state pusher-fed pattern: ISe3TrackerImpl base interface, Se3Tracker facade (collection_id per instance; wire rendezvous constants TENSOR_IDENTIFIER / DEFAULT_MAX_FLATBUFFER_SIZE hosted on the facade as the single source of truth), SchemaTracker-backed LiveSe3TrackerImpl, ReplaySe3TrackerImpl with once-per-gap logging, Se3TrackerRecordingTraits, and dispatch entries in both the live and replay factories.
- Python bindings for the schema triple and the Se3Tracker facade, exported from isaacteleop.schema and isaacteleop.deviceio_trackers.
- Tests: C++ schema test with a VT/TYPE static_assert field-id freeze block, Python binding test, and a replay round-trip TEST_CASE that pins the frozen wire strings and the replay null-at-EOF contract.
- controller_se3_tracker example plugin: producer-only logical tracker that republishes an XR controller grip pose at 90 Hz, pushing is_valid=false with an identity filler pose on tracking loss, with pre-update sample-time stamping.

Design doc: /code/docs (se3-tracker-design.md, meta-repo). Build green, ctest 150/150, clang-format and pre-commit clean.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [ ] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SE3 (6-DoF) pose tracking support across live sessions, replay, C++, and Python APIs.
  * Introduced SE3 FlatBuffer messages with tracked pose validity and timestamped records.
  * Added a controller SE3 tracker plugin that republishes left/right grip poses at 90 Hz.
  * Added a standalone example (`se3_printer`) to print valid SE3 samples.
* **Documentation**
  * Updated device/tracker reference pages and added controller plugin documentation.
* **Tests**
  * Added C++/Python schema tests and SE3 replay round-trip coverage (including no-data behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->