### PR TITLE
Remove hardcoded python 3.12 in camera_viz example

### DIFF
--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -35,7 +35,7 @@ source examples/camera_viz/.venv/bin/activate
 
 `setup` installs `isaacteleop` (which bundles Televiz) and every other Python dep from PyPI into `.venv/` via `uv` (no `--system-site-packages`), builds the native NVENC/NVDEC codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts. No need to build IsaacTeleop from source.
 
-Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`. Pass `--venv PATH` to install into an existing venv (symlinks `.venv` → PATH so `run` / `loopback` pick it up too).
+Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`. Pass `--python 3.10` (or another supported 3.10-3.13 interpreter name/path) to choose Python explicitly; by default setup uses the local `python3` when it is supported. Pass `--venv PATH` to install into an existing venv (symlinks `.venv` → PATH so `run` / `loopback` pick it up too).
 
 > **Developing against a local build?** Pass `--wheel <path>` (e.g. `camera_viz.sh setup --wheel build/wheels/isaacteleop-*.whl`) to install a locally built wheel instead of the PyPI release. See the [build-from-source guide](../../docs/source/getting_started/build_from_source/index.rst).
 

--- a/examples/camera_viz/camera_viz.sh
+++ b/examples/camera_viz/camera_viz.sh
@@ -374,11 +374,11 @@ cmd_service_restart() {
 # ──────────────────────────────────────────────────────────────────────
 
 show_help() {
-    cat <<EOF
+    cat <<'EOF'
 camera_viz.sh — local development + Jetson deployment for camera_viz
 
 LOCAL
-    setup [--venv PATH] [--sender-only] [--jetson]
+    setup [--venv PATH] [--python PYTHON] [--sender-only] [--jetson]
           [--no-v4l2] [--no-oakd] [--no-rtp] [--with-zed]
                           Create .venv, install Python deps via uv into
                           the venv, build native codec. Python deps stay
@@ -393,6 +393,9 @@ LOCAL
                           PATH instead of creating one in-place.
                           examples/camera_viz/.venv is symlinked → PATH
                           so run / loopback pick it up too.
+                          --python PYTHON selects a supported interpreter
+                          (3.10-3.13, executable name, or path). Defaults
+                          to the local python3 when it is supported.
                           --sender-only skips isaacteleop + vulkan deps
                           (use on Jetson sender hosts).
                           --jetson adds JetPack-only checks: unversioned

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -28,7 +28,8 @@ fi
 
 MODE=full
 VENV_DIR="$CAMERA_VIZ_DIR/.venv"
-PYTHON_VERSION=3.12
+PYTHON_SPEC=
+PYTHON_VERSION=
 WHEEL=
 WITH_V4L2=true
 WITH_OAKD=true
@@ -47,7 +48,7 @@ while (( $# )); do
         --jetson)       JETSON=true; shift;;
         --venv)         VENV_DIR=$2; shift 2;;
         --wheel)        WHEEL=$2; shift 2;;
-        --python)       PYTHON_VERSION=$2; shift 2;;
+        --python)       PYTHON_SPEC=$2; shift 2;;
         --no-v4l2)      WITH_V4L2=false; shift;;
         --no-oakd)      WITH_OAKD=false; shift;;
         --no-rtp)       WITH_RTP=false; shift;;
