### PR TITLE
docs: clarify that body tracking requires Pico 4 Ultra Enterprise

### DIFF
--- a/docs/source/device/body_tracking.rst
+++ b/docs/source/device/body_tracking.rst
@@ -15,13 +15,14 @@ and the BD skeleton format used on the server.
 
 .. important::
 
-   Full body tracking requires a
+   Full body tracking requires PICO's **enterprise features**. They are
+   available out of the box on the
    `PICO 4 Ultra Enterprise <https://www.picoxr.com/global/products/pico4-ultra-enterprise>`_
-   headset. PICO exposes body tracking to WebXR **only on the Enterprise
-   edition**: on the consumer PICO 4 Ultra, the browser does not grant the
-   ``body-tracking`` feature and no body data reaches the server, even with
-   Motion Trackers paired and calibrated. This is a PICO platform limitation
-   and cannot be worked around in Isaac Teleop.
+   headset. On a consumer PICO 4 Ultra, the browser does not grant the
+   ``body-tracking`` WebXR feature by default — no body data reaches the
+   server, even with Motion Trackers paired and calibrated. Consumer devices
+   can gain the feature through enterprise activation: contact PICO, then
+   use the **Activate enterprise account** option in the headset settings.
 
 .. note::
 
@@ -195,13 +196,13 @@ joint ``is_valid`` flags to determine which joints have valid poses.
 Troubleshooting
 ~~~~~~~~~~~~~~~
 
-- **Body tracking cannot be enabled on a consumer PICO 4 Ultra.** PICO has
-  not released WebXR body tracking for the consumer edition; it is only
-  available on the PICO 4 Ultra Enterprise. There is no setting or firmware
-  update that enables it on consumer devices.
-- **No body tracking data arrives on the server.** Confirm the headset is a
-  PICO 4 Ultra **Enterprise** (see above). Verify all PICO motion trackers
-  are paired, powered on, and calibrated. Confirm the PICO browser is up to
+- **Body tracking does not work on a consumer PICO 4 Ultra.** WebXR body
+  tracking is an enterprise feature; consumer devices do not enable it by
+  default. Contact PICO about enterprise activation, then use the
+  **Activate enterprise account** option in the headset settings.
+- **No body tracking data arrives on the server.** Confirm the headset has
+  enterprise features (see above). Verify all PICO motion trackers are
+  paired, powered on, and calibrated. Confirm the PICO browser is up to
   date.
 - **Some joints report** ``is_valid: false``. The PICO runtime may
   temporarily lose tracking for individual joints during fast movement or

--- a/docs/source/device/body_tracking.rst
+++ b/docs/source/device/body_tracking.rst
@@ -9,9 +9,19 @@ through the CloudXR WebXR client to the teleop server. The server exposes the
 body skeleton to applications through the ``FullBodyTrackerPico`` tracker and
 the OpenXR ``XR_BD_body_tracking`` extension.
 
-Body tracking support currently targets the **PICO 4 Ultra** with
+Body tracking support currently targets the **PICO 4 Ultra Enterprise** with
 **PICO Motion Trackers**. The rest of this guide covers PICO hardware setup
 and the BD skeleton format used on the server.
+
+.. important::
+
+   Full body tracking requires a
+   `PICO 4 Ultra Enterprise <https://www.picoxr.com/global/products/pico4-ultra-enterprise>`_
+   headset. PICO exposes body tracking to WebXR **only on the Enterprise
+   edition**: on the consumer PICO 4 Ultra, the browser does not grant the
+   ``body-tracking`` feature and no body data reaches the server, even with
+   Motion Trackers paired and calibrated. This is a PICO platform limitation
+   and cannot be worked around in Isaac Teleop.
 
 .. note::
 
@@ -30,8 +40,9 @@ Setting Up PICO Motion Trackers
 
 Full body tracking uses
 `PICO Motion Trackers <https://www.picoxr.com/global/products/pico-motion-tracker>`_
-paired with a PICO 4 Ultra headset. Make sure the PICO browser is updated to a
-version that supports body tracking. The following configurations are supported:
+paired with a PICO 4 Ultra Enterprise headset. Make sure the PICO browser is
+updated to a version that supports body tracking. The following configurations
+are supported:
 
 - **5 trackers:** best tracking quality across all 24 joints.
   Two wear modes are available: 2 ankles + 2 wrists + 1 waist, or 2 ankles +
@@ -184,9 +195,14 @@ joint ``is_valid`` flags to determine which joints have valid poses.
 Troubleshooting
 ~~~~~~~~~~~~~~~
 
