### PR TITLE
Add raw sensor data support to the Manus plugin

### DIFF
--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -7,7 +7,9 @@ MANUS Gloves
 A Linux-only plugin for integrating `MANUS <https://www.manus-meta.com/>`_ gloves
 into the Isaac Teleop framework. It provides full hand-joint tracking via the
 Manus SDK and injects the resulting poses into the OpenXR hand-tracking layer so
-any downstream retargeter can consume them transparently.
+any downstream retargeter can consume them transparently. Optionally it also
+publishes Manus flex-sensor (RawDeviceData) tip poses as ``JointStateOutput``
+tensors and consumes inbound haptic commands for vibration gloves.
 
 .. contents:: On this page
    :local:
@@ -166,6 +168,66 @@ SDK connection at a time.
 .. code-block:: bash
 
    ./install/plugins/manus/manus_hand_plugin
+
+By default the plugin enables human hand injection, flex-sensor push, and
+haptic read. Restrict datasets with ``--datasets=`` (comma-separated):
+
+.. code-block:: bash
+
+   ./install/plugins/manus/manus_hand_plugin --datasets=human,sensors,haptic
+   ./install/plugins/manus/manus_hand_plugin --datasets=human          # skeleton only
+   ./install/plugins/manus/manus_hand_plugin --datasets=sensors        # flex sensors only
+
+Data paths
+----------
+
+Human (OpenXR hand injection)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Manus raw skeleton stream is mapped to 26 OpenXR hand joints and pushed
+through ``HandInjector`` (requires ``XR_NVX1_device_interface_base``). Downstream
+hosts consume hands via ``HandsSource`` as with any other hand-tracking plugin.
+
+Sensors (flex tips via SchemaPusher)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When gloves report at least five RawDeviceData flex sensors, the plugin pushes
+a ``JointStateOutput`` (tensor id ``joint_state``) on:
+
+- ``manus_sensors_left``
+- ``manus_sensors_right``
+
+Layout: 35 joints named ``j0``..``j34``. For sensor ``i`` in thumb→pinky order,
+``j[7*i : 7*i+7]`` is ``[x, y, z, qx, qy, qz, qw]`` (meters, quaternion xyzw)
+in the Manus SDK frame after the plugin's VUH coordinate setup. Poses are raw
+Manus flex transforms; hosts that mask against a re-framed skeleton must apply
+their own sensor-pose processing.
+
+This path requires CloudXR tensor **push** extensions
+(``XR_NVX1_push_tensor`` and ``XR_NVX1_tensor_data``). When sensors first become
+available the plugin logs ``sensors=on`` once per side.
+
+Host-side consumption example:
+
+.. code-block:: python
+
+   from isaacteleop.retargeting_engine.deviceio_source_nodes import JointStateSource
+
+   SENSOR_JOINTS = [f"j{i}" for i in range(35)]
+   left = JointStateSource(
+       name="manus_sensors_left",
+       collection_id="manus_sensors_left",
+       joint_names=SENSOR_JOINTS,
+   )
+   # Decode thumb tip: joints j0..j6 -> [x, y, z, qx, qy, qz, qw]
+
+Haptic (inbound vibration)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The plugin reads ``HapticCommand`` on collection ``manus_glove_haptic``
+(``XR_NVX1_tensor_data``) and drives five finger motors via the Manus SDK.
+See the haptic feedback example and
+``isaacteleop.haptic_devices.glove.haptic_glove_device``.
 
 Wrist Positioning — Controllers vs Optical Hand Tracking
 ---------------------------------------------------------

--- a/src/plugins/manus/app/main.cpp
+++ b/src/plugins/manus/app/main.cpp
@@ -1,20 +1,107 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #include <manus/manus_hand_tracking_plugin.hpp>
 
 #include <chrono>
 #include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <string>
 #include <thread>
+#include <vector>
 
 using namespace plugins::manus;
