### PR TITLE
docs: drop outdated aarch64 nlopt source-build instructions.

### DIFF
--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -275,48 +275,6 @@ The wheels are built in the ``./install/wheels/`` directory. Install the package
 Using ``pip``, you need to pass the ``--no-index`` option to automatically find the right wheel
 based on the Python version.  Note that ``pip`` and ``uv pip`` has slightly different options.
 
-.. _aarch64-nlopt-wheel:
-
-.. note::
-   **ARM64 / aarch64 systems only** (e.g. NVIDIA DGX Spark): PyPI does not publish pre-built
-   ``nlopt`` wheels for ARM64, so pip cannot satisfy the ``retargeters`` extra automatically.
-   Build an ``nlopt`` wheel from source before running the install commands below
-   (see `issue #452 <https://github.com/NVIDIA/IsaacTeleop/issues/452>`_):
-
-   .. code-block:: bash
-
-      # Install build tools
-      sudo apt-get install -y build-essential cmake git pkg-config swig
-
-      # Clone nlopt-python and build a wheel
-      git clone --depth 1 --branch 2.10.0 https://github.com/DanielBok/nlopt-python.git /tmp/nlopt-python
-      cd /tmp/nlopt-python
-      git submodule update --init --recursive
-
-      # The Python version must match your isaacteleop install exactly (3.10, 3.11, 3.12, or 3.13).
-      # nlopt builds a CPython ABI-specific extension (.cpython-311-*.so), so a wheel built
-      # with Python 3.11 will not load under Python 3.12 or vice versa.
-      uv venv --python=3.11 /tmp/nlopt-wheel-venv
-      VIRTUAL_ENV=/tmp/nlopt-wheel-venv uv pip install numpy setuptools wheel
-      /tmp/nlopt-wheel-venv/bin/python setup.py bdist_wheel -d /tmp/nlopt-wheels/
-
-   Then pass ``--find-links=/tmp/nlopt-wheels/`` when installing so the locally-built wheel is
-   used instead of attempting a PyPI download:
-
-   .. code-block:: bash
-
-      # pip
-      pip install "isaacteleop[retargeters,cloudxr,ui]" \
-          --find-links=./install/wheels/ \
-          --find-links=/tmp/nlopt-wheels/ \
-          --no-index --force-reinstall
-
-      # uv pip
-      uv pip install "isaacteleop[retargeters,cloudxr,ui]" \
-          --find-links=./install/wheels/ \
-          --find-links=/tmp/nlopt-wheels/ \
-          --reinstall
-
 .. code-block:: bash
 
    # Pass --no-index to use only wheels in ./install/wheels/;

--- a/docs/source/getting_started/lerobot/data_collection_real.rst
+++ b/docs/source/getting_started/lerobot/data_collection_real.rst
@@ -23,8 +23,8 @@ Follow the necessary one-time steps to set up your environment and hardware:
 #. The example dependencies installed from a LeRobot source checkout. The LeRobot extras cover the
    SO-101 motor bus (``feetech``), the IK solver for the XR path (``kinematics``), and dataset
    recording (``dataset``). For Isaac Teleop, ``cloudxr`` brings the CloudXR runtime bindings and
-   ``retargeters-lite`` is the default retargeter path (it resolves on both x86_64 and aarch64; the
-   full ``retargeters`` extra is optional and x86_64-only):
+   ``retargeters-lite`` is the default retargeter path on both x86_64 and aarch64; the full
+   ``retargeters`` extra is optional:
 
    .. code-block:: bash
 

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -81,20 +81,6 @@ from PyPI (or from a local wheel if you built from source):
 Instead of installing the package from PyPI, you can build from source and install the local wheel.
 See :doc:`build_from_source/index` for more details.
 
-.. dropdown:: ARM64 / aarch64 only (e.g. NVIDIA DGX Spark)
-
-   PyPI does not publish pre-built ``nlopt`` wheels for ARM64, so the ``retargeters`` extra cannot
-   be installed directly from PyPI
-   (see `issue #452 <https://github.com/NVIDIA/IsaacTeleop/issues/452>`_). Follow the
-   :ref:`aarch64 nlopt wheel build steps <aarch64-nlopt-wheel>` from the build-from-source guide
-   first, then install ``isaacteleop`` with an additional ``--find-links``:
-
-   .. code-block:: bash
-
-      pip install 'isaacteleop[cloudxr,retargeters]~=1.0.0' \
-          --extra-index-url https://pypi.nvidia.com \
-          --find-links=/tmp/nlopt-wheels/
-
 .. _run-cloudxr-server:
 
 3. Configure CloudXR (optional)


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

PyPI now publishes Linux aarch64 nlopt wheels, so ARM64 installs no longer need a local wheel build.

Fixes #800

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Simplified build-from-source installation instructions with clearer wheel-only and reinstall commands.
  - Removed outdated ARM64-specific `nlopt` build and installation workarounds.
  - Clarified that `retargeters-lite` is the default option across supported architectures, while full retargeters are optional.
  - Streamlined the quick-start guide by removing obsolete ARM64 installation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->