### PR TITLE
[TeleViz] Opt-in native OpenXR quad layers for QuadLayer

### DIFF
--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -234,6 +234,15 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="Override display.mode from the config "
         "(default: the config's value, or xr when the config omits it).",
     )
+    parser.add_argument(
+        "--native-quad",
+        action="store_true",
+        help="Submit each camera as a native OpenXR quad layer "
+        "(XrCompositionLayerQuad) instead of the built-in compositor. "
+        "kXr only; ignored in window mode. When every layer is a native "
+        "quad the projection layer is dropped, letting the runtime engage "
+        "its quad fast path / client-reconstructed streaming.",
+    )
     args = parser.parse_args(argv)
 
     with open(args.config) as f:
@@ -274,6 +283,9 @@ def main(argv: Optional[list[str]] = None) -> int:
         if entry.stereo:
             layer_cfg.stereo = True
             layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
+        # Native OpenXR quad path (kXr only; a no-op fallback in window mode).
+        # Requires a placement, which the placement strategy applies below.
+        layer_cfg.use_openxr_quad_layer = args.native_quad
         layers.append(session.add_quad_layer(layer_cfg))
         strategies.append(entry.placement)
 

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -119,6 +119,23 @@ public:
         // false or outside kXr. mm-scale chosen because typical real-
         // world IPDs and camera baselines are 50–80 mm.
         float stereo_baseline_mm = 0.0f;
+
+        // Submit this quad as a native OpenXR quad layer
+        // (XrCompositionLayerQuad) instead of compositing it into the
+        // shared render target. kXr only: the runtime places + samples the
+        // quad directly, which enables its quad fast path (and, for
+        // quad-only frames, client-reconstructed streaming — the shared
+        // projection layer is dropped when every visible layer is native).
+        // Ignored outside kXr (window/offscreen fall back to the compositor
+        // draw path). Stereo emits one quad per eye via eyeVisibility.
+        //
+        // Trade-off vs the compositor path: a native quad carries NO depth
+        // (OpenXR quad layers have none), so it can't z-compose with 3D
+        // ProjectionLayer content — it's a flat billboard ordered by
+        // submission. ``generate_mipmaps`` is unused in native mode (the
+        // runtime samples the quad). Requires ``placement`` at record time,
+        // same as any kXr quad. Off by default.
+        bool use_openxr_quad_layer = false;
     };
 
     // Hard cap on the mip chain when generate_mipmaps is enabled.
@@ -189,6 +206,15 @@ public:
     // Timeline wait on the in-use slot's cuda_done_writing.
     std::vector<LayerBase::WaitSemaphore> get_wait_semaphores() const override;
 
+    // Native OpenXR quad path. is_native_quad() is true only when the flag
+    // is set AND this layer is in a kXr session (so window/offscreen keep
+    // using record()). acquire_native_quad() promotes the mailbox slot (like
+    // record()'s consumer side) and returns the per-eye source images +
+    // placement for the backend to blit into its quad swapchain. See
+    // Config::use_openxr_quad_layer.
+    bool is_native_quad() const noexcept override;
+    std::optional<NativeQuadView> acquire_native_quad(uint32_t in_flight_slot) override;
+
     // Drives aspect-fit letterbox in window mode; ignored in kXr.
     std::optional<float> aspect_ratio() const noexcept override;
 
@@ -225,6 +251,18 @@ private:
     // and atomically takes ownership; record() atomically promotes
     // a freshly-published slot to `in_use_`.
     static constexpr uint8_t kSlotNone = 0xFF;
+
+    // Promote latest_ -> in_use_[in_flight_slot] and update
+    // last_in_use_slot_ (shared by the render-pass consumer and the
+    // native-quad consumer). Returns the promoted slot, or kSlotNone if
+    // nothing has been published yet. Throws if in_flight_slot is out of
+    // range. Renderer thread only.
+    uint8_t promote_slot(uint32_t in_flight_slot);
+
+    // True when this layer should composite as a native OpenXR quad:
+    // the flag is set AND the attached session is kXr. Non-XR sessions
+    // (and a detached layer) fall back to the record() draw path.
+    bool native_active() const noexcept;
 
     // Picks a slot that is neither latest_ nor in any in_use_ entry.
     // Returns kSlotNone if every slot is forbidden (producer outran the

--- a/src/viz/layers/cpp/quad_layer.cpp
+++ b/src/viz/layers/cpp/quad_layer.cpp
@@ -533,24 +533,23 @@ void QuadLayer::record_mip_generation(VkCommandBuffer cmd, DeviceImage& image)
                       VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
 }
 
