### PR TITLE
fix(mcap-examples): added launcher arguments for 1.4+local

### DIFF
--- a/examples/mcap_record_replay/python/common.py
+++ b/examples/mcap_record_replay/python/common.py
@@ -12,9 +12,14 @@ Viz classes (used by replay_* and live_* scripts): ``HandViz``,
 Rendering helpers: ``HandJoints``, ``HAND_BONES``, ``BODY_BONES``.
 """
 
+import argparse
+import contextlib
+import os
+
 import numpy as np
 import viser
 
+from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.retargeting_engine.deviceio_source_nodes import (
     ControllersSource,
     FullBodySource,
@@ -49,6 +54,68 @@ from isaacteleop.retargeting_engine.tensor_types.ndarray_types import (
 
 
 _ZERO_POSITIONS = np.zeros((NUM_HAND_JOINTS, 3), dtype=np.float32)
+
+
+# ---------------------------------------------------------------------------
+# CloudXR launcher helpers shared across record / live scripts
+# ---------------------------------------------------------------------------
+
+
+def add_cloudxr_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register CloudXR launcher arguments on ``parser``.
+
+    Adds ``--launch-cloudxr-runtime`` (default: true) and
+    ``--no-launch-cloudxr-runtime`` to skip launching when a CloudXR instance
+    is already running (e.g. from GR00T-WholeBodyControl).  Also registers
+    ``--accept-eula`` and ``--cloudxr-install-dir`` for when the launcher is
+    active.  Source the CloudXR env file before running without the launcher::
+
+        source ~/.cloudxr/run/cloudxr.env
+    """
+    parser.add_argument(
+        "--launch-cloudxr-runtime",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Launch the CloudXR runtime and WSS proxy before connecting "
+            "(default: true). Pass --no-launch-cloudxr-runtime to connect "
+            "to an already-running instance (source ~/.cloudxr/run/cloudxr.env first)."
+        ),
+    )
+    parser.add_argument(
+        "--accept-eula",
+        action="store_true",
+        help="Accept the NVIDIA CloudXR EULA non-interactively (required on first launch).",
+    )
+    parser.add_argument(
+        "--cloudxr-install-dir",
+        default=os.path.expanduser("~/.cloudxr"),
+        metavar="PATH",
+        help="CloudXR install directory (default: ~/.cloudxr).",
+    )
+
+
+def cloudxr_launch_context(
+    args: argparse.Namespace,
+) -> contextlib.AbstractContextManager:
+    """Return a context manager that launches CloudXR or is a no-op.
+
+    When ``args.launch_cloudxr_runtime`` is true (the default), returns a
+    :class:`~isaacteleop.cloudxr.CloudXRLauncher` context manager that starts
+    the runtime and WSS proxy.  When false, returns
+    :func:`contextlib.nullcontext` so the caller can always write::
+
+        with cloudxr_launch_context(args) as launcher:
+            if launcher is not None:
+                print(f"WSS log: {launcher.wss_log_path}")
+            ...
+    """
+    if not args.launch_cloudxr_runtime:
+        return contextlib.nullcontext(None)
+    return CloudXRLauncher(
+        install_dir=args.cloudxr_install_dir,
+        accept_eula=args.accept_eula,
+    )
 
 
 HANDS_CHANNEL = "hands"

