### PR TITLE
fix(haptic): read cross-process commands per endpoint

### DIFF
--- a/src/core/deviceio_base/cpp/inc/deviceio_base/haptic_command_reader_tracker_base.hpp
+++ b/src/core/deviceio_base/cpp/inc/deviceio_base/haptic_command_reader_tracker_base.hpp
@@ -5,6 +5,8 @@
 
 #include "tracker.hpp"
 
+#include <string_view>
+
 namespace core
 {
 
@@ -14,7 +16,16 @@ struct HapticCommandTrackedT;
 class IHapticCommandReaderTrackerImpl : public ITrackerImpl
 {
 public:
+    // Latest command across all endpoints. Correct for a single-endpoint device;
+    // for a multi-endpoint device it returns whichever endpoint was pushed last,
+    // so prefer the endpoint overload there. Kept for backward compatibility.
     virtual const HapticCommandTrackedT& get_data() const = 0;
+
+    // Latest command for `endpoint` ("left"/"right"/...); `data` is null until a
+    // sample for that endpoint arrives. Endpoints are tracked independently so
+    // commands pushed for different endpoints on one collection do not clobber
+    // each other.
+    virtual const HapticCommandTrackedT& get_data(std::string_view endpoint) const = 0;
 };
 
 } // namespace core

--- a/src/core/deviceio_trackers/cpp/haptic_command_reader_tracker.cpp
+++ b/src/core/deviceio_trackers/cpp/haptic_command_reader_tracker.cpp
@@ -26,4 +26,10 @@ const HapticCommandTrackedT& HapticCommandReaderTracker::get_data(const ITracker
     return static_cast<const IHapticCommandReaderTrackerImpl&>(session.get_tracker_impl(*this)).get_data();
 }
 
+const HapticCommandTrackedT& HapticCommandReaderTracker::get_data(const ITrackerSession& session,
+                                                                  std::string_view endpoint) const
+{
+    return static_cast<const IHapticCommandReaderTrackerImpl&>(session.get_tracker_impl(*this)).get_data(endpoint);
+}
+
 } // namespace core

