### PR TITLE
feat(cloudxr): add optional experimental runtime packaging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,9 @@ option(ENABLE_EXPERIMENTAL_WINDOWS_BUILD "Enable experimental Windows build supp
 # TODO: Make this default to ON for Linux builds when the CloudXR runtime SDK is publicly available.
 option(ENABLE_CLOUDXR_BUNDLE_CHECK "Enable CloudXR bundle check" OFF)
 
+# When ON, also package CloudXR Experimental Runtime SDK as isaacteleop.cloudxr_exp.
+option(ENABLE_CLOUDXR_EXP_BUNDLE "Also package CloudXR Experimental Runtime SDK as isaacteleop.cloudxr_exp" OFF)
+
 ## Enforce clang-format on Linux builds by default
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(_clang_default ON)

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -82,10 +82,13 @@ Pre-download CloudXR SDK (Optional)
    :code-file:`download_cloudxr_runtime_sdk.sh <scripts/download_cloudxr_runtime_sdk.sh>`
    script.
 
-Sometimes NVIDIA might share early access CloudXR SDKs with you. In that case, you may get one of
-the two tarballs:
+Sometimes NVIDIA might share early access CloudXR SDKs with you. In that case, you may get
+tarballs such as:
 
 - ``CloudXR-<version-for-runtime-sdk>-Linux-<arch>-sdk.tar.gz`` (CloudXR Runtime SDK)
+- ``CloudXR-exp-<version-for-runtime-sdk>-Linux-<arch>-sdk.tar.gz`` (optional experimental
+  runtime). Needed for Jetson Orin support (for example :doc:`/getting_started/televiz`)
+  until the default runtime covers those platforms.
 - ``nvidia-cloudxr-<version-for-web-sdk>.tgz`` (CloudXR Web SDK)
 
 You can place them in the :code-file:`deps/cloudxr/` directory and update the ``deps/cloudxr/.env``
@@ -96,6 +99,10 @@ like this:
 
    CXR_RUNTIME_SDK_VERSION=<version-for-runtime-sdk>
    CXR_WEB_SDK_VERSION=<version-for-web-sdk>
+
+To package the experimental runtime into the wheel as ``isaacteleop.cloudxr_exp``, configure with
+``-DENABLE_CLOUDXR_EXP_BUNDLE=ON``. Select it at runtime with ``ISAAC_TELEOP_CLOUDXR_EXP``.
+See :ref:`dedicated-cloudxr-runtime`.
 
 2. CMake: Configure and build
 -----------------------------

--- a/docs/source/references/cloudxr.rst
+++ b/docs/source/references/cloudxr.rst
@@ -133,7 +133,7 @@ uses the running runtime instead of starting another one:
 Configuration
 -------------
 
-The standalone launcher accepts the same configuration flags as the embedded
+The standalone launcher accepts the same configuration options as the embedded
 one:
 
 - ``--cloudxr-env-config <PATH>`` — a ``KEY=value`` env file of CloudXR
@@ -142,6 +142,12 @@ one:
   environment variables.
 - ``--cloudxr-install-dir <PATH>`` — CloudXR install directory
   (default: ``~/.cloudxr``).
+- ``ISAAC_TELEOP_CLOUDXR_EXP=1`` — use the experimental CloudXR runtime
+  (``isaacteleop.cloudxr_exp``). That package is for Jetson Orin support (for
+  example :doc:`/getting_started/televiz`) until the default runtime covers those
+  platforms. On Tegra T234 it is selected automatically; if the package is
+  missing the launcher fails. Set ``ISAAC_TELEOP_CLOUDXR_EXP=0`` to force the
+  stable runtime.
 
 To inspect the active settings after startup:
 

--- a/scripts/download_cloudxr_runtime_sdk.sh
+++ b/scripts/download_cloudxr_runtime_sdk.sh
@@ -11,6 +11,7 @@
 # 1) Local tarball: place CloudXR-<VERSION>-Linux-<ARCH>-sdk.tar.gz in deps/cloudxr/.
 # 2) Public NGC: downloads via curl from the public NGC resource API.
 # 3) Private NGC: downloads via curl from the private NGC resource API; requires NGC_API_KEY.
+# Optional: set CXR_DOWNLOAD_EXP=1 to also download CloudXR-exp-<VERSION>-....
 
 set -Eeuo pipefail
 
@@ -53,29 +54,57 @@ case "$(uname -m)" in
 esac
 
 SDK_FILE="CloudXR-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
-SDK_DIR="CloudXR-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk"
-SDK_RELEASE_DIR="$CXR_DEPLOYMENT_DIR/$SDK_DIR"
+EXP_SDK_FILE="CloudXR-exp-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
 
 is_valid_sdk_bundle() {
     local dir="$1"
-    [[ -f "$dir/$SDK_FILE" ]]
-}
-
-# Returns 0 if the given directory has valid SDK layout (contains libcloudxr.so).
-is_valid_sdk_layout() {
-    local dir="$1"
-    [[ -d "$dir" ]] && [[ -f "$dir/libcloudxr.so" ]]
+    [[ -f "$dir/$SDK_FILE" ]] || return 1
+    if [[ "${CXR_DOWNLOAD_EXP:-0}" == "1" ]]; then
+        [[ -f "$dir/$EXP_SDK_FILE" ]] || return 1
+    fi
+    return 0
 }
 
 # -----------------------------------------------------------------------------
 # Local tarball: place $SDK_FILE in deps/cloudxr/
 # -----------------------------------------------------------------------------
 install_from_local_tarball() {
-    if [[ ! -f "$CXR_DEPLOYMENT_DIR/$SDK_FILE" ]]; then
+    if ! is_valid_sdk_bundle "$CXR_DEPLOYMENT_DIR"; then
         return 1
     fi
     echo -e "${GREEN}✓ CloudXR Runtime SDK found at $CXR_DEPLOYMENT_DIR/$SDK_FILE${NC}"
+    if [[ "${CXR_DOWNLOAD_EXP:-0}" == "1" ]]; then
+        echo -e "${GREEN}✓ CloudXR Experimental Runtime SDK found at $CXR_DEPLOYMENT_DIR/$EXP_SDK_FILE${NC}"
+    fi
     return 0
+}
+
+# -----------------------------------------------------------------------------
+# NGC download helper
+# -----------------------------------------------------------------------------
+download_ngc_file() {
+    local url="$1"
+    local out_path="$2"
+    local label="$3"
+    local auth_bearer="${4:-}"
+
+    [[ -s "$out_path" ]] && return 0
+
+    echo -e "${YELLOW}Downloading ${label}...${NC}"
+    local -a curl_args=(--fail --location --output "$out_path")
+    if [[ -n "$auth_bearer" ]]; then
+        curl_args+=(-H "Authorization: Bearer ${auth_bearer}" -H "Content-Type: application/json")
+    fi
+    if ! curl "${curl_args[@]}" "$url"; then
+        echo -e "${RED}Error: Failed to download ${label}${NC}"
+        rm -f "$out_path"
+        return 1
+    fi
+    if [[ ! -s "$out_path" ]]; then
+        echo -e "${RED}Error: Downloaded ${label} is empty${NC}"
+        rm -f "$out_path"
+        return 1
+    fi
 }
 
 # -----------------------------------------------------------------------------
@@ -83,8 +112,6 @@ install_from_local_tarball() {
 # Resource: nvidia/cloudxr-runtime-for-isaac-teleop/${CXR_RUNTIME_SDK_VERSION}
 # -----------------------------------------------------------------------------
 install_from_public_ngc() {
-    local NGC_URL="https://api.ngc.nvidia.com/v2/resources/org/nvidia/cloudxr-runtime-for-isaac-teleop/${CXR_RUNTIME_SDK_VERSION}/files?redirect=true&path=${SDK_FILE}"
-
     if ! command -v curl &> /dev/null; then
         echo -e "${RED}Error: curl not found. Please install it first.${NC}"
         echo -e "To use a local SDK instead, place $SDK_FILE in deps/cloudxr/"
@@ -98,13 +125,16 @@ install_from_public_ngc() {
 
     mkdir -p "$CXR_DEPLOYMENT_DIR"
 
-    echo -e "${YELLOW}Downloading CloudXR Runtime SDK from NGC...${NC}"
-    if ! curl --fail --location \
-        --output "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
-        "$NGC_URL"; then
-        echo -e "${RED}Error: Failed to download CloudXR Runtime SDK from NGC${NC}"
-        rm -f "$CXR_DEPLOYMENT_DIR/$SDK_FILE"
-        return 1
+    local base="https://api.ngc.nvidia.com/v2/resources/org/nvidia/cloudxr-runtime-for-isaac-teleop/${CXR_RUNTIME_SDK_VERSION}/files?redirect=true&path="
+    download_ngc_file \
+        "${base}${SDK_FILE}" \
+        "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
+        "CloudXR Runtime SDK" || return 1
+    if [[ "${CXR_DOWNLOAD_EXP:-0}" == "1" ]]; then
+        download_ngc_file \
+            "${base}${EXP_SDK_FILE}" \
+            "$CXR_DEPLOYMENT_DIR/$EXP_SDK_FILE" \
+            "CloudXR Experimental Runtime SDK" || return 1
     fi
 
     echo -e "${GREEN}✓ CloudXR Runtime SDK installed successfully${NC}"
@@ -115,14 +145,16 @@ install_from_public_ngc() {
 # Private NGC: download via curl from the private NGC resource API
 # Resource: 0566138804516934/cloudxr-dev/cloudxr-runtime-binary:${VERSION}-public
 # Requires NGC_API_KEY for Bearer-token auth.
+# Optional: CXR_RUNTIME_NGC_SUFFIX is appended to CXR_RUNTIME_SDK_VERSION (default: -public).
 # -----------------------------------------------------------------------------
 install_from_private_ngc() {
     local NGC_ORG="0566138804516934"
     local NGC_TEAM="cloudxr-dev"
     local NGC_RESOURCE="cloudxr-runtime-binary"
-    local NGC_VERSION="${CXR_RUNTIME_SDK_VERSION}-public"
+    local NGC_VERSION="${CXR_RUNTIME_SDK_VERSION}${CXR_RUNTIME_NGC_SUFFIX:--public}"
     local NGC_SDK_FILE="CloudXR-external-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
-    local NGC_URL="https://api.ngc.nvidia.com/v2/org/${NGC_ORG}/team/${NGC_TEAM}/resources/${NGC_RESOURCE}/versions/${NGC_VERSION}/files/${NGC_SDK_FILE}"
+    local NGC_EXP_SDK_FILE="CloudXR-exp-external-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
+    local base="https://api.ngc.nvidia.com/v2/org/${NGC_ORG}/team/${NGC_TEAM}/resources/${NGC_RESOURCE}/versions/${NGC_VERSION}/files"
 
     if [[ -z "${NGC_API_KEY:-}" ]]; then
         echo -e "${RED}Error: NGC_API_KEY is not set; cannot download from private NGC${NC}"
@@ -141,15 +173,17 @@ install_from_private_ngc() {
 
     mkdir -p "$CXR_DEPLOYMENT_DIR"
 
-    echo -e "${YELLOW}Downloading CloudXR Runtime SDK from private NGC...${NC}"
-    if ! curl --fail --location \
-        -H "Authorization: Bearer $NGC_API_KEY" \
-        -H "Content-Type: application/json" \
-        --output "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
-        "$NGC_URL"; then
-        echo -e "${RED}Error: Failed to download CloudXR Runtime SDK from private NGC${NC}"
-        rm -f "$CXR_DEPLOYMENT_DIR/$SDK_FILE"
-        return 1
+    download_ngc_file \
+        "${base}/${NGC_SDK_FILE}" \
+        "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
+        "CloudXR Runtime SDK" \
+        "$NGC_API_KEY" || return 1
+    if [[ "${CXR_DOWNLOAD_EXP:-0}" == "1" ]]; then
+        download_ngc_file \
+            "${base}/${NGC_EXP_SDK_FILE}" \
+            "$CXR_DEPLOYMENT_DIR/$EXP_SDK_FILE" \
+            "CloudXR Experimental Runtime SDK" \
+            "$NGC_API_KEY" || return 1
     fi
 
     echo -e "${GREEN}✓ CloudXR Runtime SDK installed successfully${NC}"
@@ -160,22 +194,6 @@ install_from_private_ngc() {
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
-
-# Check if SDK is already downloaded and extracted
-if ([[ -d "$SDK_RELEASE_DIR" ]] && is_valid_sdk_layout "$SDK_RELEASE_DIR") || \
-    (is_valid_sdk_bundle "$CXR_DEPLOYMENT_DIR"); then
-    echo -e "${GREEN}CloudXR Runtime SDK already present, skipping download${NC}"
-    exit 0
-fi
-
-# Error out if the target directory already exists
-if [[ -d "$SDK_RELEASE_DIR" ]]; then
-    echo -e "${RED}Error downloading CloudXR Runtime SDK:${NC}"
-    echo -e "${RED}  Target directory $SDK_RELEASE_DIR already exists,${NC}"
-    echo -e "${RED}  but does not contain the expected files.${NC}"
-    echo -e "${RED}  Please remove the directory and try again.${NC}"
-    exit 1
-fi
 
 # Prefer local tarball if present; otherwise use NGC
 if install_from_local_tarball; then

--- a/src/core/cloudxr/python/CMakeLists.txt
+++ b/src/core/cloudxr/python/CMakeLists.txt
@@ -5,7 +5,7 @@
 set(CLOUDXR_PYTHON_DIR "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>/isaacteleop/cloudxr")
 
 # Look for CloudXR Runtime SDK tarball: version from deps/cloudxr/.env.default (CXR_RUNTIME_SDK_VERSION)
-# (e.g. CloudXR-6.1.0-rc2-Linux-amd64-sdk.tar.gz)
+# (e.g. CloudXR-6.1.0-rc2-Linux-amd64-sdk.tar.gz). Overridable via CXR_RUNTIME_SDK_VERSION in the environment.
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64")
     set(CLOUDXR_CPU_ARCH "amd64")
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|arm64")
@@ -27,19 +27,34 @@ if(CMAKE_MATCH_1)
 else()
     message(FATAL_ERROR "No valid CXR_RUNTIME_SDK_VERSION found in deps/cloudxr/.env.default.")
 endif()
+if(DEFINED ENV{CXR_RUNTIME_SDK_VERSION} AND NOT "$ENV{CXR_RUNTIME_SDK_VERSION}" STREQUAL "")
+    set(CXR_RUNTIME_SDK_VERSION "$ENV{CXR_RUNTIME_SDK_VERSION}")
+endif()
 
 set(CLOUDXR_SDK_FILE "CloudXR-${CXR_RUNTIME_SDK_VERSION}-Linux-${CLOUDXR_CPU_ARCH}-sdk.tar.gz")
 set(CLOUDXR_SDK_PATH "${CMAKE_SOURCE_DIR}/deps/cloudxr/${CLOUDXR_SDK_FILE}")
-if(NOT EXISTS "${CLOUDXR_SDK_PATH}")
+set(CLOUDXR_SDK_EXP_FILE
+    "CloudXR-exp-${CXR_RUNTIME_SDK_VERSION}-Linux-${CLOUDXR_CPU_ARCH}-sdk.tar.gz")
+set(CLOUDXR_SDK_EXP_PATH "${CMAKE_SOURCE_DIR}/deps/cloudxr/${CLOUDXR_SDK_EXP_FILE}")
+if(NOT EXISTS "${CLOUDXR_SDK_PATH}" OR
+   (ENABLE_CLOUDXR_EXP_BUNDLE AND NOT EXISTS "${CLOUDXR_SDK_EXP_PATH}"))
     set(DOWNLOAD_SCRIPT "${CMAKE_SOURCE_DIR}/scripts/download_cloudxr_runtime_sdk.sh")
     if(NOT EXISTS "${DOWNLOAD_SCRIPT}")
         message(FATAL_ERROR "download_cloudxr_runtime_sdk.sh not found: ${DOWNLOAD_SCRIPT}")
     endif()
 
+    if(ENABLE_CLOUDXR_EXP_BUNDLE)
+        set(_cloudxr_download_exp "1")
+    else()
+        set(_cloudxr_download_exp "0")
+    endif()
     message(STATUS "CloudXR SDK tarball not found; running ${DOWNLOAD_SCRIPT} (CXR_RUNTIME_SDK_VERSION=${CXR_RUNTIME_SDK_VERSION})")
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E env
             "CXR_RUNTIME_SDK_VERSION=${CXR_RUNTIME_SDK_VERSION}"
+            "CXR_RUNTIME_NGC_SUFFIX=$ENV{CXR_RUNTIME_NGC_SUFFIX}"
+            "CXR_DOWNLOAD_EXP=${_cloudxr_download_exp}"
+            "NGC_API_KEY=$ENV{NGC_API_KEY}"
             /bin/bash "${DOWNLOAD_SCRIPT}"
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         RESULT_VARIABLE DOWNLOAD_EXIT_CODE
@@ -52,17 +67,48 @@ if(NOT EXISTS "${CLOUDXR_SDK_PATH}")
         message(STATUS "CloudXR SDK tarball download failed with exit code: ${DOWNLOAD_EXIT_CODE}")
         message(STATUS "stdout:\n${DOWNLOAD_OUT}")
         message(STATUS "stderr:\n${DOWNLOAD_ERR}")
-        set(CLOUDXR_SDK_PATH "")
+        if(NOT EXISTS "${CLOUDXR_SDK_PATH}")
+            set(CLOUDXR_SDK_PATH "")
+        endif()
     endif()
 endif()
 
-set(CLOUDXR_NATIVE_AVAILABLE FALSE)
 # Always create native dir for uniform package structure, even if the SDK tarball is not available
 set(CLOUDXR_NATIVE_DIR "${CLOUDXR_PYTHON_DIR}/native")
-add_custom_target(cloudxr_native_dir ALL
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${CLOUDXR_NATIVE_DIR}"
-    COMMENT "Creating python_package/.../cloudxr/native/"
-)
+
+# Package a CloudXR runtime SDK tarball into out_dir (core libs only).
+find_program(PATCHELF_EXECUTABLE patchelf)
+function(cloudxr_add_runtime_bundle dir_target bundle_target patchelf_target out_dir sdk_tarball)
+    add_custom_target(${dir_target} ALL
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${out_dir}"
+        COMMENT "Creating ${out_dir}"
+    )
+    add_custom_target(${bundle_target} ALL
+        COMMAND ${CMAKE_COMMAND} -E tar xzf "${sdk_tarball}"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${out_dir}/include"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${out_dir}/plugins"
+        WORKING_DIRECTORY "${out_dir}"
+        COMMENT "Extracting CloudXR SDK into ${out_dir} (no plugins)"
+    )
+    add_dependencies(${bundle_target} ${dir_target})
+    # libcloudxr.so carries a NEEDED entry for libssl.so.3 even though it never
+    # calls OpenSSL. Loading it from Python pulls in a second, incompatible
+    # libssl.so.3 and NVST crashes. Strip that dependency at build time.
+    # A future SDK built with -Wl,--as-needed will make this unnecessary.
+    if(PATCHELF_EXECUTABLE)
+        add_custom_target(${patchelf_target} ALL
+            COMMAND ${PATCHELF_EXECUTABLE} --remove-needed libssl.so.3
+                    "${out_dir}/libcloudxr.so"
+            COMMENT "Stripping spurious libssl.so.3 dependency from ${out_dir}/libcloudxr.so"
+        )
+        add_dependencies(${patchelf_target} ${bundle_target})
+    else()
+        message(WARNING "patchelf not found; ${out_dir}/libcloudxr.so will retain its "
+                        "libssl.so.3 dependency. Install patchelf to avoid OpenSSL "
+                        "symbol conflicts.")
+    endif()
+endfunction()
+
 if(NOT EXISTS "${CLOUDXR_SDK_PATH}")
     set(error_message "CloudXR SDK tarball is required. Place ${CLOUDXR_SDK_FILE} in "
                       "deps/cloudxr/ or run scripts/download_cloudxr_runtime_sdk.sh.")
@@ -71,33 +117,32 @@ if(NOT EXISTS "${CLOUDXR_SDK_PATH}")
     else()
         message(WARNING "${error_message} Skipping cloudxr_native_bundle.")
     endif()
-else()
-    set(CLOUDXR_NATIVE_AVAILABLE TRUE)
-    add_custom_target(cloudxr_native_bundle ALL
-        COMMAND ${CMAKE_COMMAND} -E tar xzf "${CLOUDXR_SDK_PATH}"
-        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLOUDXR_NATIVE_DIR}/include"
-        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLOUDXR_NATIVE_DIR}/plugins"
-        WORKING_DIRECTORY "${CLOUDXR_NATIVE_DIR}"
-        COMMENT "Extracting CloudXR SDK tarball and keeping runtime core files (no plugins) in python_package/.../cloudxr/native/"
+    add_custom_target(cloudxr_native_dir ALL
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CLOUDXR_NATIVE_DIR}"
+        COMMENT "Creating python_package/.../cloudxr/native/"
     )
-    add_dependencies(cloudxr_native_bundle cloudxr_native_dir)
+else()
+    cloudxr_add_runtime_bundle(
+        cloudxr_native_dir cloudxr_native_bundle cloudxr_patchelf
+        "${CLOUDXR_NATIVE_DIR}" "${CLOUDXR_SDK_PATH}")
+endif()
 
-    # libcloudxr.so in the SDK tarball carries a NEEDED entry for libssl.so.3 even
-    # though it never calls any OpenSSL functions. When Python (which bundles its own
-    # OpenSSL) loads libcloudxr.so, the loader pulls in a second, incompatible
-    # libssl.so.3 and NVST crashes. Strip the spurious dependency at build time.
-    # A future SDK built with -Wl,--as-needed will make this step unnecessary.
-    find_program(PATCHELF_EXECUTABLE patchelf)
-    if(PATCHELF_EXECUTABLE)
-        add_custom_target(cloudxr_patchelf ALL
-            COMMAND ${PATCHELF_EXECUTABLE} --remove-needed libssl.so.3
-                    "${CLOUDXR_NATIVE_DIR}/libcloudxr.so"
-            COMMENT "Stripping spurious libssl.so.3 dependency from libcloudxr.so"
-        )
-        add_dependencies(cloudxr_patchelf cloudxr_native_bundle)
+if(ENABLE_CLOUDXR_EXP_BUNDLE)
+    if(NOT EXISTS "${CLOUDXR_SDK_EXP_PATH}")
+        set(exp_error_message
+            "CloudXR Experimental Runtime SDK tarball is required. Place ${CLOUDXR_SDK_EXP_FILE} in "
+            "deps/cloudxr/, or set NGC_API_KEY and update CXR_RUNTIME_SDK_VERSION to a version that publishes it.")
+        if(ENABLE_CLOUDXR_BUNDLE_CHECK)
+            message(FATAL_ERROR "${exp_error_message}")
+        else()
+            message(WARNING "${exp_error_message} Skipping cloudxr_exp_bundle.")
+        endif()
     else()
-        message(WARNING "patchelf not found; libcloudxr.so will retain its libssl.so.3 "
-                        "dependency. Install patchelf to avoid OpenSSL symbol conflicts.")
+        set(CLOUDXR_EXP_DIR
+            "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>/isaacteleop/cloudxr_exp")
+        cloudxr_add_runtime_bundle(
+            cloudxr_exp_dir cloudxr_exp_bundle cloudxr_patchelf_exp
+            "${CLOUDXR_EXP_DIR}/native" "${CLOUDXR_SDK_EXP_PATH}")
     endif()
 endif()
 
@@ -118,12 +163,31 @@ add_custom_target(cloudxr_python ALL
     COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLOUDXR_PYTHON_DIR}/__pycache__"
     COMMENT "Copying cloudxr Python files to package structure"
 )
-if(CLOUDXR_NATIVE_AVAILABLE)
-    if(PATCHELF_EXECUTABLE)
-        add_dependencies(cloudxr_python cloudxr_patchelf)
-    else()
-        add_dependencies(cloudxr_python cloudxr_native_bundle)
-    endif()
-else()
+if(TARGET cloudxr_patchelf)
+    add_dependencies(cloudxr_python cloudxr_patchelf)
+elseif(TARGET cloudxr_native_bundle)
+    add_dependencies(cloudxr_python cloudxr_native_bundle)
+elseif(TARGET cloudxr_native_dir)
     add_dependencies(cloudxr_python cloudxr_native_dir)
+endif()
+if(TARGET cloudxr_patchelf_exp)
+    add_dependencies(cloudxr_python cloudxr_patchelf_exp)
+elseif(TARGET cloudxr_exp_bundle)
+    add_dependencies(cloudxr_python cloudxr_exp_bundle)
+endif()
+
+# Python modules for isaacteleop.cloudxr_exp (natives staged above when enabled).
+if(TARGET cloudxr_exp_dir)
+    add_custom_command(TARGET cloudxr_python POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CLOUDXR_EXP_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy
+            "${CMAKE_CURRENT_SOURCE_DIR}/exp_init.py"
+            "${CLOUDXR_EXP_DIR}/__init__.py"
+        COMMAND ${CMAKE_COMMAND} -E copy
+            "${CMAKE_CURRENT_SOURCE_DIR}/runtime.py"
+            "${CMAKE_CURRENT_SOURCE_DIR}/env_config.py"
+            "${CLOUDXR_EXP_DIR}/"
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CLOUDXR_EXP_DIR}/__pycache__"
+        COMMENT "Copying cloudxr_exp Python files to package structure"
+    )
 endif()

--- a/src/core/cloudxr/python/exp_init.py
+++ b/src/core/cloudxr/python/exp_init.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental CloudXR runtime (``isaacteleop.cloudxr_exp``)."""

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -28,6 +28,8 @@ from .env_config import EnvConfig
 from .runtime import (
     RUNTIME_STARTUP_TIMEOUT_SEC,
     RUNTIME_TERMINATE_TIMEOUT_SEC,
+    get_sdk_path,
+    resolve_cloudxr_runtime_module,
     check_eula,
     wait_for_runtime_ready_sync,
 )
@@ -39,7 +41,7 @@ DEFAULT_DEVICE_PROFILE = "Quest3"
 _RUNTIME_WORKER_CODE = """\
 import sys, os
 sys.path = [p for p in sys.path if p]
-from isaacteleop.cloudxr.runtime import run
+from {runtime_mod}.runtime import run
 run()
 """
 
@@ -174,9 +176,11 @@ class CloudXRLauncher:
         # LD_PRELOAD the bundled libraries so every OpenSSL symbol in the worker
         # resolves to the version libNvStreamServer.so was built against.
         worker_env = os.environ.copy()
-        native_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "native")
+        runtime_mod = resolve_cloudxr_runtime_module()
+        sdk_dir = get_sdk_path()
+        logger.info("CloudXR Runtime: module=%s sdk_path=%s", runtime_mod, sdk_dir)
         bundled_ssl = [
-            os.path.join(native_dir, lib)
+            os.path.join(sdk_dir, lib)
             for lib in ("libcrypto_nvst.so.3", "libssl_nvst.so.3")
         ]
         if all(os.path.isfile(lib) for lib in bundled_ssl):
@@ -185,7 +189,11 @@ class CloudXRLauncher:
             worker_env["LD_PRELOAD"] = f"{preload} {prev}" if prev else preload
 
         self._runtime_proc = subprocess.Popen(
-            [sys.executable, "-c", _RUNTIME_WORKER_CODE],
+            [
+                sys.executable,
+                "-c",
+                _RUNTIME_WORKER_CODE.format(runtime_mod=runtime_mod),
+            ],
             env=worker_env,
             stderr=subprocess.PIPE,
             start_new_session=True,

--- a/src/core/cloudxr/python/runtime.py
+++ b/src/core/cloudxr/python/runtime.py
@@ -3,6 +3,8 @@
 import asyncio
 import ctypes
 import glob
+import importlib
+import importlib.util
 import multiprocessing
 import os
 import shutil
@@ -11,6 +13,7 @@ import sys
 import threading
 import time
 from collections.abc import Callable
+from pathlib import Path
 
 from .env_config import get_env_config
 
@@ -27,6 +30,72 @@ RUNTIME_TERMINATE_TIMEOUT_SEC: float = 10
 
 RUNTIME_POLL_INTERVAL_SEC: float = 0.5
 """Polling interval [s] used by :func:`wait_for_runtime_ready_sync`."""
+
+_CLOUDXR_EXP_ENV = "ISAAC_TELEOP_CLOUDXR_EXP"
+_CLOUDXR_MODULE = "isaacteleop.cloudxr"
+_CLOUDXR_EXP_MODULE = "isaacteleop.cloudxr_exp"
+
+
+def _is_tegra_t234() -> bool:
+    """Return True on Jetson Orin-class platforms (T234 / CHIPID 0x23)."""
+    boot = Path("/etc/nv_boot_control.conf")
+    if boot.is_file():
+        try:
+            text = boot.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            text = ""
+        for line in text.splitlines():
+            key, _, value = line.partition("=")
+            if key.strip() == "TEGRA_CHIPID" and value.strip() == "0x23":
+                return True
+
+    compatible = Path("/proc/device-tree/compatible")
+    if compatible.is_file():
+        try:
+            data = compatible.read_bytes().decode("utf-8", errors="ignore")
+        except OSError:
+            data = ""
+        if "tegra234" in data:
+            return True
+    return False
+
+
+def _should_use_exp() -> bool:
+    """Return True when the experimental CloudXR runtime should be used."""
+    raw = os.environ.get(_CLOUDXR_EXP_ENV, "").strip().lower()
+    if not raw:
+        return _is_tegra_t234()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _is_exp_available() -> bool:
+    try:
+        return importlib.util.find_spec(f"{_CLOUDXR_EXP_MODULE}.runtime") is not None
+    except ModuleNotFoundError:
+        return False
+
+
+def resolve_cloudxr_runtime_module() -> str:
+    """Return the module prefix whose ``runtime.run`` should be spawned."""
+    if _should_use_exp():
+        if not _is_exp_available():
+            raise RuntimeError(
+                f"Experimental CloudXR runtime package {_CLOUDXR_EXP_MODULE} is not installed. "
+                f"Rebuild with -DENABLE_CLOUDXR_EXP_BUNDLE=ON to include it, "
+                f"or set {_CLOUDXR_EXP_ENV}=0 to force the stable runtime."
+            )
+        return _CLOUDXR_EXP_MODULE
+    return _CLOUDXR_MODULE
+
+
+def get_sdk_path() -> str:
+    """Return ``native/`` for the resolved stable or experimental runtime package."""
+    mod = resolve_cloudxr_runtime_module()
+    pkg = importlib.import_module(mod)
+    sdk_dir = os.path.join(os.path.dirname(os.path.abspath(pkg.__file__)), "native")
+    if not os.path.isfile(os.path.join(sdk_dir, "libcloudxr.so")):
+        raise RuntimeError(f"CloudXR SDK missing libcloudxr.so at {sdk_dir}.")
+    return sdk_dir
 
 
 def _write_eula_marker(marker: str) -> None:
@@ -63,17 +132,6 @@ def check_eula(*, accept_eula: bool | None = None) -> None:
         sys.exit(1)
 
     _write_eula_marker(marker)
-
-
-def _get_sdk_path() -> str | None:
-    """Return the path to the bundled CloudXR native libs (wheel package data), or None."""
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    native_dir = os.path.join(this_dir, "native")
-
-    if not os.path.isfile(os.path.join(native_dir, "libcloudxr.so")):
-        raise RuntimeError(f"CloudXR SDK missing libcloudxr.so at {native_dir}. ")
-
-    return native_dir
 
 
 async def wait_for_runtime_ready(
@@ -152,8 +210,8 @@ def _load_libcloudxr(sdk_path: str) -> ctypes.CDLL:
 
 
 def runtime_version() -> str:
-    """Query the CloudXR runtime version from the native library (major.minor.patch)."""
-    sdk_path = _get_sdk_path()
+    """Query the selected CloudXR runtime version (major.minor.patch)."""
+    sdk_path = get_sdk_path()
     lib = _load_libcloudxr(sdk_path)
     if not hasattr(lib, "nv_cxr_get_runtime_version"):
         return "unknown"
@@ -209,7 +267,7 @@ def _setup_openxr_dir(sdk_path: str, run_dir: str) -> str:
 def run() -> None:
     """Run the CloudXR runtime service until SIGINT/SIGTERM. Blocks until shutdown."""
     cfg = get_env_config()
-    sdk_path = _get_sdk_path()
+    sdk_path = get_sdk_path()
     run_dir = cfg.openxr_run_dir()
     openxr_dir = _setup_openxr_dir(sdk_path, run_dir)
 

--- a/src/core/cloudxr_tests/python/test_runtime.py
+++ b/src/core/cloudxr_tests/python/test_runtime.py
@@ -12,6 +12,9 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from isaacteleop.cloudxr.runtime import (
+    _should_use_exp,
+    get_sdk_path,
+    resolve_cloudxr_runtime_module,
     terminate_or_kill_runtime,
     wait_for_runtime_ready_sync,
 )
@@ -30,6 +33,131 @@ class _FakeEnvConfig:
 
     def openxr_run_dir(self) -> str:
         return self._run_dir
+
+
+# ============================================================================
+# TestShouldUseExp / resolve / get_sdk_path
+# ============================================================================
+
+
+class TestShouldUseExp:
+    """Tests for ISAAC_TELEOP_CLOUDXR_EXP selection."""
+
+    def test_default_is_false_off_tegra(self, monkeypatch):
+        monkeypatch.delenv("ISAAC_TELEOP_CLOUDXR_EXP", raising=False)
+        monkeypatch.setattr("isaacteleop.cloudxr.runtime._is_tegra_t234", lambda: False)
+        assert _should_use_exp() is False
+
+    def test_auto_true_on_t234(self, monkeypatch):
+        monkeypatch.delenv("ISAAC_TELEOP_CLOUDXR_EXP", raising=False)
+        monkeypatch.setattr("isaacteleop.cloudxr.runtime._is_tegra_t234", lambda: True)
+        assert _should_use_exp() is True
+
+    def test_accepts_truthy(self, monkeypatch):
+        monkeypatch.setenv("ISAAC_TELEOP_CLOUDXR_EXP", "1")
+        assert _should_use_exp() is True
+        monkeypatch.setenv("ISAAC_TELEOP_CLOUDXR_EXP", "true")
+        assert _should_use_exp() is True
+
+    def test_rejects_falsy_even_on_t234(self, monkeypatch):
+        monkeypatch.setattr("isaacteleop.cloudxr.runtime._is_tegra_t234", lambda: True)
+        monkeypatch.setenv("ISAAC_TELEOP_CLOUDXR_EXP", "0")
+        assert _should_use_exp() is False
+        monkeypatch.setenv("ISAAC_TELEOP_CLOUDXR_EXP", "false")
+        assert _should_use_exp() is False
+
+
+class TestResolveCloudxrRuntimeModule:
+    """Tests for stable vs cloudxr_exp module selection."""
+
+    def test_stable_when_exp_not_wanted(self, monkeypatch):
+        monkeypatch.delenv("ISAAC_TELEOP_CLOUDXR_EXP", raising=False)
+        monkeypatch.setattr("isaacteleop.cloudxr.runtime._is_tegra_t234", lambda: False)
+        assert resolve_cloudxr_runtime_module() == "isaacteleop.cloudxr"
+
+    def test_exp_when_available(self, monkeypatch):
+        monkeypatch.setenv("ISAAC_TELEOP_CLOUDXR_EXP", "1")
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.runtime._is_exp_available", lambda: True
+        )
+        assert resolve_cloudxr_runtime_module() == "isaacteleop.cloudxr_exp"
+
+    def test_explicit_exp_missing_raises(self, monkeypatch):
+        monkeypatch.setenv("ISAAC_TELEOP_CLOUDXR_EXP", "1")
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.runtime._is_exp_available", lambda: False
+        )
+        with pytest.raises(RuntimeError, match="cloudxr_exp|ENABLE_CLOUDXR_EXP"):
+            resolve_cloudxr_runtime_module()
+
+    def test_is_exp_available_handles_missing_parent(self, monkeypatch):
+        def _boom(_name: str):
+            raise ModuleNotFoundError("isaacteleop.cloudxr_exp")
+
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.runtime.importlib.util.find_spec", _boom
+        )
+        from isaacteleop.cloudxr.runtime import _is_exp_available
+
+        assert _is_exp_available() is False
+
+    def test_auto_t234_missing_raises(self, monkeypatch):
+        monkeypatch.delenv("ISAAC_TELEOP_CLOUDXR_EXP", raising=False)
+        monkeypatch.setattr("isaacteleop.cloudxr.runtime._is_tegra_t234", lambda: True)
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.runtime._is_exp_available", lambda: False
+        )
+        with pytest.raises(RuntimeError, match="cloudxr_exp|ENABLE_CLOUDXR_EXP"):
+            resolve_cloudxr_runtime_module()
+
+
+class TestGetSdkPath:
+    """Tests for selected-package native/ resolution."""
+
+    def test_uses_resolved_package_native(self, tmp_path, monkeypatch):
+        native = tmp_path / "native"
+        native.mkdir()
+        (native / "libcloudxr.so").write_bytes(b"")
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.runtime.resolve_cloudxr_runtime_module",
+            lambda: "isaacteleop.cloudxr",
+        )
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.__file__", str(tmp_path / "__init__.py")
+        )
+        assert get_sdk_path() == str(native)
+
+    def test_missing_raises(self, tmp_path, monkeypatch):
+        (tmp_path / "native").mkdir()
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.runtime.resolve_cloudxr_runtime_module",
+            lambda: "isaacteleop.cloudxr",
+        )
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.__file__", str(tmp_path / "__init__.py")
+        )
+        with pytest.raises(RuntimeError, match="libcloudxr.so"):
+            get_sdk_path()
+
+    def test_follows_exp_selection(self, monkeypatch):
+        fake_pkg = MagicMock()
+        fake_pkg.__file__ = "/fake/cloudxr_exp/__init__.py"
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.runtime.resolve_cloudxr_runtime_module",
+            lambda: "isaacteleop.cloudxr_exp",
+        )
+
+        def _import_module(name: str):
+            if name == "isaacteleop.cloudxr_exp":
+                return fake_pkg
+            raise AssertionError(f"unexpected import: {name}")
+
+        monkeypatch.setattr(
+            "isaacteleop.cloudxr.runtime.importlib.import_module",
+            _import_module,
+        )
+        monkeypatch.setattr(os.path, "isfile", lambda p: p.endswith("libcloudxr.so"))
+        assert get_sdk_path() == "/fake/cloudxr_exp/native"
 
 
 # ============================================================================

--- a/src/core/python/CMakeLists.txt
+++ b/src/core/python/CMakeLists.txt
@@ -24,6 +24,17 @@ else()
     set(VIZ_PACKAGE_DATA_BLOCK "")
 endif()
 
+# isaacteleop.cloudxr_exp when ENABLE_CLOUDXR_EXP_BUNDLE=ON.
+if(ENABLE_CLOUDXR_EXP_BUNDLE)
+    set(CLOUDXR_EXP_PACKAGES_BLOCK
+        "    \"isaacteleop.cloudxr_exp\",\n")
+    set(CLOUDXR_EXP_PACKAGE_DATA_BLOCK
+        "\"isaacteleop.cloudxr_exp\" = [\"native/*.so\", \"native/*.so.*\", \"native/openxr_cloudxr.json\"]\n")
+else()
+    set(CLOUDXR_EXP_PACKAGES_BLOCK "")
+    set(CLOUDXR_EXP_PACKAGE_DATA_BLOCK "")
+endif()
+
 set(ROBOTIC_GROUNDING_SRC "${CMAKE_SOURCE_DIR}/deps/v2d/src/robotic_grounding")
 if(BUNDLE_ROBOTIC_GROUNDING)
     if(NOT EXISTS "${ROBOTIC_GROUNDING_SRC}/__init__.py")

--- a/src/core/python/pyproject.toml.in
+++ b/src/core/python/pyproject.toml.in
@@ -57,7 +57,10 @@ packages = [
     "isaacteleop.cloudxr",
     "isaacteleop.rig",
     "isaacteleop.haptic_devices",
-@VIZ_PACKAGES_BLOCK@@ROBOTIC_GROUNDING_PACKAGES_BLOCK@]
+@CLOUDXR_EXP_PACKAGES_BLOCK@
+@VIZ_PACKAGES_BLOCK@
+@ROBOTIC_GROUNDING_PACKAGES_BLOCK@
+]
 include-package-data = false
 
 [tool.setuptools.package-data]
@@ -71,7 +74,9 @@ isaacteleop = ["*.so", "*.pyd", "*.pyi", "py.typed"]
 "isaacteleop.schema" = ["*.so", "*.pyd", "*.pyi"]
 "isaacteleop.cloudxr" = ["native/*.so", "native/*.so.*", "native/openxr_cloudxr.json"]
 "isaacteleop.haptic_devices" = ["*.so", "*.pyd", "*.pyi"]
-@VIZ_PACKAGE_DATA_BLOCK@@ROBOTIC_GROUNDING_PACKAGE_DATA_BLOCK@
+@CLOUDXR_EXP_PACKAGE_DATA_BLOCK@
+@VIZ_PACKAGE_DATA_BLOCK@
+@ROBOTIC_GROUNDING_PACKAGE_DATA_BLOCK@
 
 [tool.uv]
 # Only use managed Python installations (not system Python)


### PR DESCRIPTION
## Description

Opt-in packaging for a sibling experimental CloudXR runtime package
(`isaacteleop.cloudxr_exp` with its own `native/`) in the same wheel as the
default `isaacteleop.cloudxr` bundle.

- CMake: `-DENABLE_CLOUDXR_EXP_BUNDLE=ON` (default OFF) downloads/packages the
  exp tarball when available; `ENABLE_CLOUDXR_BUNDLE_CHECK` still owns hard-fail
  vs warn for missing artifacts.
- Runtime: `ISAAC_TELEOP_CLOUDXR_EXP` selects stable vs exp via
  `resolve_cloudxr_runtime_module()` / `get_sdk_path()` (used by
  `CloudXRLauncher`). On Tegra T234, exp is preferred automatically when the
  env is unset; missing exp fails (set `ISAAC_TELEOP_CLOUDXR_EXP=0` to force
  stable). Explicit `ISAAC_TELEOP_CLOUDXR_EXP=1` also fails if exp is not in
  the wheel.
- Docs: CloudXR reference covers runtime selection; build-from-source covers
  the cmake/tarball side (including Orin / TeleViz motivation for exp).

Public CI remains stable-only (flag stays OFF). Layout is ready for a later
dedicated-wheel split if needed.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- Unit: `test_runtime.py` (selection helpers, `resolve_cloudxr_runtime_module`,
  `get_sdk_path`).
- Local dual-bundle smoke:
  - `CXR_RUNTIME_SDK_VERSION=222d1f93 cmake -B build -DENABLE_CLOUDXR_EXP_BUNDLE=ON`
  - Installed `cp311` wheel; `ISAAC_TELEOP_CLOUDXR_EXP=0` →
    `…/cloudxr/native` (StreamSDK `gcomp/rel/gs_04_86`);
    `ISAAC_TELEOP_CLOUDXR_EXP=1` → `…/cloudxr_exp/native` (StreamSDK
    `gcomp/dev`); both report CloudXR `6.3.0` via `runtime_version()` in
    separate processes.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional support for packaging and using an experimental CloudXR runtime bundle.
  * Added environment-based runtime selection between standard and experimental CloudXR libraries.
  * Improved CloudXR SDK download support, including optional experimental releases.

* **Documentation**
  * Added setup and usage instructions for downloading, packaging, and selecting the experimental runtime.

* **Tests**
  * Added coverage for experimental runtime selection and missing-library handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->