--- a/examples/mcap_record_replay/python/common.py
+++ b/examples/mcap_record_replay/python/common.py
@@ -44,7 +44,7 @@ from isaacteleop.retargeting_engine.tensor_types import (
     HandInputIndex,
 )
 from isaacteleop.retargeting_engine.tensor_types.indices import (
-    BodyJointIndex,
+    BodyJointPicoIndex as BodyJointIndex,
     ControllerInputIndex,
 )
 from isaacteleop.retargeting_engine.tensor_types.ndarray_types import (

--- a/examples/mcap_record_replay/python/common.py
+++ b/examples/mcap_record_replay/python/common.py
@@ -43,10 +43,14 @@ from isaacteleop.retargeting_engine.tensor_types import (
     HandInput,
     HandInputIndex,
 )
-from isaacteleop.retargeting_engine.tensor_types.indices import (
-    BodyJointPicoIndex as BodyJointIndex,
-    ControllerInputIndex,
-)
+from isaacteleop.retargeting_engine.tensor_types.indices import ControllerInputIndex
+
+try:
+    from isaacteleop.retargeting_engine.tensor_types.indices import BodyJointIndex
+except ImportError:
+    from isaacteleop.retargeting_engine.tensor_types.indices import (  # type: ignore[no-redef]
+        BodyJointPicoIndex as BodyJointIndex,
+    )
 from isaacteleop.retargeting_engine.tensor_types.ndarray_types import (
     DLDataType,
     NDArrayType,

--- a/examples/mcap_record_replay/python/live_controller.py
+++ b/examples/mcap_record_replay/python/live_controller.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 
@@ -30,7 +29,9 @@ from common import (
     ControllerViz,
     LEFT_COLOR,
     RIGHT_COLOR,
+    add_cloudxr_arguments,
     build_controller_pipeline,
+    cloudxr_launch_context,
     controller_state,
 )
 
@@ -43,6 +44,7 @@ def main(argv: list[str]) -> int:
         help="Viser HTTP bind address (default: 127.0.0.1; pass 0.0.0.0 to expose externally)",
     )
     parser.add_argument("--port", type=int, default=8080, help="Viser HTTP port")
+    add_cloudxr_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -54,8 +56,9 @@ def main(argv: list[str]) -> int:
         pipeline=build_controller_pipeline(),
     )
 
-    with contextlib.nullcontext(None):
-        print("[live] connecting to existing CloudXR instance")
+    with cloudxr_launch_context(args) as launcher:
+        if launcher is not None:
+            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/live_controller.py
+++ b/examples/mcap_record_replay/python/live_controller.py
@@ -18,12 +18,12 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
+import contextlib
 import sys
 import time
 
 import viser
 
-from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
 from common import (
@@ -43,7 +43,6 @@ def main(argv: list[str]) -> int:
         help="Viser HTTP bind address (default: 127.0.0.1; pass 0.0.0.0 to expose externally)",
     )
     parser.add_argument("--port", type=int, default=8080, help="Viser HTTP port")
-    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -55,9 +54,8 @@ def main(argv: list[str]) -> int:
         pipeline=build_controller_pipeline(),
     )
 
-    with CloudXRLauncher.launch_context(args) as launcher:
-        if launcher is not None:
-            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+    with contextlib.nullcontext(None):
+        print("[live] connecting to existing CloudXR instance")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/live_full_body.py
+++ b/examples/mcap_record_replay/python/live_full_body.py
@@ -18,13 +18,13 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
+import contextlib
 import sys
 import time
 
 import numpy as np
 import viser
 
-from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.retargeting_engine.tensor_types.indices import FullBodyInputIndex
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
@@ -39,7 +39,6 @@ def main(argv: list[str]) -> int:
         help="Viser HTTP bind address (default: 127.0.0.1; pass 0.0.0.0 to expose externally)",
     )
     parser.add_argument("--port", type=int, default=8080, help="Viser HTTP port")
-    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -51,9 +50,8 @@ def main(argv: list[str]) -> int:
         pipeline=build_full_body_pipeline(),
     )
 
-    with CloudXRLauncher.launch_context(args) as launcher:
-        if launcher is not None:
-            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+    with contextlib.nullcontext(None):
+        print("[live] connecting to existing CloudXR instance")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/live_full_body.py
+++ b/examples/mcap_record_replay/python/live_full_body.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 
@@ -28,7 +27,13 @@ import viser
 from isaacteleop.retargeting_engine.tensor_types.indices import FullBodyInputIndex
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
-from common import BODY_JOINT_NAMES, FullBodyViz, build_full_body_pipeline
+from common import (
+    BODY_JOINT_NAMES,
+    FullBodyViz,
+    add_cloudxr_arguments,
+    build_full_body_pipeline,
+    cloudxr_launch_context,
+)
 
 
 def main(argv: list[str]) -> int:
