### PR TITLE
feat(webxr): add time-paced input replay

### DIFF
--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -138,7 +138,7 @@ function buildOobHubWsUrlFromQuery(searchParams: URLSearchParams): string | null
 }
 
 function AppContent() {
-  const { recorder, onLoadRecording } = useRecorder();
+  const { recorder, onLoadRecording, setReplayPacing } = useRecorder();
   const COUNTDOWN_MAX_SECONDS = 9;
   // 2D UI management
   const [cloudXR2DUI, setCloudXR2DUI] = useState<CloudXR2DUI | null>(null);
@@ -749,6 +749,10 @@ function AppContent() {
     () => (cloudXR2DUI ? cloudXR2DUI.getConfiguration() : null),
     [cloudXR2DUI, configVersion]
   );
+
+  useEffect(() => {
+    setReplayPacing(config?.replayPacing ?? 'time');
+  }, [config?.replayPacing, setReplayPacing]);
 
   // Build ICE server config from URL params (set in USB-local mode by oob_teleop_env.py).
   // turnServer e.g. "turn:127.0.0.1:3478?transport=tcp", iceRelayOnly=1 forces relay-only ICE.

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -61,6 +61,7 @@ import {
 } from '@helpers/utils';
 import { URL_PARAMS } from './config/params';
 import { seedsFromParams } from './config/resolve';
+import type { ReplayPacing } from './xrInputRecorder';
 import {
   getGridValidationError,
   getGridValidationMessageForConnect,
@@ -74,6 +75,7 @@ import {
 type AppConfig = CloudXRConfig & ReactUIConfig & {
   showTrace: boolean;
   showRecordingControls: boolean;
+  replayPacing: ReplayPacing;
 };
 
 /**
@@ -171,6 +173,7 @@ export class CloudXR2DUI {
   private controllerModelVisibilitySelect!: HTMLSelectElement;
   private showTraceInXRSelect!: HTMLSelectElement;
   private showRecordingControlsSelect!: HTMLSelectElement;
+  private replayPacingSelect!: HTMLSelectElement;
   /** Skip client CloudXR `render` (headless: client blit off; tracking on) */
   private headlessInput!: HTMLInputElement;
   /** When to reload the page after the XR session ends (never / clean / any) */
@@ -469,6 +472,7 @@ export class CloudXR2DUI {
     this.showTraceInXRSelect = this.getElement<HTMLSelectElement>('showTraceInXR');
     this.showRecordingControlsSelect =
       this.getElement<HTMLSelectElement>('showRecordingControls');
+    this.replayPacingSelect = this.getElement<HTMLSelectElement>('replayPacing');
     this.headlessInput = this.getElement<HTMLInputElement>('cloudxrHeadless');
     this.autoRefreshModeSelect = this.getElement<HTMLSelectElement>('cloudxrAutoRefreshMode');
     this.teleopModeSubtitle = this.getElement<HTMLElement>('teleopModeSubtitle');
@@ -527,6 +531,7 @@ export class CloudXR2DUI {
       hideControllerModel: false,
       showTrace: false,
       showRecordingControls: false,
+      replayPacing: 'time',
       headless: false,
       autoRefreshMode: 'clean',
       teleopPath: DEFAULT_TELEOP_PATH,
@@ -571,6 +576,7 @@ export class CloudXR2DUI {
       { el: this.controllerModelVisibilitySelect, key: 'controllerModelVisibility' },
       { el: this.showTraceInXRSelect, key: 'showTraceInXR' },
       { el: this.showRecordingControlsSelect, key: 'showRecordingControls' },
+      { el: this.replayPacingSelect, key: 'replayPacing' },
       { el: this.autoRefreshModeSelect, key: 'autoRefreshMode' },
     ];
   }
@@ -812,6 +818,7 @@ export class CloudXR2DUI {
     addListener(this.controllerModelVisibilitySelect, 'change', updateConfig);
     addListener(this.showTraceInXRSelect, 'change', updateConfig);
     addListener(this.showRecordingControlsSelect, 'change', updateConfig);
+    addListener(this.replayPacingSelect, 'change', updateConfig);
     addListener(this.headlessInput, 'change', () => {
       savePerProject('headless', this.teleopPath, this.headlessInput.checked ? 'true' : 'false');
       this.applyHeadlessImmersiveDropdown();
@@ -1024,6 +1031,7 @@ export class CloudXR2DUI {
       hideControllerModel: this.controllerModelVisibilitySelect.value === 'hide',
       showTrace: this.showTraceInXRSelect.value === 'true',
       showRecordingControls: this.showRecordingControlsSelect.value === 'true',
+      replayPacing: this.replayPacingSelect.value === 'frame' ? 'frame' : 'time',
       // See immersiveMode above: when true, callers must start an immersive-vr WebXR session.
       headless: this.headlessInput.checked,
       autoRefreshMode: parseAutoRefreshMode(

--- a/deps/cloudxr/webxr_client/src/RecorderContext.tsx
+++ b/deps/cloudxr/webxr_client/src/RecorderContext.tsx
@@ -32,17 +32,23 @@ import React, {
   useState,
 } from "react";
 
-import { XRInputRecorder, type Recording } from "./xrInputRecorder";
+import {
+  XRInputRecorder,
+  type Recording,
+  type ReplayPacing,
+} from "./xrInputRecorder";
 
 export interface RecorderContextValue {
   recorder: XRInputRecorder;
   mode: "idle" | "recording" | "replaying";
   savedRecording: Recording | null;
   recordedFrameCount: number;
+  replayPacing: ReplayPacing;
   startRecord: () => void;
   stopRecord: () => void;
   startReplay: () => void;
   stopReplay: () => void;
+  setReplayPacing: (pacing: ReplayPacing) => void;
   onSaveRecording: () => void;
   onLoadRecording: () => void;
   onFrameRecord: (count: number) => void;
@@ -57,6 +63,7 @@ export function RecorderProvider({ children }: { children: React.ReactNode }) {
     null,
   );
   const [recordedFrameCount, setRecordedFrameCount] = useState(0);
+  const [replayPacing, setReplayPacingState] = useState<ReplayPacing>("time");
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const startRecord = useCallback(() => {
@@ -77,15 +84,19 @@ export function RecorderProvider({ children }: { children: React.ReactNode }) {
 
   const startReplay = useCallback(() => {
     if (recorder.mode !== "idle" || !savedRecording) return;
-    recorder.startReplay(savedRecording, true);
+    recorder.startReplay(savedRecording, true, replayPacing);
     setMode("replaying");
-  }, [recorder, savedRecording]);
+  }, [recorder, replayPacing, savedRecording]);
 
   const stopReplay = useCallback(() => {
     if (recorder.mode !== "replaying") return;
     recorder.stopReplay();
     setMode("idle");
   }, [recorder]);
+
+  const setReplayPacing = useCallback((pacing: ReplayPacing) => {
+    setReplayPacingState(pacing);
+  }, []);
 
   const onSaveRecording = useCallback(() => {
     if (!savedRecording) return;
@@ -130,10 +141,12 @@ export function RecorderProvider({ children }: { children: React.ReactNode }) {
     mode,
     savedRecording,
     recordedFrameCount,
+    replayPacing,
     startRecord,
     stopRecord,
     startReplay,
     stopReplay,
+    setReplayPacing,
     onSaveRecording,
     onLoadRecording,
     onFrameRecord,

--- a/deps/cloudxr/webxr_client/src/config/params.ts
+++ b/deps/cloudxr/webxr_client/src/config/params.ts
@@ -79,6 +79,7 @@ export const URL_PARAMS: UrlParam[] = [
   { key: 'controllerModelVisibility', elementId: 'controllerModelVisibility', isValid: oneOf('show', 'hide'), description: 'Show or hide controller model meshes in XR.' },
   { key: 'showTraceInXR', elementId: 'showTraceInXR', isValid: isBool, description: 'Show rolling hand/controller traces in XR (true/false).' },
   { key: 'showRecordingControls', elementId: 'showRecordingControls', isValid: isBool, description: 'Show recording controls in XR (true/false).' },
+  { key: 'replayPacing', elementId: 'replayPacing', isValid: oneOf('frame', 'time'), description: 'Input replay pacing: time (default) or frame.' },
   { key: 'panelHiddenAtStart', elementId: 'panelHiddenAtStart', isValid: isBool, description: 'Start with the in-XR control panel hidden (true/false).' },
   { key: 'headless', elementId: 'cloudxrHeadless', kind: 'checked', isValid: isBool, description: 'Headless: skip all client render code, keep tracking (true/false).' },
   { key: 'autoRefreshMode', elementId: 'cloudxrAutoRefreshMode', isValid: oneOf('never', 'clean', 'any'), description: 'Reload page after session ends: never, clean, or any.' },

--- a/deps/cloudxr/webxr_client/src/config/resolve.test.ts
+++ b/deps/cloudxr/webxr_client/src/config/resolve.test.ts
@@ -136,6 +136,7 @@ function sampleValid(key: string): string {
     controllerModelVisibility: 'show',
     showTraceInXR: 'false',
     showRecordingControls: 'false',
+    replayPacing: 'time',
     autoRefreshMode: 'clean',
     enablePoseSmoothing: 'true',
     enableTexSubImage2D: 'true',

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -1092,6 +1092,16 @@ limitations under the License.
                             <button id="loadRecordingBtn" class="reset-button">Load Recording…</button>
                         </div>
                         <div class="config-section">
+                            <label for="replayPacing" class="input-label">Replay Pacing</label>
+                            <select id="replayPacing" class="ui-input config-input">
+                                <option value="frame">Frame paced</option>
+                                <option value="time" selected>Time paced</option>
+                            </select>
+                            <div class="config-text">
+                                Frame paced sends one recorded sample per XR frame. Time paced follows the recording timestamps and interpolates between samples.
+                            </div>
+                        </div>
+                        <div class="config-section">
                             <label for="enablePoseSmoothing" class="input-label">Pose Smoothing</label>
                             <select id="enablePoseSmoothing" class="ui-input config-input">
                                 <option value="true" selected>Enabled</option>

--- a/deps/cloudxr/webxr_client/src/xrInputRecorder.test.ts
+++ b/deps/cloudxr/webxr_client/src/xrInputRecorder.test.ts
@@ -211,6 +211,20 @@ describe("lifecycle and frame advancement", () => {
     expect(recorder.currentFrame?.handJoints.left.wrist?.px).toBe(7);
   });
 
+  test("holds the earlier gamepad sample when controller layouts differ", () => {
+    const first = timedFrame(0, 0);
+    const second = timedFrame(100, 10);
+    second.gamepads.left!.axes.push(20);
+    second.gamepads.left!.buttons.push({ value: 20, pressed: true, touched: true });
+
+    const recorder = new XRInputRecorder();
+    recorder.startReplay(recording(first, second), false);
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1000), sceneSpace);
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1050), sceneSpace);
+
+    expect(recorder.currentFrame?.gamepads.left).toEqual(first.gamepads.left);
+  });
+
   test("holds the final timed sample before looping", () => {
     const recorder = new XRInputRecorder();
     recorder.startReplay(recording(timedFrame(0, 0), timedFrame(100, 10)), true, "time");

--- a/deps/cloudxr/webxr_client/src/xrInputRecorder.test.ts
+++ b/deps/cloudxr/webxr_client/src/xrInputRecorder.test.ts
@@ -115,6 +115,10 @@ function recording(...frames: RecordedFrame[]): Recording {
   return { version: 1, frames };
 }
 
+function timedFrame(timeMs: number, x: number): RecordedFrame {
+  return { ...frameData(x), timeMs };
+}
+
 function recordFrames(count: number): Recording {
   const recorder = new XRInputRecorder();
   recorder.startRecording();
@@ -169,18 +173,71 @@ describe("lifecycle and frame advancement", () => {
 
   test("loops replay by frame and can clamp at the final frame", () => {
     const looped = new XRInputRecorder();
-    looped.startReplay(recording(frameData(1), frameData(2)));
+    looped.startReplay(recording(frameData(1), frameData(2)), true, "frame");
     looped.beginFrame(makeFrame(), sceneSpace);
     looped.beginFrame(makeFrame(), sceneSpace);
     expect(looped.replayFrameIndex).toBe(0);
 
     const clamped = new XRInputRecorder();
-    clamped.startReplay(recording(frameData(1), frameData(2)), false);
+    clamped.startReplay(recording(frameData(1), frameData(2)), false, "frame");
     clamped.beginFrame(makeFrame(), sceneSpace);
     clamped.beginFrame(makeFrame(), sceneSpace);
     clamped.beginFrame(makeFrame(), sceneSpace);
     expect(clamped.currentFrame).toEqual(frameData(2));
     expect(clamped.replayFrameIndex).toBe(1);
+  });
+
+  test("time-paces replay by default and interpolates timestamped samples", () => {
+    const first = timedFrame(0, 0);
+    first.gamepads.left!.buttons[0].pressed = false;
+    const second = timedFrame(100, 10);
+    second.poses.leftGrip = {
+      ...second.poses.leftGrip!,
+      oz: 1,
+      ow: 0,
+    };
+
+    const recorder = new XRInputRecorder();
+    recorder.startReplay(recording(first, second), false);
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1000), sceneSpace);
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1050), sceneSpace);
+
+    expect(recorder.currentFrame?.timeMs).toBe(50);
+    expect(recorder.currentFrame?.poses.leftGrip?.px).toBe(5);
+    expect(recorder.currentFrame?.poses.leftGrip?.oz).toBeCloseTo(Math.sqrt(0.5));
+    expect(recorder.currentFrame?.poses.leftGrip?.ow).toBeCloseTo(Math.sqrt(0.5));
+    expect(recorder.currentFrame?.gamepads.left?.axes).toEqual([5]);
+    expect(recorder.currentFrame?.gamepads.left?.buttons[0].pressed).toBe(false);
+    expect(recorder.currentFrame?.handJoints.left.wrist?.px).toBe(7);
+  });
+
+  test("holds the final timed sample before looping", () => {
+    const recorder = new XRInputRecorder();
+    recorder.startReplay(recording(timedFrame(0, 0), timedFrame(100, 10)), true, "time");
+
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1000), sceneSpace);
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1100), sceneSpace);
+    expect(recorder.currentFrame).toEqual(timedFrame(100, 10));
+
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1150), sceneSpace);
+    expect(recorder.currentFrame).toEqual(timedFrame(100, 10));
+
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1200), sceneSpace);
+    expect(recorder.currentFrame).toEqual(timedFrame(0, 0));
+  });
+
+  test("pauses time-paced replay while advancement is gated off", () => {
+    const recorder = new XRInputRecorder();
+    recorder.startReplay(recording(timedFrame(0, 0), timedFrame(100, 10)), false, "time");
+
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1000), sceneSpace);
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1040), sceneSpace);
+    recorder.beginFrame(makeFrame([], undefined, undefined, 1100), sceneSpace, false);
+    recorder.beginFrame(makeFrame([], undefined, undefined, 2000), sceneSpace);
+    expect(recorder.currentFrame?.poses.leftGrip?.px).toBe(4);
+
+    recorder.beginFrame(makeFrame([], undefined, undefined, 2020), sceneSpace);
+    expect(recorder.currentFrame?.poses.leftGrip?.px).toBe(6);
   });
 
   test("captures live input while idle only when requested", () => {

--- a/deps/cloudxr/webxr_client/src/xrInputRecorder.ts
+++ b/deps/cloudxr/webxr_client/src/xrInputRecorder.ts
@@ -64,6 +64,8 @@ export type Recording = {
   frames: RecordedFrame[];
 };
 
+export type ReplayPacing = "frame" | "time";
+
 type Handedness = "left" | "right";
 
 function emptyFrame(timeMs = 0): RecordedFrame {
@@ -181,6 +183,171 @@ function proxyInputSource(
   });
 }
 
+function lerp(from: number, to: number, alpha: number): number {
+  return from + (to - from) * alpha;
+}
+
+function interpolatePose<T extends PoseData>(from: T, to: T, alpha: number): T {
+  let tox = to.ox;
+  let toy = to.oy;
+  let toz = to.oz;
+  let tow = to.ow;
+  const dot = from.ox * tox + from.oy * toy + from.oz * toz + from.ow * tow;
+  if (dot < 0) {
+    tox = -tox;
+    toy = -toy;
+    toz = -toz;
+    tow = -tow;
+  }
+
+  const shortestDot = Math.abs(dot);
+  let fromScale = 1 - alpha;
+  let toScale = alpha;
+  if (shortestDot < 0.9995) {
+    const angle = Math.acos(Math.min(1, shortestDot));
+    const sinAngle = Math.sin(angle);
+    fromScale = Math.sin((1 - alpha) * angle) / sinAngle;
+    toScale = Math.sin(alpha * angle) / sinAngle;
+  }
+
+  let ox = from.ox * fromScale + tox * toScale;
+  let oy = from.oy * fromScale + toy * toScale;
+  let oz = from.oz * fromScale + toz * toScale;
+  let ow = from.ow * fromScale + tow * toScale;
+  const magnitude = Math.hypot(ox, oy, oz, ow);
+  if (magnitude > 0) {
+    ox /= magnitude;
+    oy /= magnitude;
+    oz /= magnitude;
+    ow /= magnitude;
+  }
+
+  return {
+    ...from,
+    px: lerp(from.px, to.px, alpha),
+    py: lerp(from.py, to.py, alpha),
+    pz: lerp(from.pz, to.pz, alpha),
+    ox,
+    oy,
+    oz,
+    ow,
+  };
+}
+
+function interpolateOptionalPose<T extends PoseData>(
+  from: T | null | undefined,
+  to: T | null | undefined,
+  alpha: number,
+): T | null {
+  // Tracking presence is discrete. Do not invent a pose before it appears or
+  // keep one after the timestamp at which it disappears.
+  if (!from || !to) return from ?? null;
+  return interpolatePose(from, to, alpha);
+}
+
+function interpolateGamepad(
+  from: SerializedGamepad | null,
+  to: SerializedGamepad | null,
+  alpha: number,
+): SerializedGamepad | null {
+  if (!from || !to) return from;
+  return {
+    axes: from.axes.map((value, index) =>
+      index < to.axes.length ? lerp(value, to.axes[index], alpha) : value,
+    ),
+    buttons: from.buttons.map((button, index) => {
+      const next = to.buttons[index];
+      return {
+        value: next ? lerp(button.value, next.value, alpha) : button.value,
+        pressed: button.pressed,
+        touched: button.touched,
+      };
+    }),
+  };
+}
+
+function interpolateJoints(
+  from: JointPoses,
+  to: JointPoses,
+  alpha: number,
+): JointPoses {
+  const result: JointPoses = {};
+  for (const name of new Set([...Object.keys(from), ...Object.keys(to)])) {
+    const fromJoint = from[name];
+    const toJoint = to[name];
+    if (!fromJoint || !toJoint) {
+      result[name] = fromJoint ?? null;
+      continue;
+    }
+    result[name] = {
+      ...interpolatePose(fromJoint, toJoint, alpha),
+      radius: lerp(fromJoint.radius, toJoint.radius, alpha),
+    };
+  }
+  return result;
+}
+
+function interpolateFrame(
+  from: RecordedFrame,
+  to: RecordedFrame,
+  timeMs: number,
+): RecordedFrame {
+  const interval = to.timeMs - from.timeMs;
+  const alpha = interval > 0 ? (timeMs - from.timeMs) / interval : 0;
+  return {
+    timeMs,
+    poses: {
+      leftGrip: interpolateOptionalPose(from.poses.leftGrip, to.poses.leftGrip, alpha),
+      leftAim: interpolateOptionalPose(from.poses.leftAim, to.poses.leftAim, alpha),
+      rightGrip: interpolateOptionalPose(from.poses.rightGrip, to.poses.rightGrip, alpha),
+      rightAim: interpolateOptionalPose(from.poses.rightAim, to.poses.rightAim, alpha),
+    },
+    gamepads: {
+      left: interpolateGamepad(from.gamepads.left, to.gamepads.left, alpha),
+      right: interpolateGamepad(from.gamepads.right, to.gamepads.right, alpha),
+    },
+    handJoints: {
+      left: interpolateJoints(from.handJoints.left, to.handJoints.left, alpha),
+      right: interpolateJoints(from.handJoints.right, to.handJoints.right, alpha),
+    },
+  };
+}
+
+function sampleAtTime(
+  frames: RecordedFrame[],
+  timeMs: number,
+): { frame: RecordedFrame; index: number } {
+  if (timeMs <= frames[0].timeMs) return { frame: frames[0], index: 0 };
+
+  let low = 0;
+  let high = frames.length;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (frames[middle].timeMs <= timeMs) low = middle + 1;
+    else high = middle;
+  }
+
+  const index = low - 1;
+  if (index >= frames.length - 1 || frames[index].timeMs === timeMs) {
+    return { frame: frames[index], index };
+  }
+  return {
+    frame: interpolateFrame(frames[index], frames[index + 1], timeMs),
+    index,
+  };
+}
+
+function replayDuration(frames: RecordedFrame[]): number {
+  if (frames.length < 2) return 0;
+  const firstTime = frames[0].timeMs;
+  const lastTime = frames[frames.length - 1].timeMs;
+  for (let index = frames.length - 1; index > 0; index--) {
+    const terminalInterval = frames[index].timeMs - frames[index - 1].timeMs;
+    if (terminalInterval > 0) return lastTime - firstTime + terminalInterval;
+  }
+  return 0;
+}
+
 /** Apply the real baseSpace <- sceneSpace transform to a recorded pose. */
 function transformFromScene<T extends PoseData>(
   pose: T,
@@ -212,6 +379,9 @@ export class XRInputRecorder {
   private _replayFrames: RecordedFrame[] = [];
   private _replayIndex = 0;
   private _loopReplay = true;
+  private _replayPacing: ReplayPacing = "time";
+  private _replayElapsedMs = 0;
+  private _lastReplayDisplayTime: number | null = null;
   private _currentFrame: RecordedFrame | null = null;
   private _sceneReferenceSpace: XRReferenceSpace | null = null;
   private _recordingStartTime: number | null = null;
@@ -248,11 +418,18 @@ export class XRInputRecorder {
     this._mode = "idle";
   }
 
-  startReplay(recording: Recording, loop = true): void {
+  startReplay(
+    recording: Recording,
+    loop = true,
+    pacing: ReplayPacing = "time",
+  ): void {
     this._assertIdle();
     this._replayFrames = recording.frames;
     this._replayIndex = 0;
     this._loopReplay = loop;
+    this._replayPacing = pacing;
+    this._replayElapsedMs = 0;
+    this._lastReplayDisplayTime = null;
     this._currentFrame = null;
     this._mode = "replaying";
   }
@@ -260,6 +437,7 @@ export class XRInputRecorder {
   stopReplay(): void {
     if (this._mode !== "replaying") return;
     this._currentFrame = null;
+    this._lastReplayDisplayTime = null;
     this._mode = "idle";
   }
 
@@ -283,7 +461,10 @@ export class XRInputRecorder {
       return;
     }
 
-    if (!connected) return;
+    if (!connected) {
+      if (this._mode === "replaying") this._lastReplayDisplayTime = null;
+      return;
+    }
 
     if (this._mode === "recording") {
       if (!sceneReferenceSpace) return;
@@ -302,12 +483,35 @@ export class XRInputRecorder {
       return;
     }
 
+    if (this._replayPacing === "time") {
+      this._advanceTimedReplay(frame.predictedDisplayTime);
+      return;
+    }
+
     this._currentFrame = this._replayFrames[this._replayIndex];
     if (this._replayIndex < this._replayFrames.length - 1) {
       this._replayIndex++;
     } else if (this._loopReplay) {
       this._replayIndex = 0;
     }
+  }
+
+  private _advanceTimedReplay(displayTime: number): void {
+    if (this._lastReplayDisplayTime !== null) {
+      this._replayElapsedMs += Math.max(0, displayTime - this._lastReplayDisplayTime);
+    }
+    this._lastReplayDisplayTime = displayTime;
+
+    const firstTime = this._replayFrames[0].timeMs;
+    const lastTime = this._replayFrames[this._replayFrames.length - 1].timeMs;
+    const duration = replayDuration(this._replayFrames);
+    const elapsed = this._loopReplay && duration > 0
+      ? this._replayElapsedMs % duration
+      : this._replayElapsedMs;
+    const sampleTime = Math.min(firstTime + elapsed, lastTime);
+    const sample = sampleAtTime(this._replayFrames, sampleTime);
+    this._currentFrame = sample.frame;
+    this._replayIndex = sample.index;
   }
 
   /**

--- a/deps/cloudxr/webxr_client/src/xrInputRecorder.ts
+++ b/deps/cloudxr/webxr_client/src/xrInputRecorder.ts
@@ -251,14 +251,17 @@ function interpolateGamepad(
   alpha: number,
 ): SerializedGamepad | null {
   if (!from || !to) return from;
+  // A layout change means the input source changed. Keep the complete earlier
+  // sample until the next timestamp instead of partially mixing two devices.
+  if (from.axes.length !== to.axes.length || from.buttons.length !== to.buttons.length) {
+    return from;
+  }
   return {
-    axes: from.axes.map((value, index) =>
-      index < to.axes.length ? lerp(value, to.axes[index], alpha) : value,
-    ),
+    axes: from.axes.map((value, index) => lerp(value, to.axes[index], alpha)),
     buttons: from.buttons.map((button, index) => {
       const next = to.buttons[index];
       return {
-        value: next ? lerp(button.value, next.value, alpha) : button.value,
+        value: lerp(button.value, next.value, alpha),
         pressed: button.pressed,
         touched: button.touched,
       };


### PR DESCRIPTION
## Description

Add time-paced XR input replay using the relative `timeMs` values already stored in version 1 recordings.

- Sample replay from `XRFrame.predictedDisplayTime` instead of consuming exactly one recording frame per render frame.
- Interpolate positions, orientations, joint radii, axes, and analog button values between timestamped samples.
- Hold discrete tracking and button state until the next sample, clamp rather than extrapolate, and pause the replay clock while advancement is gated.
- Make time pacing the default while retaining frame pacing as a persisted Troubleshooting option and URL parameter.
- Keep the recording schema at version 1 so existing timestamped recordings remain reusable.

See https://nvidia.github.io/IsaacTeleop/preview/pr-814/client/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- `npm test -- --runInBand` (46 tests passed)
- `npm run build`
- `SKIP=check-copyright-year pre-commit run --all-files`
- `git diff --check`

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] I have signed off all my commits (`git commit -s`) per the DCO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable replay pacing with **Time paced** and **Frame paced** modes.
  * Time-paced replay now smoothly interpolates recorded controller, hand, and pose data.
  * Added Replay Pacing controls to the Troubleshooting settings.
  * Replay pacing preferences are saved and restored with other settings.

* **Bug Fixes**
  * Improved replay timing across pauses, loops, and connection interruptions.



<!-- end of auto-generated comment: release notes by coderabbit.ai -->