### PR TITLE
feat(build): scikit-build-core from-source install (#735)

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -45,6 +45,16 @@ jobs:
       with:
         fetch-depth: 0 # Full history for accurate git describe
 
+    # CMakePresets.json defines one preset per supported Python (py3.10 … py3.13),
+    # each configuring an isolated build/cmake-cpython-3XX directory. Derive the
+    # preset name and its build directory once here; later steps (ctest, coverage,
+    # test packaging, install) need the directory the preset chose.
+    - name: Resolve CMake preset
+      run: |
+        py="${{ matrix.python_version }}"
+        echo "CMAKE_PRESET=py${py}" >> "$GITHUB_ENV"
+        echo "BUILD_DIR=build/cmake-cpython-${py//./}" >> "$GITHUB_ENV"
+
     - name: Install uv
       uses: ./.github/actions/setup-uv
 
@@ -102,10 +112,10 @@ jobs:
       with:
         path: |
           ~/vcpkg
-          build/vcpkg_installed
-        key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('cmake/DepthAIVcpkgManifest.cmake') }}
+          ${{ env.BUILD_DIR }}/vcpkg_installed
+        key: vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.CMAKE_PRESET }}-${{ env.VCPKG_COMMIT }}-${{ hashFiles('cmake/DepthAIVcpkgManifest.cmake') }}
         restore-keys: |
-          vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.VCPKG_COMMIT }}-
+          vcpkg-${{ runner.os }}-${{ runner.arch }}-${{ env.CMAKE_PRESET }}-${{ env.VCPKG_COMMIT }}-
 
     - name: Setup vcpkg
       run: |
@@ -142,9 +152,10 @@ jobs:
           )
         fi
 
-        cmake -B build \
+        # The preset supplies ISAAC_TELEOP_PYTHON_VERSION and the per-Python
+        # build directory; everything else is a command-line -D override.
+        cmake --preset "${CMAKE_PRESET}" \
           -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-          -DISAAC_TELEOP_PYTHON_VERSION=${{ matrix.python_version }} \
           -DCMAKE_C_COMPILER_LAUNCHER=ccache \
           -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DBUILD_PLUGIN_OAK_CAMERA=ON \
@@ -155,13 +166,13 @@ jobs:
           "${coverage_args[@]}"
 
     - name: Build
-      run: cmake --build build --parallel 4
+      run: cmake --build --preset "${CMAKE_PRESET}" --parallel 4
 
     - name: ccache stats
       run: ccache --show-stats
 
     - name: Run All Tests
-      run: ctest --test-dir build --output-on-failure --parallel
+      run: ctest --test-dir "${BUILD_DIR}" --output-on-failure --parallel
 
     - name: Generate coverage report
       if: ${{ matrix.build_type == 'Debug' && matrix.python_version == '3.11' && matrix.arch == 'x64' }}