+
+namespace
+{
+
+bool starts_with(const std::string& value, const std::string& prefix)
+{
+    return value.size() >= prefix.size() && value.compare(0, prefix.size(), prefix) == 0;
+}
+
+std::vector<std::string> split_csv(const std::string& text)
+{
+    std::vector<std::string> out;
+    std::stringstream ss(text);
+    std::string item;
+    while (std::getline(ss, item, ','))
+    {
+        // Trim whitespace
+        const auto start = item.find_first_not_of(" \t");
+        if (start == std::string::npos)
+        {
+            continue;
+        }
+        const auto end = item.find_last_not_of(" \t");
+        out.push_back(item.substr(start, end - start + 1));
+    }
+    return out;
+}
+
+ManusPluginConfig parse_args(int argc, char** argv)
+{
+    ManusPluginConfig config;
+    std::string datasets_arg = "human,sensors,haptic";
+
+    for (int i = 1; i < argc; ++i)
+    {
+        const std::string arg = argv[i];
+        if (starts_with(arg, "--datasets="))
+        {
+            datasets_arg = arg.substr(std::string("--datasets=").size());
+        }
+        else if (starts_with(arg, "--plugin-root-id="))
+        {
+            // Injected by the PluginManager; not used by this plugin.
+        }
+        else
+        {
+            std::cerr << "ManusHandPlugin: ignoring unknown argument '" << arg << "'" << std::endl;
+        }
+    }
+
+    config.human = false;
+    config.sensors = false;
+    config.haptic = false;
+    for (const auto& ds : split_csv(datasets_arg))
+    {
+        if (ds == "human")
+        {
+            config.human = true;
+        }
+        else if (ds == "sensors")
+        {
+            config.sensors = true;
+        }
+        else if (ds == "haptic")
+        {
+            config.haptic = true;
+        }
+        else
+        {
+            std::cerr << "ManusHandPlugin: ignoring unknown data set '" << ds << "'" << std::endl;
+        }
+    }
+
+    if (!config.human && !config.sensors && !config.haptic)
+    {
+        throw std::runtime_error("ManusHandPlugin: --datasets must enable at least one of human,sensors,haptic");
+    }
+
+    return config;
+}
+
+} // namespace
 
 int main(int argc, char** argv)
 try
 {
     std::cout << "Manus Hand Plugin starting..." << std::endl;
 
-    auto& tracker = ManusTracker::instance();
+    const ManusPluginConfig config = parse_args(argc, argv);
+    auto& tracker = ManusTracker::instance(config);
 
     std::cout << "Plugin running. Press Ctrl+C to stop." << std::endl;
 

--- a/src/plugins/manus/core/CMakeLists.txt
+++ b/src/plugins/manus/core/CMakeLists.txt
@@ -19,9 +19,11 @@ target_link_libraries(manus_plugin_core
         deviceio::deviceio_trackers
     OpenXR::openxr_loader
     oxr::oxr_core
+    pusherio::pusherio
   PRIVATE
     oxr::oxr_utils
     Teleop::openxr_extensions
+    isaacteleop_schema
 )
 
 set_target_properties(manus_plugin_core PROPERTIES

--- a/src/plugins/manus/core/inc/manus/manus_glove_collection.hpp
+++ b/src/plugins/manus/core/inc/manus/manus_glove_collection.hpp
@@ -22,5 +22,25 @@ namespace manus
 // rejects a collection whose sample size exceeds its buffer).
 inline constexpr const char* MANUS_GLOVE_COLLECTION_ID = "manus_glove_haptic";
 
+// Outbound flex-sensor (Manus RawDeviceData) collections pushed as JointStateOutput
+// with tensor identifier "joint_state". Hosts discover them via JointStateSource.
+//
+// Packing (35 positional joints j0..j34): for sensor i in thumb→pinky order
+// (i = 0..4), joints j[7*i .. 7*i+6] hold one SE(3) tip as
+//   [x, y, z, qx, qy, qz, qw]
+// in meters / xyzw, in the Manus SDK frame after the plugin's VUH coordinate
+// setup. All 35 joints are valid=true only when sensorCount >= 5; otherwise the
+// plugin skips the push so the host sees "no sensors".
+//
+// These are raw Manus flex transforms (same source as SharpaManusClient's
+// RawDeviceData callback).
+inline constexpr const char* MANUS_SENSORS_COLLECTION_PREFIX = "manus_sensors";
+inline constexpr const char* MANUS_SENSORS_LEFT_COLLECTION_ID = "manus_sensors_left";
+inline constexpr const char* MANUS_SENSORS_RIGHT_COLLECTION_ID = "manus_sensors_right";
+
+inline constexpr int kManusSensorCount = 5;
+inline constexpr int kManusSensorPoseFloats = 7; // xyz + quat xyzw
+inline constexpr int kManusSensorJointCount = kManusSensorCount * kManusSensorPoseFloats; // 35
+
 } // namespace manus
 } // namespace plugins

--- a/src/plugins/manus/core/inc/manus/manus_hand_tracking_plugin.hpp
+++ b/src/plugins/manus/core/inc/manus/manus_hand_tracking_plugin.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include "manus_glove_collection.hpp"
+
 #include <deviceio_session/deviceio_session.hpp>
 #include <deviceio_trackers/controller_tracker.hpp>
 #include <deviceio_trackers/hand_tracker.hpp>