-void QuadLayer::record_pre_render_pass(VkCommandBuffer cmd, uint32_t in_flight_slot)
+uint8_t QuadLayer::promote_slot(uint32_t in_flight_slot)
 {
-    require_alive(slots_[0], "record_pre_render_pass");
-
     // Backends are contracted to image_count <= kMaxFramesInFlight; if
     // that ever breaks, two in-flight frames would alias on the same
     // in_use_ entry and we'd lose the slot-tracking invariant.
     if (in_flight_slot >= kMaxFramesInFlight)
     {
-        throw std::logic_error("QuadLayer::record_pre_render_pass: in_flight_slot " + std::to_string(in_flight_slot) +
+        throw std::logic_error("QuadLayer: in_flight_slot " + std::to_string(in_flight_slot) +
                                " >= kMaxFramesInFlight (" + std::to_string(kMaxFramesInFlight) +
                                "); bump kMaxFramesInFlight to match the backend's image_count");
     }
 
     // Promote latest_ -> in_use_[in_flight_slot]. The compositor's
     // per-slot fence wait at the top of render() guarantees the GPU
-    // has finished sampling the previous in_use_ value. record() reads
-    // the same entry — pre-pass and pass MUST agree on in_flight_slot.
+    // has finished sampling the previous in_use_ value. record() (or the
+    // native-quad copy) reads the same entry — the promoting call and the
+    // consuming call MUST agree on in_flight_slot.
     const uint8_t latest = latest_.load(std::memory_order_acquire);
     const uint32_t idx = in_flight_slot;
     if (latest != kSlotNone)
@@ -558,14 +557,78 @@ void QuadLayer::record_pre_render_pass(VkCommandBuffer cmd, uint32_t in_flight_s
         in_use_[idx].store(latest, std::memory_order_release);
     }
     const uint8_t cur = in_use_[idx].load(std::memory_order_acquire);
+    if (cur != kSlotNone)
+    {
+        // Record which slot this frame is sampling so get_wait_semaphores
+        // (called by the compositor before submit) reads the matching
+        // cuda_done_writing semaphore.
+        last_in_use_slot_.store(cur, std::memory_order_release);
+    }
+    return cur;
+}
+
+bool QuadLayer::native_active() const noexcept
+{
+    // Flag only takes effect in a kXr session; window/offscreen fall back
+    // to the record() draw path. A detached layer (no session) is not
+    // native either, so standalone construction/tests keep the draw path.
+    return config_.use_openxr_quad_layer && session() != nullptr && session()->is_xr_mode();
+}
+
+bool QuadLayer::is_native_quad() const noexcept
+{
+    return native_active();
+}
+
+std::optional<NativeQuadView> QuadLayer::acquire_native_quad(uint32_t in_flight_slot)
+{
+    require_alive(slots_[0], "acquire_native_quad");
+
+    // Promote first, matching record()'s consumer ordering: before the first
+    // publish there is nothing to composite, so return early WITHOUT requiring
+    // a placement. This keeps a native-quad session from throwing on startup
+    // frames where the placement strategy hasn't run yet (e.g. XR tracking
+    // not locked, head pose still unavailable).
+    const uint8_t cur = promote_slot(in_flight_slot);
+    if (cur == kSlotNone)
+    {
+        return std::nullopt;
+    }
+
+    // Snapshot placement under lock so set_placement() can run concurrently.
+    std::optional<Config::Placement> placement;
+    {
+        std::lock_guard<std::mutex> lk(placement_mutex_);
+        placement = placement_;
+    }
+    // With content to show, a native quad needs a world placement (pose +
+    // size). Same requirement as any kXr quad in record(); missing it here is
+    // a programming error (the app published a frame but never placed it).
+    if (!placement.has_value())
+    {
+        throw std::logic_error("QuadLayer: native OpenXR quad requires Config::placement to be set");
+    }
+
+    NativeQuadView v{};
+    v.color_left = slots_[cur]->vk_image();
+    v.color_right = config_.stereo ? slots_right_[cur]->vk_image() : VK_NULL_HANDLE;
+    v.extent = config_.resolution;
+    v.pose = placement->pose;
+    v.size_meters = placement->size_meters;
+    v.stereo_baseline_mm = config_.stereo ? config_.stereo_baseline_mm : 0.0f;
+    v.source_id = this;
+    return v;
+}
+
+void QuadLayer::record_pre_render_pass(VkCommandBuffer cmd, uint32_t in_flight_slot)
+{
+    require_alive(slots_[0], "record_pre_render_pass");
+
+    const uint8_t cur = promote_slot(in_flight_slot);
     if (cur == kSlotNone)
     {
         return;
     }
-    // Record which slot this frame is sampling so get_wait_semaphores
-    // (called by compositor between record and submit) reads the
-    // matching cuda_done_writing semaphore.
-    last_in_use_slot_.store(cur, std::memory_order_release);
 
     // Mip generation (if configured). Reads level 0 written by CUDA,
     // writes levels 1..N-1, ends with the whole image back in
@@ -705,8 +768,12 @@ std::vector<LayerBase::WaitSemaphore> QuadLayer::get_wait_semaphores() const
     {
         return {};
     }
+    // Native quad: first GPU read is the backend's copy into the quad
+    // swapchain (TRANSFER). Composited-with-mips: the mip-gen blit chain
+    // reads level 0 at TRANSFER first. Plain composited: the fragment
+    // sampler is the first read.
     const VkPipelineStageFlags wait_stage =
-        (mip_levels_ > 1) ? VK_PIPELINE_STAGE_TRANSFER_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+        (native_active() || mip_levels_ > 1) ? VK_PIPELINE_STAGE_TRANSFER_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     return {
         WaitSemaphore{
             image.cuda_done_writing(),

--- a/src/viz/layers_tests/cpp/test_quad_layer.cpp
+++ b/src/viz/layers_tests/cpp/test_quad_layer.cpp
@@ -16,6 +16,7 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 #include <limits>
+#include <optional>
 #include <stdexcept>
 #include <vector>
 
@@ -60,6 +61,78 @@ TEST_CASE("QuadLayer ctor rejects null render pass", "[unit][quad_layer]")
     QuadLayer::Config cfg;
     cfg.resolution = { 64, 64 };
     CHECK_THROWS_AS(QuadLayer(ctx, VK_NULL_HANDLE, cfg), std::invalid_argument);
+}
+
+TEST_CASE("QuadLayer::Config use_openxr_quad_layer defaults off and is settable", "[unit][quad_layer][native]")
+{
+    QuadLayer::Config cfg;
+    CHECK_FALSE(cfg.use_openxr_quad_layer);
+    cfg.use_openxr_quad_layer = true;
+    CHECK(cfg.use_openxr_quad_layer);
+}
+
+// A native-quad layer only goes native inside a kXr session; a detached
+// layer (and any window/offscreen session) keeps the record() draw path.
+// The full XR submission path needs a live OpenXR runtime, so it's covered
+// manually against CloudXR — here we pin the fallback gate + acquire
+// preconditions that are exercisable without a headset.
+TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_layer][native]")
+{
+    if (!is_gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+    auto& ctx = shared_vk_context();
+    auto target = RenderTarget::create(ctx, RenderTarget::Config{ Resolution{ 64, 64 } });
+
+    QuadLayer::Config cfg;
+    cfg.resolution = { 64, 64 };
+    cfg.use_openxr_quad_layer = true;
+    QuadLayer::Config::Placement pl;
+    pl.pose = viz::Pose3D{};
+    pl.size_meters = glm::vec2(1.0f, 1.0f);
+    cfg.placement = pl;
+    QuadLayer layer(ctx, target->render_pass(), cfg);
+
+    // No session attached → not native (so the compositor uses record()).
+    CHECK_FALSE(layer.is_native_quad());
+
+    // Nothing published yet → nullopt (no quad this frame), even before any
+    // placement matters.
+    CHECK_FALSE(layer.acquire_native_quad(0).has_value());
+
+    // Out-of-range in_flight_slot is rejected (same guard as record()).
+    CHECK_THROWS_AS(layer.acquire_native_quad(QuadLayer::kMaxFramesInFlight), std::logic_error);
+
+    // A native-quad layer with no placement is lenient before the first
+    // publish (returns nullopt) — this keeps a native session from throwing
+    // on startup frames where the placement strategy hasn't run yet — but
+    // once a frame is published without a placement, it's a misconfiguration.
+    QuadLayer::Config no_placement;
+    no_placement.resolution = { 64, 64 };
+    no_placement.use_openxr_quad_layer = true;
+    QuadLayer layer_np(ctx, target->render_pass(), no_placement);
+    CHECK_FALSE(layer_np.acquire_native_quad(0).has_value()); // lenient pre-publish
+
+    void* dev_ptr = nullptr;
+    REQUIRE(cudaMalloc(&dev_ptr, static_cast<size_t>(64) * 64 * 4) == cudaSuccess);
+    struct CudaFree
+    {
+        void* p;
+        ~CudaFree()
+        {
+            cudaFree(p);
+        }
+    } cuda_free{ dev_ptr };
+    viz::VizBuffer src{};
+    src.data = dev_ptr;
+    src.width = 64;
+    src.height = 64;
+    src.format = PixelFormat::kRGBA8;
+    src.pitch = static_cast<size_t>(64) * 4;
+    src.space = viz::MemorySpace::kDevice;
+    layer_np.submit(src);
+    CHECK_THROWS_AS(layer_np.acquire_native_quad(0), std::logic_error); // content, no placement
 }
 
 TEST_CASE("QuadLayer creates valid Vulkan + CUDA handles for every mailbox slot", "[gpu][quad_layer]")

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -72,7 +72,15 @@ void bind_layers(py::module_& m)
                        "Horizontal disparity between left and right planes (millimeters), "
                        "applied along the placement's local +x axis. 0 → both eyes see the "
                        "same world quad. Ignored unless stereo + kXr. mm-scale chosen because "
-                       "typical IPDs / stereo camera baselines are 50–80 mm.");
+                       "typical IPDs / stereo camera baselines are 50–80 mm.")
+        .def_readwrite("use_openxr_quad_layer", &viz::QuadLayer::Config::use_openxr_quad_layer,
+                       "Submit as a native OpenXR quad layer (XrCompositionLayerQuad) instead "
+                       "of compositing into the shared render target. kXr only (ignored in "
+                       "window/offscreen). Lets the runtime place + sample the quad directly, "
+                       "enabling its quad fast path; a frame whose visible layers are all native "
+                       "quads drops the projection layer entirely. Native quads carry no depth "
+                       "(flat billboard, submission-order composited) and require placement. "
+                       "Stereo emits one quad per eye. Off by default.");
 
     // ── QuadLayer (non-owning; session owns the lifetime) ─────────────
 

--- a/src/viz/session/cpp/inc/viz/session/display_backend.hpp
+++ b/src/viz/session/cpp/inc/viz/session/display_backend.hpp
@@ -148,6 +148,28 @@ public:
         return current_extent();
     }
 
