### PR TITLE
Fix resource leaks when TeleopSession setup fails

### DIFF
--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -208,8 +208,8 @@ class TeleopSession:
         self._active_retargeting_execution_mode: Optional[RetargetingExecutionMode] = (
             None
         )
-        self._is_active: bool = False
-        self._setup_complete: bool = False
+        # True from the start of __enter__ until __exit__ or rollback finishes.
+        self._in_context: bool = False
         # Discover sources and external leaves from pipeline
         self._discover_sources()
 
@@ -919,12 +919,15 @@ class TeleopSession:
 
         Returns:
             self for context manager protocol
+
+        Raises:
+            RuntimeError: If the session is already active.
         """
-        if self._is_active:
+        # Detect nested context-manager use; this does not make the session thread-safe.
+        if self._in_context:
             raise RuntimeError("TeleopSession is already active")
 
-        self._is_active = True
-        self._setup_complete = False
+        self._in_context = True
         stack = ExitStack()
         try:
             self._enter_resources(stack)
@@ -937,10 +940,9 @@ class TeleopSession:
                 logger.exception("Failed to roll back TeleopSession setup")
             finally:
                 self._oxr_session = None
-                self._is_active = False
+                self._in_context = False
             raise
 
-        self._setup_complete = True
         return self
 
     def _enter_resources(self, stack: ExitStack) -> None:
@@ -1054,7 +1056,7 @@ class TeleopSession:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Exit the context - cleanup resources."""
-        if not self._setup_complete:
+        if not self._in_context:
             return False
 
         runner_error = None
@@ -1079,14 +1081,13 @@ class TeleopSession:
         # exceptions from the user body, even if a child context manager would.
         try:
             self._exit_stack.__exit__(exc_type, exc_val, exc_tb)
-            self._exit_stack = ExitStack()
         finally:
             # The ExitStack above closes the OpenXR session; drop our reference so the
             # public `oxr_session` property honors its documented None contract post-exit
             # rather than surfacing a torn-down session -- even if a managed context's
             # cleanup raised. (deviceio_session has no such property/contract.)
             self._oxr_session = None
-            self._is_active = False
+            self._in_context = False
 
         if runner_error is not None:
             raise runner_error

--- a/src/core/teleop_session_manager/python/teleop_session.py
+++ b/src/core/teleop_session_manager/python/teleop_session.py
@@ -208,6 +208,7 @@ class TeleopSession:
         self._active_retargeting_execution_mode: Optional[RetargetingExecutionMode] = (
             None
         )
+        self._is_active: bool = False
         self._setup_complete: bool = False
         # Discover sources and external leaves from pipeline
         self._discover_sources()
@@ -919,6 +920,31 @@ class TeleopSession:
         Returns:
             self for context manager protocol
         """
+        if self._is_active:
+            raise RuntimeError("TeleopSession is already active")
+
+        self._is_active = True
+        self._setup_complete = False
+        stack = ExitStack()
+        try:
+            self._enter_resources(stack)
+            self._exit_stack = stack.pop_all()
+        except BaseException as error:
+            try:
+                # Give resources the setup error, but do not let one suppress it.
+                stack.__exit__(type(error), error, error.__traceback__)
+            except BaseException:
+                logger.exception("Failed to roll back TeleopSession setup")
+            finally:
+                self._oxr_session = None
+                self._is_active = False
+            raise
+
+        self._setup_complete = True
+        return self
+
+    def _enter_resources(self, stack: ExitStack) -> None:
+        """Acquire and initialize resources for one context-manager run."""
         # Reset run-scoped plugin containers on each context entry.
         self.plugin_managers = []
         self.plugin_contexts = []
@@ -942,7 +968,7 @@ class TeleopSession:
                 )
 
         if self.config.mode == SessionMode.REPLAY:
-            self.deviceio_session = self._exit_stack.enter_context(
+            self.deviceio_session = stack.enter_context(
                 deviceio.ReplaySession.run(mcap_config)
             )
         else:
@@ -978,13 +1004,13 @@ class TeleopSession:
             if self.config.oxr_handles is not None:
                 handles = self.config.oxr_handles
             else:
-                self._oxr_session = self._exit_stack.enter_context(
+                self._oxr_session = stack.enter_context(
                     oxr.OpenXRSession(self.config.app_name, required_extensions)
                 )
                 handles = self._oxr_session.get_handles()
 
             # Create DeviceIO session with all trackers
-            self.deviceio_session = self._exit_stack.enter_context(
+            self.deviceio_session = stack.enter_context(
                 deviceio.DeviceIOSession.run(trackers, handles, mcap_config)
             )
 
@@ -1014,7 +1040,7 @@ class TeleopSession:
                     plugin_config.plugin_root_id,
                     plugin_config.plugin_args,
                 )
-                self._exit_stack.enter_context(context)
+                stack.enter_context(context)
                 self.plugin_contexts.append(context)
 
         # Initialize runtime state
@@ -1025,9 +1051,6 @@ class TeleopSession:
         self._last_execution_state = None
         self._async_runner = None
         self._active_retargeting_execution_mode = self.config.retargeting_execution.mode
-
-        self._setup_complete = True
-        return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Exit the context - cleanup resources."""
@@ -1063,6 +1086,7 @@ class TeleopSession:
             # rather than surfacing a torn-down session -- even if a managed context's
             # cleanup raised. (deviceio_session has no such property/contract.)
             self._oxr_session = None