@@ -39,6 +44,7 @@ def main(argv: list[str]) -> int:
         help="Viser HTTP bind address (default: 127.0.0.1; pass 0.0.0.0 to expose externally)",
     )
     parser.add_argument("--port", type=int, default=8080, help="Viser HTTP port")
+    add_cloudxr_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -50,8 +56,9 @@ def main(argv: list[str]) -> int:
         pipeline=build_full_body_pipeline(),
     )
 
-    with contextlib.nullcontext(None):
-        print("[live] connecting to existing CloudXR instance")
+    with cloudxr_launch_context(args) as launcher:
+        if launcher is not None:
+            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/live_hand.py
+++ b/examples/mcap_record_replay/python/live_hand.py
@@ -17,13 +17,13 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
+import contextlib
 import sys
 import time
 
 import numpy as np
 import viser
 
-from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
 from common import HandViz, LEFT_COLOR, RIGHT_COLOR, build_hand_pipeline
@@ -37,7 +37,6 @@ def main(argv: list[str]) -> int:
         help="Viser HTTP bind address (default: 127.0.0.1; pass 0.0.0.0 to expose externally)",
     )
     parser.add_argument("--port", type=int, default=8080, help="Viser HTTP port")
-    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -49,9 +48,8 @@ def main(argv: list[str]) -> int:
         pipeline=build_hand_pipeline(),
     )
 
-    with CloudXRLauncher.launch_context(args) as launcher:
-        if launcher is not None:
-            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+    with contextlib.nullcontext(None):
+        print("[live] connecting to existing CloudXR instance")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/live_hand.py
+++ b/examples/mcap_record_replay/python/live_hand.py
@@ -17,7 +17,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 
@@ -26,7 +25,14 @@ import viser
 
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
-from common import HandViz, LEFT_COLOR, RIGHT_COLOR, build_hand_pipeline
+from common import (
+    HandViz,
+    LEFT_COLOR,
+    RIGHT_COLOR,
+    add_cloudxr_arguments,
+    build_hand_pipeline,
+    cloudxr_launch_context,
+)
 
 
 def main(argv: list[str]) -> int:
@@ -37,6 +43,7 @@ def main(argv: list[str]) -> int:
         help="Viser HTTP bind address (default: 127.0.0.1; pass 0.0.0.0 to expose externally)",
     )
     parser.add_argument("--port", type=int, default=8080, help="Viser HTTP port")
+    add_cloudxr_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     server = viser.ViserServer(host=args.host, port=args.port)
@@ -48,8 +55,9 @@ def main(argv: list[str]) -> int:
         pipeline=build_hand_pipeline(),
     )
 
-    with contextlib.nullcontext(None):
-        print("[live] connecting to existing CloudXR instance")
+    with cloudxr_launch_context(args) as launcher:
+        if launcher is not None:
+            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/record_controller.py
+++ b/examples/mcap_record_replay/python/record_controller.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from datetime import datetime
@@ -28,7 +27,11 @@ from isaacteleop.deviceio import McapRecordingConfig
 from isaacteleop.retargeting_engine.tensor_types.indices import ControllerInputIndex
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
-from common import build_controller_pipeline
+from common import (
+    add_cloudxr_arguments,
+    build_controller_pipeline,
+    cloudxr_launch_context,
+)
 
 
 def main(argv: list[str]) -> int:
@@ -37,6 +40,7 @@ def main(argv: list[str]) -> int:
         "duration", nargs="?", type=float, default=5.0, help="Recording duration (s)"
     )
     parser.add_argument("output", nargs="?", help="Output .mcap path")
+    add_cloudxr_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -50,7 +54,6 @@ def main(argv: list[str]) -> int:
         mcap_path = out_dir / f"controllers_{datetime.now():%Y%m%d_%H%M%S}.mcap"
 
     print(f"[record] writing {mcap_path} for {duration_s:.1f}s")