+    // True when the backend can composite native OpenXR quad layers
+    // (XrCompositionLayerQuad). Only the kXr backend does. The compositor
+    // pairs this with a layer's is_native_quad() to route it natively.
+    virtual bool supports_native_quad() const noexcept
+    {
+        return false;
+    }
+
+    // Native-quad path: for each NativeQuadView, copy the source image(s)
+    // into a backend-owned per-quad swapchain and remember it for
+    // submission at end_frame (as one XrCompositionLayerQuad per eye).
+    // Recorded into the compositor's command buffer (so the layer's
+    // CUDA-done wait semaphores, threaded at TRANSFER stage, gate the copy)
+    // OUTSIDE any render pass. Empty ``views`` → nothing to composite.
+    // end_frame submits the shared projection layer only if the render pass
+    // or direct path also ran this frame. Default: unsupported (no-op).
+    virtual void record_native_quads(VkCommandBuffer /*cmd*/,
+                                     const Frame& /*frame*/,
+                                     const std::vector<NativeQuadView>& /*views*/)
+    {
+    }
+
     // Called after a successful submit. The host has NOT waited on the
     // in-flight fence (multi-frame-in-flight: that wait happens at the
     // top of render() for this slot's NEXT use), so the GPU may still

--- a/src/viz/session/cpp/inc/viz/session/layer_base.hpp
+++ b/src/viz/session/cpp/inc/viz/session/layer_base.hpp
@@ -47,6 +47,38 @@ struct DirectPresentView
     Resolution extent{}; // must equal the swapchain per-view size
 };
 
+// Per-frame descriptor for a layer that composites as a native OpenXR
+// quad (XrCompositionLayerQuad) instead of drawing into the shared render
+// target. The XR backend owns a color swapchain per quad, copies
+// ``color_left`` (and ``color_right`` for stereo) straight in, and submits
+// one XrCompositionLayerQuad per eye — no shared RT, no projection draw.
+// Only meaningful in kXr; non-XR backends never ask for one.
+//
+// A native quad carries no depth: XrCompositionLayerQuad has no depth
+// field, so the runtime composites it in submission order (flat billboard),
+// not z-tested against projection-layer 3D content. This is inherent to
+// OpenXR quad layers and is also what lets the runtime's quad fast path /
+// client-reconstructed streaming treat it cheaply.
+struct NativeQuadView
+{
+    // Source images (resting layout SHADER_READ_ONLY_OPTIMAL). Backend
+    // copies these into its own quad swapchain(s).
+    VkImage color_left = VK_NULL_HANDLE;
+    VkImage color_right = VK_NULL_HANDLE; // VK_NULL_HANDLE => mono (eyeVisibility BOTH)
+    Resolution extent{}; // per-eye source size; the quad swapchain matches it
+
+    // Placement in the session's reference space + physical size (meters).
+    Pose3D pose{};
+    glm::vec2 size_meters{ 0.0f, 0.0f };
+    // Per-eye horizontal disparity along the placement's local +x axis
+    // (millimeters); left eye shifts −half, right eye +half. Ignored mono.
+    float stereo_baseline_mm = 0.0f;
+
+    // Stable identity the backend keys its persistent quad swapchain(s) on
+    // across frames (the layer's ``this``). Never dereferenced by the backend.
+    const void* source_id = nullptr;
+};
+
 // Abstract layer drawn into the compositor's render pass (RGBA8_SRGB
 // color + D32_SFLOAT depth, single-sample). record() issues draw calls;
 // it must NOT end the render pass or submit. Resource lifetime is the
@@ -144,6 +176,28 @@ public:
     virtual std::vector<DirectPresentView> acquire_direct_views(uint32_t /*in_flight_slot*/)
     {
         return {};
+    }
+
+    // Native OpenXR quad support (see NativeQuadView). When true, the
+    // compositor — on a backend that supports_native_quad() — routes this
+    // layer through acquire_native_quad()/record_native_quads() instead of
+    // record(), and DROPS the shared projection layer for frames where every
+    // visible layer is a native quad (unlocking the runtime's quad fast
+    // path). Must return false unless the layer is in a kXr session, so the
+    // window/offscreen fallback still uses record(). Default: not native.
+    virtual bool is_native_quad() const noexcept
+    {
+        return false;
+    }
+
+    // Promote this frame's content into ``in_flight_slot`` (same slot the
+    // compositor passes to get_wait_semaphores()) and return the native
+    // quad descriptor. nullopt = nothing fresh to composite this frame (no
+    // publish yet) — the backend submits no quad for this layer. Called
+    // instead of record_pre_render_pass()/record() on the native-quad path.
+    virtual std::optional<NativeQuadView> acquire_native_quad(uint32_t /*in_flight_slot*/)
+    {
+        return std::nullopt;
     }
 
     // Let a layer reject a backend it can't run on. Called once by add_layer

--- a/src/viz/session/cpp/inc/viz/session/xr_backend.hpp
+++ b/src/viz/session/cpp/inc/viz/session/xr_backend.hpp
@@ -9,6 +9,7 @@
 #include <viz/xr/openxr_session.hpp>
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -78,6 +79,16 @@ public:
     void record_direct(VkCommandBuffer cmd, const Frame& frame, const std::vector<DirectPresentView>& views) override;
     Resolution recommended_view_resolution() const override;
 
+    // Native OpenXR quad layers (XrCompositionLayerQuad). Copies each
+    // NativeQuadView's source image(s) into a per-quad color swapchain and
+    // records the submission for end_frame; quad-only frames drop the shared
+    // projection layer (see projection_active_).
+    bool supports_native_quad() const noexcept override
+    {
+        return true;
+    }
+    void record_native_quads(VkCommandBuffer cmd, const Frame& frame, const std::vector<NativeQuadView>& views) override;
+
     void poll_events() override;
     bool should_close() const override;
     Resolution current_extent() const override;
@@ -127,6 +138,18 @@ private:
     void destroy_swapchains();
     void create_intermediate();
 
+    // Native-quad color swapchain(s) for one QuadLayer: 1 (mono) or 2
+    // (stereo, [left, right]). Created lazily on first submission, keyed by
+    // the layer's stable source_id, reused each frame.
+    struct NativeQuadSwapchain
+    {
+        std::vector<ViewSwapchain> eyes; // 1 mono, 2 stereo
+    };
+    // Ensure (lazily create) the quad swapchain(s) for ``key`` sized to
+    // ``extent`` with ``eye_count`` eyes; returns the cached entry.
+    NativeQuadSwapchain& ensure_native_quad_swapchain(const void* key, Resolution extent, uint32_t eye_count);
+    void destroy_native_quad_swapchains();
+
     // Per-eye staging buffers that bridge a direct ProjectionLayer's depth
     // (stored as R32_SFLOAT — CUDA can't interop a depth-format image) into
     // the D32_SFLOAT depth swapchain via image->buffer->image. The float bits