@@ -11,6 +13,7 @@
 #include <oxr/oxr_session.hpp>
 #include <oxr_utils/oxr_time.hpp>
 #include <plugin_utils/hand_injector.hpp>
+#include <pusherio/schema_pusher.hpp>
 
 #include <ManusSDK.h>
 #include <XR_MNDX_xdev_space.h>
@@ -37,11 +40,21 @@ namespace manus
 // different actuator count would change this and the values it consumes.
 inline constexpr std::size_t kManusFingerCount = 5;
 
+/// Runtime feature flags for manus_hand_plugin (parsed from --datasets=...).
+struct ManusPluginConfig
+{
+    std::string app_name = "ManusHandPlugin";
+    bool human = true; // OpenXR HandInjector
+    bool sensors = true; // RawDeviceData -> SchemaPusher
+    bool haptic = true; // inbound HapticCommandReaderTracker
+};
+
 class __attribute__((visibility("default"))) ManusTracker
 {
 public:
-    /// Get the singleton instance
-    static ManusTracker& instance(const std::string& app_name = "ManusHandPlugin") noexcept(false);
+    /// Get the singleton instance. The first call constructs with ``config``;
+    /// later calls (e.g. from Manus SDK callbacks) ignore ``config``.
+    static ManusTracker& instance(const ManusPluginConfig& config = ManusPluginConfig{}) noexcept(false);
 
     void update();
     std::vector<SkeletonNode> get_left_hand_nodes() const;
@@ -64,14 +77,14 @@ public:
 
 private:
     // Lifecycle
-    explicit ManusTracker(const std::string& app_name) noexcept(false);
+    explicit ManusTracker(const ManusPluginConfig& config) noexcept(false);
     ~ManusTracker();
 
     ManusTracker(const ManusTracker&) = delete;
     ManusTracker& operator=(const ManusTracker&) = delete;
     ManusTracker(ManusTracker&&) = delete;
     ManusTracker& operator=(ManusTracker&&) = delete;
-    void initialize(const std::string& app_name) noexcept(false);
+    void initialize() noexcept(false);
     void shutdown_sdk();
 
     // ManusSDK specific methods
@@ -80,6 +93,10 @@ private:
     void DisconnectFromGloves();
     static void OnSkeletonStream(const SkeletonStreamInfo* skeleton_stream_info);
     static void OnLandscapeStream(const Landscape* landscape);
+    static void OnRawDeviceDataStream(const RawDeviceDataInfo* raw_device_data_info);
+
+    void push_sensor_states();
+    void push_sensor_side(bool is_left, core::SchemaPusher& pusher);
 
     // OpenXR specific methods
     void inject_hand_data();
@@ -93,6 +110,8 @@ private:
     bool get_controller_wrist_pose(bool is_left, XrPosef& out_wrist_pose);
 
     // -- Member Variables --
+
+    ManusPluginConfig m_config;
 
     // Lifecycle
     std::mutex m_lifecycle_mutex;
@@ -110,6 +129,12 @@ private:
     // no `mutable` is needed; const callers do not touch these flags.
     std::array<std::atomic<bool>, 2> m_haptic_error_logged{ { false, false } };
 
+    // Flex-sensor cache (RawDeviceData). Indexed 0=left, 1=right.
+    mutable std::mutex m_sensor_mutex;
+    std::array<uint32_t, 2> m_sensor_count{ { 0, 0 } };
+    std::array<std::array<ManusTransform, kManusSensorCount>, 2> m_sensor_transforms{};
+    std::array<bool, 2> m_sensors_logged_on{ { false, false } };
+
     // OpenXR State
     std::shared_ptr<core::OpenXRSession> m_session;
     core::OpenXRSessionHandles m_handles;
@@ -121,6 +146,8 @@ private:
     // inc/manus/manus_glove_collection.hpp. Read each frame in update().
     std::shared_ptr<core::HapticCommandReaderTracker> m_haptic_reader;
     std::unique_ptr<core::DeviceIOSession> m_deviceio_session;
+    std::unique_ptr<core::SchemaPusher> m_left_sensor_pusher;
+    std::unique_ptr<core::SchemaPusher> m_right_sensor_pusher;
 
     // XDev native hand trackers (Quest 3 hand tracking via XR_MNDX_xdev_space)
     XrXDevListMNDX m_xdev_list = XR_NULL_HANDLE;

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -5,11 +5,15 @@
 
 #include "inc/manus/manus_glove_collection.hpp"
 
+#include <flatbuffers/flatbuffers.h>
 #include <oxr/oxr_session.hpp>
 #include <oxr_utils/math.hpp>
+#include <oxr_utils/os_time.hpp>
 #include <oxr_utils/pose_conversions.hpp>
 #include <plugin_utils/hand_injector.hpp>
+#include <pusherio/schema_pusher.hpp>
 #include <schema/haptic_command_generated.h>
+#include <schema/joint_state_generated.h>
 
 #include <ManusSDK.h>
 #include <ManusSDKTypeInitializers.h>
@@ -62,14 +66,17 @@ SDKReturnCode get_raw_skeleton_node_count(uint32_t glove_id, uint32_t& node_coun
 #endif
 }
 
+// Must agree with JointStateTracker::DEFAULT_MAX_FLATBUFFER_SIZE on the consumer side.
+constexpr size_t kSensorFlatbufferSize = 4096;
+
 } // anonymous namespace
 
 static constexpr XrPosef kLeftHandOffset = { { -0.70710678f, -0.5f, 0.0f, 0.5f }, { -0.1f, 0.02f, -0.02f } };
 static constexpr XrPosef kRightHandOffset = { { -0.70710678f, 0.5f, 0.0f, 0.5f }, { 0.1f, 0.02f, -0.02f } };
 