-    print("[record] connecting to existing CloudXR instance")
 
     config = TeleopSessionConfig(
         app_name="McapControllerRecordExample",
@@ -58,7 +61,11 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    with contextlib.nullcontext(None):
+    with cloudxr_launch_context(args) as launcher:
+        if launcher is not None:
+            print(
+                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
+            )
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:

--- a/examples/mcap_record_replay/python/record_controller.py
+++ b/examples/mcap_record_replay/python/record_controller.py
@@ -18,12 +18,12 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
+import contextlib
 import sys
 import time
 from datetime import datetime
 from pathlib import Path
 
-from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.deviceio import McapRecordingConfig
 from isaacteleop.retargeting_engine.tensor_types.indices import ControllerInputIndex
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
@@ -37,7 +37,6 @@ def main(argv: list[str]) -> int:
         "duration", nargs="?", type=float, default=5.0, help="Recording duration (s)"
     )
     parser.add_argument("output", nargs="?", help="Output .mcap path")
-    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -51,6 +50,7 @@ def main(argv: list[str]) -> int:
         mcap_path = out_dir / f"controllers_{datetime.now():%Y%m%d_%H%M%S}.mcap"
 
     print(f"[record] writing {mcap_path} for {duration_s:.1f}s")
+    print("[record] connecting to existing CloudXR instance")
 
     config = TeleopSessionConfig(
         app_name="McapControllerRecordExample",
@@ -58,11 +58,7 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    with CloudXRLauncher.launch_context(args) as launcher:
-        if launcher is not None:
-            print(
-                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
-            )
+    with contextlib.nullcontext(None):
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:

--- a/examples/mcap_record_replay/python/record_full_body.py
+++ b/examples/mcap_record_replay/python/record_full_body.py
@@ -18,6 +18,7 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
+import contextlib
 import sys
 import time
 from datetime import datetime
@@ -25,7 +26,6 @@ from pathlib import Path
 
 import numpy as np
 
-from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.deviceio import McapRecordingConfig
 from isaacteleop.retargeting_engine.tensor_types.indices import FullBodyInputIndex
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
@@ -39,7 +39,6 @@ def main(argv: list[str]) -> int:
         "duration", nargs="?", type=float, default=5.0, help="Recording duration (s)"
     )
     parser.add_argument("output", nargs="?", help="Output .mcap path")
-    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -53,6 +52,7 @@ def main(argv: list[str]) -> int:
         mcap_path = out_dir / f"full_body_{datetime.now():%Y%m%d_%H%M%S}.mcap"
 
     print(f"[record] writing {mcap_path} for {duration_s:.1f}s")
+    print("[record] connecting to existing CloudXR instance")
 
     config = TeleopSessionConfig(
         app_name="McapFullBodyRecordExample",
@@ -60,11 +60,7 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    with CloudXRLauncher.launch_context(args) as launcher:
-        if launcher is not None:
-            print(
-                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
-            )
+    with contextlib.nullcontext(None):
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:

--- a/examples/mcap_record_replay/python/record_full_body.py
+++ b/examples/mcap_record_replay/python/record_full_body.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from datetime import datetime
@@ -30,7 +29,12 @@ from isaacteleop.deviceio import McapRecordingConfig
 from isaacteleop.retargeting_engine.tensor_types.indices import FullBodyInputIndex
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
-from common import BODY_JOINT_NAMES, build_full_body_pipeline
+from common import (
+    BODY_JOINT_NAMES,
+    add_cloudxr_arguments,
+    build_full_body_pipeline,
+    cloudxr_launch_context,
+)
 
 
 def main(argv: list[str]) -> int:
@@ -39,6 +43,7 @@ def main(argv: list[str]) -> int:
         "duration", nargs="?", type=float, default=5.0, help="Recording duration (s)"
     )
     parser.add_argument("output", nargs="?", help="Output .mcap path")
+    add_cloudxr_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -52,7 +57,6 @@ def main(argv: list[str]) -> int:
         mcap_path = out_dir / f"full_body_{datetime.now():%Y%m%d_%H%M%S}.mcap"
 
     print(f"[record] writing {mcap_path} for {duration_s:.1f}s")