@@ -171,10 +182,10 @@ jobs:
 
         gcovr_args=(
           --root "${GITHUB_WORKSPACE}"
-          --object-directory build/src
+          --object-directory "${BUILD_DIR}/src"
           # CMake compiler-id probes are not test targets and produce noisy gcov warnings.
-          --gcov-exclude "build/CMakeFiles/.*/CompilerId.*/.*"
-          --exclude-directories "build/CMakeFiles"
+          --gcov-exclude "${BUILD_DIR}/CMakeFiles/.*/CompilerId.*/.*"
+          --exclude-directories "${BUILD_DIR}/CMakeFiles"
           --filter "src/"
           --exclude "src/.*/.*_tests/.*"
           --exclude "src/.*/tests/.*"
@@ -226,10 +237,10 @@ jobs:
         mkdir -p viz-tests-pkg
         # Glob all viz_*_tests executables (covers viz_core_tests today, and
         # viz_layers_tests / viz_session_tests / viz_xr_tests as they ship).
-        find build/src/viz -name 'viz_*_tests' -type f -executable \
+        find "${BUILD_DIR}/src/viz" -name 'viz_*_tests' -type f -executable \
           -exec cp -v {} viz-tests-pkg/ \;
         if ! ls viz-tests-pkg/viz_*_tests >/dev/null 2>&1; then
-          echo "No viz test binaries found under build/src/viz/"
+          echo "No viz test binaries found under ${BUILD_DIR}/src/viz/"
           exit 1
         fi
         tar -cvzf viz-tests.tar.gz -C viz-tests-pkg .
@@ -245,7 +256,7 @@ jobs:
 
     - name: Install (Release only)
       if: matrix.build_type == 'Release'
-      run: cmake --install build
+      run: cmake --install "${BUILD_DIR}"
 
     - name: Repair wheel tags with auditwheel (Release only)
       if: matrix.build_type == 'Release'

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -292,6 +292,95 @@ jobs:
         if-no-files-found: error
         retention-days: 7
 
+  pip-editable-install:
+    # Validates the scikit-build-core (PEP 517/660) from-source install path added
+    # for issue #735: an sdist build and `pip install -e .` over the root
+    # pyproject.toml, which drives the same top-level CMake build as build-ubuntu.
+    # This guards the standards-based path so it does not rot. Single config
+    # (x64 / Python 3.11 / Release) is sufficient -- the backend just wraps CMake,
+    # already matrix-tested above. No CUDA/Vulkan here, so BUILD_VIZ stays auto-OFF.
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
+        persist-credentials: false
+
+    - name: Install uv
+      uses: ./.github/actions/setup-uv
+
+    - name: Install Apt dependencies
+      run: |
+        sudo apt-get update
+        # clang-format-14: the pip build enforces the clang-format gate (no
+        # cmake.define override), so the tool must be present or the build FATALs.
+        sudo apt-get install -y $CORE_APT_DEPS ccache patchelf clang-format-14
+
+    - name: Build sdist (validates backend config + metadata)
+      run: |
+        set -euo pipefail
+        uv build --sdist --python 3.11 --out-dir dist
+        ls -la dist
+
+    - name: Editable install
+      run: |
+        set -euo pipefail
+        uv venv --python 3.11 .venv-skbuild
+        # Editable install through scikit-build-core. It drives the same CMake
+        # build, scoped by pyproject.toml (no examples/tests/plugins/clang-format),
+        # and fetches C++ deps via FetchContent.
+        uv pip install --python .venv-skbuild -e .
+
+    - name: Import smoke test
+      run: |
+        set -euo pipefail
+        cat > "${RUNNER_TEMP}/skbuild_smoke.py" <<'PY'
+        import importlib.util
+
+        # (1) ABI check: actually import the compiled pybind11 extensions and the
+        # eager pure-Python packages. `import isaacteleop` also exercises the eager
+        # submodule chain (cloudxr, teleop_session_manager) that the base install
+        # must satisfy with only numpy+pyyaml.
+        import isaacteleop
+        for mod in (
+            "oxr",
+            "deviceio",
+            "deviceio_trackers",
+            "deviceio_session",
+            "schema",
+            "plugin_manager",
+        ):
+            importlib.import_module(f"isaacteleop.{mod}")
+
+        # (2) Completeness check: every top-level subpackage that the classic wheel
+        # ships (minus GPU-only `viz`, which is auto-OFF here) must be PACKAGED.
+        # find_spec locates the package without importing its optional third-party
+        # deps, so a subpackage silently dropped from the build fails loudly here
+        # even though the smoke env installs no extras.
+        expected = [
+            "isaacteleop.mcap",
+            "isaacteleop.rig",
+            "isaacteleop.cloudxr",
+            "isaacteleop.teleop_session_manager",
+            "isaacteleop.retargeters",
+            "isaacteleop.retargeting_engine",
+            "isaacteleop.retargeting_engine_ui",
+            "isaacteleop.haptic_devices",
+        ]
+        missing = [m for m in expected if importlib.util.find_spec(m) is None]
+        assert not missing, f"subpackages missing from the wheel: {missing}"
+
+        print("isaacteleop", isaacteleop.__version__, "imported OK;",
+              "all expected subpackages present")
+        PY
+        # Run the editable install directly with the venv's interpreter -- NOT via
+        # `uv run`, which (with [tool.uv] package = false) would use the project's
+        # own .venv without isaacteleop, rather than .venv-skbuild.
+        .venv-skbuild/bin/python "${RUNNER_TEMP}/skbuild_smoke.py"
+
   test-viz-gpu:
     # Runs [gpu]-tagged Catch2 tests for the Televiz module on a self-hosted
     # GPU runner. The build-ubuntu job runs on a GPU-less GitHub-hosted runner

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -25,6 +25,11 @@ jobs:
 
     env:
       SCCACHE_GHA_ENABLED: "true"
+      # CMakePresets.json preset used to configure/build, and the build directory
+      # it selects. Windows has no Python matrix, so it pins the CMakeLists
+      # default (3.11); keep the two in sync if that changes.
+      CMAKE_PRESET: py3.11
+      BUILD_DIR: build/cmake-cpython-311
 
     strategy:
       matrix:
@@ -48,15 +53,20 @@ jobs:
       uses: ilammy/msvc-dev-cmd@v1
 
     # vcpkg - required when BUILD_PLUGIN_OAK_CAMERA=ON for DepthAI v3.x deps
+    #
+    # vcpkg installs manifest ports into ${CMAKE_BINARY_DIR}/vcpkg_installed, so
+    # this path tracks the preset's build directory. The preset is part of the key
+    # for the same reason: an entry saved from a different build directory would
+    # restore to a path this job never reads.
     - name: Cache vcpkg
       uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: |
           C:\vcpkg
-          build\vcpkg_installed
-        key: vcpkg-${{ runner.os }}-${{ hashFiles('cmake/DepthAIVcpkgManifest.cmake') }}
+          ${{ env.BUILD_DIR }}/vcpkg_installed
+        key: vcpkg-${{ runner.os }}-${{ env.CMAKE_PRESET }}-${{ hashFiles('cmake/DepthAIVcpkgManifest.cmake') }}
         restore-keys: |
-          vcpkg-${{ runner.os }}-
+          vcpkg-${{ runner.os }}-${{ env.CMAKE_PRESET }}-
 
     - name: Setup vcpkg
       run: |
@@ -94,11 +104,14 @@ jobs:
 
     - name: Configure CMake
       # Note:
+      # The py3.11 preset selects Python 3.11 (the CMakeLists default) and the
+      # build/cmake-cpython-311 build directory; the generator and the flags below
+      # are command-line additions on top of it.
       # sccache does not work with VSBuild, so we use Ninja generator here.
       # -G Ninja would pickup mingw64 by default on Windows, so we explicitly set the compiler to cl.exe
       # Force embedded debug info (Z7) to avoid PDB contention whenever debug info is generated.
       run: >
-        cmake -B build -G Ninja
+        cmake --preset ${{ env.CMAKE_PRESET }} -G Ninja
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DENABLE_EXPERIMENTAL_WINDOWS_BUILD=ON
         -DCMAKE_C_COMPILER_LAUNCHER=sccache
@@ -111,7 +124,7 @@ jobs:
         -DCMAKE_TOOLCHAIN_FILE="${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake"
 
     - name: Build
-      run: cmake --build build --parallel
+      run: cmake --build --preset ${{ env.CMAKE_PRESET }} --parallel
 
     - name: Run All Tests
-      run: ctest --test-dir build --output-on-failure --parallel
+      run: ctest --test-dir ${{ env.BUILD_DIR }} --output-on-failure --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,3 +201,41 @@ endif()
 
 # Formatting enforcement (runs on Linux by default)
 include(cmake/ClangFormat.cmake)
+
+# ==============================================================================
+# scikit-build-core: install every built executable into the venv's bin/
+# ==============================================================================
+# Under pip (SKBUILD), put all executables built from this repo -- examples, C++
+# test binaries, plugin tools, etc. -- on the venv PATH via the wheel's scripts
+# scheme. We walk the directory tree from the project root but skip deps/ (and any
+# FetchContent _deps/ subtree) so third-party executables (e.g. flatc) are never
+# swept in. Shared libraries (Python extension modules, plugin .so) are not
+# executables and are handled elsewhere / not installed here; a plugin that skips a
+# missing SDK becomes a UTILITY target and is naturally excluded. Tagged with the
+# isaacteleop_binaries component, selected via install.components in pyproject.toml.
+if(SKBUILD)
+    function(isaac_teleop_install_executables _dir)
+        # Skip third-party dependency trees (deps/ and FetchContent's _deps/).
+        if(_dir STREQUAL "${CMAKE_SOURCE_DIR}/deps" OR _dir MATCHES "/_deps/")
+            return()
+        endif()
+        get_property(_subdirs DIRECTORY "${_dir}" PROPERTY SUBDIRECTORIES)
+        foreach(_subdir IN LISTS _subdirs)
+            isaac_teleop_install_executables("${_subdir}")
+        endforeach()
+        get_property(_targets DIRECTORY "${_dir}" PROPERTY BUILDSYSTEM_TARGETS)
+        foreach(_target IN LISTS _targets)
+            get_target_property(_type "${_target}" TYPE)
+            get_target_property(_imported "${_target}" IMPORTED)
+            if(_type STREQUAL "EXECUTABLE" AND NOT _imported)
+                install(TARGETS "${_target}"
+                    RUNTIME DESTINATION "${SKBUILD_SCRIPTS_DIR}"
+                    COMPONENT isaacteleop_binaries)
+            endif()
+        endforeach()
+    endfunction()
+
+    # Walk from the project root (deps/ skipped) so every executable built from
+    # this repo -- across src/ and examples/ -- is installed.
+    isaac_teleop_install_executables("${CMAKE_SOURCE_DIR}")
+endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,36 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": { "major": 3, "minor": 21, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "py3.10",
+      "displayName": "Python 3.10 (build/cmake-cpython-310)",
+      "binaryDir": "${sourceDir}/build/cmake-cpython-310",
+      "cacheVariables": { "ISAAC_TELEOP_PYTHON_VERSION": "3.10" }
+    },
+    {
+      "name": "py3.11",
+      "displayName": "Python 3.11 (build/cmake-cpython-311)",
+      "binaryDir": "${sourceDir}/build/cmake-cpython-311",
+      "cacheVariables": { "ISAAC_TELEOP_PYTHON_VERSION": "3.11" }
+    },
+    {
+      "name": "py3.12",
+      "displayName": "Python 3.12 (build/cmake-cpython-312)",
+      "binaryDir": "${sourceDir}/build/cmake-cpython-312",
+      "cacheVariables": { "ISAAC_TELEOP_PYTHON_VERSION": "3.12" }
+    },
+    {
+      "name": "py3.13",
+      "displayName": "Python 3.13 (build/cmake-cpython-313)",
+      "binaryDir": "${sourceDir}/build/cmake-cpython-313",
+      "cacheVariables": { "ISAAC_TELEOP_PYTHON_VERSION": "3.13" }
+    }
+  ],
+  "buildPresets": [
+    { "name": "py3.10", "configurePreset": "py3.10" },
+    { "name": "py3.11", "configurePreset": "py3.11" },
+    { "name": "py3.12", "configurePreset": "py3.12" },
+    { "name": "py3.13", "configurePreset": "py3.13" }
+  ]
+}