-ManusTracker& ManusTracker::instance(const std::string& app_name) noexcept(false)
+ManusTracker& ManusTracker::instance(const ManusPluginConfig& config) noexcept(false)
 {
-    static ManusTracker s(app_name);
+    static ManusTracker s(config);
     return s;
 }
 
@@ -77,7 +84,7 @@ void ManusTracker::update()
 {
     if (!m_deviceio_session)
     {
-        // OpenXR unavailable — nothing to update for positioning/injection
+        // OpenXR unavailable — nothing to update for positioning/injection/push
         return;
     }
 
@@ -104,7 +111,15 @@ void ManusTracker::update()
         }
     }
 
-    inject_hand_data();
+    if (m_config.sensors)
+    {
+        push_sensor_states();
+    }
+
+    if (m_config.human)
+    {
+        inject_hand_data();
+    }
 }
 
 std::vector<SkeletonNode> ManusTracker::get_left_hand_nodes() const
@@ -173,9 +188,9 @@ void ManusTracker::apply_haptic_command(bool is_left, const std::array<float, kM
     }
 }
 
-ManusTracker::ManusTracker(const std::string& app_name) noexcept(false)
+ManusTracker::ManusTracker(const ManusPluginConfig& config) noexcept(false) : m_config(config)
 {
-    initialize(app_name);
+    initialize();
 }
 
 ManusTracker::~ManusTracker()
@@ -192,7 +207,7 @@ ManusTracker::~ManusTracker()
     shutdown_sdk();
 }
 
-void ManusTracker::initialize(const std::string& app_name) noexcept(false)
+void ManusTracker::initialize() noexcept(false)
 {
     std::cout << "[Manus] Initializing SDK..." << std::endl;
     const SDKReturnCode t_InitializeResult = CoreSdk_InitializeIntegrated();
@@ -202,6 +217,9 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
                                  std::to_string(static_cast<int>(t_InitializeResult)));
     }
     std::cout << "[Manus] SDK initialized successfully" << std::endl;
+    std::cout << "[Manus] datasets: human=" << (m_config.human ? "on" : "off")
+              << " sensors=" << (m_config.sensors ? "on" : "off") << " haptic=" << (m_config.haptic ? "on" : "off")
+              << std::endl;
 
     RegisterCallbacks();
 
@@ -224,73 +242,138 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
 
     ConnectToGloves();
 