--- a/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/haptic_command_reader_tracker.hpp
+++ b/src/core/deviceio_trackers/cpp/inc/deviceio_trackers/haptic_command_reader_tracker.hpp
@@ -14,10 +14,12 @@ namespace core
 {
 
 // Consumer ITracker (plugin side): reads the most-recent HapticCommand
-// FlatBuffer pushed by a TensorPushTracker on the same `collection_id`
-// (the producer encodes a HapticCommand and pushes it under the canonical
-// "haptic_command" tensor identifier). A vendor plugin reuses this directly
-// instead of writing its own SchemaTracker boilerplate.
+// FlatBuffer per endpoint pushed by a TensorPushTracker on the same
+// `collection_id` (the producer encodes one HapticCommand per endpoint and
+// pushes them under the canonical "haptic_command" tensor identifier). Commands
+// are bucketed by their `endpoint` field so multiple endpoints (e.g. left/right)
+// sharing one collection are read independently. A vendor plugin reuses this
+// directly instead of writing its own SchemaTracker boilerplate.
 class HapticCommandReaderTracker : public ITracker
 {
 public:
@@ -31,9 +33,14 @@ public:
         return TRACKER_NAME;
     }
 
-    // `tracked.data` is null until the first sample arrives or after the
-    // producer collection disappears from the tensor list.
+    // Latest command across all endpoints (backward compatible). Correct for a
+    // single-endpoint device; a multi-endpoint device should use the endpoint
+    // overload, as this returns whichever endpoint was pushed last.
     const HapticCommandTrackedT& get_data(const ITrackerSession& session) const;
+
+    // Latest command for `endpoint`; `tracked.data` is null until a sample for
+    // that endpoint arrives, or after the producer collection disappears.
+    const HapticCommandTrackedT& get_data(const ITrackerSession& session, std::string_view endpoint) const;
 
     const std::string& collection_id() const
     {

--- a/src/core/live_trackers/cpp/live_haptic_command_reader_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_haptic_command_reader_tracker_impl.cpp
@@ -3,6 +3,12 @@
 
 #include "live_haptic_command_reader_tracker_impl.hpp"
 
+#include <flatbuffers/flatbuffers.h>
+
+#include <memory>
+#include <string>
+#include <string_view>
+
 namespace core
 {
 
@@ -37,12 +43,54 @@ LiveHapticCommandReaderTrackerImpl::LiveHapticCommandReaderTrackerImpl(const Ope
 
 void LiveHapticCommandReaderTrackerImpl::update(int64_t /*monotonic_time_ns*/)
 {
-    schema_reader_.update(tracked_.data);
+    samples_.clear();
+    const bool present = schema_reader_.read_all_samples(samples_);
+    if (samples_.empty())
+    {
+        // Producer collection gone: drop stale commands so a disconnected device
+        // stops rendering. A present-but-sample-less tick holds the last values.
+        if (!present)
+        {
+            tracked_by_endpoint_.clear();
+            latest_endpoint_.clear();
+        }
+        return;
+    }
+
+    // Latest-wins per endpoint across every sample drained this tick. The single
+    // collection interleaves all endpoints, so bucket by HapticCommand.endpoint
+    // instead of collapsing to one latest sample (which would drop every endpoint
+    // but the last one pushed each frame).
+    for (const auto& sample : samples_)
+    {
+        const auto* fb = flatbuffers::GetRoot<HapticCommand>(sample.buffer.data());
+        if (fb == nullptr)
+        {
+            continue;
+        }
+        const std::string endpoint = fb->endpoint() != nullptr ? fb->endpoint()->str() : std::string{};
+        HapticCommandTrackedT& tracked = tracked_by_endpoint_[endpoint];
+        if (!tracked.data)
+        {
+            tracked.data = std::make_unique<HapticCommandT>();
+        }
+        fb->UnPackTo(tracked.data.get());
+        latest_endpoint_ = endpoint;
+    }
 }
 
 const HapticCommandTrackedT& LiveHapticCommandReaderTrackerImpl::get_data() const
 {
-    return tracked_;
+    // Backward-compatible latest-across-all-endpoints view: the endpoint of the
+    // most recently drained sample.
+    return get_data(latest_endpoint_);
+}
+
+const HapticCommandTrackedT& LiveHapticCommandReaderTrackerImpl::get_data(std::string_view endpoint) const
+{
+    static const HapticCommandTrackedT kEmpty{};
+    const auto it = tracked_by_endpoint_.find(endpoint);
+    return it != tracked_by_endpoint_.end() ? it->second : kEmpty;
 }
 
 } // namespace core

--- a/src/core/live_trackers/cpp/live_haptic_command_reader_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_haptic_command_reader_tracker_impl.hpp
@@ -11,7 +11,10 @@
 #include <schema/haptic_command_generated.h>
 
 #include <cstdint>
+#include <functional>
+#include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace core
@@ -38,10 +41,18 @@ public:
 
     void update(int64_t monotonic_time_ns) override;
     const HapticCommandTrackedT& get_data() const override;
+    const HapticCommandTrackedT& get_data(std::string_view endpoint) const override;
 
 private:
     HapticCommandSchemaTracker schema_reader_;
-    HapticCommandTrackedT tracked_;
+    // Latest command per endpoint. One push-tensor collection carries every
+    // endpoint's command (each tagged by HapticCommand.endpoint); bucketing by
+    // that tag keeps concurrent endpoints (e.g. left/right) from overwriting one
+    // another the way a single latest-sample slot would.
+    std::map<std::string, HapticCommandTrackedT, std::less<>> tracked_by_endpoint_;
+    // Endpoint of the most recently drained sample, backing the no-arg get_data().
+    std::string latest_endpoint_;
+    std::vector<SchemaTrackerBase::SampleResult> samples_;
 };
 
 } // namespace core

--- a/src/core/replay_trackers/cpp/replay_haptic_command_reader_tracker_impl.cpp
+++ b/src/core/replay_trackers/cpp/replay_haptic_command_reader_tracker_impl.cpp
@@ -15,4 +15,9 @@ const HapticCommandTrackedT& ReplayHapticCommandReaderTrackerImpl::get_data() co
     return tracked_;
 }
 
+const HapticCommandTrackedT& ReplayHapticCommandReaderTrackerImpl::get_data(std::string_view /*endpoint*/) const
+{
+    return tracked_;
+}
+
 } // namespace core