@@ -157,6 +180,27 @@ private:
     std::vector<ViewSwapchain> depth_swapchains_;
     bool depth_layer_enabled_ = false;
 
+    // Persistent per-QuadLayer native-quad swapchains, keyed by the layer's
+    // source_id. Created lazily in record_native_quads, destroyed with the
+    // backend. (Removing a native quad layer mid-session leaves its
+    // swapchain allocated until destroy — layer removal is rare.)
+    std::map<const void*, NativeQuadSwapchain> native_quad_swapchains_;
+
+    // One XrCompositionLayerQuad to submit this frame. Storage for the
+    // built XrCompositionLayerQuad lives in end_frame; this holds the
+    // inputs record_native_quads gathered. eye_visibility selects the eye
+    // (BOTH for mono).
+    struct NativeQuadSubmit
+    {
+        XrSwapchain swapchain = XR_NULL_HANDLE;
+        uint32_t width = 0;
+        uint32_t height = 0;
+        XrPosef pose{};
+        XrExtent2Df size{};
+        XrEyeVisibility eye_visibility = XR_EYE_VISIBILITY_BOTH;
+    };
+    std::vector<NativeQuadSubmit> active_native_quads_;
+
     // Per-eye R32_SFLOAT->D32_SFLOAT bridge buffers (see create_depth_staging).
     struct DepthStaging
     {
@@ -172,6 +216,12 @@ private:
     std::vector<XrView> last_views_;
     bool frame_began_ = false;
     bool frame_renderable_ = false; // false on shouldRender=0 / locate failure
+    // Set when the shared render pass (record_post_render_pass) or the
+    // direct path (record_direct) produced content for the projection
+    // layer this frame. When false at end_frame (every visible layer was a
+    // native quad), the projection layer is dropped so the runtime sees a
+    // quad-only frame and can engage its client-reconstructed path.
+    bool projection_active_ = false;
     // Monotonic counter that drives Frame::backend_token; the contract
     // (display_backend.hpp) requires 0..image_count()-1, which the
     // compositor then mods by its slot count. Image_count is 1 today

--- a/src/viz/session/cpp/viz_compositor.cpp
+++ b/src/viz/session/cpp/viz_compositor.cpp
@@ -301,20 +301,48 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
     // window/offscreen letterboxing only.
     const bool xr_mode = backend_->is_xr();
 
+    // Partition visible layers into native OpenXR quads (composited by the
+    // runtime as XrCompositionLayerQuad) and the rest (composited into the
+    // shared render target). is_native_quad() is true only in a kXr session,
+    // so window/offscreen keep every layer on the composite path.
+    std::vector<LayerBase*> composite_layers;
+    std::vector<LayerBase*> native_layers;
+    composite_layers.reserve(visible_layers.size());
+    const bool backend_native = backend_->supports_native_quad();
+    for (LayerBase* layer : visible_layers)
+    {
+        if (backend_native && layer->is_native_quad())
+        {
+            native_layers.push_back(layer);
+        }
+        else
+        {
+            composite_layers.push_back(layer);
+        }
+    }
+
+    // Run the shared render pass (and thus submit the projection layer) when
+    // there is composite content, OR when there are no native quads at all
+    // (preserve the "no visible layers → cleared frame" behavior). A
+    // native-quad-only frame skips the render pass entirely, so the backend
+    // drops the projection layer and the runtime sees a quad-only frame.
+    const bool run_composite = !composite_layers.empty() || native_layers.empty();
+
     // Direct-present: a single ProjectionLayer copied straight to the
-    // swapchain (no shared render pass). VizSession's add_layer guarantees
-    // a direct layer is the session's only layer, so size()==1 suffices.
+    // swapchain (no shared render pass). VizSession's add_layer guarantees a
+    // direct layer is the session's only layer (and it's never a native
+    // quad), so a composite_layers size of 1 suffices.
     const bool direct_mode =
-        visible_layers.size() == 1 && visible_layers[0]->supports_direct_present() && backend_->supports_direct();
+        composite_layers.size() == 1 && composite_layers[0]->supports_direct_present() && backend_->supports_direct();
 
     // Per-layer aspect-fit tiles (window/offscreen composited path only).
     std::vector<TileSlot> tiles;
-    if (!xr_mode && !direct_mode && !visible_layers.empty())
+    if (!xr_mode && !direct_mode && !composite_layers.empty())
     {
         const float fb_aspect = static_cast<float>(rt_extent.width) / static_cast<float>(rt_extent.height);
         std::vector<float> aspects;
-        aspects.reserve(visible_layers.size());
-        for (LayerBase* layer : visible_layers)
+        aspects.reserve(composite_layers.size());
+        for (LayerBase* layer : composite_layers)
         {
             aspects.push_back(layer->aspect_ratio().value_or(fb_aspect));
         }
@@ -334,13 +362,27 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
         vkCmdWriteTimestamp(command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, gpu_timestamp_pool_, query_base + 0);
     }
 
+    // Native quads: promote each layer's mailbox slot and gather its per-eye
+    // source images. Must precede the wait-semaphore gather below so
+    // get_wait_semaphores() reflects the promoted slot (like acquire_direct_views).
+    // acquire_native_quad returns nullopt when the layer hasn't published yet.
+    std::vector<NativeQuadView> native_views;
+    native_views.reserve(native_layers.size());
+    for (LayerBase* layer : native_layers)
+    {
+        if (auto v = layer->acquire_native_quad(slot))
+        {
+            native_views.push_back(*v);
+        }
+    }
+
     if (direct_mode)
     {
         // Promote the layer's latest published (color, depth) for this slot
         // and copy straight into the swapchain — no render pass, no shared
         // RT. acquire_direct_views must precede the wait-semaphore gather
         // below so get_wait_semaphores reflects the promoted slot.
-        const std::vector<DirectPresentView> direct_views = visible_layers[0]->acquire_direct_views(slot);
+        const std::vector<DirectPresentView> direct_views = composite_layers[0]->acquire_direct_views(slot);
 
         // ts1: nothing rendered into the RT; mark the point for symmetry.
         if (gpu_timestamp_pool_ != VK_NULL_HANDLE)
@@ -358,13 +400,13 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
                 command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, gpu_timestamp_pool_, query_base + 2);
         }
     }
-    else
+    else if (run_composite)
     {
         // Pre-pass hook for transfer/compute work that can't run inside a
         // render pass (e.g. QuadLayer mip-chain blits). Ordering: all
         // layers' pre-pass run BEFORE any record(), so a layer can rely on
         // its own pre-pass results inside record().
-        for (LayerBase* layer : visible_layers)
+        for (LayerBase* layer : composite_layers)
         {
             layer->record_pre_render_pass(command_buffer, slot);
         }
@@ -391,7 +433,7 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
             const VkRect2D rt_full{ { 0, 0 }, { rt_extent.width, rt_extent.height } };
             vkCmdSetScissor(command_buffer, 0, 1, &rt_full);
         }