+    const bool needs_openxr = m_config.human || m_config.sensors || m_config.haptic;
+    if (!needs_openxr)
+    {
+        std::cout << "[Manus] No OpenXR datasets enabled; running Manus-only (skeleton callbacks only)." << std::endl;
+        std::lock_guard<std::mutex> lock(m_lifecycle_mutex);
+        m_initialized = true;
+        return;
+    }
+
     std::string error_msg = "Unknown error";
     bool success = false;
 
     try
     {
-        // Create ControllerTracker unconditionally; HandTracker requires
-        // XR_EXT_hand_tracking which is optional — only add it when the runtime
-        // advertises support so xrCreateInstance does not fail with
-        // XR_ERROR_EXTENSION_NOT_PRESENT on runtimes that lack the extension.
-        m_controller_tracker = std::make_shared<core::ControllerTracker>();
-        std::vector<std::shared_ptr<core::ITracker>> trackers = { m_controller_tracker };
+        std::vector<std::shared_ptr<core::ITracker>> trackers;
 
-        const bool hand_tracking_supported = is_openxr_extension_supported(XR_EXT_HAND_TRACKING_EXTENSION_NAME);
-        if (hand_tracking_supported)
+        if (m_config.human)
         {
-            m_hand_tracker = std::make_shared<core::HandTracker>();
-            trackers.push_back(m_hand_tracker);
+            // Create ControllerTracker unconditionally; HandTracker requires
+            // XR_EXT_hand_tracking which is optional — only add it when the runtime
+            // advertises support so xrCreateInstance does not fail with
+            // XR_ERROR_EXTENSION_NOT_PRESENT on runtimes that lack the extension.
+            m_controller_tracker = std::make_shared<core::ControllerTracker>();
+            trackers.push_back(m_controller_tracker);
+
+            const bool hand_tracking_supported = is_openxr_extension_supported(XR_EXT_HAND_TRACKING_EXTENSION_NAME);
+            if (hand_tracking_supported)
+            {
+                m_hand_tracker = std::make_shared<core::HandTracker>();
+                trackers.push_back(m_hand_tracker);
+            }
+            else
+            {
+                std::cout << "[Manus] " << XR_EXT_HAND_TRACKING_EXTENSION_NAME
+                          << " is not supported by the current runtime; HandTracker will not be created." << std::endl;
+            }
         }
-        else
+
+        if (m_config.haptic)
         {
-            std::cout << "[Manus] " << XR_EXT_HAND_TRACKING_EXTENSION_NAME
-                      << " is not supported by the current runtime; HandTracker will not be created." << std::endl;
+            // Registering the reader pulls XR_NVX1_tensor_data into the
+            // OpenXRSession's required-extension set; the session will fail
+            // loudly on a runtime that doesn't advertise it. The reader's buffer
+            // must be >= the producer's collection sample size; we use the shared
+            // default (matching the producer's PushTensorHapticDevice) rather than
+            // a Manus-specific size that could drift below it.
+            m_haptic_reader = std::make_shared<core::HapticCommandReaderTracker>(MANUS_GLOVE_COLLECTION_ID);
+            trackers.push_back(m_haptic_reader);
         }
 
-        // Registering the reader pulls XR_NVX1_tensor_data into the
-        // OpenXRSession's required-extension set; the session will fail
-        // loudly on a runtime that doesn't advertise it. The reader's buffer
-        // must be >= the producer's collection sample size; we use the shared
-        // default (matching the producer's PushTensorHapticDevice) rather than
-        // a Manus-specific size that could drift below it.
-        m_haptic_reader = std::make_shared<core::HapticCommandReaderTracker>(MANUS_GLOVE_COLLECTION_ID);
-        trackers.push_back(m_haptic_reader);
+        std::vector<std::string> extensions;
+        if (!trackers.empty())
+        {
+            extensions = core::DeviceIOSession::get_required_extensions(trackers);
+        }
 
-        // Get required extensions from trackers
-        auto extensions = core::DeviceIOSession::get_required_extensions(trackers);
-        extensions.push_back(XR_NVX1_DEVICE_INTERFACE_BASE_EXTENSION_NAME);
+        if (m_config.sensors)
+        {
+            for (const auto& ext : core::SchemaPusher::get_required_extensions())
+            {
+                if (std::find(extensions.begin(), extensions.end(), ext) == extensions.end())
+                {
+                    extensions.push_back(ext);
+                }
+            }
+        }
+
+        if (m_config.human)
+        {
+            extensions.push_back(XR_NVX1_DEVICE_INTERFACE_BASE_EXTENSION_NAME);
+        }
 
         // XR_MNDX_XDEV_SPACE_EXTENSION_NAME is optional: it enables optical (HMD) hand
         // tracking as a higher-quality wrist source. If the runtime does not advertise
         // it we fall back to controller-based tracking instead of crashing.
-        const bool xdev_extension_supported = is_openxr_extension_supported(XR_MNDX_XDEV_SPACE_EXTENSION_NAME);
-        if (xdev_extension_supported)
+        bool xdev_extension_supported = false;
+        if (m_config.human)
         {
-            extensions.push_back(XR_MNDX_XDEV_SPACE_EXTENSION_NAME);
-        }
-        else
-        {
-            std::cout << "[Manus] " << XR_MNDX_XDEV_SPACE_EXTENSION_NAME
-                      << " is not supported by the current runtime; optical hand tracking"
-                      << " will not be available and controller fallback will be used." << std::endl;
+            xdev_extension_supported = is_openxr_extension_supported(XR_MNDX_XDEV_SPACE_EXTENSION_NAME);
+            if (xdev_extension_supported)
+            {
+                extensions.push_back(XR_MNDX_XDEV_SPACE_EXTENSION_NAME);
+            }
+            else
+            {
+                std::cout << "[Manus] " << XR_MNDX_XDEV_SPACE_EXTENSION_NAME
+                          << " is not supported by the current runtime; optical hand tracking"
+                          << " will not be available and controller fallback will be used." << std::endl;
+            }
         }
 
         // Create session with required extensions - constructor automatically begins the session
         const bool wait_for_openxr_system = true;
-        m_session = std::make_shared<core::OpenXRSession>(app_name, extensions, wait_for_openxr_system);
+        m_session = std::make_shared<core::OpenXRSession>(m_config.app_name, extensions, wait_for_openxr_system);
         m_handles = m_session->get_handles();
 
         // Initialize time converter now that handles are ready
         m_time_converter.emplace(m_handles);
 
-        // Initialize hand injectors (one per hand)
-        m_left_injector = std::make_unique<plugin_utils::HandInjector>(
-            m_handles.instance, m_handles.session, XR_HAND_LEFT_EXT, m_handles.space);
-        m_right_injector = std::make_unique<plugin_utils::HandInjector>(
-            m_handles.instance, m_handles.session, XR_HAND_RIGHT_EXT, m_handles.space);
+        if (m_config.human)
+        {
+            m_left_injector = std::make_unique<plugin_utils::HandInjector>(
+                m_handles.instance, m_handles.session, XR_HAND_LEFT_EXT, m_handles.space);
+            m_right_injector = std::make_unique<plugin_utils::HandInjector>(
+                m_handles.instance, m_handles.session, XR_HAND_RIGHT_EXT, m_handles.space);
+        }
 
-        m_deviceio_session = core::DeviceIOSession::run(trackers, m_handles);
+        if (m_config.sensors)
+        {
+            m_left_sensor_pusher = std::make_unique<core::SchemaPusher>(
+                m_handles, core::SchemaPusherConfig{ .collection_id = MANUS_SENSORS_LEFT_COLLECTION_ID,
+                                                     .max_flatbuffer_size = kSensorFlatbufferSize,
+                                                     .tensor_identifier = "joint_state",
+                                                     .localized_name = "Manus Sensors Left",
+                                                     .app_name = m_config.app_name });
+            m_right_sensor_pusher = std::make_unique<core::SchemaPusher>(
+                m_handles, core::SchemaPusherConfig{ .collection_id = MANUS_SENSORS_RIGHT_COLLECTION_ID,
+                                                     .max_flatbuffer_size = kSensorFlatbufferSize,
+                                                     .tensor_identifier = "joint_state",
+                                                     .localized_name = "Manus Sensors Right",
+                                                     .app_name = m_config.app_name });
+        }
+
+        if (!trackers.empty())
+        {
+            m_deviceio_session = core::DeviceIOSession::run(trackers, m_handles);
+        }
+        else
+        {
+            // Sensors-only: still need a DeviceIOSession clock for update(); use an empty tracker list.
+            m_deviceio_session = core::DeviceIOSession::run({}, m_handles);
+        }
 
         // Only attempt XDev hand tracker setup when the extension was actually enabled.
         // Skipping here avoids calling xrGetInstanceProcAddr for MNDX entry points that
@@ -300,8 +383,15 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
             initialize_xdev_hand_trackers();
         }
 