-    print("[record] connecting to existing CloudXR instance")
 
     config = TeleopSessionConfig(
         app_name="McapFullBodyRecordExample",
@@ -60,7 +64,11 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    with contextlib.nullcontext(None):
+    with cloudxr_launch_context(args) as launcher:
+        if launcher is not None:
+            print(
+                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
+            )
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:

--- a/examples/mcap_record_replay/python/record_hand.py
+++ b/examples/mcap_record_replay/python/record_hand.py
@@ -18,12 +18,12 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
+import contextlib
 import sys
 import time
 from datetime import datetime
 from pathlib import Path
 
-from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.deviceio import McapRecordingConfig
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
@@ -36,7 +36,6 @@ def main(argv: list[str]) -> int:
         "duration", nargs="?", type=float, default=5.0, help="Recording duration (s)"
     )
     parser.add_argument("output", nargs="?", help="Output .mcap path")
-    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -50,6 +49,7 @@ def main(argv: list[str]) -> int:
         mcap_path = out_dir / f"hands_{datetime.now():%Y%m%d_%H%M%S}.mcap"
 
     print(f"[record] writing {mcap_path} for {duration_s:.1f}s")
+    print("[record] connecting to existing CloudXR instance")
 
     config = TeleopSessionConfig(
         app_name="McapHandRecordExample",
@@ -57,11 +57,7 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    with CloudXRLauncher.launch_context(args) as launcher:
-        if launcher is not None:
-            print(
-                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
-            )
+    with contextlib.nullcontext(None):
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:

--- a/examples/mcap_record_replay/python/record_hand.py
+++ b/examples/mcap_record_replay/python/record_hand.py
@@ -18,7 +18,6 @@ See: https://nvidia.github.io/IsaacTeleop/main/references/mcap_record_replay.htm
 """
 
 import argparse
-import contextlib
 import sys
 import time
 from datetime import datetime
@@ -27,7 +26,7 @@ from pathlib import Path
 from isaacteleop.deviceio import McapRecordingConfig
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 
-from common import build_hand_pipeline
+from common import add_cloudxr_arguments, build_hand_pipeline, cloudxr_launch_context
 
 
 def main(argv: list[str]) -> int:
@@ -36,6 +35,7 @@ def main(argv: list[str]) -> int:
         "duration", nargs="?", type=float, default=5.0, help="Recording duration (s)"
     )
     parser.add_argument("output", nargs="?", help="Output .mcap path")
+    add_cloudxr_arguments(parser)
     args = parser.parse_args(argv[1:])
 
     duration_s: float = args.duration
@@ -49,7 +49,6 @@ def main(argv: list[str]) -> int:
         mcap_path = out_dir / f"hands_{datetime.now():%Y%m%d_%H%M%S}.mcap"
 
     print(f"[record] writing {mcap_path} for {duration_s:.1f}s")
-    print("[record] connecting to existing CloudXR instance")
 
     config = TeleopSessionConfig(
         app_name="McapHandRecordExample",
@@ -57,7 +56,11 @@ def main(argv: list[str]) -> int:
         mcap_config=McapRecordingConfig(str(mcap_path)),
     )
 
-    with contextlib.nullcontext(None):
+    with cloudxr_launch_context(args) as launcher:
+        if launcher is not None:
+            print(
+                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
+            )
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:


### PR DESCRIPTION
Installed isaacteleop 1.3.9rc1 lacks add_launcher_arguments() and launch_context() added in 1.4+local. Replace CloudXRLauncher usage with contextlib.nullcontext so all six mcap_record_replay example scripts connect to an already-running CloudXR instance instead of trying to launch a new one.

This initial diff also tries to  bypass CloudXRLauncher for existing CloudXR instances. However I DON"T want this to happen all the time. I only want this to happen if the switch is specified: 
  --no-launch-cloudxr-runtime
I plan to repair this before checking in. If you see the hook to the launcher in any of the files feel free to mark it in error. I will get around to fixing it ASAP.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated live visualization and recording examples to connect to an already-running CloudXR instance instead of starting one automatically.
  * Removed CloudXR-specific startup options from these example commands.
  * Existing controller, hand, full-body visualization, and MCAP recording workflows remain available.
  * Added connection status messaging when attaching to CloudXR.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->