### PR TITLE
feat(oob): TELEOP_OOB_HUB_ONLY env var — start hub without adb

### DIFF
--- a/docs/source/references/oob_teleop_control.rst
+++ b/docs/source/references/oob_teleop_control.rst
@@ -38,6 +38,14 @@ This will:
 4. Accept the self-signed certificate and click CONNECT automatically
    via Chrome DevTools Protocol (CDP)
 
+To start the hub **without** any ``adb`` interaction — useful in containers,
+CI, or wireless-only environments — set ``TELEOP_OOB_HUB_ONLY=1`` and open
+the teleop URL on the headset manually:
+
+.. code-block:: bash
+
+   TELEOP_OOB_HUB_ONLY=1 python -m isaacteleop.cloudxr --accept-eula --setup-oob
+
 You should see output confirming the hub is running:
 
 .. code-block:: text
@@ -367,6 +375,18 @@ Environment variables
        (no fragment — the web client picks its own landing route). Set
        to e.g. ``/real/gear/dexmate`` to force a specific route. A
        leading ``#`` is stripped automatically.
+   * - ``TELEOP_OOB_HUB_ONLY``
+     - Set to any non-empty value (e.g. ``1``) to start the OOB hub
+       without any ``adb`` interaction. The hub starts normally and
+       accepts WebSocket connections, but the launcher skips
+       ``adb devices``, ``adb shell`` wakefulness checks, CDP port
+       forwarding, and the automated browser open + CONNECT click.
+       Useful in environments where ``adb`` is unavailable or
+       unreliable (CI, containers, wireless-only setups). The operator
+       must open the teleop page on the headset manually with the
+       correct ``oobEnable=1&serverIP=<HOST>&port=<PORT>`` parameters.
+       Only meaningful together with ``--setup-oob``; has no effect
+       without it.
    * - ``ANDROID_SERIAL``
      - Pin a specific adb device when more than one is connected. The
        launcher refuses to start with multiple devices unless this is

--- a/docs/source/references/oob_teleop_control.rst
+++ b/docs/source/references/oob_teleop_control.rst
@@ -40,7 +40,8 @@ This will:
 
 To start the hub **without** any ``adb`` interaction — useful in containers,
 CI, or wireless-only environments — set ``TELEOP_OOB_HUB_ONLY=1`` and open
-the teleop URL on the headset manually:
+the teleop URL on the headset manually. This mode supports WiFi setup only
+and is **not compatible with** ``--usb-local``:
 
 .. code-block:: bash
 
@@ -386,7 +387,9 @@ Environment variables
        must open the teleop page on the headset manually with the
        correct ``oobEnable=1&serverIP=<HOST>&port=<PORT>`` parameters.
        Only meaningful together with ``--setup-oob``; has no effect
-       without it.
+       without it. **Not compatible with** ``--usb-local`` — hub-only
+       mode supports WiFi setup only; the launcher rejects the
+       combination at startup.
    * - ``ANDROID_SERIAL``
      - Pin a specific adb device when more than one is connected. The
        launcher refuses to start with multiple devices unless this is

--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -123,6 +123,14 @@ def main() -> None:
         )
         raise SystemExit(1)
 
+    if args.usb_local and os.getenv("TELEOP_OOB_HUB_ONLY"):
+        print(
+            "\n\033[31mTELEOP_OOB_HUB_ONLY is not compatible with --usb-local "
+            "(hub-only mode supports WiFi setup only).\033[0m\n",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
     # Valid flag combinations and what they mean:
     #
     #   (none)                        Plain: headset navigates to GitHub Pages URL over WiFi.

--- a/src/core/cloudxr/python/__main__.py
+++ b/src/core/cloudxr/python/__main__.py
@@ -165,11 +165,21 @@ def main() -> None:
         oob_progress("usb-local", "preflight OK")
     elif args.setup_oob:
         # WiFi OOB: resolve LAN host + warn on port/ufw issues.
-        oob_progress("setup-oob", "preflight: adb, single headset, awake ...")
-        require_adb_on_path()
+        # TELEOP_OOB_HUB_ONLY skips all adb steps — hub starts, but the
+        # operator is responsible for opening the teleop page on the headset.
+        _oob_hub_only = bool(os.getenv("TELEOP_OOB_HUB_ONLY"))
+        if _oob_hub_only:
+            oob_progress(
+                "setup-oob",
+                "hub-only mode (TELEOP_OOB_HUB_ONLY) — skipping adb preflight",
+            )
+        else:
+            oob_progress("setup-oob", "preflight: adb, single headset, awake ...")
+            require_adb_on_path()
         _oob_lan_host = resolve_lan_host_for_oob()
-        assert_exactly_one_adb_device()
-        assert_headset_awake()
+        if not _oob_hub_only:
+            assert_exactly_one_adb_device()
+            assert_headset_awake()
         try:
             print_host_preflight_warnings(usb_local=False)
         except RuntimeError as exc:

--- a/src/core/cloudxr/python/wss.py
+++ b/src/core/cloudxr/python/wss.py
@@ -757,7 +757,7 @@ async def run(
                         f"verified: adb reverse TURN {_usb_turn_port_resolved}",
                     )
 
-                if setup_oob:
+                if setup_oob and not os.getenv("TELEOP_OOB_HUB_ONLY"):
                     from .oob_teleop_adb import (  # noqa: PLC0415
                         build_teleop_url,
                         monitor_headset_wifi,


### PR DESCRIPTION
## Summary

- Adds `TELEOP_OOB_HUB_ONLY=1` env var as a bypass for `--setup-oob`'s adb automation
- When set, the OOB hub starts normally but all adb interaction is skipped: no device check, no wakefulness assert, no CDP forward cleanup, no WiFi monitor, no automated page open or CONNECT click
- The operator is responsible for opening the teleop URL on the headset manually (`oobEnable=1&serverIP=<HOST>&port=<PORT>`)
- Useful in containers, CI, or wireless-only environments where `adb` is unavailable or unreliable

## Changes

- `__main__.py`: read `TELEOP_OOB_HUB_ONLY` in the `--setup-oob` preflight block and skip all adb steps
- `wss.py`: gate the ADB+CDP automation block (`teardown_adb_forward_cdp`, `monitor_headset_wifi`, `run_oob_connect`) on `not os.getenv("TELEOP_OOB_HUB_ONLY")`
- `docs/source/references/oob_teleop_control.rst`: document the env var in the env vars table and add a usage note in Quick start

## Test plan

- [x] `TELEOP_OOB_HUB_ONLY=1 python -m isaacteleop.cloudxr --setup-oob` starts without requiring `adb` on PATH
- [x] Hub WebSocket endpoint (`wss://<host>:48322/oob/v1/ws`) accepts headset connections normally
- [x] Without `TELEOP_OOB_HUB_ONLY`, `--setup-oob` behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hub-only OOB teleoperation mode controlled by `TELEOP_OOB_HUB_ONLY=1`.
  * Enables starting the teleoperation hub without ADB access or automatic headset setup.
  * Added Quick start instructions for manually opening the teleoperation URL.

* **Documentation**
  * Documented the new environment variable, behavior, and requirement to use it with `--setup-oob`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->