-- **No body tracking data arrives on the server.** Verify all PICO motion
-  trackers are paired, powered on, and calibrated. Confirm the PICO browser
-  is up to date.
+- **Body tracking cannot be enabled on a consumer PICO 4 Ultra.** PICO has
+  not released WebXR body tracking for the consumer edition; it is only
+  available on the PICO 4 Ultra Enterprise. There is no setting or firmware
+  update that enables it on consumer devices.
+- **No body tracking data arrives on the server.** Confirm the headset is a
+  PICO 4 Ultra **Enterprise** (see above). Verify all PICO motion trackers
+  are paired, powered on, and calibrated. Confirm the PICO browser is up to
+  date.
 - **Some joints report** ``is_valid: false``. The PICO runtime may
   temporarily lose tracking for individual joints during fast movement or
   partial occlusion. These joints will recover automatically once tracking is

--- a/docs/source/overview/ecosystem.rst
+++ b/docs/source/overview/ecosystem.rst
@@ -65,8 +65,9 @@ see :ref:`device-interface-device-plugin` for details.
    * - `Pico Motion Tracker`_
      - Full body tracking
      - `Isaac Teleop Web Client`_ (browser)
-     - | Requires a `Pico 4 Ultra Enterprise`_ headset —
-       | **not supported on the consumer Pico 4 Ultra**
+     - | Requires a `Pico 4 Ultra Enterprise`_ headset,
+       | or a consumer Pico 4 Ultra with **enterprise**
+       | **features activated** (contact PICO)
        | Requires Pico OS 15.4.4U or newer
        | Requires Pico Browser 4.0.40 or newer
 

--- a/docs/source/overview/ecosystem.rst
+++ b/docs/source/overview/ecosystem.rst
@@ -65,8 +65,10 @@ see :ref:`device-interface-device-plugin` for details.
    * - `Pico Motion Tracker`_
      - Full body tracking
      - `Isaac Teleop Web Client`_ (browser)
-     - | Requires Pico OS 15.4.4U or newer
-       | Requires Pico Browser 4.0.40 or newer (Enterprise enabled)
+     - | Requires a `Pico 4 Ultra Enterprise`_ headset —
+       | **not supported on the consumer Pico 4 Ultra**
+       | Requires Pico OS 15.4.4U or newer
+       | Requires Pico Browser 4.0.40 or newer
 
 In addition to the fully integrated XR headsets, Isaac Teleop also supports standalone input
 devices. Those devices are typically directly connected to the workstation where the Isaac Teleop
@@ -165,7 +167,7 @@ directly. Each device name in the tables above links to the corresponding manufa
      - Meta Quest 2/3/3S
      -
    * - `Pico`_ (ByteDance)
-     - Pico 4 Ultra, Pico Motion Tracker
+     - Pico 4 Ultra, Pico 4 Ultra Enterprise, Pico Motion Tracker
      - | Veronica Li
        | Email: Veronica.li@bytedance.com
        | Mobile: +1 (909) 569-2774
@@ -246,6 +248,7 @@ WeChat app** (Discover → Scan) to join. Scanning with your phone's built-in ca
 .. _`Apple Vision Pro`: https://www.apple.com/apple-vision-pro/
 .. _`Meta Quest 2/3/3S`: https://www.meta.com/quest/
 .. _`Pico 4 Ultra`: https://www.picoxr.com/products/pico4-ultra
+.. _`Pico 4 Ultra Enterprise`: https://www.picoxr.com/global/products/pico4-ultra-enterprise
 .. _`Pico Motion Tracker`: https://www.picoxr.com/global/products/pico-motion-tracker
 .. _`MANUS Gloves`: https://www.manus-meta.com/robotics#nvidia
 .. _`Logitech Rudder Pedals`: https://www.logitechg.com/en-us/products/flight/flight-simulator-rudder-pedals.html


### PR DESCRIPTION
Fixes #789

PICO ships WebXR body tracking as an **enterprise feature**: it works out of the box on the **Pico 4 Ultra Enterprise**, while a consumer Pico 4 Ultra does not grant the `body-tracking` WebXR feature by default — even with Motion Trackers paired. Consumer devices can gain it through enterprise activation (contact PICO, then **Activate enterprise account** in the headset settings). Our docs only hinted at this via a `(Enterprise enabled)` parenthetical on the browser-version requirement, which the reporter of #789 (reasonably) missed.

## Changes

**`overview/ecosystem.rst`** (the page linked from the issue)
- The Pico Motion Tracker row now leads with the headset requirement: a Pico 4 Ultra Enterprise (linked to the product page), or a consumer Pico 4 Ultra with enterprise features activated (contact PICO). The ambiguous `(Enterprise enabled)` parenthetical is gone.
- The Pico acquisition-contact row now lists the Enterprise edition.

**`device/body_tracking.rst`**
- New `important` admonition at the top of the page stating the enterprise-feature requirement and the activation path for consumer devices.
- The setup section and page intro now name the Enterprise edition explicitly.
- New troubleshooting entry for body tracking not working on a consumer PICO 4 Ultra (with the activation path), and the no-data entry now starts with checking for enterprise features.

Docs build clean with Sphinx (no new warnings); the Enterprise product page URL was verified live.