--- a/CMakePresets.json.license
+++ b/CMakePresets.json.license
@@ -1,0 +1,2 @@
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0

--- a/cmake/SetupPython.cmake
+++ b/cmake/SetupPython.cmake
@@ -69,49 +69,67 @@ option(BUILD_PYTHON_BINDINGS "Build Python bindings" ON)
 
 # Guard to prevent multiple inclusions from overwriting our settings
 if(NOT ISAAC_TELEOP_PYTHON_CONFIGURED)
-    # Unset any previously found Python to prevent interference from venvs
-    unset(Python3_EXECUTABLE CACHE)
-    unset(Python3_LIBRARY CACHE)
-    unset(Python3_INCLUDE_DIR CACHE)
-    unset(PYTHON_EXECUTABLE CACHE)
+    if(SKBUILD)
+        # ----------------------------------------------------------------------
+        # Building the wheel via scikit-build-core (pip / uv build / PEP 517/660).
+        # ----------------------------------------------------------------------
+        # The interpreter running the build backend is what determines the wheel's
+        # ABI tag (e.g. cp311). We therefore MUST compile the extensions against
+        # that SAME interpreter, rather than forcing a uv-managed one -- otherwise
+        # the wheel gets tagged for one Python but contains .so built for another.
+        # scikit-build-core provides Python3_EXECUTABLE and the FindPython hints;
+        # honor them instead of running the uv discovery below.
+        message(STATUS "SKBUILD: using scikit-build-core's Python interpreter for the wheel build")
+        find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+        # Keep ISAAC_TELEOP_PYTHON_VERSION consistent with the real interpreter so
+        # any downstream consumer of the variable matches the compiled ABI.
+        set(ISAAC_TELEOP_PYTHON_VERSION "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}"
+            CACHE STRING "Python version for Isaac Teleop" FORCE)
+    else()
+        # Unset any previously found Python to prevent interference from venvs
+        unset(Python3_EXECUTABLE CACHE)
+        unset(Python3_LIBRARY CACHE)
+        unset(Python3_INCLUDE_DIR CACHE)
+        unset(PYTHON_EXECUTABLE CACHE)
 
-    # Check if uv is available
-    find_program(UV_EXECUTABLE uv)
+        # Check if uv is available
+        find_program(UV_EXECUTABLE uv)
 