-        std::cout << "[Manus] Initialized with wrist source: " << (m_xdev_available ? "HandTracking" : "Controllers")
-                  << std::endl;
+        if (m_config.human)
+        {
+            std::cout << "[Manus] Initialized with wrist source: " << (m_xdev_available ? "HandTracking" : "Controllers")
+                      << std::endl;
+        }
+        else
+        {
+            std::cout << "[Manus] OpenXR session ready (human injection disabled)." << std::endl;
+        }
 
         success = true;
     }
@@ -313,7 +403,21 @@ void ManusTracker::initialize(const std::string& app_name) noexcept(false)
     if (!success)
     {
         std::cerr << "[Manus] Warning: OpenXR initialization failed: " << error_msg << std::endl;
-        std::cerr << "[Manus] Continuing in Manus-only mode (no hand injection or OpenXR positioning)." << std::endl;
+        std::cerr << "[Manus] Continuing in Manus-only mode (no hand injection, sensor push, or OpenXR positioning)."
+                  << std::endl;
+        // Drop every OpenXR-related member that may have been created before the
+        // throw (trackers/injectors first — they may hold session handles).
+        cleanup_xdev_hand_trackers();
+        m_left_injector.reset();
+        m_right_injector.reset();
+        m_left_sensor_pusher.reset();
+        m_right_sensor_pusher.reset();
+        m_controller_tracker.reset();
+        m_hand_tracker.reset();
+        m_haptic_reader.reset();
+        m_deviceio_session.reset();
+        m_time_converter.reset();
+        m_session.reset();
     }
 
     std::lock_guard<std::mutex> lock(m_lifecycle_mutex);