--- a/src/core/replay_trackers/cpp/replay_haptic_command_reader_tracker_impl.hpp
+++ b/src/core/replay_trackers/cpp/replay_haptic_command_reader_tracker_impl.hpp
@@ -7,6 +7,7 @@
 #include <schema/haptic_command_generated.h>
 
 #include <cstdint>
+#include <string_view>
 
 namespace core
 {
@@ -20,6 +21,7 @@ public:
 
     void update(int64_t monotonic_time_ns) override;
     const HapticCommandTrackedT& get_data() const override;
+    const HapticCommandTrackedT& get_data(std::string_view endpoint) const override;
 
 private:
     HapticCommandTrackedT tracked_;

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <mutex>
 #include <stdexcept>
+#include <string_view>
 #include <thread>
 #include <vector>
 
@@ -91,23 +92,26 @@ void ManusTracker::update()
     // Update DeviceIOSession which handles time conversion and tracker updates internally
     m_deviceio_session->update();
 
-    // Latest-wins: the hardware only retains the most recent vibration call,
-    // so dropping intermediate samples on a slow tick is fine. The generic
-    // HapticCommand carries an endpoint string ("left"/"right"); commands for
-    // other endpoints or with a non-5-finger values vector are ignored (this
-    // plugin only drives 5-finger gloves).
+    // Latest-wins per endpoint: the hardware only retains the most recent
+    // vibration call, so dropping intermediate samples on a slow tick is fine.
+    // The producer pushes an independent HapticCommand per hand on one
+    // collection, so read each side separately -- reading a single latest sample
+    // would let whichever hand was pushed last clobber the other. Non-5-finger
+    // payloads are ignored (this plugin only drives 5-finger gloves).
     if (m_haptic_reader)
     {
-        const auto& tracked = m_haptic_reader->get_data(*m_deviceio_session);
-        if (tracked.data && tracked.data->values.size() == kManusFingerCount &&
-            (tracked.data->endpoint == "left" || tracked.data->endpoint == "right"))
+        for (const std::string_view endpoint : { std::string_view("left"), std::string_view("right") })
         {
-            std::array<float, kManusFingerCount> powers{};
-            for (size_t i = 0; i < kManusFingerCount; ++i)
+            const auto& tracked = m_haptic_reader->get_data(*m_deviceio_session, endpoint);
+            if (tracked.data && tracked.data->values.size() == kManusFingerCount)
             {
-                powers[i] = tracked.data->values[i];
+                std::array<float, kManusFingerCount> powers{};
+                for (size_t i = 0; i < kManusFingerCount; ++i)
+                {
+                    powers[i] = tracked.data->values[i];
+                }
+                apply_haptic_command(endpoint == "left", powers);
             }
-            apply_haptic_command(tracked.data->endpoint == "left", powers);
         }
     }
 


### PR DESCRIPTION
## Description

PushTensorHapticDevice pushes one HapticCommand per endpoint onto a single push-tensor collection each frame, but the HapticCommand reader collapsed every drained sample into one latest slot. With multiple endpoints (e.g. a glove's left + right), only the last-pushed endpoint survived and the other hand was silently dropped -- why left-hand glove haptics never fired while the CLI showed them being pushed.

Bucket drained samples by HapticCommand.endpoint and keep the latest per endpoint. The transport already delivers every sample (read_all_samples drains by index), so no wire/schema or producer change is needed and it generalizes to any endpoint set. The Manus plugin now reads "left" and "right" independently.

Add HapticCommandReaderTracker::get_data(session, endpoint) for per-endpoint access, and keep the existing get_data(session) (latest across endpoints) so single-endpoint consumers stay source- and behavior-compatible.

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing
unit test and e2e testing in Isaac Lab

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Haptic command tracking now supports retrieving the latest command for a specific endpoint.
  * Multiple haptic commands can be processed per update, with the latest value retained independently for each endpoint.
  * Existing retrieval behavior remains available for compatibility, returning the most recently received command.

* **Bug Fixes**
  * Improved multi-endpoint haptic handling so updates from one endpoint no longer overwrite another endpoint’s data.
  * Left- and right-hand haptic inputs are now applied independently when valid finger data is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->