-        for (size_t i = 0; i < visible_layers.size(); ++i)
+        for (size_t i = 0; i < composite_layers.size(); ++i)
         {
             std::vector<ViewInfo> layer_views = frame.views;
             if (layer_views.empty())
@@ -405,7 +447,7 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
                 vkCmdSetScissor(command_buffer, 0, 1, &scissor_rect);
                 layer_views[0].viewport = to_rect2d(viewport_rect);
             }
-            visible_layers[i]->record(command_buffer, layer_views, rt, slot);
+            composite_layers[i]->record(command_buffer, layer_views, rt, slot);
         }
 
         vkCmdEndRenderPass(command_buffer);
@@ -426,6 +468,23 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
                 command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, gpu_timestamp_pool_, query_base + 2);
         }
     }
+    else
+    {
+        // Native-quad-only frame: no shared render pass, no projection layer.
+        // Mark ts1/ts2 for gpu-timing symmetry (no render/post-pass work).
+        if (gpu_timestamp_pool_ != VK_NULL_HANDLE)
+        {
+            vkCmdWriteTimestamp(
+                command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, gpu_timestamp_pool_, query_base + 1);
+            vkCmdWriteTimestamp(
+                command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, gpu_timestamp_pool_, query_base + 2);
+        }
+    }
+
+    // Copy each native quad's source image(s) into the backend's runtime quad
+    // swapchain(s). No-op (and no projection-layer effect) when empty. Outside
+    // any render pass; the layer's CUDA-done waits gate it at TRANSFER stage.
+    backend_->record_native_quads(command_buffer, frame, native_views);
 
     // ts3: cmd-buffer-end (total = ts3-ts0).
     if (gpu_timestamp_pool_ != VK_NULL_HANDLE)

--- a/src/viz/session/cpp/xr_backend.cpp
+++ b/src/viz/session/cpp/xr_backend.cpp
@@ -147,6 +147,7 @@ void XrBackend::destroy()
     // images, so xrDestroySwapchain is enough (no vkDestroyImage).
     render_target_.reset();
     destroy_depth_staging();
+    destroy_native_quad_swapchains();
     destroy_swapchains();
     session_.reset();
     ctx_ = nullptr;
@@ -172,6 +173,14 @@ void XrBackend::release_acquired_swapchains() noexcept
     {
         release_one(sw);
     }
+    for (auto& [key, qs] : native_quad_swapchains_)
+    {
+        (void)key;
+        for (auto& sw : qs.eyes)
+        {
+            release_one(sw);
+        }
+    }
 }
 
 void XrBackend::abort_in_flight_frame() noexcept
@@ -186,6 +195,8 @@ void XrBackend::abort_in_flight_frame() noexcept
     release_acquired_swapchains();
     frame_began_ = false;
     frame_renderable_ = false;
+    projection_active_ = false;
+    active_native_quads_.clear();
     try
     {
         session_->end_frame(last_frame_state_.predictedDisplayTime, {});
@@ -217,6 +228,24 @@ void XrBackend::destroy_swapchains()
         sw.images.clear();
     }
     depth_swapchains_.clear();
+}
+
+void XrBackend::destroy_native_quad_swapchains()
+{
+    for (auto& [key, qs] : native_quad_swapchains_)
+    {
+        (void)key;
+        for (auto& sw : qs.eyes)
+        {
+            if (sw.handle != XR_NULL_HANDLE)
+            {
+                (void)xrDestroySwapchain(sw.handle);
+                sw.handle = XR_NULL_HANDLE;
+            }
+            sw.images.clear();
+        }
+    }
+    native_quad_swapchains_.clear();
 }
 
 int64_t XrBackend::pick_swapchain_format() const
@@ -423,6 +452,20 @@ glm::mat4 pose_to_world_matrix(const XrPosef& pose)
     return glm::translate(glm::mat4(1.0f), p) * glm::mat4_cast(q);
 }
 
+// Pose3D (glm, quat as w,x,y,z) → XrPosef (quat as x,y,z,w wire order).
+XrPosef pose3d_to_xr_pose(const Pose3D& p)
+{
+    XrPosef out{};
+    out.orientation.x = p.orientation.x;
+    out.orientation.y = p.orientation.y;
+    out.orientation.z = p.orientation.z;
+    out.orientation.w = p.orientation.w;
+    out.position.x = p.position.x;
+    out.position.y = p.position.y;
+    out.position.z = p.position.z;
+    return out;
+}
+
 // Per-eye projection from XR's signed-angle FOV. frustumRH_ZO gives
 // right-handed view + [0,1] depth (Vulkan). top/bottom are swapped
 // (angleUp → bottom) so XR-world +Y maps to Vulkan-clip −Y.
@@ -456,6 +499,11 @@ std::optional<DisplayBackend::Frame> XrBackend::begin_frame(int64_t /*ignored*/)
     session_->begin_frame();
     frame_began_ = true;
     frame_renderable_ = false;
+    // Reset per-frame composition state. projection_active_ is raised by
+    // record_post_render_pass / record_direct; native quads accumulate in
+    // record_native_quads. end_frame consumes both.
+    projection_active_ = false;
+    active_native_quads_.clear();
 
     // From here on, an exception MUST balance xrBeginFrame with an
     // empty xrEndFrame and release any swapchains we acquired. The
@@ -622,6 +670,8 @@ void XrBackend::record_post_render_pass(VkCommandBuffer cmd, const Frame& frame)
     {
         return;
     }
+    // The shared RT produced content this frame → submit the projection layer.
+    projection_active_ = true;
     const VkImage src = render_target_->color_image();
 
     // Wide intermediate split-blit: each per-eye region of the source
@@ -705,6 +755,8 @@ void XrBackend::record_direct(VkCommandBuffer cmd, const Frame& /*frame*/, const
     {
         return;
     }
+    // Direct-present fills the projection swapchains → submit the projection layer.
+    projection_active_ = true;
 
     // Direct-present: copy a ProjectionLayer's per-eye (color, depth)
     // straight into the per-eye swapchains — no wide intermediate, no
@@ -842,6 +894,191 @@ void XrBackend::record_direct(VkCommandBuffer cmd, const Frame& /*frame*/, const
     }
 }
 
