### PR TITLE
docs: add Try It on Brev section to quick start

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -15,26 +15,23 @@ commands to the terminal.
 
 .. _try-on-brev:
 
-Try It on Brev — No Local Setup Required
------------------------------------------
+Try It on Brev — Zero Setup
+---------------------------
 
-Skip local installation: launch a pre-configured GPU cloud environment in one click and get the
-**server side** of Isaac Teleop running — CloudXR streaming server plus the retargeting pipeline
-backed by an Isaac Lab simulation.
+Experience **Isaac Teleop** remote teleoperation with no local install. Brev provisions the
+server side — CloudXR runtime, retargeting pipeline, and an
+`Isaac Lab <https://developer.nvidia.com/isaac/lab>`__ simulation — on a cloud GPU.
+Just grab the instance IP and connect from your headset.
 
 .. note::
 
-   **What Brev sets up (server side):** CloudXR runtime, IsaacTeleop retargeting, and an Isaac Lab
-   simulation backend — all on a cloud GPU.
+   **Server (Brev):** CloudXR + Isaac Teleop retargeting + Isaac Lab sim on a cloud GPU.
 
-   **What you still need to do (client side):** grab the IP address of your Brev instance, then
-   open `https://nvidia.github.io/IsaacTeleop/client <https://nvidia.github.io/IsaacTeleop/client>`__
-   in your headset or desktop browser, enter the IP, accept the self-signed certificate, and click
-   **Connect**. See step :ref:`connect-xr-headset` for the full walkthrough.
+   **Client (you):** open the `web client <https://nvidia.github.io/IsaacTeleop/client>`__
+   in your headset or browser, enter the Brev instance IP, accept the certificate, and click
+   **Connect** — see step :ref:`connect-xr-headset`.
 
-   IsaacTeleop is not limited to simulation — the same pipeline drives real robots, ROS 2 nodes,
-   and custom backends. The Brev environments are a fast way to try the XR-to-robot pipeline
-   without any local setup.
+   Isaac Teleop is not limited to simulation; it drives real robots and ROS 2 pipelines too.
 
 .. grid:: 2
    :gutter: 2
@@ -43,13 +40,13 @@ backed by an Isaac Lab simulation.
       :link: https://brev.nvidia.com/launchable/deploy?launchableID=env-3B3ETyweD8hOcZfNzaE12cnGNBq
       :link-type: url
 
-      Stable release · recommended for most users
+      Stable
 
    .. grid-item-card:: Launch on Brev — Isaac Lab 3.0 beta 1
       :link: https://brev.nvidia.com/launchable/deploy/now?launchableID=env-3B2jdZR8Ct0vQCzwseLuOZXoMyk
       :link-type: url
 
-      Latest features · bleeding-edge
+      Latest · recommended upgrade path
 
 ----
 

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -18,15 +18,23 @@ commands to the terminal.
 Try It on Brev — No Local Setup Required
 -----------------------------------------
 
-Skip the install entirely: launch a pre-configured GPU cloud environment with a single click
-and experience the full Isaac Teleop retargeting pipeline inside an Isaac Lab simulation.
+Skip local installation: launch a pre-configured GPU cloud environment in one click and get the
+**server side** of Isaac Teleop running — CloudXR streaming server plus the retargeting pipeline
+backed by an Isaac Lab simulation.
 
 .. note::
 
-   These Brev environments run IsaacTeleop against an **Isaac Lab simulation** backend —
-   a great way to explore the XR-to-robot pipeline in minutes. IsaacTeleop is not limited
-   to simulation; the same pipeline drives real robots, ROS 2 nodes, and custom backends.
-   For production use, follow the local setup steps below.
+   **What Brev sets up (server side):** CloudXR runtime, IsaacTeleop retargeting, and an Isaac Lab
+   simulation backend — all on a cloud GPU.
+
+   **What you still need to do (client side):** grab the IP address of your Brev instance, then
+   open `https://nvidia.github.io/IsaacTeleop/client <https://nvidia.github.io/IsaacTeleop/client>`__
+   in your headset or desktop browser, enter the IP, accept the self-signed certificate, and click
+   **Connect**. See step :ref:`connect-xr-headset` for the full walkthrough.
+
+   IsaacTeleop is not limited to simulation — the same pipeline drives real robots, ROS 2 nodes,
+   and custom backends. The Brev environments are a fast way to try the XR-to-robot pipeline
+   without any local setup.
 
 .. grid:: 2
    :gutter: 2
@@ -37,7 +45,7 @@ and experience the full Isaac Teleop retargeting pipeline inside an Isaac Lab si
 
       Stable release · recommended for most users
 
-   .. grid-item-card:: Launch on Brev — Isaac Lab 3.0
+   .. grid-item-card:: Launch on Brev — Isaac Lab 3.0 beta 1
       :link: https://brev.nvidia.com/launchable/deploy/now?launchableID=env-3B2jdZR8Ct0vQCzwseLuOZXoMyk
       :link-type: url
 

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -13,6 +13,38 @@ commands to the terminal.
    :depth: 1
    :backlinks: none
 
+.. _try-on-brev:
+
+Try It on Brev — No Local Setup Required
+-----------------------------------------
+
+Skip the install entirely: launch a pre-configured GPU cloud environment with a single click
+and experience the full Isaac Teleop retargeting pipeline inside an Isaac Lab simulation.
+
+.. note::
+
+   These Brev environments run IsaacTeleop against an **Isaac Lab simulation** backend —
+   a great way to explore the XR-to-robot pipeline in minutes. IsaacTeleop is not limited
+   to simulation; the same pipeline drives real robots, ROS 2 nodes, and custom backends.
+   For production use, follow the local setup steps below.
+
+.. grid:: 2
+   :gutter: 2
+
+   .. grid-item-card:: Launch on Brev — Isaac Lab 2.3
+      :link: https://brev.nvidia.com/launchable/deploy?launchableID=env-3B3ETyweD8hOcZfNzaE12cnGNBq
+      :link-type: url
+
+      Stable release · recommended for most users
+
+   .. grid-item-card:: Launch on Brev — Isaac Lab 3.0
+      :link: https://brev.nvidia.com/launchable/deploy/now?launchableID=env-3B2jdZR8Ct0vQCzwseLuOZXoMyk
+      :link-type: url
+
+      Latest features · bleeding-edge
+
+----
+
 .. _check-out-code-base:
 
 1. Check out code base (for examples)


### PR DESCRIPTION
## Summary

- Adds a **Try It on Brev — No Local Setup Required** section at the top of the Quick Start guide, before the numbered install steps
- Two clickable cards link directly to the IsaacLab 2.3 and IsaacLab 3.0 Brev launchable environments
- A callout note clarifies that these environments use **Isaac Lab as a simulation backend** and that Isaac Teleop itself is not limited to simulation (also works with real robots, ROS 2, custom backends)

Modeled after the Isaac Lab Launchable section in the Isaac Lab docs: https://isaac-sim.github.io/IsaacLab/main/source/setup/quickstart.html#quick-start-using-isaac-launchable

## Test plan

- [x] Build docs locally (`make html` in `docs/`) and confirm the new section renders with two cards before step 1
- [x] Verify both Brev links resolve correctly
- [x] Confirm the note text accurately reflects what IsaacTeleop is vs. what the Brev envs provide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Try It on Brev — Zero Setup” section to the Quick Start guide.
  * Documented how to run Isaac Teleop in a provisioned cloud environment without local installation.
  * Added launch options for Isaac Lab 2.3 and Isaac Lab 3.0 beta 1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->