+            self._is_active = False
 
         if runner_error is not None:
             raise runner_error

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1052,7 +1052,6 @@ class TestSessionLifecycle:
                 assert s is session
                 assert s.oxr_session is mock_oxr
                 assert s.deviceio_session is mock_dio
-                assert s._setup_complete is True
                 assert s.frame_count == 0
 
     def test_enter_rejects_nested_active_session(self):
@@ -1076,6 +1075,7 @@ class TestSessionLifecycle:
     ):
         """A failed __enter__ should propagate after unwinding resources in reverse order."""
         events = []
+        failures_remaining = {failure_stage}
 
         class TrackedContext:
             def __init__(self, name):
@@ -1086,7 +1086,8 @@ class TestSessionLifecycle:
 
             def __enter__(self):
                 events.append(("enter", self.name))
-                if self.name == failure_stage:
+                if self.name in failures_remaining:
+                    failures_remaining.remove(self.name)
                     raise RuntimeError(f"{self.name} failed")
                 return self
 
@@ -1133,8 +1134,20 @@ class TestSessionLifecycle:
             ("exit", name) for name in reversed(resource_order[:failure_index])
         )
         assert events == expected_events
-        assert session._setup_complete is False
         assert session.oxr_session is None
+
+        events.clear()
+        with mock_session_dependencies(
+            mock_oxr=TrackedContext("openxr"),
+            mock_dio=TrackedContext("deviceio"),
+            mock_pm=TrackedPluginManager(),
+        ):
+            with session:
+                pass
+
+        expected_events = [("enter", name) for name in resource_order]
+        expected_events.extend(("exit", name) for name in reversed(resource_order))
+        assert events == expected_events
 
     def test_enter_preserves_setup_error_if_rollback_fails(self, caplog):
         """A resource cleanup error should not replace the setup error."""
@@ -1159,7 +1172,10 @@ class TestSessionLifecycle:
             session.__enter__()
 
         assert "Failed to roll back TeleopSession setup" in caplog.text
-        assert session._is_active is False
+
+        with mock_session_dependencies():
+            with session:
+                pass
 
     def test_enter_initializes_runtime_state(self):
         """__enter__ should reset frame count and record start time."""
@@ -1174,19 +1190,28 @@ class TestSessionLifecycle:
                 assert s.frame_count == 0
                 assert before <= s.start_time <= after
 
-    def test_exit_cleans_up(self):
-        """__exit__ should clean up via ExitStack."""
+    def test_exit_is_noop_when_session_is_not_active(self):
+        """A direct __exit__ after context exit should not repeat resource cleanup."""
         pipeline = MockPipeline(leaf_nodes=[])
 
-        config = make_config(pipeline)
-        with mock_session_dependencies():
-            session = TeleopSession(config)
-            with session as s:
-                assert s._setup_complete is True
+        class CountingOpenXRSession(MockOpenXRSession):
+            def __init__(self):
+                super().__init__()
+                self.exit_count = 0
 
-        # After exit, setup_complete is still True (not reset)
-        # but the exit stack has been unwound
-        assert session._setup_complete is True
+            def __exit__(self, *args):
+                self.exit_count += 1
+
+        mock_oxr = CountingOpenXRSession()
+        config = make_config(pipeline)
+        with mock_session_dependencies(mock_oxr=mock_oxr):
+            session = TeleopSession(config)
+            with session:
+                pass
+
+            assert mock_oxr.exit_count == 1
+            assert session.__exit__(None, None, None) is False
+            assert mock_oxr.exit_count == 1
 
     def test_exit_clears_oxr_session(self):
         """After the with-block exits, the public oxr_session property honors its None contract."""
@@ -1232,7 +1257,7 @@ class TestSessionLifecycle:
             session = TeleopSession(config)
             with session as s:
                 entered = True
-                assert s._setup_complete is True
+                assert s is session
 
         assert entered is True
 

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1055,6 +1055,112 @@ class TestSessionLifecycle:
                 assert s._setup_complete is True
                 assert s.frame_count == 0
 