+XrBackend::NativeQuadSwapchain& XrBackend::ensure_native_quad_swapchain(const void* key,
+                                                                        Resolution extent,
+                                                                        uint32_t eye_count)
+{
+    // Called from record_native_quads, i.e. between xrBeginFrame/xrEndFrame.
+    // xrCreateSwapchain is not part of the frame loop and is legal to call at
+    // any time after session creation (Monado/CloudXR allow it), so creating
+    // on a quad's first appearance is fine; every later frame hits the cache
+    // below. If some runtime ever rejects mid-frame creation, pre-create here
+    // from a layer-add hook instead.
+    auto it = native_quad_swapchains_.find(key);
+    if (it != native_quad_swapchains_.end() && it->second.eyes.size() == eye_count && !it->second.eyes.empty() &&
+        it->second.eyes[0].width == extent.width && it->second.eyes[0].height == extent.height)
+    {
+        return it->second;
+    }
+    // Fresh (or shape changed): (re)create. A shape change on an existing
+    // key is not expected — a QuadLayer's resolution/stereo are fixed at
+    // construction — but destroy the stale one defensively if it happens.
+    if (it != native_quad_swapchains_.end())
+    {
+        for (auto& sw : it->second.eyes)
+        {
+            if (sw.handle != XR_NULL_HANDLE)
+            {
+                (void)xrDestroySwapchain(sw.handle);
+            }
+        }
+        native_quad_swapchains_.erase(it);
+    }
+
+    // Destroy any already-created eye swapchains if creation of a later eye
+    // throws below (e.g. eye 1 of a stereo pair) — otherwise the eye-0 handle
+    // in this local would leak until session destroy.
+    NativeQuadSwapchain qs;
+    struct PartialGuard
+    {
+        NativeQuadSwapchain& qs;
+        bool dismissed = false;
+        ~PartialGuard()
+        {
+            if (dismissed)
+            {
+                return;
+            }
+            for (auto& sw : qs.eyes)
+            {
+                if (sw.handle != XR_NULL_HANDLE)
+                {
+                    (void)xrDestroySwapchain(sw.handle);
+                    sw.handle = XR_NULL_HANDLE;
+                }
+            }
+        }
+    } partial_guard{ qs };
+    qs.eyes.assign(eye_count, ViewSwapchain{});
+    for (uint32_t e = 0; e < eye_count; ++e)
+    {
+        XrSwapchainCreateInfo info{ XR_TYPE_SWAPCHAIN_CREATE_INFO };
+        // Mirror the projection swapchains' usage: the runtime reads these
+        // as composition sources, and COLOR_ATTACHMENT is the layout we
+        // release them in (a transition to COLOR_ATTACHMENT_OPTIMAL requires
+        // that usage bit).
+        info.usageFlags = XR_SWAPCHAIN_USAGE_TRANSFER_DST_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT;
+        info.format = swapchain_format_;
+        info.sampleCount = 1;
+        info.width = extent.width;
+        info.height = extent.height;
+        info.faceCount = 1;
+        info.arraySize = 1;
+        info.mipCount = 1;
+        check_xr(xrCreateSwapchain(session_->session(), &info, &qs.eyes[e].handle), "xrCreateSwapchain(native quad)");
+        qs.eyes[e].width = info.width;
+        qs.eyes[e].height = info.height;
+
+        uint32_t img_count = 0;
+        check_xr(xrEnumerateSwapchainImages(qs.eyes[e].handle, 0, &img_count, nullptr),
+                 "xrEnumerateSwapchainImages(native quad count)");
+        std::vector<XrSwapchainImageVulkan2KHR> vk_images(
+            img_count, XrSwapchainImageVulkan2KHR{ XR_TYPE_SWAPCHAIN_IMAGE_VULKAN2_KHR });
+        check_xr(xrEnumerateSwapchainImages(qs.eyes[e].handle, img_count, &img_count,
+                                            reinterpret_cast<XrSwapchainImageBaseHeader*>(vk_images.data())),
+                 "xrEnumerateSwapchainImages(native quad data)");
+        qs.eyes[e].images.reserve(img_count);
+        for (const auto& vi : vk_images)
+        {
+            qs.eyes[e].images.push_back(vi.image);
+        }
+    }
+    // Once emplace succeeds the map owns the handles (qs is moved-from, its
+    // eyes vector empty, so the guard's sweep is a no-op either way).
+    auto [ins, ok] = native_quad_swapchains_.emplace(key, std::move(qs));
+    partial_guard.dismissed = true;
+    (void)ok;
+    return ins->second;
+}
+
+void XrBackend::record_native_quads(VkCommandBuffer cmd, const Frame& /*frame*/, const std::vector<NativeQuadView>& views)
+{
+    if (!frame_renderable_ || views.empty())
+    {
+        return;
+    }
+
+    for (const auto& view : views)
+    {
+        const bool stereo = view.color_right != VK_NULL_HANDLE;
+        const uint32_t eye_count = stereo ? 2u : 1u;
+        NativeQuadSwapchain& qs = ensure_native_quad_swapchain(view.source_id, view.extent, eye_count);
+
+        // Per-eye baseline offset along the placement's local +x axis
+        // (world space), mirroring QuadLayer::record()'s stereo shift.
+        glm::vec3 baseline_axis_ws{ 0.0f };
+        const bool apply_baseline = stereo && view.stereo_baseline_mm != 0.0f;
+        if (apply_baseline)
+        {
+            baseline_axis_ws = glm::mat3_cast(view.pose.orientation) * glm::vec3(1.0f, 0.0f, 0.0f);
+        }
+
+        for (uint32_t e = 0; e < eye_count; ++e)
+        {
+            ViewSwapchain& sw = qs.eyes[e];
+
+            // Acquire + wait this quad swapchain image (released in end_frame).
+            XrSwapchainImageAcquireInfo acquire_info{ XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO };
+            check_xr(xrAcquireSwapchainImage(sw.handle, &acquire_info, &sw.current_image_index),
+                     "xrAcquireSwapchainImage(native quad)");
+            sw.acquired = true;
+            XrSwapchainImageWaitInfo wait_info{ XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO };
+            wait_info.timeout = XR_INFINITE_DURATION;
+            check_xr(xrWaitSwapchainImage(sw.handle, &wait_info), "xrWaitSwapchainImage(native quad)");
+
+            const VkImage dst = sw.images[sw.current_image_index];
+            const VkImage src = (e == 0) ? view.color_left : view.color_right;
+
+            transition_image(cmd, dst, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 0,
+                             VK_ACCESS_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT);
+            // Source DeviceImage rests in SHADER_READ_ONLY; move to TRANSFER_SRC
+            // and back so the next frame sees the same resting layout. Verbatim
+            // 1:1 copy (size-compatible UNORM↔SRGB, no color conversion) — the
+            // quad swapchain matches the source resolution.
+            transition_image(cmd, src, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+                             VK_ACCESS_SHADER_READ_BIT, VK_ACCESS_TRANSFER_READ_BIT,
+                             VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+            VkImageCopy region{};
+            region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            region.srcSubresource.layerCount = 1;
+            region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+            region.dstSubresource.layerCount = 1;
+            region.extent = { sw.width, sw.height, 1 };
+            vkCmdCopyImage(
+                cmd, src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+
+            transition_image(cmd, src, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+                             VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_SHADER_READ_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
+                             VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
+            // OpenXR expects COLOR_ATTACHMENT_OPTIMAL at xrEndFrame.
+            transition_image(cmd, dst, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+                             VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_COLOR_ATTACHMENT_READ_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
+
+            // Per-eye placement pose (baseline-shifted for stereo).
+            Pose3D eye_pose = view.pose;
+            if (apply_baseline)
+            {
+                const float sign = (e == 0) ? -1.0f : +1.0f;
+                // 0.5 halves the disparity per eye; 0.001 converts mm → m.
+                eye_pose.position += sign * (view.stereo_baseline_mm * 0.0005f) * baseline_axis_ws;
+            }
+
+            NativeQuadSubmit submit{};
+            submit.swapchain = sw.handle;
+            submit.width = sw.width;
+            submit.height = sw.height;
+            submit.pose = pose3d_to_xr_pose(eye_pose);
+            submit.size = XrExtent2Df{ view.size_meters.x, view.size_meters.y };
+            submit.eye_visibility =
+                stereo ? (e == 0 ? XR_EYE_VISIBILITY_LEFT : XR_EYE_VISIBILITY_RIGHT) : XR_EYE_VISIBILITY_BOTH;
+            active_native_quads_.push_back(submit);
+        }
+    }
+}
+
 Resolution XrBackend::recommended_view_resolution() const
 {
     if (session_)
@@ -891,12 +1128,29 @@ void XrBackend::end_frame(const Frame& /*frame*/)
         check_xr(xrReleaseSwapchainImage(sw.handle, &release_info), "xrReleaseSwapchainImage(depth)");
         sw.acquired = false;
     }
+    // Release native-quad swapchains acquired in record_native_quads. Their
+    // XrCompositionLayerQuad references the handle (not the image), so
+    // releasing before xrEndFrame is correct — matching the projection path.
+    for (auto& [key, qs] : native_quad_swapchains_)
+    {
+        (void)key;
+        for (auto& sw : qs.eyes)
+        {
+            if (!sw.acquired)
+            {
+                continue;
+            }
+            XrSwapchainImageReleaseInfo release_info{ XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO };
+            check_xr(xrReleaseSwapchainImage(sw.handle, &release_info), "xrReleaseSwapchainImage(native quad)");
+            sw.acquired = false;
+        }
+    }
 
     // Per-eye depth_info, chained via .next on each ProjectionView.
     // Storage outlives xrEndFrame. nearZ/farZ MUST match the projection
     // matrix; runtime uses them to reconstruct world-space depth.
     std::vector<XrCompositionLayerDepthInfoKHR> depth_infos;
-    if (depth_layer_enabled_)
+    if (depth_layer_enabled_ && projection_active_)
     {
         depth_infos.assign(
             depth_swapchains_.size(), XrCompositionLayerDepthInfoKHR{ XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR });
@@ -914,41 +1168,77 @@ void XrBackend::end_frame(const Frame& /*frame*/)
         }
     }
 
-    // Per-eye projection views referencing their own swapchain at the
-    // full recommended rect.
-    std::vector<XrCompositionLayerProjectionView> proj_views(
-        view_swapchains_.size(), XrCompositionLayerProjectionView{ XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW });
-    for (size_t i = 0; i < view_swapchains_.size(); ++i)
+    // Non-opaque env modes need the alpha-blend layer flag for the runtime
+    // to honor our alpha channel. Straight alpha (not premultiplied). Shared
+    // by the projection layer and native quads. Note: with this flag set,
+    // the runtime's client-reconstructed optimization stays off (it excludes
+    // source-alpha layers) — so passthrough quads composite correctly but
+    // don't get the color-only fast path; opaque VR quads do.
+    const bool is_passthrough = session_->environment_blend_mode() != XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
+    const XrCompositionLayerFlags blend_flags = is_passthrough ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
+
+    // Composition layer list, assembled from (optional) projection + native
+    // quads. All backing storage below outlives the session_->end_frame call.
+    std::vector<const XrCompositionLayerBaseHeader*> layers;
+
+    // Projection layer — only when the shared RT / direct path produced
+    // content this frame. Dropped for quad-only frames so the runtime sees a
+    // quad-only submission (enabling client-reconstructed streaming).
+    std::vector<XrCompositionLayerProjectionView> proj_views;
+    XrCompositionLayerProjection projection_layer{ XR_TYPE_COMPOSITION_LAYER_PROJECTION };
+    if (projection_active_)
     {
-        proj_views[i].pose = last_views_[i].pose;
-        proj_views[i].fov = last_views_[i].fov;
-        proj_views[i].subImage.swapchain = view_swapchains_[i].handle;
-        proj_views[i].subImage.imageRect.offset = { 0, 0 };
-        proj_views[i].subImage.imageRect.extent = { static_cast<int32_t>(view_swapchains_[i].width),
-                                                    static_cast<int32_t>(view_swapchains_[i].height) };
-        proj_views[i].subImage.imageArrayIndex = 0;
-        if (depth_layer_enabled_ && i < depth_infos.size())
+        proj_views.assign(
+            view_swapchains_.size(), XrCompositionLayerProjectionView{ XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW });
+        for (size_t i = 0; i < view_swapchains_.size(); ++i)
         {
-            proj_views[i].next = &depth_infos[i];
+            proj_views[i].pose = last_views_[i].pose;
+            proj_views[i].fov = last_views_[i].fov;
+            proj_views[i].subImage.swapchain = view_swapchains_[i].handle;
+            proj_views[i].subImage.imageRect.offset = { 0, 0 };
+            proj_views[i].subImage.imageRect.extent = { static_cast<int32_t>(view_swapchains_[i].width),
+                                                        static_cast<int32_t>(view_swapchains_[i].height) };
+            proj_views[i].subImage.imageArrayIndex = 0;
+            if (depth_layer_enabled_ && i < depth_infos.size())
+            {
+                proj_views[i].next = &depth_infos[i];
+            }
         }
+        projection_layer.layerFlags = blend_flags;
+        projection_layer.space = session_->reference_space();
+        projection_layer.viewCount = static_cast<uint32_t>(proj_views.size());
+        projection_layer.views = proj_views.data();
+        layers.push_back(reinterpret_cast<const XrCompositionLayerBaseHeader*>(&projection_layer));
     }
 
-    XrCompositionLayerProjection projection_layer{ XR_TYPE_COMPOSITION_LAYER_PROJECTION };
-    // Non-opaque env modes need the alpha-blend layer flag for the
-    // runtime to honor our alpha channel. Straight alpha (not premul).
-    const bool is_passthrough = session_->environment_blend_mode() != XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
-    projection_layer.layerFlags = is_passthrough ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
-    projection_layer.space = session_->reference_space();
-    projection_layer.viewCount = static_cast<uint32_t>(proj_views.size());
-    projection_layer.views = proj_views.data();
+    // Native quad layers gathered in record_native_quads (one per eye).
+    std::vector<XrCompositionLayerQuad> quad_layers;
+    quad_layers.reserve(active_native_quads_.size());
+    for (const auto& q : active_native_quads_)
+    {
+        XrCompositionLayerQuad ql{ XR_TYPE_COMPOSITION_LAYER_QUAD };
+        ql.layerFlags = blend_flags;
+        ql.space = session_->reference_space();
+        ql.eyeVisibility = q.eye_visibility;
+        ql.subImage.swapchain = q.swapchain;
+        ql.subImage.imageRect.offset = { 0, 0 };
+        ql.subImage.imageRect.extent = { static_cast<int32_t>(q.width), static_cast<int32_t>(q.height) };
+        ql.subImage.imageArrayIndex = 0;
+        ql.pose = q.pose;
+        ql.size = q.size;
+        quad_layers.push_back(ql);
+    }
+    for (const auto& ql : quad_layers)
+    {
+        layers.push_back(reinterpret_cast<const XrCompositionLayerBaseHeader*>(&ql));
+    }
 
-    const std::vector<const XrCompositionLayerBaseHeader*> layers = {
-        reinterpret_cast<const XrCompositionLayerBaseHeader*>(&projection_layer),
-    };
     // Clear flags BEFORE end_frame so a throw doesn't trigger a second
     // xrEndFrame from the compositor's FrameGuard → abort_frame path.
     frame_began_ = false;
     frame_renderable_ = false;
+    projection_active_ = false;
+    active_native_quads_.clear();
     session_->end_frame(last_frame_state_.predictedDisplayTime, layers);
 }
 

--- a/src/viz/session_tests/cpp/test_quad_milestone.cpp
+++ b/src/viz/session_tests/cpp/test_quad_milestone.cpp
@@ -486,3 +486,67 @@ TEST_CASE("QuadLayer fast producer: render samples only the latest publish", "[g
     CHECK(sample.b == expected.b);
     CHECK(sample.a == expected.a);
 }
+
+TEST_CASE("QuadLayer use_openxr_quad_layer falls back to the compositor outside kXr", "[gpu][quad_layer][native]")
+{
+    // The native OpenXR quad path only engages in a kXr session (needs a
+    // live runtime, validated manually against CloudXR). In offscreen the
+    // flag must be a no-op: is_native_quad() stays false and the layer still
+    // composites through record() exactly as a plain QuadLayer would.
+    if (!is_gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    constexpr uint32_t kSide = 64;
+    VizSession::Config cfg{};
+    cfg.mode = DisplayMode::kOffscreen;
+    cfg.external_context = &shared_vk_context();
+    cfg.window_width = kSide;
+    cfg.window_height = kSide;
+
+    auto session = VizSession::create(cfg);
+    REQUIRE(session != nullptr);
+    const auto* ctx = session->get_vk_context();
+    REQUIRE(ctx != nullptr);
+
+    QuadLayer::Config layer_cfg;
+    layer_cfg.name = "native_fallback";
+    layer_cfg.resolution = { kSide, kSide };
+    layer_cfg.use_openxr_quad_layer = true; // ignored outside kXr
+    // Placement is provided (a kXr native quad requires it); offscreen
+    // ignores it and draws fullscreen.
+    QuadLayer::Config::Placement pl;
+    pl.size_meters = glm::vec2(1.0f, 1.0f);
+    layer_cfg.placement = pl;
+    auto* layer = session->add_layer<QuadLayer>(*ctx, session->get_render_pass(), layer_cfg);
+    REQUIRE(layer != nullptr);
+
+    // Offscreen backend doesn't support native quads → the layer stays on
+    // the draw path, so the compositor renders it into the shared RT.
+    CHECK_FALSE(layer->is_native_quad());
+
+    const auto host_pattern = build_host_pattern(kSide);
+    void* device_ptr = nullptr;
+    REQUIRE(cudaMalloc(&device_ptr, host_pattern.size() * sizeof(Rgba)) == cudaSuccess);
+    CudaFreeGuard guard{ device_ptr };
+    REQUIRE(cudaMemcpy(device_ptr, host_pattern.data(), host_pattern.size() * sizeof(Rgba), cudaMemcpyHostToDevice) ==
+            cudaSuccess);
+    REQUIRE(cudaDeviceSynchronize() == cudaSuccess);
+
+    viz::VizBuffer src{};
+    src.data = device_ptr;
+    src.width = kSide;
+    src.height = kSide;
+    src.format = PixelFormat::kRGBA8;
+    src.pitch = static_cast<size_t>(kSide) * 4;
+    src.space = viz::MemorySpace::kDevice;
+    layer->submit(src);
+
+    session->render();
+
+    const auto image = session->readback_to_host();
+    REQUIRE(image.resolution().width == kSide);
+    REQUIRE(image.resolution().height == kSide);
+    check_quadrant_pattern(image, kSide);
+}


### PR DESCRIPTION
  ## Description
  
  Adds an opt-in native OpenXR quad path to Televiz: `QuadLayer::Config::use_openxr_quad_layer`.
  
  When set on a layer in a `kXr` session, the quad is submitted to the runtime as a native
  `XrCompositionLayerQuad` — the backend copies the CUDA-fed image into a per-layer, lazily-created
  color swapchain and lets the runtime place and sample the quad directly — instead of compositing it
  into the shared render target. Stereo layers emit one quad per eye via `eyeVisibility`, with the
  per-eye baseline offset matching the compositor path's convention. Frames whose visible layers are
  all native quads drop the shared projection layer entirely, so the runtime sees a quad-only
  submission and can engage its quad fast path / client-reconstructed streaming. Window/offscreen
  modes ignore the flag and keep the compositor draw path.
  
  Trade-off (documented on the config field): a native quad carries no depth — OpenXR quad layers
  have none — so it composites in submission order rather than z-testing against `ProjectionLayer`
  content, and `generate_mipmaps` is unused in native mode. In non-opaque (passthrough) blend modes
  the source-alpha layer flag keeps quads compositing correctly but excludes them from the runtime's
  client-reconstructed optimization; opaque VR sessions get the fast path.
  
  Implementation notes:
  
  - `layer_base`/`display_backend`: `NativeQuadView` descriptor plus `is_native_quad()` /
    `acquire_native_quad()` and `supports_native_quad()` / `record_native_quads()` extension points
  - `quad_layer`: extracted `promote_slot()` shared by the render-pass and native-quad consumers;
    `cuda_done_writing` waits at TRANSFER stage in native mode (the backend copy is the first GPU read)
  - `xr_backend`: per-quad swapchain cache keyed by layer identity (exception-safe partial-creation
    cleanup), `projection_active_` gating in `end_frame`, abort/release/destroy coverage
  - `viz_compositor`: partitions native vs composited layers; skips the shared render pass on
    quad-only frames
  - Python: exposes the flag on `QuadLayerConfig` (stub regenerated); `camera_viz` gains `--native-quad`
  
  ## Type of change 
  
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality) 
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update

  ## Testing

  Linux x86_64, 2× RTX 6000 Ada, CUDA 13.x.

  - **Unit/GPU (Release)**: full viz suites pass — `viz_core_tests` (186 assertions),
    `viz_layers_tests` (351), `viz_session_tests` (386). New `[native]` tests cover the config
    default, the native gate (`is_native_quad()` false without a kXr session), acquire preconditions
    (pre-publish leniency, placement required once content is published, out-of-range in-flight
    slot), and the offscreen fallback (flag set → still composites through `record()`, pixel-verified
    via readback).
  - **ASAN+UBSAN**: same suites pass with zero reports (`ASAN_OPTIONS=protect_shadow_gap=0` for CUDA).
  - **Python**: all 4 viz binding test files pass; flag round-trips through `QuadLayerConfig`.
  - **Live XR** against a local CloudXR runtime 6.2.0 (no client attached): mono native, stereo
    native, mixed native+composited (projection + quad in one `xrEndFrame`), and per-frame visibility
    toggling (projection layer drops and re-engages mid-session) — 300+ frames total, no XR errors,
    ~33 fps runtime pacing. Visual placement/disparity and streaming-fast-path engagement with a
    headset client remain to be verified manually.
  - `SKIP=check-copyright-year pre-commit run` passes on all changed files; clang-format clean.

  ## Checklist

  - [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
  - [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
  - [ ] I have made corresponding changes to the documentation
  - [x] I have added tests that prove my fix/feature works (or explained why not)
  - [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional native OpenXR quad-layer rendering for XR sessions.
  * Added `--native-quad` to the camera visualization example.
  * Native quad layers now support stereo placement, sizing, and per-eye imagery.
  * Quad-only XR frames can be presented without an intermediate projection layer.
  * Non-XR sessions continue using the existing compositor path.

* **Bug Fixes**
  * Improved frame synchronization for native quad rendering.

* **Tests**
  * Added coverage for configuration, prerequisites, fallback behavior, and quad-only presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->