@@ -329,6 +433,7 @@ void ManusTracker::shutdown_sdk()
     CoreSdk_RegisterCallbackForRawSkeletonStream(nullptr);
     CoreSdk_RegisterCallbackForLandscapeStream(nullptr);
     CoreSdk_RegisterCallbackForErgonomicsStream(nullptr);
+    CoreSdk_RegisterCallbackForRawDeviceDataStream(nullptr);
     DisconnectFromGloves();
     CoreSdk_ShutDown();
 }
@@ -337,6 +442,10 @@ void ManusTracker::RegisterCallbacks()
 {
     CoreSdk_RegisterCallbackForRawSkeletonStream(OnSkeletonStream);
     CoreSdk_RegisterCallbackForLandscapeStream(OnLandscapeStream);
+    if (m_config.sensors)
+    {
+        CoreSdk_RegisterCallbackForRawDeviceDataStream(OnRawDeviceDataStream);
+    }
 }
 
 void ManusTracker::ConnectToGloves() noexcept(false)
@@ -536,6 +645,10 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
             tracker.left_glove_id.reset();
             tracker.m_left_hand_nodes.clear();
             tracker.m_left_node_info.clear();
+            {
+                std::lock_guard<std::mutex> sensor_lock(tracker.m_sensor_mutex);
+                tracker.m_sensor_count[0] = 0;
+            }
         }
         if (!right_present && tracker.right_glove_id.has_value())
         {
@@ -543,8 +656,122 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
             tracker.right_glove_id.reset();
             tracker.m_right_hand_nodes.clear();
             tracker.m_right_node_info.clear();
+            {
+                std::lock_guard<std::mutex> sensor_lock(tracker.m_sensor_mutex);
+                tracker.m_sensor_count[1] = 0;
+            }
         }
     }