+    def test_enter_rejects_nested_active_session(self):
+        """A session should be reusable after exit but not re-enterable while active."""
+        config = make_config(MockPipeline(leaf_nodes=[]))
+
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with session:
+                with pytest.raises(RuntimeError, match="already active"):
+                    session.__enter__()
+
+            with session:
+                pass
+
+    @pytest.mark.parametrize(
+        "failure_stage", ["openxr", "deviceio", "plugin_1", "plugin_2"]
+    )
+    def test_enter_failure_exits_previously_acquired_resources_once(
+        self, tmp_path, failure_stage
+    ):
+        """A failed __enter__ should propagate after unwinding resources in reverse order."""
+        events = []
+
+        class TrackedContext:
+            def __init__(self, name):
+                self.name = name
+
+            def get_handles(self):
+                return MockOpenXRHandles()
+
+            def __enter__(self):
+                events.append(("enter", self.name))
+                if self.name == failure_stage:
+                    raise RuntimeError(f"{self.name} failed")
+                return self
+
+            def __exit__(self, *args):
+                events.append(("exit", self.name))
+                return True
+
+        plugin_contexts = {
+            name: TrackedContext(name) for name in ("plugin_1", "plugin_2")
+        }
+
+        class TrackedPluginManager:
+            def get_plugin_names(self):
+                return list(plugin_contexts)
+
+            def start(self, plugin_name, *args):
+                return plugin_contexts[plugin_name]
+
+        plugins = [
+            PluginConfig(
+                plugin_name=name,
+                plugin_root_id="/root",
+                search_paths=[tmp_path],
+            )
+            for name in plugin_contexts
+        ]
+        config = make_config(MockPipeline(leaf_nodes=[]), plugins=plugins)
+
+        with mock_session_dependencies(
+            mock_oxr=TrackedContext("openxr"),
+            mock_dio=TrackedContext("deviceio"),
+            mock_pm=TrackedPluginManager(),
+        ):
+            session = TeleopSession(config)
+            with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+                session.__enter__()
+
+        resource_order = ["openxr", "deviceio", "plugin_1", "plugin_2"]
+        failure_index = resource_order.index(failure_stage)
+        expected_events = [
+            ("enter", name) for name in resource_order[: failure_index + 1]
+        ]
+        expected_events.extend(
+            ("exit", name) for name in reversed(resource_order[:failure_index])
+        )
+        assert events == expected_events
+        assert session._setup_complete is False
+        assert session.oxr_session is None
+
+    def test_enter_preserves_setup_error_if_rollback_fails(self, caplog):
+        """A resource cleanup error should not replace the setup error."""
+        session = TeleopSession(make_config(MockPipeline(leaf_nodes=[])))
+
+        class FailingExit:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                raise RuntimeError("rollback failed")
+
+        def fail_setup(stack):
+            stack.enter_context(FailingExit())
+            raise ValueError("setup failed")
+
+        with (
+            caplog.at_level(logging.ERROR),
+            patch.object(session, "_enter_resources", side_effect=fail_setup),
+            pytest.raises(ValueError, match="setup failed"),
+        ):
+            session.__enter__()
+
+        assert "Failed to roll back TeleopSession setup" in caplog.text
+        assert session._is_active is False
+
     def test_enter_initializes_runtime_state(self):
         """__enter__ should reset frame count and record start time."""
         pipeline = MockPipeline(leaf_nodes=[])


### PR DESCRIPTION
## Description

`TeleopSession.__enter__` acquired OpenXR, DeviceIO, and plugin contexts onto the session-owned `ExitStack`. If a later setup step raised, the `with` body never started and Python did not call `TeleopSession.__exit__`, leaving the resources acquired so far alive.

This change makes session startup transactional:

- acquire resources on a temporary `ExitStack`
- on failure, unwind the temporary stack in reverse order and clear the stale OpenXR reference
- keep propagating the setup error even if a child suppresses it or raises during rollback; rollback failures are logged
- transfer stack ownership to the session only after every setup step succeeds
- reject nested entry so an active session stack cannot be overwritten

There is no public API change.

The parameterized regression test fails OpenXR, DeviceIO, the first plugin, and a later plugin in turn, checking exact-once reverse-order cleanup. Additional tests cover rollback cleanup failure and nested entry while preserving normal reuse after exit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- `ctest --test-dir build -R "^teleop_session_manager_" --output-on-failure --parallel 4` (4/4 passed, macOS arm64, Release, Python 3.11)
- `SKIP=check-copyright-year pre-commit run --all-files`

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] Documentation is not required because the public API is unchanged
- [x] I have added tests that prove the fix works
- [x] I have signed off all commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)