@@ -56,6 +57,85 @@ while (( $# )); do
         *) echo "_install_deps.sh: unknown arg: $1" >&2; exit 1;;
     esac
 done
+
+is_supported_python_version() {
+    case "$1" in
+        3.10|3.11|3.12|3.13) return 0;;
+        *) return 1;;
+    esac
+}
+
+python_version_from_exe() {
+    "$1" -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null
+}
+
+resolve_python() {
+    local version=""
+    local exe=""
+
+    # Re-running setup should respect the venv that is already on disk.
+    if [[ -x "$VENV_DIR/bin/python" ]]; then
+        version="$(python_version_from_exe "$VENV_DIR/bin/python" || true)"
+        if is_supported_python_version "$version"; then
+            PYTHON_SPEC="$VENV_DIR/bin/python"
+            PYTHON_VERSION="$version"
+            return 0
+        fi
+        echo "_install_deps.sh: existing venv uses unsupported Python $version; remove $VENV_DIR and re-run." >&2
+        exit 1
+    fi
+
+    if [[ -n "$PYTHON_SPEC" ]]; then
+        case "$PYTHON_SPEC" in
+            3.10|3.11|3.12|3.13)
+                exe="$(command -v "python$PYTHON_SPEC" || true)"
+                if [[ -x "$exe" ]]; then
+                    PYTHON_SPEC="$exe"
+                fi
+                PYTHON_VERSION="${PYTHON_SPEC##*python}"
+                is_supported_python_version "$PYTHON_VERSION" || PYTHON_VERSION="$PYTHON_SPEC"
+                ;;
+            *)
+                if [[ "$PYTHON_SPEC" == */* ]]; then
+                    exe="$PYTHON_SPEC"
+                else
+                    exe="$(command -v "$PYTHON_SPEC" || true)"
+                fi
+                if [[ -x "$exe" ]]; then
+                    version="$(python_version_from_exe "$exe" || true)"
+                    if is_supported_python_version "$version"; then
+                        PYTHON_SPEC="$exe"
+                        PYTHON_VERSION="$version"
+                    fi
+                fi
+                ;;
+        esac
+        if ! is_supported_python_version "$PYTHON_VERSION"; then
+            echo "_install_deps.sh: --python must resolve to Python 3.10, 3.11, 3.12, or 3.13 (got '$PYTHON_SPEC')." >&2
+            exit 1
+        fi
+        return 0
+    fi
+
+    # Prefer the distro/system Python when it is already in camera_viz's
+    # supported range. This keeps Ubuntu 22.04 / JetPack 6 on Python 3.10
+    # instead of asking apt for unavailable python3.12-dev packages.
+    for candidate in python3 python3.13 python3.12 python3.11 python3.10; do
+        exe="$(command -v "$candidate" || true)"
+        [[ -x "$exe" ]] || continue
+        version="$(python_version_from_exe "$exe" || true)"
+        if is_supported_python_version "$version"; then
+            PYTHON_SPEC="$exe"
+            PYTHON_VERSION="$version"
+            return 0
+        fi
+    done
+
+    # Last resort: let uv provision a managed interpreter.
+    PYTHON_SPEC=3.12
+    PYTHON_VERSION=3.12
+}
+resolve_python
 
 # major picks the cupy wheel (cupy-cuda12x / cupy-cuda13x).
 # major.minor picks the apt nvrtc package (cuda-nvrtc-12-6 on Orin/JP6,
@@ -312,7 +392,7 @@ fi
 
 echo "==> mode:   $MODE"
 echo "==> venv:   $VENV_DIR"
-echo "==> python: $PYTHON_VERSION"
+echo "==> python: $PYTHON_SPEC ($PYTHON_VERSION)"
 [[ "$MODE" == full ]] && echo "==> isaacteleop: $ISAACTELEOP_PKG"
 
 if [[ ! -d "$VENV_DIR" ]]; then
@@ -329,7 +409,7 @@ if [[ ! -d "$VENV_DIR" ]]; then
         }
         uv venv "$VENV_DIR" --python "$sys_py"
     else
-        uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
+        uv venv "$VENV_DIR" --python "$PYTHON_SPEC"
     fi
 fi
 PY="$VENV_DIR/bin/python"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->
Test in Orin with python3.10 only.

## Checklist

- [ ] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting a specific supported Python interpreter during camera visualization setup.
  - Setup can now use an existing virtual environment and automatically connect it for subsequent commands.
  - Python selection supports versions 3.10–3.13 by executable name or path, with automatic detection when no interpreter is specified.

- **Documentation**
  - Updated setup instructions and command help to describe the new Python and virtual environment options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->