### PR TITLE
ROS: Reframe teleop_ros2 as the supported ROS 2 reference publisher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ option(BUILD_PLUGINS "Build plugins" ON)
 option(BUILD_PLUGIN_OAK_CAMERA "Build OAK camera plugin (requires vcpkg for DepthAI v3.x)" OFF)
 option(BUILD_PLUGIN_OGLO "Build OGLO tactile glove plugin (BLE, Linux only; fetches SimpleBLE + nlohmann/json)" OFF)
 option(BUILD_EXAMPLES "Build examples" ON)
-option(BUILD_EXAMPLE_TELEOP_ROS2 "Build only the teleop_ros2 example (e.g. for Docker)" OFF)
+option(BUILD_EXAMPLE_TELEOP_ROS2 "Build only the teleop_ros2 ROS 2 reference integration (e.g. for Docker)" OFF)
 option(BUILD_TESTING "Build unit tests" ON)
 # Televiz (src/viz) needs Vulkan, the CUDA Toolkit, and glslangValidator.
 # Default BUILD_VIZ ON when all three are present (so it builds out of the box)

--- a/examples/teleop_ros2/AGENTS.md
+++ b/examples/teleop_ros2/AGENTS.md
@@ -5,16 +5,20 @@ SPDX-License-Identifier: Apache-2.0
 
 # Teleop ROS 2 Agent Notes
 
+Supported ROS 2 reference publisher for Isaac Teleop. Hosted under `examples/`
+because it depends on ROS 2 and the `isaacteleop` wheel; it is not part of the
+core library. Consumed by Isaac ROS Teleop.
+
 ## Docker Validation
 
-- This example needs ROS 2 plus the built `isaacteleop` wheel, which are not present in the dev container. Run/validate it inside the `examples/teleop_ros2/Dockerfile` image (the same path CI's `test-teleop-ros2` job uses), not directly on the host.
+- This reference integration needs ROS 2 plus the built `isaacteleop` wheel, which are not present in the dev container. Run/validate it inside the `examples/teleop_ros2/Dockerfile` image (the same path CI's `test-teleop-ros2` job uses), not directly on the host.
 - To exercise it without live XR hardware, replay an MCAP fixture: build the image, run the installed `teleop_ros2_mcap_generator` to write a fixture, then run `teleop_ros2_node.py` with `-p mode:=<mode> -p mcap_replay_path:=<file>` and check topics (e.g. via `integration_tests/teleop_ros2_topic_verifier.py`). Replay mode does not launch CloudXR, so no GPU/NGC runtime is required. Share the fixture across containers with `-v /tmp:/tmp` and `--network host` for ROS 2 discovery.
 - The image build disables some CI gates (`-DENABLE_CLANG_FORMAT_CHECK=OFF`, `-DBUILD_TESTING=OFF`), so a green Docker build does not mean C++ formatting or ctest pass. Validate those separately.
 - When creating temporary Docker images for `examples/teleop_ros2` validation, remove them before finishing the task unless the user explicitly asks to keep them.
 
 ## Source Layout
 
-- In source code files under this example, preserve the existing grouped/sorted organization for helpers, message builders, classes, and member functions: scan the surrounding order before inserting, and do not place helpers near call sites when the existing section is sorted.
+- In source code files under this package, preserve the existing grouped/sorted organization for helpers, message builders, classes, and member functions: scan the surrounding order before inserting, and do not place helpers near call sites when the existing section is sorted.
 - In Python integration test verifier code, do not use bare `assert` for runtime validation; Python optimization can disable it, so raise explicit exceptions from validators.
 - Keep ROS publisher methods at one abstraction level: call one output-specific pure
   builder, then publish or broadcast its result. Compose payload construction and

--- a/examples/teleop_ros2/CMakeLists.txt
+++ b/examples/teleop_ros2/CMakeLists.txt
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20)
-project(teleop_ros2_examples)
+project(teleop_ros2_ref)
 
 include(${CMAKE_SOURCE_DIR}/cmake/InstallPythonExample.cmake)
 

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -36,7 +36,7 @@ parameter:
   and
   `examples/teleop_ros2/assets/urdf/sharpa_standalone/right_sharpa_wave.urdf`.
   Set `config_asset_root` to use a different directory containing `configs/`
-  and `assets/`; the empty default uses the installed or source example root.
+  and `assets/`; the empty default uses the installed or source tree root.
 - `hand_retargeter:=pink_ik`: uses `SharpaHandRetargeter`. It requires the
   `isaacteleop[grounding]` runtime dependencies and the bundled
   `robotic_grounding` package data that provides the Sharpa MJCF assets.

--- a/examples/teleop_ros2/python/integration_tests/__init__.py
+++ b/examples/teleop_ros2/python/integration_tests/__init__.py
@@ -2,4 +2,4 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Integration tests for the Teleop ROS 2 example."""
+"""Integration tests for the Teleop ROS 2 reference publisher."""

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -182,7 +182,7 @@ def _load_config_asset_root(node: Node) -> Path:
             type=ParameterType.PARAMETER_STRING,
             description=(
                 "Directory containing teleop_ros2 configs/ and assets/. "
-                "Leave empty to use the installed or source example root."
+                "Leave empty to use the installed or source tree root."
             ),
         ),
     )

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 [project]
-name = "teleop-ros2-example"
+name = "teleop-ros2-ref"
 version = "0.1.0"
-description = "Isaac Teleop ROS2 Example"
+description = "Isaac Teleop ROS 2 reference publisher"
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "isaacteleop[cloudxr,grounding,retargeters]",

--- a/examples/teleop_ros2/python/teleop_ros2_retargeters/__init__.py
+++ b/examples/teleop_ros2/python/teleop_ros2_retargeters/__init__.py
@@ -2,7 +2,7 @@
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Example-local retargeters for the ROS 2 teleop publisher."""
+"""Package-local retargeters for the ROS 2 teleop publisher."""
 
 from .joint_name_alias_retargeter import JointNameAliasRetargeter
 

--- a/examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py
+++ b/examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py
@@ -42,16 +42,16 @@ _URDF_SOURCES = {
 }
 
 
-def _example_root() -> Path:
+def _tree_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
 def _default_output_dir() -> Path:
-    return _example_root() / "assets" / "urdf" / "sharpa_standalone"
+    return _tree_root() / "assets" / "urdf" / "sharpa_standalone"
 
 
 def _default_config_dir() -> Path:
-    return _example_root() / "configs"
+    return _tree_root() / "configs"
 
 
 def _parse_retargeting_config(path: Path) -> tuple[set[str], set[str]]:


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Clarify docs and package metadata so the node reads as a reference integration consumed by Isaac ROS Teleop, not a disposable example, without moving its path.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the ROS 2 teleoperation integration is a reference publisher rather than an example.
  * Improved setup guidance for configuration paths and package layout.
  * Updated integration test and retargeter descriptions for consistency.

* **Build & Packaging**
  * Updated project and package labels to identify the ROS 2 reference integration.
  * Clarified the build option description without changing its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->