### PR TITLE
ci: pin vcpkg to an immutable commit

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -15,6 +15,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+# Pin vcpkg to an immutable commit for reproducible, supply-chain-stable CI
+# instead of tracking its moving default branch. Port versions are fixed by the
+# consuming manifest's builtin-baseline (e.g. DepthAI's vcpkg.json), so
+# this commit only needs to be recent enough to contain that baseline. Update
+# the commit and its release-date comment together.
+env:
+  VCPKG_COMMIT: d015e31e90838a4c9dfa3eed45979bc70d9357fc  # 2026.05.25
+
 jobs:
   build-ubuntu:
     # Pin to 22.04 so the wheel is built with GCC 11's libstdc++. The resulting wheel
@@ -92,14 +100,15 @@ jobs:
         path: |
           ~/vcpkg
           build/vcpkg_installed
-        key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('cmake/DepthAIVcpkgManifest.cmake') }}
+        key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('cmake/DepthAIVcpkgManifest.cmake') }}
         restore-keys: |
-          vcpkg-${{ runner.os }}-${{ runner.arch }}-
+          vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-
 
     - name: Setup vcpkg
       run: |
         if [ ! -f ~/vcpkg/vcpkg ]; then
           git clone https://github.com/microsoft/vcpkg ~/vcpkg
+          git -C ~/vcpkg checkout --detach "$VCPKG_COMMIT"
           ~/vcpkg/bootstrap-vcpkg.sh -disableMetrics
         fi
         echo "VCPKG_ROOT=$HOME/vcpkg" >> $GITHUB_ENV


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Pinned the vcpkg dependency to a specific commit for more consistent and reproducible build results.
  - Updated dependency caching to reflect the pinned version and avoid using stale artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->