+}
+
+void ManusTracker::OnRawDeviceDataStream(const RawDeviceDataInfo* raw_device_data_info)
+{
+    auto& tracker = instance();
+    std::lock_guard<std::mutex> instance_lock(tracker.m_lifecycle_mutex);
+    if (!tracker.m_initialized || !tracker.m_config.sensors)
+    {
+        return;
+    }
+
+    for (uint32_t i = 0; i < raw_device_data_info->rawDeviceDataCount; ++i)
+    {
+        RawDeviceData raw{};
+        if (CoreSdk_GetRawDeviceData(i, &raw) != SDKReturnCode::SDKReturnCode_Success)
+        {
+            continue;
+        }
+
+        bool is_left = false;
+        bool is_right = false;
+        {
+            std::lock_guard<std::mutex> landscape_lock(tracker.landscape_mutex);
+            is_left = tracker.left_glove_id && raw.id == *tracker.left_glove_id;
+            is_right = tracker.right_glove_id && raw.id == *tracker.right_glove_id;
+        }
+        if (!is_left && !is_right)
+        {
+            continue;
+        }
+        if (raw.sensorCount == 0)
+        {
+            continue;
+        }
+
+        const size_t side = is_left ? 0 : 1;
+        const uint32_t count = std::min(raw.sensorCount, static_cast<uint32_t>(kManusSensorCount));
+        std::lock_guard<std::mutex> sensor_lock(tracker.m_sensor_mutex);
+        tracker.m_sensor_count[side] = count;
+        for (uint32_t j = 0; j < count; ++j)
+        {
+            tracker.m_sensor_transforms[side][j] = raw.sensorData[j];
+        }
+    }
+}
+
+void ManusTracker::push_sensor_states()
+{
+    if (m_left_sensor_pusher)
+    {
+        push_sensor_side(true, *m_left_sensor_pusher);
+    }
+    if (m_right_sensor_pusher)
+    {
+        push_sensor_side(false, *m_right_sensor_pusher);
+    }
+}
+
+void ManusTracker::push_sensor_side(bool is_left, core::SchemaPusher& pusher)
+{
+    const size_t side = is_left ? 0 : 1;
+    uint32_t count = 0;
+    std::array<ManusTransform, kManusSensorCount> transforms{};
+    {
+        std::lock_guard<std::mutex> sensor_lock(m_sensor_mutex);
+        count = m_sensor_count[side];
+        transforms = m_sensor_transforms[side];
+    }
+
+    // Hosts treat missing pushes as "no sensors"; only emit a full 5-tip pack.
+    if (count < static_cast<uint32_t>(kManusSensorCount))
+    {
+        return;
+    }
+
+    if (!m_sensors_logged_on[side])
+    {
+        m_sensors_logged_on[side] = true;
+        std::cout << "[Manus] " << (is_left ? "left" : "right") << " sensors=on" << std::endl;
+    }
+
+    core::JointStateOutputT out;
+    out.device_id = is_left ? MANUS_SENSORS_LEFT_COLLECTION_ID : MANUS_SENSORS_RIGHT_COLLECTION_ID;
+    out.has_velocity = false;
+    out.has_effort = false;
+    out.ee_pose_valid = false;
+    out.joints.reserve(static_cast<size_t>(kManusSensorJointCount));
+
+    for (int sensor = 0; sensor < kManusSensorCount; ++sensor)
+    {
+        const ManusTransform& t = transforms[static_cast<size_t>(sensor)];
+        // Manus SDK quaternions are wxyz; JointState / Pose wire contract is xyzw.
+        const float pose[kManusSensorPoseFloats] = {
+            t.position.x, t.position.y, t.position.z, t.rotation.x, t.rotation.y, t.rotation.z, t.rotation.w,
+        };
+        for (int k = 0; k < kManusSensorPoseFloats; ++k)
+        {
+            auto joint = std::make_shared<core::JointStateT>();
+            joint->name = "j" + std::to_string(sensor * kManusSensorPoseFloats + k);
+            joint->position = pose[k];
+            joint->valid = true;
+            out.joints.push_back(std::move(joint));
+        }
+    }
+
+    const auto sample_time_ns = core::os_monotonic_now_ns();
+    flatbuffers::FlatBufferBuilder builder(kSensorFlatbufferSize);
+    auto offset = core::JointStateOutput::Pack(builder, &out);
+    builder.Finish(offset);
+    pusher.push_buffer(builder.GetBufferPointer(), builder.GetSize(), sample_time_ns, sample_time_ns);
 }
 
 void ManusTracker::initialize_xdev_hand_trackers()

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -692,12 +692,16 @@ void ManusTracker::OnRawDeviceDataStream(const RawDeviceDataInfo* raw_device_dat
         {
             continue;
         }
+
+        const size_t side = is_left ? 0 : 1;
         if (raw.sensorCount == 0)
         {
+            // Clear cached count so push_sensor_side stops emitting stale tips.
+            std::lock_guard<std::mutex> sensor_lock(tracker.m_sensor_mutex);
+            tracker.m_sensor_count[side] = 0;
             continue;
         }
 
-        const size_t side = is_left ? 0 : 1;
         const uint32_t count = std::min(raw.sensorCount, static_cast<uint32_t>(kManusSensorCount));
         std::lock_guard<std::mutex> sensor_lock(tracker.m_sensor_mutex);
         tracker.m_sensor_count[side] = count;

--- a/src/plugins/manus/tools/manus_hand_tracker_printer.cpp
+++ b/src/plugins/manus/tools/manus_hand_tracker_printer.cpp
@@ -20,8 +20,9 @@ try
 
     std::cout << "[Manus] Initializing Manus Tracker..." << std::endl;
 
-    // Initialize the Manus tracker
-    auto& tracker = plugins::manus::ManusTracker::instance("ManusHandPrinter");
+    plugins::manus::ManusPluginConfig config;
+    config.app_name = "ManusHandPrinter";
+    auto& tracker = plugins::manus::ManusTracker::instance(config);
 
     // Start Vulkan visualizer in a background thread.
     // If X11 or Vulkan is unavailable the thread exits cleanly and printing


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Add raw sensor data support to the Manus plugin

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Manually verified Manus plugin

## Checklist

- [X] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [X] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix/feature works (or explained why not)
- [X] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a configurable `--datasets=` option to enable human hand injection, flex-sensor pose publishing, and haptic command control (with validation for empty selections).
  - Added optional publishing of Manus flex-sensor tip poses as `JointStateOutput` using a defined 35-joint left/right layout.
  - Added a “Manus-only” mode that skips OpenXR when human hand tracking isn’t enabled.

- **Documentation**
  - Expanded MANUS glove documentation with detailed run instructions, data paths, tensor layouts, and example invocations.

- **Refactor**
  - Updated the plugin to be configuration-driven for cleaner enablement of dataset capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->