-    if(NOT UV_EXECUTABLE)
-        message(FATAL_ERROR "uv not found. Please install uv: curl -LsSf https://astral.sh/uv/install.sh | sh")
+        if(NOT UV_EXECUTABLE)
+            message(FATAL_ERROR "uv not found. Please install uv: curl -LsSf https://astral.sh/uv/install.sh | sh")
+        endif()
+
+        # First, ensure the required Python version is installed as a managed version
+        message(STATUS "Ensuring Python ${ISAAC_TELEOP_PYTHON_VERSION} is installed via uv...")
+        execute_process(
+            COMMAND ${UV_EXECUTABLE} python install ${ISAAC_TELEOP_PYTHON_VERSION} --quiet
+            OUTPUT_QUIET
+            ERROR_QUIET
+            RESULT_VARIABLE UV_INSTALL_RESULT
+        )
+
+        # Now find the managed Python
+        execute_process(
+            COMMAND ${UV_EXECUTABLE} python find ${ISAAC_TELEOP_PYTHON_VERSION}
+            OUTPUT_VARIABLE UV_PYTHON_PATH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+            RESULT_VARIABLE UV_FIND_RESULT
+        )
+
+        if(NOT UV_FIND_RESULT EQUAL 0 OR NOT EXISTS "${UV_PYTHON_PATH}")
+            message(FATAL_ERROR "Could not find managed Python ${ISAAC_TELEOP_PYTHON_VERSION} with uv.")
+        endif()
+
+        # Force CMake to use our specific Python
+        set(Python3_EXECUTABLE "${UV_PYTHON_PATH}" CACHE FILEPATH "Path to Python3 executable" FORCE)
+        set(PYTHON_EXECUTABLE "${UV_PYTHON_PATH}" CACHE FILEPATH "Path to Python executable" FORCE)
+        message(STATUS "Using managed Python ${ISAAC_TELEOP_PYTHON_VERSION} from uv: ${Python3_EXECUTABLE}")
+
+        # Find Python using the executable we determined
+        # Use EXACT to prevent CMake from finding a different version
+        find_package(Python3 ${ISAAC_TELEOP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
     endif()
-
-    # First, ensure the required Python version is installed as a managed version
-    message(STATUS "Ensuring Python ${ISAAC_TELEOP_PYTHON_VERSION} is installed via uv...")
-    execute_process(
-        COMMAND ${UV_EXECUTABLE} python install ${ISAAC_TELEOP_PYTHON_VERSION} --quiet
-        OUTPUT_QUIET
-        ERROR_QUIET
-        RESULT_VARIABLE UV_INSTALL_RESULT
-    )
-
-    # Now find the managed Python
-    execute_process(
-        COMMAND ${UV_EXECUTABLE} python find ${ISAAC_TELEOP_PYTHON_VERSION}
-        OUTPUT_VARIABLE UV_PYTHON_PATH
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-        RESULT_VARIABLE UV_FIND_RESULT
-    )
-
-    if(NOT UV_FIND_RESULT EQUAL 0 OR NOT EXISTS "${UV_PYTHON_PATH}")
-        message(FATAL_ERROR "Could not find managed Python ${ISAAC_TELEOP_PYTHON_VERSION} with uv.")
-    endif()
-
-    # Force CMake to use our specific Python
-    set(Python3_EXECUTABLE "${UV_PYTHON_PATH}" CACHE FILEPATH "Path to Python3 executable" FORCE)
-    set(PYTHON_EXECUTABLE "${UV_PYTHON_PATH}" CACHE FILEPATH "Path to Python executable" FORCE)
-    message(STATUS "Using managed Python ${ISAAC_TELEOP_PYTHON_VERSION} from uv: ${Python3_EXECUTABLE}")
-
-    # Find Python using the executable we determined
-    # Use EXACT to prevent CMake from finding a different version
-    find_package(Python3 ${ISAAC_TELEOP_PYTHON_VERSION} EXACT REQUIRED COMPONENTS Interpreter Development)
 
     message(STATUS "Building Python bindings with: ${Python3_EXECUTABLE} (version ${Python3_VERSION})")
 

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -107,13 +107,30 @@ See :ref:`dedicated-cloudxr-runtime`.
 2. CMake: Configure and build
 -----------------------------
 
-From the project root:
+From the project root, configure with a **preset** — there is one per supported
+Python version (``py3.10`` … ``py3.13``; see :code-file:`CMakePresets.json`). A
+preset selects the Python version and an isolated per-version build directory, so
+different versions never share (and clobber) one configured CMake cache:
 
 .. code-block:: bash
 
-   cmake -B build
-   cmake --build build --parallel
-   cmake --install build
+   cmake --preset py3.12                       # configure
+   cmake --build --preset py3.12 --parallel    # build
+   cmake --install build/cmake-cpython-312     # install
+
+``cmake --preset py3.12`` is shorthand for the explicit configure it expands to —
+an isolated build directory plus the Python version:
+
+.. code-block:: bash
+
+   cmake -B build/cmake-cpython-312 -DISAAC_TELEOP_PYTHON_VERSION=3.12
+
+Add any other options as ``-D`` flags on the same line; a command-line ``-D``
+overrides the preset (e.g. ``cmake --preset py3.12 -DCMAKE_BUILD_TYPE=Debug``).
+Pick the preset that matches your interpreter rather than overriding
+``ISAAC_TELEOP_PYTHON_VERSION`` by hand. (A bare ``cmake -B build`` still works
+for a quick default build — Python 3.11 into ``./build`` — but the presets are
+the recommended path.)
 
 This will:
 
@@ -134,7 +151,7 @@ To disable enforcement, set ``ENABLE_CLANG_FORMAT_CHECK`` to ``OFF``:
 
 .. code-block:: bash
 
-   cmake -B build -DENABLE_CLANG_FORMAT_CHECK=OFF
+   cmake --preset py3.12 -DENABLE_CLANG_FORMAT_CHECK=OFF
 
 Useful targets:
 
@@ -143,8 +160,8 @@ Useful targets:
 
 .. code-block:: bash
 
-   cmake --build build --target clang_format_check
-   cmake --build build --target clang_format_fix
+   cmake --build --preset py3.12 --target clang_format_check
+   cmake --build --preset py3.12 --target clang_format_fix
 
 Other Build options
 ~~~~~~~~~~~~~~~~~~~
@@ -211,55 +228,55 @@ The CMake options (defined in root :code-file:`CMakeLists.txt` and :code-file:`c
 Examples
 ~~~~~~~~
 
-Build with a different Python version (must match a version supported by ``SetupPython.cmake``):
+Build for a different Python version — use the matching preset (``py3.10``,
+``py3.11``, ``py3.12``, ``py3.13``):
 
 .. code-block:: bash
 
-   cmake -B build -DISAAC_TELEOP_PYTHON_VERSION=3.12
-   cmake --build build
+   cmake --preset py3.10
+   cmake --build --preset py3.10 --parallel
 
 Debug build:
 
 .. code-block:: bash
 
-   cmake -B build -DCMAKE_BUILD_TYPE=Debug
-   cmake --build build
+   cmake --preset py3.12 -DCMAKE_BUILD_TYPE=Debug
+   cmake --build --preset py3.12
 
 Build without examples:
 
 .. code-block:: bash
 
-   cmake -B build -DBUILD_EXAMPLES=OFF
-   cmake --build build
+   cmake --preset py3.12 -DBUILD_EXAMPLES=OFF
+   cmake --build --preset py3.12
 
 Build without Python bindings:
 
 .. code-block:: bash
 
-   cmake -B build -DBUILD_PYTHON_BINDINGS=OFF
-   cmake --build build
+   cmake --preset py3.12 -DBUILD_PYTHON_BINDINGS=OFF
+   cmake --build --preset py3.12
 
 Build with OAK camera plugin (pulls Hunter/DepthAI):
 
 .. code-block:: bash
 
-   cmake -B build -DBUILD_PLUGIN_OAK_CAMERA=ON
-   cmake --build build
+   cmake --preset py3.12 -DBUILD_PLUGIN_OAK_CAMERA=ON
+   cmake --build --preset py3.12
 
 Build only the teleop_ros2 example (e.g. for Docker, as in :code-file:`build-ubuntu.yml <.github/workflows/build-ubuntu.yml>` teleop-ros2-docker job):
 
 .. code-block:: bash
 
-   cmake -B build -DBUILD_EXAMPLES=OFF -DBUILD_EXAMPLE_TELEOP_ROS2=ON
-   cmake --build build
+   cmake --preset py3.12 -DBUILD_EXAMPLES=OFF -DBUILD_EXAMPLE_TELEOP_ROS2=ON
+   cmake --build --preset py3.12
 
-Clean rebuild:
+Clean rebuild (``--fresh`` wipes the preset's CMake cache and reconfigures):
 
 .. code-block:: bash
 
-   rm -rf build
-   cmake -B build
-   cmake --build build
+   cmake --preset py3.12 --fresh
+   cmake --build --preset py3.12
 
 3. Running tests
 ----------------
@@ -268,10 +285,10 @@ When ``BUILD_TESTING`` is ``ON``, CTest is enabled at the top level. Run all tes
 
 .. code-block:: bash
 
-   cmake --build build --target test
+   cmake --build --preset py3.12 --target test
 
    # Or with ctest (e.g. parallel, output on failure)
-   ctest --test-dir build --output-on-failure --parallel
+   ctest --test-dir build/cmake-cpython-312 --output-on-failure --parallel
 
 The CI uses ``ctest`` (see :code-file:`build-ubuntu.yml <.github/workflows/build-ubuntu.yml>`).
 
@@ -292,6 +309,85 @@ based on the Python version.  Note that ``pip`` and ``uv pip`` has slightly diff
 
    # Pass --reinstall to replace an existing install.
    uv pip install "isaacteleop[retargeters,cloudxr,ui]" --find-links=./install/wheels/ --reinstall
+
+Alternative: install directly from source with pip
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The repository also ships a root :code-file:`pyproject.toml` using the
+`scikit-build-core <https://scikit-build-core.readthedocs.io/>`_ backend, which
+drives the same top-level ``CMakeLists.txt``. This lets you build and install
+with standard Python tooling, without running the ``cmake -B build`` steps
+yourself; the classic flow above (which CI uses to produce ``install/wheels/`` and
+the released wheels) is unchanged, so the two coexist.
+
+.. code-block:: bash
+
+   pip install .            # build + install the compiled wheel from source
+   pip install -e .         # editable / developer install
+
+.. note::
+
+   The CMake build tree is kept under ``build/wheel-<cache-tag>/`` (e.g.
+   ``build/wheel-cpython-311/``) — one per Python version, so different
+   interpreters never share a configured CMake cache — instead of a temporary
+   directory. Re-installs are therefore incremental. The classic CMake path uses
+   sibling ``build/cmake-<cache-tag>/`` trees (via the presets below) with the same
+   per-version tag, so the two never collide; ``build/`` is gitignored.
+
+What this path does and how it differs from the classic flow:
+
+- **Full build, no overrides.** The backend passes no ``cmake.define`` overrides,
+  so ``BUILD_EXAMPLES``, ``BUILD_TESTING``, and ``BUILD_PLUGINS`` stay at their
+  CMake defaults: a ``pip install`` builds the full default target — extensions,
+  examples, C++ tests, and plugins (a plugin without its SDK skips gracefully). It
+  installs only the ``isaacteleop_wheel`` and ``isaacteleop_binaries`` components,
+  so C++ library/header install rules do not leak into the wheel.
+- **clang-format is enforced.** Because the gate is left on, the build **fails** if
+  ``clang-format-14`` is not installed or any C++ file is unformatted — a
+  ``pip install`` therefore requires ``clang-format-14`` on Linux.
+- **All executables on PATH.** Every executable built from ``src/`` and
+  ``examples/`` — example programs, C++ test binaries, plugin tools
+  (``oxr_simple_api_demo``, ``se3_printer``, ``schema_tests``, …) — is installed
+  into the venv's ``bin/`` (the wheel's scripts scheme; see the executable-install
+  loop in the root ``CMakeLists.txt``), so they are on ``PATH`` once the venv is
+  active. They statically link the teleop core libraries, so they are
+  self-contained. Shared libraries (Python extension modules, plugin ``.so``) are
+  not executables and are **not** placed in ``bin/``.
+- **ABI.** Extensions are compiled against the interpreter that runs the build
+  (so the wheel's ABI tag matches) and against NumPy 2.x, so a single wheel works
+  with both NumPy 1.x and 2.x at runtime.
+- **No type stubs.** The pip-built wheel omits the ``.pyi`` stubs that the classic
+  and released wheels ship (stub generation shells out to ``uv``, which is not
+  guaranteed inside pip's build isolation). Imports and runtime behavior are
+  unaffected.
+- **Version.** The pip-facing version is derived from the ``VERSION`` file as
+  ``MAJOR.MINOR+local`` — the same value the classic flow produces for a
+  non-CI/local build. The pip path is a from-source/dev build, so it is always
+  tagged ``+local``; the git-aware release versioning (tags, ``a1`` / ``rc1`` /
+  ``.devN`` labels) stays with the classic flow via
+  :code-file:`cmake/IsaacTeleopVersion.cmake`.
+
+.. admonition:: Editable installs and iterating on pure-Python subpackages
+
+   An editable install (``pip install -e .``) does **not** recompile on import, so
+   it is fast and works offline. However, the pure-Python subpackages (e.g.
+   ``isaacteleop.retargeters``) are *copied* from ``src/`` into the package tree by
+   CMake, so editing ``src/retargeters/`` does not take effect live — re-run
+   ``pip install -e .`` (or ``cmake --build``) to re-stage. Making source-tree
+   edits live for the pure-Python packages is a planned follow-up (see `issue #735
+   <https://github.com/NVIDIA/IsaacTeleop/issues/735>`_).
+
+See :doc:`/references/build` for the full build-system reference.
+
+.. admonition:: ``retargeters`` extra on aarch64 (Jetson / DGX)
+
+   The full ``retargeters`` extra does **not** resolve on ``aarch64`` (some of its
+   pinned dependencies have no aarch64 wheels). On Jetson/DGX-class robotics
+   targets, install the ``retargeters-lite`` extra instead:
+
+   .. code-block:: bash
+
+      pip install "isaacteleop[retargeters-lite]"
 
 .. toctree::
    :hidden:

--- a/docs/source/references/build.rst
+++ b/docs/source/references/build.rst
@@ -66,6 +66,52 @@ After building, install the wheel with ``uv`` or ``pip``:
    # or
    pip install install/wheels/isaacteleop-*.whl
 
+Installing from source with pip (scikit-build-core)
+---------------------------------------------------
+
+In addition to the CMake ``--preset`` flow above (which stages the package
+and produces a wheel under ``install/wheels/``), the repository ships a root
+:code-file:`pyproject.toml` that exposes ``isaacteleop`` through the
+`scikit-build-core <https://scikit-build-core.readthedocs.io/>`_ build backend,
+driving the *same* top-level ``CMakeLists.txt`` (so the two paths coexist):
+
+.. code-block:: bash
+
+   pip install .            # build + install the compiled wheel from source
+   pip install -e .         # editable / developer install
+
+For the walkthrough — how this scoped build differs from the classic flow (ABI,
+omitted type stubs, versioning) and the caveat on iterating on pure-Python
+subpackages under an editable install — see
+:doc:`/getting_started/build_from_source/index`.
+
+Build directory layout and per-Python-version builds
+----------------------------------------------------
+
+A CMake binary directory holds exactly one configured Python version (the
+interpreter and ABI are baked into ``CMakeCache.txt``), so the two build paths use
+distinct, per-version directories under ``build/`` — never a shared one. Both key
+the directory off the interpreter's ``cache_tag`` (``sys.implementation.cache_tag``,
+e.g. ``cpython-312``) so the per-version tag is consistent between them:
+
+- **pip / scikit-build-core** → ``build/wheel-<cache-tag>/`` (e.g.
+  ``build/wheel-cpython-312/``), set by ``build-dir`` in
+  :code-file:`pyproject.toml` and chosen automatically per interpreter.
+- **classic CMake** → ``build/cmake-<cache-tag>/``, via the presets in
+  :code-file:`CMakePresets.json` (``py3.10`` … ``py3.13``). Each preset sets
+  ``ISAAC_TELEOP_PYTHON_VERSION`` and its own ``binaryDir``:
+
+  .. code-block:: bash
+
+     cmake --preset py3.12                     # configures build/cmake-cpython-312
+     cmake --build --preset py3.12 --parallel
+     cmake --install build/cmake-cpython-312
+
+The wheel/ABI tag (``cp312-cp312-linux_aarch64``) can't be expressed as a CMake
+preset, so ``cache_tag`` is the common tag both paths share. Because each Python
+version gets its own directory, switching versions never reuses a stale configured
+cache. ``build/`` is gitignored.
+
 Output locations
 ----------------
 
@@ -98,19 +144,19 @@ You can inspect the ``_deps`` directory in your build tree for fetch logs.
 CMake can't find OpenXR
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-OpenXR is fetched automatically; it is not a system package. If configuration fails, try a clean configure:
+OpenXR is fetched automatically; it is not a system package. If configuration fails, try a clean configure
+(``--fresh`` wipes the preset's CMake cache and reconfigures):
 
 .. code-block:: bash
 
-   rm -rf build
-   cmake -B build
+   cmake --preset py3.12 --fresh
 
 Examples or tests can't find the library
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When building from the top-level, examples and tests use the build tree. Ensure you run
-``cmake --build build`` from the project root and run executables from the build directory (or use
-``cmake --install build`` and run from ``install/``).
+``cmake --build --preset py3.12`` from the project root and run executables from the build directory
+(``build/cmake-cpython-312/``, or use ``cmake --install build/cmake-cpython-312`` and run from ``install/``).
 
 uv or Python version
 ~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# scikit-build-core backend for `pip install .` / `pip install -e .` / sdist from
+# source. Drives the same top-level CMakeLists.txt as the classic `cmake -B build`
+# flow (both coexist). See docs: getting_started/build_from_source.
+[build-system]
+requires = ["scikit-build-core>=1.0", "numpy>=2.0"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "isaacteleop"
+dynamic = ["version"]
+description = "Isaac Teleop"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "Apache-2.0"
+authors = [
+    { name = "NVIDIA" },
+]
+
+# Mirror of src/core/python/requirements*.txt (keep in sync); see those files for
+# the rationale behind the retargeters/grounding version pins.
+dependencies = [
+    "numpy>=1.23.0",
+    "pyyaml>=6.0.3",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pybind11-stubgen>=2.5",
+    "types-PyYAML",
+    "scipy-stubs",
+]
+ui = [
+    "imgui[glfw]>=2.0.0",
+]
+retargeters = [
+    "dex-retargeting>=0.4.6,<0.6.0",
+    "scipy>=1.15.0",
+    "pyyaml>=6.0.3",
+    "torch>=2.7.0",
+    "nlopt>=2.6.2",
+    "pin>=2.7.0",
+    "cmeel-urdfdom<5",
+    "cmeel-tinyxml2<11",
+]
+retargeters-lite = [
+    "scipy>=1.15.0",
+]
+grounding = [
+    "pin>=2.7.0",
+    "pin-pink>=4.0.0",
+    "loop-rate-limiters>=1.0.0",
+    "daqp>=0.5.0",
+    "cmeel-urdfdom<5",
+    "cmeel-tinyxml2<11",
+]
+cloudxr = [
+    "websockets>=14.0",
+]
+
+# Derive the version from the VERSION file (MAJOR.MINOR.x) as MAJOR.MINOR+local,
+# matching what the classic flow (cmake/IsaacTeleopVersion.cmake) emits for a
+# non-CI/local build. The pip path is a from-source/dev build, so it is always
+# tagged `+local`; release versioning (tags, a1/rc1/.devN) stays with the classic
+# flow. scikit-build-core finalizes metadata before CMake runs, so it cannot reuse
+# the CMake-computed version directly.
+[[tool.dynamic-metadata]]
+provider = "scikit_build_core.metadata.regex"
+field = "version"
+input = "VERSION"
+regex = '^(?P<major>\d+)\.(?P<minor>\d+)'
+result = "{major}.{minor}+local"
+
+# uv-only: don't let `uv run` / `uv sync` implicitly build + install this project
+# into their managed environment. Without this, every `uv run` executed from the
+# repo (e.g. CI steps that just want a downloaded wheel) triggers a full
+# scikit-build-core source build. Explicit builds -- pip install ., pip install -e .,
+# python -m build, uv build, uv pip install -- are unaffected (they use
+# [build-system], not [tool.uv]).
+[tool.uv]
+package = false
+
+[tool.scikit-build]
+# Floor matches CMakeLists' cmake_minimum_required; the <4 cap keeps the build on
+# a 3.x CMake like Ubuntu 22.04 (3.22) / 24.04 (3.28) ship, so pip/isolated builds
+# (and CI) don't silently pull the latest 4.x line from PyPI and drift from the OS.
+cmake.version = ">=3.20,<4"
+cmake.build-type = "Release"
+
+# Keep the CMake build tree under build/wheel-<cache-tag>/ (e.g.
+# build/wheel-cpython-312/) rather than a temp dir: re-installs are incremental,
+# and different Python versions never share one configured CMake cache (which
+# would silently reuse the wrong interpreter). {cache_tag} (sys.implementation.
+# cache_tag) is used so the tag matches the classic CMake path's
+# build/cmake-<cache-tag>/ trees (see CMakePresets.json) — the wheel/ABI tag can't
+# be expressed as a CMake preset, so cache_tag is the common per-version tag.
+# build/ is gitignored.
+build-dir = "build/wheel-{cache_tag}"
+
+# No cmake.define overrides: BUILD_EXAMPLES, BUILD_TESTING, BUILD_PLUGINS and the
+# Linux clang-format gate all stay at their CMake defaults. So a `pip install`
+# builds the full default (ALL) target -- every extension, the staged
+# python_package, examples, tests, and plugins (plugins without their SDK skip
+# gracefully). It also ENFORCES clang-format: the build fails if clang-format-14
+# is missing or any C++ file is unformatted. The classic python_wheel ALL target
+# is gated to non-SKBUILD (src/core/python/CMakeLists.txt) so ALL doesn't trigger a
+# nested `uv build`; python_stubs isn't part of ALL, so the pip wheel omits .pyi.
+
+# Install the staged Python tree (isaacteleop_wheel component) plus every built
+# executable -- examples, C++ test binaries, plugin tools -- on the venv PATH
+# (isaacteleop_binaries -> the venv's bin/ via SKBUILD_SCRIPTS_DIR; see the
+# executable-install loop in the root CMakeLists.txt). Plugin/extension .so are not
+# executables and are not placed in bin/. Restricting to these two components keeps
+# the project's C++ library/header install() rules out of the wheel.
+install.components = ["isaacteleop_wheel", "isaacteleop_binaries"]
+
+# Editable installs don't recompile on import; editing pure-Python src/ is not live.
+[tool.scikit-build.editable]
+mode = "redirect"
+rebuild = false

--- a/src/core/python/CMakeLists.txt
+++ b/src/core/python/CMakeLists.txt
@@ -169,23 +169,62 @@ add_custom_target(python_stubs
     SOURCES "${STUBGEN_SCRIPT}" "${STUBGEN_PYPROJECT}"
 )
 
-# Custom target to build the wheel using uv
-# Depends on python_stubs to ensure py.typed marker and .pyi files are present
-# This is required for mypy type checking of code that imports from isaacteleop
-add_custom_target(python_wheel ALL
-    COMMAND ${CMAKE_COMMAND} -E echo "Building Python wheel with uv..."
-    COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/wheels"
-    COMMAND uv build --wheel --python ${ISAAC_TELEOP_PYTHON_VERSION}
-            --out-dir "${CMAKE_BINARY_DIR}/wheels" "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>" ||
-            "${Python3_EXECUTABLE}" -m build --wheel
-            --outdir "${CMAKE_BINARY_DIR}/wheels" "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
-    DEPENDS python_stubs
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-    COMMENT "Building Python wheel with uv (fallback to python -m build)"
-)
+# Custom target to build the wheel using uv (classic `cmake -B build` flow only).
+# Depends on python_stubs to ensure py.typed marker and .pyi files are present.
+# Gated to non-SKBUILD: under scikit-build-core, pip already owns wheel assembly,
+# so this ALL target must NOT run -- otherwise building the default target would
+# trigger a nested `uv build` inside the pip build.
+if(NOT SKBUILD)
+    add_custom_target(python_wheel ALL
+        COMMAND ${CMAKE_COMMAND} -E echo "Building Python wheel with uv..."
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/wheels"
+        COMMAND uv build --wheel --python ${ISAAC_TELEOP_PYTHON_VERSION}
+                --out-dir "${CMAKE_BINARY_DIR}/wheels" "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>" ||
+                "${Python3_EXECUTABLE}" -m build --wheel
+                --outdir "${CMAKE_BINARY_DIR}/wheels" "${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
+        DEPENDS python_stubs
+        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+        COMMENT "Building Python wheel with uv (fallback to python -m build)"
+    )
+endif()
 
-# Install the wheel
-install(DIRECTORY "${CMAKE_BINARY_DIR}/wheels/"
-    DESTINATION wheels
-    FILES_MATCHING PATTERN "*.whl"
-)
+# Install the wheel built by the classic `cmake -B build` flow. Under
+# scikit-build-core (SKBUILD) the wheel is assembled by pip from the staged tree
+# instead -- see the block below -- so this rule is skipped there.
+if(NOT SKBUILD)
+    install(DIRECTORY "${CMAKE_BINARY_DIR}/wheels/"
+        DESTINATION wheels
+        FILES_MATCHING PATTERN "*.whl"
+    )
+endif()
+
+# ==============================================================================
+# scikit-build-core (PEP 517/660) wheel packaging
+# ==============================================================================
+# When pip / `uv build` / `python -m build` drives the build through
+# scikit-build-core, it builds the `python_package` target (see
+# build.targets in the root pyproject.toml), which -- with its module
+# dependencies -- produces the fully-staged package tree at
+# python_package/<config>/isaacteleop/ (compiled .so via each module's
+# LIBRARY_OUTPUT_DIRECTORY, pure-Python subpackages copied in, __init__.py files).
+# This single install rule copies that tree into the wheel's platlib. It is
+# tagged with the `isaacteleop_wheel` component, selected via install.components
+# in pyproject.toml, so the project's C++ library/header/example install() rules
+# do NOT leak into the wheel.
+if(SKBUILD)
+    # scikit-build-core uses a single-config generator (Ninja) with
+    # cmake.build-type set, so CMAKE_BUILD_TYPE resolves the staging dir's
+    # $<CONFIG>. install(DIRECTORY) does not evaluate generator expressions in its
+    # source path, so use the concrete config; fall back to Release defensively.
+    set(_it_wheel_config "${CMAKE_BUILD_TYPE}")
+    if(NOT _it_wheel_config)
+        set(_it_wheel_config "Release")
+    endif()
+
+    install(
+        DIRECTORY "${CMAKE_BINARY_DIR}/python_package/${_it_wheel_config}/isaacteleop"
+        DESTINATION "."
+        COMPONENT isaacteleop_wheel
+        USE_SOURCE_PERMISSIONS
+    )
+endif()


### PR DESCRIPTION
## Summary

Adds a root `pyproject.toml` using the [scikit-build-core](https://scikit-build-core.readthedocs.io/) (PEP 517/660) backend, so `isaacteleop` builds and installs from source with standard Python tooling — the from-source / developer path requested in #735:

```bash
pip install .            # build + install the compiled wheel from source
pip install -e .         # editable / developer install
python -m build --sdist  # source distribution
```

It drives the **same top-level `CMakeLists.txt`** as the classic `cmake -B build` flow, so the two coexist; the classic flow (which CI uses to produce `install/wheels/` and the released wheels) is unchanged.

## What's in it

- **`pyproject.toml`** — scikit-build-core backend; extras mirrored from `src/core/python/requirements*.txt`. Version is derived from `VERSION` as `MAJOR.MINOR+local`. The build tree is kept per-Python at `build/wheel-<cache_tag>/`, and CMake is capped to a 3.x line (`>=3.20,<4`) so pip/isolated builds match the Ubuntu 22.04/24.04 line instead of pulling CMake 4.x.
- **Full build + executables on PATH** — a `pip install` builds the default target (extensions, examples, C++ tests, and plugins — a plugin without its SDK skips gracefully) and installs **every built executable** onto the venv `PATH` via a `SKBUILD`-gated loop in the root `CMakeLists.txt` (`${SKBUILD_SCRIPTS_DIR}`). Shared libraries (Python extension modules, plugin `.so`) are not executables and stay out of `bin/`. **clang-format is enforced** — the build fails if `clang-format-14` is missing or any C++ file is unformatted.
- **`CMakePresets.json`** — `py3.10`–`py3.13` presets that set `ISAAC_TELEOP_PYTHON_VERSION` and build into `build/cmake-<cache_tag>/`, sharing the same per-version tag as the wheel build dir so the two never collide.
- **`cmake/SetupPython.cmake`** — under `SKBUILD`, compile against the interpreter running the build so the wheel's ABI tag matches; the classic uv-managed path is unchanged, and the `python_wheel` target is gated to non-`SKBUILD`.
- **CI** — a `pip-editable-install` job (sdist build + `pip install -e .` + import/completeness smoke), with `clang-format-14` installed.
- **Docs** — build-from-source guide (pip/editable/sdist, presets, the executables-on-PATH and clang-format behavior) and build reference, plus the aarch64 `retargeters` → `retargeters-lite` note.

## Behavior / scope notes

- **Version** on the pip path is `MAJOR.MINOR+local` (a from-source/dev build); git-aware release versioning (`a1`/`rc1`/`.devN`, tags) stays with the classic flow.
- **Editable** installs don't rebuild on import; because the pure-Python subpackages are copy-staged, editing `src/retargeters/` isn't live without re-staging. Making those edits live (a src-layout relocation) is a follow-up.
- The pip-built wheel omits `.pyi` stubs (stub generation shells out to `uv`, not guaranteed in pip build isolation); the classic/released wheel still ships them.

## Validation

Verified locally: `pip install -e .` builds and installs the example + test executables into the venv `bin/` (they run self-contained), and `cmake --preset py3.12` configures. The `pip-editable-install` CI job is the gate for a clean-environment build.

Closes #735.