### PR TITLE
refactor(so101)!: consolidate the clutch retargeter onto engage-relative full pose

### DIFF
--- a/docs/source/references/retargeting/index.rst
+++ b/docs/source/references/retargeting/index.rst
@@ -49,9 +49,12 @@ Available Retargeters
 .. dropdown:: SO101ClutchRetargeter / SO101GripperRetargeter
 
    Retargeters for the SO-101 5-DOF arm under full-pose SE3 IK. ``SO101ClutchRetargeter``
-   outputs a 7-D ``ee_pose`` like ``Se3AbsRetargeter`` but clutch-rebases controller position
-   around an origin captured on engage (no teleport) and composes a fixed orientation
-   calibration offset onto the grip orientation so the gripper pose follows the controller pose.
+   outputs a 7-D ``ee_pose`` like ``Se3AbsRetargeter`` but clutch-rebases the **full pose** around
+   an origin captured on engage (no teleport): it re-latches both the home position and the home
+   orientation on every engage and composes the orientation delta on the **left** (base frame),
+   with no fixed calibration offset. It engages on ``RUNNING`` **and**
+   ``squeeze > squeeze_threshold``, re-seeds its held pose from the configured home on ``reset``,
+   and can latch its home position from the arm's measured EE pose.
    ``SO101GripperRetargeter`` maps the trigger to a proportional jaw closedness in ``[0, 1]``.
    See :doc:`so101` for the full setup.
 

--- a/docs/source/references/retargeting/so101.rst
+++ b/docs/source/references/retargeting/so101.rst
@@ -8,12 +8,13 @@ The SO-101 is a low-cost 5-DOF arm with a single-jaw gripper. The controller is 
 like holding the **leader arm**: the gripper pose follows the controller pose directly. A
 full SE3 pose is commanded and a single differential IK solves all 5 arm joints, tracking
 position exactly and orientation best-effort (a 5-DOF arm is over-determined by one DOF on a
-6-DOF pose). These two retargeters provide the pieces for comfortable XR controller
+6-DOF pose). These retargeters provide the pieces for comfortable XR controller
 teleoperation of the arm (used by the Isaac Lab ``Isaac-Stack-Cube-SO101-IK-Abs-v0``
 cube-stacking task):
 
 * :class:`~isaacteleop.retargeters.SO101ClutchRetargeter` -- absolute EE **pose** (position +
-  orientation) with clutch-style position rebasing (no teleport on engage).
+  orientation) clutched as a *full pose*: both the home position and the home orientation are
+  re-latched on every engage, so there is no teleport when the operator engages.
 * :class:`~isaacteleop.retargeters.SO101GripperRetargeter` -- proportional (analog) jaw
   closedness from the controller trigger.
 
@@ -32,10 +33,10 @@ At a glance
      - What it does
    * - ``SO101ClutchRetargeter``
      - 7-D ``ee_pose`` (xyz + xyzw quat)
-     - Same output contract as ``Se3AbsRetargeter``, but rebases controller motion around an
-       origin captured on engage: ``pos = home + scale * (p_ctrl - p0)``. The orientation is
-       the controller grip orientation composed with a fixed calibration offset; it drives the
-       SE3 IK.
+     - Same output contract as ``Se3AbsRetargeter``, but clutches the **full pose**: re-latches
+       both the home position and the home orientation on every engage, composing the orientation
+       delta on the **left** (base frame) with no fixed offset. Engages on
+       ``RUNNING`` **and** ``squeeze > squeeze_threshold``.
    * - ``SO101GripperRetargeter``
      - 1 float ``gripper_command`` ``c`` in ``[0, 1]``
      - Trigger -> jaw closedness (``0`` = open, ``1`` = closed), with a released-end deadzone.
@@ -43,46 +44,135 @@ At a glance
 Why a clutch
 ------------
 
-``Se3AbsRetargeter`` maps the controller's absolute position straight to the EE target, so
-engaging teleop teleports the arm to wherever the controller happens to be. The clutch instead
-**re-arms** whenever teleop is not ``RUNNING`` and latches a controller origin ``p0`` on the
-first ``RUNNING`` frame (the headset "Play"). From then on the EE position is driven by the
-*delta* relative to ``p0``, so engaging with a steady controller does not move the arm. On the
-latching frame ``p_ctrl == p0``, so the emitted position is exactly the home (no jump). The last
-pose is held on a dropped frame.
+``Se3AbsRetargeter`` maps the controller's absolute pose straight to the EE target, so engaging
+teleop teleports the arm to wherever the controller happens to be. ``SO101ClutchRetargeter``
+instead latches an **engage origin** and drives the EE from the *delta* relative to it, keeping
+position-control IK (``use_relative_mode=False``): it emits an **absolute** target, just rebased.
 
-The clutch keeps position-control IK (``use_relative_mode=False``): it emits an **absolute**
-target, just rebased.
+Each engaged frame emits::
 
-Frames and the home
-^^^^^^^^^^^^^^^^^^^^
+   pos = home_pos + position_scale * (grip_pos - origin_pos)
+   rot = (R_ctrl @ R_origin^-1) @ R_home
 
-The controller stream reaching the clutch is already expressed in the robot **base** frame: the
-Isaac Lab ``IsaacTeleopDevice`` rebases it upstream via its ``target_frame_prim_path`` (set to
-the robot base), composing ``base_T_world`` onto the XR anchor before the controllers are
-transformed. The clutch therefore applies the controller delta to the home directly, with no
-world->base rotation of its own, and needs **no** live end-effector or base feed.
+On the engage frame ``grip_pos == origin_pos`` and ``R_ctrl == R_origin``, so the output is
+*exactly* the home pose whatever the scale -- no teleport. Because the orientation delta is
+left-composed, a hand rotation about base Z maps to an EE rotation about base Z.
 
-The ``home`` is the clutch's own running home: it is seeded on reset / first engage from the
-static ``home_base_T_ee`` reset-origin (the gripper's pose in the base frame at the reset pose,
-only its translation is used), and thereafter holds the last commanded pose so a mid-task
-re-clutch resumes from where the arm was left.
+Frames
+^^^^^^
+
+The controller stream reaching ``SO101ClutchRetargeter`` must already be expressed in the robot
+**base** frame. In Isaac Lab the ``IsaacTeleopDevice`` rebases it upstream via its
+``target_frame_prim_path`` (set to the robot base), composing ``base_T_world`` onto the XR anchor
+before the controllers are transformed; standalone graphs use ``ControllersSource.transformed``.
+The clutch applies the delta directly, with no world->base rotation of its own.
+
+Under an upstream rigid rebase ``p -> R @ p + t`` the rebase's translation ``t`` cancels exactly
+in ``grip_pos - origin_pos``. Its rotation ``R`` does not: it rotates the translation delta and
+conjugates the orientation delta, so a wrong rebase rotation mis-maps *both* channels -- a hand
+push along +X can come out as EE motion along +Y. That rebase is static configuration and nothing
+in the retargeter can validate it.
+
+Engaging
+^^^^^^^^
+
+Engagement is ``execution_state == RUNNING`` **and** ``squeeze > squeeze_threshold``. The two
+conjuncts are different things and both are load-bearing: ``squeeze`` is *operator intent*, while
+``execution_state`` is *system readiness*. An owning application that is still homing the arm
+should hold ``STOPPED`` so a squeeze cannot latch a home the arm has not reached yet -- which also
+makes it safe to supply the real home late, via
+:meth:`~isaacteleop.retargeters.SO101ClutchRetargeter.set_home_base_T_ee`, when the retargeting
+graph must be built before the arm is homed.
+
+Latching uses a **pending-latch sentinel**: the latch is *owed* until a frame arrives that can be
+trusted, and it is re-armed on every disengaged, dropped, invalid or degenerate frame. Both halves
+matter. Re-arming on dropped frames in particular is what prevents a jump when the operator
+releases and re-squeezes *across* a tracking dropout -- the squeeze is unobservable inside the
+gap, so without it the clutch would rebase against the previous engagement's origin and command
+the whole accumulated hand motion at once.
+
+Owning loops should read
+:attr:`~isaacteleop.retargeters.SO101ClutchRetargeter.is_engaged` rather than re-deriving
+engagement from the squeeze: its rising edge *is* the latch frame, including the cases where the
+latch was deferred by an unusable frame the loop cannot observe.
+
+The home
+^^^^^^^^
+
+``home_base_T_ee`` is a **required** ``base_T_ee`` 4x4 transform and **both** blocks are used: the
+translation seeds the home position, the rotation seeds the home orientation. Its rotation block
+must be a proper rotation (orthonormal, ``det == +1``); a scaled or reflected block would still
+normalize to a unit quaternion and command a quietly wrong orientation, so it is rejected at
+construction.
+
+Home latching on each engage is deliberately **asymmetric**: the home *position* comes from the
+arm's measured pose when
+:data:`~isaacteleop.retargeters.SO101ClutchRetargeter.MEASURED_BASE_T_EE_INPUT` is connected (so
+an arm that sagged while disengaged is not snapped back to a stale command), while the home
+*orientation* is always the last commanded rotation. The 5-DOF wrist tracks orientation only
+softly, so latching the measured orientation would inject that tracking offset into the command on
+every re-clutch.
+
+``MEASURED_BASE_T_EE_INPUT`` is declared ``OptionalType`` and a consumer **may omit it entirely**
+from ``connect()`` -- optional inputs are exempt from the missing-input check. A consumer whose
+owning task slews the arm to a known configured home (Isaac Lab) legitimately leaves it unwired
+and rides the last-commanded fallback; that is a designed path, not degraded mode, so it is
+silent.
+
+What ``OptionalType`` does **not** buy is the right to skip a key you *did* wire. When the input
+is connected to a ``ValueInput`` leaf, that leaf is an external graph input, and ``TeleopSession``
+validates every external leaf name is present in ``external_inputs`` on **every** step,
+independently of ``OptionalType``. Such a producer must send the key unconditionally, carrying an
+absent ``OptionalTensorGroup`` on frames with no pose.
+
+Reset
+^^^^^
+
+On ``execution_events.reset`` the held pose is re-seeded from the **configured** home -- the
+transform most recently given to the constructor or to
+:meth:`~isaacteleop.retargeters.SO101ClutchRetargeter.set_home_base_T_ee` -- and the latch is
+re-armed.
+
+The seed is a *static configured* transform, never live arm state, and that is the whole point.
+The reset pulse can reach the retargeter on either side of the owner's actual teleport (Isaac
+Lab's ``record_demos.py`` fires it from a headset control event *before* the teleport and from a
+success condition *after* it), so anything read from the arm at reset time is stale on one of
+those orderings.
+
+The owning task is expected to slew the arm to that same configured pose on reset -- Isaac Lab's
+robot ``init_state`` does exactly that -- which is what makes the re-seed jump-free. An owner
+whose reset does *not* move the arm should keep the configured home up to date with
+:meth:`~isaacteleop.retargeters.SO101ClutchRetargeter.set_home_base_T_ee`, or simply not fire
+``reset``.
+
+"Never live arm state" scopes to the **re-seed**, not the whole frame. A frame carrying ``reset``
+can also latch the clutch, and the re-seed does not change how that latch behaves: the normal
+engage rule applies, so on such a frame the home position comes from ``measured_base_T_ee`` when it
+is connected, not from the re-seed. That does **not** escape the ordering problem above -- the grip
+validity flag and the squeeze qualify the *controller* pose, and say nothing about whether the arm
+has been teleported yet, so on a reset-before-teleport ordering that measurement is the previous
+episode's arm state. No consumer wires both today; one that does should either not fire ``reset``
+on a frame it also engages, or leave the measured input unwired. The re-seed's own job is
+unaffected: it defines what the retargeter holds, and re-latches *from*, when nothing engages.
 
 .. note::
 
-   The fallback home, the position sign/scale knobs, and the orientation calibration offset
-   carry ``TODO(tune-in-sim)`` markers: the rebasing math is exact and unit-tested, but the
-   end-to-end controller->EE handedness and the neutral-controller -> neutral-gripper offset
-   should be confirmed in simulation.
+   There is deliberately **no** ``orientation_offset``. It is not merely unnecessary, it is
+   wrong: appending a fixed offset gives ``(R_ctrl . R_origin^-1 . R_home) . R_off``, and on the
+   engage frame ``R_ctrl == R_origin``, so the output is ``R_home . R_off != R_home`` -- breaking
+   the no-teleport invariant. Worse, because ``R_home`` re-latches from the last *commanded*
+   rotation, the error compounds as ``R_off``, ``R_off^2``, ``R_off^3`` over successive re-clutches.
 
-Orientation calibration
------------------------
+.. note::
 
-The clutch emits the controller grip orientation composed with a fixed calibration offset:
-``q_cmd = orientation_offset (x) q_grip`` (base-frame left multiply, renormalized). The offset
-defaults to identity (passthrough); a non-identity offset maps a neutrally-held controller to a
-sensible neutral gripper orientation for the SE3 IK. This single rotational offset replaces the
-per-DOF roll/pitch calibration hacks of earlier revisions.
+   Orientation **wind-up** is a real property of this algebra and is preserved intentionally: the
+   commanded rotation is unbounded in SO(3) across repeated re-clutches, and ``wrist_roll`` sits in
+   the null space of the 5-DOF position objective.
+
+Also note that ``position_scale`` applies to **translation only** -- the orientation delta is
+always 1:1, since a scaled rotation is disorienting and the 5-DOF wrist tracks orientation softly
+anyway. A value ``< 1`` shrinks robot travel relative to hand travel, which is what lets a
+comfortable operator arm sweep (~0.7 m) stay inside the SO-101's ~0.35 m reach.
 
 Gripper
 -------
@@ -99,6 +189,8 @@ Use it from Python
 
 .. code-block:: python
 
+   import numpy as np
+
    from isaacteleop.retargeters import (
        SO101ClutchRetargeter,
        SO101GripperRetargeter,
@@ -108,14 +200,21 @@ Use it from Python
    from isaacteleop.retargeting_engine.interface import OutputCombiner, ValueInput
    from isaacteleop.retargeting_engine.tensor_types import TransformMatrix
 
-   def build_so101_stack_pipeline():
+   def build_so101_stack_pipeline(base_T_gripper_home: np.ndarray):
        controllers = ControllersSource(name="controllers")
        world_T_anchor = ValueInput("world_T_anchor", TransformMatrix())
-       # The device rebases controller poses into the robot base frame upstream via
-       # target_frame_prim_path, so the clutch needs no live EE / base feed.
+       # The clutch requires a base-frame controller stream; rebase it upstream.
        xformed = controllers.transformed(world_T_anchor.output(ValueInput.VALUE))
 
-       clutch = SO101ClutchRetargeter(name="ee_pose", input_device=ControllersSource.RIGHT)
+       # home_base_T_ee is REQUIRED and both blocks are used. Pass the arm's pose at the reset
+       # pose, or a placeholder plus a set_home_base_T_ee() call before the first RUNNING frame.
+       clutch = SO101ClutchRetargeter(
+           name="ee_pose",
+           home_base_T_ee=base_T_gripper_home,
+           input_device=ControllersSource.RIGHT,
+       )
+       # MEASURED_BASE_T_EE_INPUT is optional and deliberately left unwired here: the owning task
+       # slews the arm to base_T_gripper_home, so the last-commanded home fallback is correct.
        connected_clutch = clutch.connect({
            ControllersSource.RIGHT: xformed.output(ControllersSource.RIGHT),
        })

--- a/src/core/retargeting_engine_tests/python/test_retargeter_reset.py
+++ b/src/core/retargeting_engine_tests/python/test_retargeter_reset.py
@@ -5,9 +5,12 @@
 Tests for retargeter reset behaviour via ExecutionEvents.
 
 Verifies that stateful retargeters (GripperRetargeter,
-LocomotionRootCmdRetargeter, Se3AbsRetargeter, Se3RelRetargeter)
-correctly reinitialize their cross-step state when
-``context.execution_events.reset`` is True.
+LocomotionRootCmdRetargeter, Se3AbsRetargeter, Se3RelRetargeter,
+SO101ClutchRetargeter) correctly reinitialize their cross-step state
+when ``context.execution_events.reset`` is True. Note that
+"reinitialize" is retargeter-specific: the SO-101 clutch re-seeds its
+held pose from the CONFIGURED home (never from live arm state) and
+re-arms its latch.
 """
 
 import numpy as np
@@ -25,6 +28,10 @@ from isaacteleop.retargeting_engine.interface.retargeter_core_types import Graph
 from isaacteleop.retargeting_engine.interface.tensor_group_type import (
     OptionalTensorGroupType,
 )
+from isaacteleop.retargeting_engine.tensor_types import (
+    ControllerInput,
+    ControllerInputIndex,
+)
 
 from isaacteleop.retargeters import (
     GripperRetargeter,
@@ -34,7 +41,9 @@ from isaacteleop.retargeters import (
     Se3AbsRetargeter,
     Se3RelRetargeter,
     Se3RetargeterConfig,
+    SO101ClutchRetargeter,
 )
+from isaacteleop.retargeters.SO101.clutch_retargeter import _mat_to_quat_xyzw
 
 
 def _make_context(*, reset: bool = False) -> ComputeContext:
@@ -220,3 +229,141 @@ class TestGripperRetargeterReset:
         assert retargeter._previous_gripper_command is True, (
             "gripper state should stay closed without reset"
         )
+
+
+# ---------------------------------------------------------------------------
+# SO101ClutchRetargeter
+# ---------------------------------------------------------------------------
+
+
+class TestSO101ClutchRetargeterReset:
+    """Reset re-seeds the held pose from the CONFIGURED home and re-arms the pending latch.
+
+    The seed is a *static configured* transform, never live arm state: the reset pulse can reach
+    the retargeter on either side of the owning task's actual teleport (Isaac Lab fires it from
+    both a headset control event and a success condition), so anything read from the arm at reset
+    time is stale on one of those orderings. The owning task is expected to slew the arm to that
+    same configured pose, which is what makes the re-seed jump-free.
+
+    The home rotation block here is deliberately NOT identity. With an identity block the
+    "reset restores the rotation" assertions below pass even against a seeding path that hardcodes
+    the identity quaternion, so the fixture would be vacuous exactly where it matters most.
+    """
+
+    # Rz(90 deg) rotation block, translation (0.1, 0.2, 0.3).
+    _HOME = np.array(
+        [
+            [0.0, -1.0, 0.0, 0.1],
+            [1.0, 0.0, 0.0, 0.2],
+            [0.0, 0.0, 1.0, 0.3],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    _HOME_QUAT = _mat_to_quat_xyzw(_HOME[:3, :3])
+
+    @pytest.fixture()
+    def retargeter(self):
+        return SO101ClutchRetargeter("clutch", self._HOME)
+
+    def _controller(self, grip_pos, squeeze):
+        tg = TensorGroup(ControllerInput())
+        tg[ControllerInputIndex.GRIP_POSITION] = np.asarray(grip_pos, dtype=np.float32)
+        tg[ControllerInputIndex.GRIP_ORIENTATION] = np.array(
+            [0.0, 0.0, 0.0, 1.0], dtype=np.float32
+        )
+        tg[ControllerInputIndex.GRIP_IS_VALID] = True
+        tg[ControllerInputIndex.AIM_POSITION] = np.zeros(3, dtype=np.float32)
+        tg[ControllerInputIndex.AIM_ORIENTATION] = np.array(
+            [0.0, 0.0, 0.0, 1.0], dtype=np.float32
+        )
+        tg[ControllerInputIndex.AIM_IS_VALID] = True
+        for idx in (
+            ControllerInputIndex.PRIMARY_CLICK,
+            ControllerInputIndex.SECONDARY_CLICK,
+            ControllerInputIndex.THUMBSTICK_X,
+            ControllerInputIndex.THUMBSTICK_Y,
+            ControllerInputIndex.THUMBSTICK_CLICK,
+            ControllerInputIndex.MENU_CLICK,
+            ControllerInputIndex.TRIGGER_VALUE,
+        ):
+            tg[idx] = 0.0
+        tg[ControllerInputIndex.SQUEEZE_VALUE] = float(squeeze)
+        return tg
+
+    def _drive(self, retargeter, inputs, outputs, grip_pos, squeeze, reset=False):
+        inputs["controller_right"] = self._controller(grip_pos, squeeze)
+        retargeter.compute(inputs, outputs, _make_context(reset=reset))
+        return np.asarray(np.from_dlpack(outputs["ee_pose"][0]), dtype=np.float64)
+
+    def test_reset_rearms_the_latch(self, retargeter):
+        """After reset the next engaged frame re-latches instead of tracking the old origin.
+
+        The controller has moved to (9, 0, 0), 8 m past the origin the pre-reset engagement
+        latched. Without the re-arm the emitted position would be that whole stale delta.
+        """
+        inputs, outputs = _build_io(retargeter)
+        self._drive(retargeter, inputs, outputs, (0.0, 0.0, 0.0), 1.0)
+        self._drive(retargeter, inputs, outputs, (1.0, 0.0, 0.0), 1.0)
+        assert retargeter.is_engaged
+
+        # Reset while engaged: re-seeds and disarms, then re-latches in the SAME pass, so the
+        # emitted pose is the configured home rather than the pre-reset commanded pose.
+        pose = self._drive(
+            retargeter, inputs, outputs, (9.0, 0.0, 0.0), 1.0, reset=True
+        )
+        npt.assert_allclose(pose[:3], [0.1, 0.2, 0.3], atol=1e-6)
+        assert retargeter.is_engaged
+
+    def test_reset_reseeds_the_commanded_pose_from_the_configured_home(
+        self, retargeter
+    ):
+        """Reset drags position AND orientation back to the configured home.
+
+        The rotation half is the load-bearing assertion: the home rotation block is Rz(90), so an
+        implementation that seeded the held pose at the identity quaternion would fail here while
+        still passing every position assertion in this class.
+        """
+        inputs, outputs = _build_io(retargeter)
+        self._drive(retargeter, inputs, outputs, (0.0, 0.0, 0.0), 1.0)
+        self._drive(retargeter, inputs, outputs, (1.0, 0.0, 0.0), 1.0)
+        assert not np.allclose(retargeter._last_commanded_pos, self._HOME[:3, 3])
+
+        # Reset on a disengaged frame: the held pose is re-seeded and emitted as-is.
+        pose = self._drive(
+            retargeter, inputs, outputs, (5.0, 5.0, 5.0), 0.0, reset=True
+        )
+        npt.assert_allclose(pose[:3], self._HOME[:3, 3], atol=1e-6)
+        npt.assert_allclose(pose[3:7], self._HOME_QUAT, atol=1e-6)
+        npt.assert_allclose(
+            retargeter._last_commanded_pos, self._HOME[:3, 3], atol=1e-12
+        )
+        npt.assert_allclose(retargeter._last_commanded_rot, self._HOME_QUAT, atol=1e-12)
+        assert not retargeter.is_engaged
+
+    def test_reset_seeds_the_most_recently_supplied_home(self, retargeter):
+        """``set_home_base_T_ee`` changes what a later reset seeds, not just the current pose.
+
+        An owner that re-homes its arm mid-session must be able to move the reset destination with
+        it; a reset that snapped back to the construction-time pose would drive the arm to a place
+        the owner no longer resets to.
+        """
+        inputs, outputs = _build_io(retargeter)
+        new_home = np.array(
+            [
+                [1.0, 0.0, 0.0, -0.4],
+                [0.0, 0.0, -1.0, 0.5],
+                [0.0, 1.0, 0.0, 0.6],
+                [0.0, 0.0, 0.0, 1.0],
+            ]
+        )  # Rx(90 deg) rotation block, translation (-0.4, 0.5, 0.6)
+        new_quat = _mat_to_quat_xyzw(new_home[:3, :3])
+        retargeter.set_home_base_T_ee(new_home)
+
+        # Drive away from the new home, then reset: it must land on the NEW home, both blocks.
+        self._drive(retargeter, inputs, outputs, (0.0, 0.0, 0.0), 1.0)
+        self._drive(retargeter, inputs, outputs, (1.0, 0.0, 0.0), 1.0)
+        pose = self._drive(
+            retargeter, inputs, outputs, (5.0, 5.0, 5.0), 0.0, reset=True
+        )
+        npt.assert_allclose(pose[:3], new_home[:3, 3], atol=1e-6)
+        npt.assert_allclose(pose[3:7], new_quat, atol=1e-6)

--- a/src/core/retargeting_engine_tests/python/test_so101_retargeters.py
+++ b/src/core/retargeting_engine_tests/python/test_so101_retargeters.py
@@ -519,3 +519,71 @@ class TestSO101ClutchRetargeter:
         r.compute(inputs2, outputs2, _make_context())
         np.testing.assert_allclose(_read_pose(outputs2)[:3], home, atol=1e-6)
         assert r._origin is not None
+
+    def test_position_scale_scales_delta(self):
+        """A non-unity ``position_scale`` scales the clutch delta without teleporting on engage."""
+        scale = 0.5
+        r = SO101ClutchRetargeter(name="ee_pose", position_scale=scale)
+        home = np.array(_CLUTCH_HOME_EE_POS)
+        p0 = np.array([0.5, -0.3, 0.7])
+
+        # Engage frame: p_ctrl == origin, so the EE sits exactly at home even at non-unity scale.
+        inputs, outputs = _build_io(r)
+        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
+        r.compute(inputs, outputs, _make_context())
+        np.testing.assert_allclose(_read_pose(outputs)[:3], home, atol=1e-6)
+
+        # A controller delta after engage advances the EE by scale * delta from home.
+        delta = np.array([0.05, -0.02, 0.10])
+        inputs2, outputs2 = _build_io(r)
+        inputs2[ControllersSource.RIGHT] = _make_controller(grip_pos=p0 + delta)
+        r.compute(inputs2, outputs2, _make_context())
+        np.testing.assert_allclose(
+            _read_pose(outputs2)[:3], home + scale * delta, atol=1e-5
+        )
+
+    @pytest.mark.parametrize("bad_scale", [0.0, -1.0, float("nan"), float("inf")])
+    def test_invalid_position_scale_rejected(self, bad_scale):
+        """A non-positive or non-finite ``position_scale`` is rejected at construction."""
+        with pytest.raises(ValueError):
+            SO101ClutchRetargeter(name="ee_pose", position_scale=bad_scale)
+
+    def test_reengage_ratchets_scaled_delta_per_cycle(self):
+        """N re-clutch cycles accumulate ``scale * delta`` each, ratcheting by ``N * scale * delta``.
+
+        This is the issue's motivating regression: at 1:1 motion (``scale == 1``) each re-engage
+        ratchets a full delta onto the running home, driving the target out of reach; a sub-unity
+        scale attenuates each cycle's advance so the same operator motion stays in the workspace.
+        """
+        home = np.array(_CLUTCH_HOME_EE_POS)
+        delta = np.array([0.05, -0.02, 0.10])
+        n_cycles = 3
+
+        def _run_cycles(scale):
+            r = SO101ClutchRetargeter(name="ee_pose", position_scale=scale)
+            outputs = None
+            for i in range(n_cycles):
+                p0 = np.array(
+                    [float(i), float(i), float(i)]
+                )  # fresh origin each engage
+                # Engage: latch the origin at p0 and resume from the running home.
+                inputs, outputs = _build_io(r)
+                inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
+                r.compute(inputs, outputs, _make_context())
+                # Move +delta: the running home advances by scale * delta.
+                inputs, outputs = _build_io(r)
+                inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0 + delta)
+                r.compute(inputs, outputs, _make_context())
+                # Disengage (STOPPED): freeze the running home, re-arm the origin.
+                inputs, outputs = _build_io(r)
+                inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
+                r.compute(inputs, outputs, _make_context(state=ExecutionState.STOPPED))
+            return _read_pose(outputs)[:3]
+
+        # Sub-unity scale ratchets N * scale * delta over the N cycles.
+        scale = 0.5
+        np.testing.assert_allclose(
+            _run_cycles(scale), home + n_cycles * scale * delta, atol=1e-5
+        )
+        # Unit-scale contrast: each cycle ratchets a full delta -> N * delta.
+        np.testing.assert_allclose(_run_cycles(1.0), home + n_cycles * delta, atol=1e-5)

--- a/src/core/retargeting_engine_tests/python/test_so101_retargeters.py
+++ b/src/core/retargeting_engine_tests/python/test_so101_retargeters.py
@@ -6,8 +6,9 @@
 Covers the SO-101 retargeters that drive the full-pose SE3 IK stacking pipeline:
 
 * :class:`~isaacteleop.retargeters.SO101GripperRetargeter` -- analog trigger -> jaw closedness.
-* :class:`~isaacteleop.retargeters.SO101ClutchRetargeter` -- clutch-rebased absolute EE pose
-  (position + calibration-composed grip orientation) for the 5-joint pose IK.
+* :class:`~isaacteleop.retargeters.SO101ClutchRetargeter` -- the engage-relative full-pose clutch,
+  re-latching both home position and orientation on every engage with a base-frame left-composed
+  orientation delta.
 
 Each retargeter is exercised both at the pure-math level (the module-private helper functions)
 and at the ``BaseRetargeter.compute`` level (build inputs/outputs, drive a frame, read the
@@ -25,24 +26,29 @@ from isaacteleop.retargeting_engine.interface import (
     ExecutionEvents,
     ExecutionState,
     OptionalTensorGroup,
+    OutputCombiner,
     TensorGroup,
+    ValueInput,
 )
 from isaacteleop.retargeting_engine.interface.retargeter_core_types import GraphTime
 from isaacteleop.retargeting_engine.interface.tensor_group_type import (
+    OptionalType,
     OptionalTensorGroupType,
 )
 from isaacteleop.retargeting_engine.tensor_types import (
     ControllerInput,
     ControllerInputIndex,
+    TransformMatrix,
 )
 from isaacteleop.retargeters import (
     SO101ClutchRetargeter,
     SO101GripperRetargeter,
 )
 from isaacteleop.retargeters.SO101.clutch_retargeter import (
-    _CLUTCH_HOME_EE_POS,
+    _mat_to_quat_xyzw,
+    _normalize_quat,
+    _quat_inv,
     _quat_mul,
-    _rebased_position,
 )
 from isaacteleop.retargeters.SO101.gripper_retargeter import (
     GRIPPER_COMMAND_KEY,
@@ -92,6 +98,7 @@ def _make_controller(
     grip_ori=_ID_QUAT,
     aim_ori=_ID_QUAT,
     trigger: float = 0.0,
+    squeeze: float = 0.0,
     grip_is_valid: bool = True,
 ) -> TensorGroup:
     """Build a present ControllerInput TensorGroup with the given grip/aim pose / trigger.
@@ -99,20 +106,41 @@ def _make_controller(
     The grip pose drives roll; the aim pose (pointer ray) drives pitch. ``grip_is_valid`` sets the
     grip pose validity flag (OpenXR location-flag derived); pass ``False`` to model a present
     controller whose grip pose is not yet localizable.
+
+    ``squeeze`` is the grip/squeeze trigger that drives
+    :class:`SO101ClutchRetargeter`'s engage signal.
+
+    ALL 14 elements are written, matching what the real ``ControllersSource._update_group`` does.
+    Two distinct things require it: reading an unset element raises ``ValueError``
+    (``interface/tensor.py:83-84``), and passing this group through a ``ValueInput`` in a graph
+    deep-copies every slot -- so a partially-populated group fails on a slot nothing even reads.
     """
     tg = TensorGroup(ControllerInput())
     tg[ControllerInputIndex.GRIP_POSITION] = np.asarray(grip_pos, dtype=np.float32)
     tg[ControllerInputIndex.GRIP_ORIENTATION] = np.asarray(grip_ori, dtype=np.float32)
     tg[ControllerInputIndex.GRIP_IS_VALID] = grip_is_valid
+    tg[ControllerInputIndex.AIM_POSITION] = np.zeros(3, dtype=np.float32)
     tg[ControllerInputIndex.AIM_ORIENTATION] = np.asarray(aim_ori, dtype=np.float32)
     tg[ControllerInputIndex.AIM_IS_VALID] = True
+    tg[ControllerInputIndex.PRIMARY_CLICK] = 0.0
+    tg[ControllerInputIndex.SECONDARY_CLICK] = 0.0
+    tg[ControllerInputIndex.THUMBSTICK_X] = 0.0
+    tg[ControllerInputIndex.THUMBSTICK_Y] = 0.0
+    tg[ControllerInputIndex.THUMBSTICK_CLICK] = 0.0
+    tg[ControllerInputIndex.MENU_CLICK] = 0.0
     tg[ControllerInputIndex.TRIGGER_VALUE] = float(trigger)
+    tg[ControllerInputIndex.SQUEEZE_VALUE] = float(squeeze)
     return tg
 
 
-def _make_home_transform(translation) -> np.ndarray:
-    """Build a (4, 4) ``base_T_ee`` home transform with identity rotation and the given origin."""
+def _make_home_transform(translation, rotation_3x3=None) -> np.ndarray:
+    """Build a (4, 4) ``base_T_ee`` home transform from a translation and optional rotation.
+
+    The rotation defaults to identity. :class:`SO101ClutchRetargeter` reads both blocks.
+    """
     m = np.eye(4, dtype=np.float64)
+    if rotation_3x3 is not None:
+        m[:3, :3] = np.asarray(rotation_3x3, dtype=np.float64)
     m[:3, 3] = np.asarray(translation, dtype=np.float64)
     return m
 
@@ -217,373 +245,809 @@ class TestSO101GripperRetargeter:
 # ===========================================================================
 # SO101ClutchRetargeter
 # ===========================================================================
+#
+# The clutch re-latches BOTH home position and orientation on every engage, and composes the
+# orientation delta on the LEFT (base frame). A right-composed delta, or a fixed appended
+# orientation offset, is a different convention that breaks the no-teleport invariant.
+#
+# ``engage()``/``rebase()`` do not exist here -- engagement is a squeeze rising edge observed
+# across ``compute()`` frames -- so the invariants below are expressed as frame sequences. A
+# rising-edge frame both latches AND emits, so a test whose engage and rebase poses are identical
+# needs one frame while a test that moves the controller needs two.
 
 
-class TestRebasedPositionMath:
-    """The pure clutch rebasing math (origin + scale). Controller poses arrive already in the
-    robot base frame (the Lab device rebases them via ``target_frame_prim_path``), so no
-    world->base rotation is applied here."""
-
-    HOME = np.array(_CLUTCH_HOME_EE_POS, dtype=np.float64)
-    ORIGIN = np.array([0.31, -0.12, 0.44], dtype=np.float64)
-
-    def test_first_frame_is_home(self):
-        """With ``p_ctrl == origin`` (the latching frame), the rebased position is exactly home."""
-        out = _rebased_position(self.ORIGIN.copy(), self.ORIGIN, self.HOME, 1.0)
-        np.testing.assert_allclose(out, self.HOME, atol=1e-9)
-
-    def test_applies_delta(self):
-        """A +delta controller move shifts the EE by +delta from home (scale 1)."""
-        delta = np.array([0.05, -0.02, 0.10], dtype=np.float64)
-        out = _rebased_position(self.ORIGIN + delta, self.ORIGIN, self.HOME, 1.0)
-        np.testing.assert_allclose(out, self.HOME + delta, atol=1e-9)
-
-    def test_honors_scale(self):
-        """The translation scale multiplies the controller delta before adding it to home."""
-        delta = np.array([0.05, -0.02, 0.10], dtype=np.float64)
-        out = _rebased_position(self.ORIGIN + delta, self.ORIGIN, self.HOME, 2.0)
-        np.testing.assert_allclose(out, self.HOME + 2.0 * delta, atol=1e-9)
+def _quat_to_matrix(q) -> np.ndarray:
+    """Convert an [x, y, z, w] quaternion to a 3x3 rotation matrix."""
+    x, y, z, w = _normalize_quat(np.asarray(q, dtype=np.float64))
+    return np.array(
+        [
+            [1 - 2 * (y * y + z * z), 2 * (x * y - z * w), 2 * (x * z + y * w)],
+            [2 * (x * y + z * w), 1 - 2 * (x * x + z * z), 2 * (y * z - x * w)],
+            [2 * (x * z - y * w), 2 * (y * z + x * w), 1 - 2 * (x * x + y * y)],
+        ],
+        dtype=np.float64,
+    )
 
 
-class TestSO101ClutchRetargeter:
-    """End-to-end ``compute`` behavior of the clutch EE-pose retargeter."""
+def _rot_dist(a, b) -> float:
+    """Frobenius distance between two rotations given as [x, y, z, w] quaternions.
 
-    def test_output_spec_is_7d_pose(self):
-        """Outputs a single 7D ee_pose (position + quaternion)."""
-        r = SO101ClutchRetargeter(name="ee_pose")
-        pose_type = r.output_spec()["ee_pose"].types[0]
-        assert pose_type.shape == (7,)
+    Deliberately NOT a geodesic ``arccos`` angle: ``arccos((tr - 1) / 2)`` has a ``sqrt(eps)``
+    conditioning floor near identity and reports ~5.2e-08 rad for a pair this metric resolves at
+    ~4.9e-15, which makes tight tolerances unachievable and reads as a code fault. Frobenius is
+    also sign-agnostic by construction (``q`` and ``-q`` are the same rotation).
+    """
+    return float(np.linalg.norm(_quat_to_matrix(a) - _quat_to_matrix(b)))
 
-    def test_input_spec_is_controller_only(self):
-        """The clutch consumes only the controller; no live EE or base transform inputs.
 
-        The world->base rebase happens upstream (the device's ``target_frame_prim_path``) and the
-        reset-origin home is the static ``home_base_T_ee`` config, so the clutch needs neither a
-        per-frame ``robot_ee_pos`` nor a ``robot_base_pos`` input.
-        """
-        r = SO101ClutchRetargeter(name="ee_pose")
-        assert list(r.input_spec()) == [ControllersSource.RIGHT]
-        assert not hasattr(SO101ClutchRetargeter, "ROBOT_EE_POS_INPUT")
-        assert not hasattr(SO101ClutchRetargeter, "ROBOT_BASE_POS_INPUT")
+def _make_measured(translation) -> TensorGroup:
+    """Build a ``base_T_ee`` TransformMatrix group for the measured-EE-pose input."""
+    tg = TensorGroup(TransformMatrix())
+    tg[0] = _make_home_transform(translation).astype(np.float32)
+    return tg
 
-    def test_not_running_holds_home_without_latching(self):
-        """While not RUNNING the clutch holds the configured home and does not latch an origin."""
-        r = SO101ClutchRetargeter(name="ee_pose")
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=(0.5, 0.5, 0.5))
-        r.compute(inputs, outputs, _make_context(state=ExecutionState.STOPPED))
-        pose = _read_pose(outputs)
-        np.testing.assert_allclose(pose[:3], np.array(_CLUTCH_HOME_EE_POS), atol=1e-6)
-        assert r._origin is None  # not latched while stopped
 
-    def test_engage_latches_origin_at_home(self):
-        """The first RUNNING frame latches the origin so the EE sits exactly at the configured home.
+class _Driver:
+    """Drives a :class:`SO101ClutchRetargeter` one frame at a time.
 
-        On the latching frame ``p_ctrl == origin`` so the emitted position equals home (no
-        teleport on engage). An identity offset is used here so the grip orientation passes
-        through unchanged (the default ``Rz(pi)`` offset is covered by
-        :meth:`test_calibration_offset_composed_into_orientation`).
-        """
-        r = SO101ClutchRetargeter(
-            name="ee_pose", orientation_offset=np.array([0.0, 0.0, 0.0, 1.0])
+    Named for what it does rather than for the class under test: this file also exercises the
+    SO-101 gripper retargeter, so a bare ``_Clutch`` would read as the only subject here.
+    """
+
+    def __init__(self, home_base_T_ee=None, **kwargs):  # noqa: N803
+        if home_base_T_ee is None:
+            home_base_T_ee = _make_home_transform((0.0, 0.0, 0.0))
+        self.r = SO101ClutchRetargeter("clutch", home_base_T_ee, **kwargs)
+        self.inputs, self.outputs = _build_io(self.r)
+
+    def frame(
+        self,
+        grip_pos=(0.0, 0.0, 0.0),
+        grip_ori=_ID_QUAT,
+        *,
+        squeeze: float = 1.0,
+        grip_is_valid: bool = True,
+        present: bool = True,
+        measured=None,
+        state: ExecutionState = ExecutionState.RUNNING,
+        reset: bool = False,
+    ) -> np.ndarray:
+        """Drive one frame and return the emitted 7D pose."""
+        key = ControllersSource.RIGHT
+        if present:
+            self.inputs[key] = _make_controller(
+                grip_pos=grip_pos,
+                grip_ori=grip_ori,
+                squeeze=squeeze,
+                grip_is_valid=grip_is_valid,
+            )
+        else:
+            self.inputs[key] = OptionalTensorGroup(ControllerInput())
+        self.inputs[SO101ClutchRetargeter.MEASURED_BASE_T_EE_INPUT] = (
+            _make_measured(measured)
+            if measured is not None
+            else OptionalTensorGroup(TransformMatrix())
         )
-        inputs, outputs = _build_io(r)
-        grip_ori = _quat_xyzw([0, 0, 1], 0.3).astype(np.float32)
-        inputs[ControllersSource.RIGHT] = _make_controller(
-            grip_pos=(0.5, -0.3, 0.7), grip_ori=grip_ori
+        self.r.compute(
+            self.inputs, self.outputs, _make_context(reset=reset, state=state)
         )
-        r.compute(inputs, outputs, _make_context())
-        pose = _read_pose(outputs)
-        np.testing.assert_allclose(pose[:3], np.array(_CLUTCH_HOME_EE_POS), atol=1e-6)
-        np.testing.assert_allclose(pose[3:], grip_ori, atol=1e-6)
+        return _read_pose(self.outputs)
 
-    def test_motion_after_engage_applies_delta(self):
-        """A controller delta after engage shifts the EE by that delta from home (base frame)."""
-        r = SO101ClutchRetargeter(name="ee_pose")
-        p0 = np.array([0.5, -0.3, 0.7])
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
-        r.compute(inputs, outputs, _make_context())  # engage frame: latch origin == p0
+    def engage(self, grip_pos=(0.0, 0.0, 0.0), grip_ori=_ID_QUAT, **kw) -> np.ndarray:
+        """Release then re-squeeze, so the next frame is a rising edge that latches."""
+        self.frame(grip_pos, grip_ori, squeeze=0.0)
+        return self.frame(grip_pos, grip_ori, squeeze=1.0, **kw)
 
-        delta = np.array([0.05, -0.02, 0.10])
-        inputs2, outputs2 = _build_io(r)
-        inputs2[ControllersSource.RIGHT] = _make_controller(grip_pos=p0 + delta)
-        r.compute(inputs2, outputs2, _make_context())
-        pose = _read_pose(outputs2)
-        expected = np.array(_CLUTCH_HOME_EE_POS) + delta
-        np.testing.assert_allclose(pose[:3], expected, atol=1e-5)
 
-    def test_configured_home_overrides_default(self):
-        """A ``home_base_T_ee`` transform sets the engage home from its translation block."""
-        home_xyz = (0.30, 0.10, 0.25)
-        r = SO101ClutchRetargeter(
-            name="ee_pose", home_base_T_ee=_make_home_transform(home_xyz)
+class TestEngageRelativeClutchQuaternionHelpers:
+    """The inlined quaternion helpers, pinned against independent references.
+
+    The branch-on-trace matrix->quaternion conversion is the one piece of this retargeter that is
+    not eyeball-verifiable, so it is checked over random SO(3) with all four Shepperd branches
+    covered rather than on a handful of axis rotations.
+    """
+
+    def test_mat_to_quat_round_trips_over_random_so3(self):
+        """matrix -> quat -> matrix reproduces the input over uniformly random rotations."""
+        rng = np.random.default_rng(20260727)
+        branches = {"trace": 0, "xx": 0, "yy": 0, "zz": 0}
+        worst = 0.0
+        for _ in range(2000):
+            # QR of a Gaussian matrix is uniform on O(3) only after the sign fix below; without
+            # it the sample is badly skewed and two Shepperd branches go almost unvisited.
+            q, upper = np.linalg.qr(rng.standard_normal((3, 3)))
+            q = q @ np.diag(np.sign(np.diag(upper)))
+            if np.linalg.det(q) < 0:
+                q[:, 0] *= -1
+            if np.trace(q) > 0:
+                branches["trace"] += 1
+            elif q[0, 0] > q[1, 1] and q[0, 0] > q[2, 2]:
+                branches["xx"] += 1
+            elif q[1, 1] > q[2, 2]:
+                branches["yy"] += 1
+            else:
+                branches["zz"] += 1
+            worst = max(
+                worst, float(np.linalg.norm(_quat_to_matrix(_mat_to_quat_xyzw(q)) - q))
+            )
+        assert worst < 1e-12
+        # All four branches must actually be exercised, or this proves much less than it looks.
+        assert all(count > 100 for count in branches.values()), branches
+
+    def test_mat_to_quat_handles_180_degree_rotations(self):
+        """The trace <= 0 branches: 180 degrees about each principal axis."""
+        for axis in np.eye(3):
+            expected = _quat_to_matrix(_quat_xyzw(axis, math.pi))
+            assert (
+                _rot_dist(_mat_to_quat_xyzw(expected), _quat_xyzw(axis, math.pi))
+                < 1e-12
+            )
+
+    def test_mat_to_quat_output_is_normalized(self):
+        """Unlike the engine-private original, this copy normalizes -- downstream assumes unit."""
+        m = _quat_to_matrix(_quat_xyzw([1.0, 2.0, 3.0], 1.1))
+        assert abs(float(np.linalg.norm(_mat_to_quat_xyzw(m))) - 1.0) < 1e-12
+
+    def test_quat_inv_inverts_even_a_non_unit_quaternion(self):
+        """``_quat_inv`` normalizes before conjugating, so non-unit input still inverts."""
+        q = np.array([0.3, -0.4, 0.5, 0.7]) * 7.0
+        assert _rot_dist(_quat_mul(q, _quat_inv(q)), _ID_QUAT) < 1e-12
+
+    def test_quat_mul_matches_matrix_composition(self):
+        """``_quat_mul(a, b)`` composes as ``R(a) @ R(b)`` -- operand order is load-bearing."""
+        a = _quat_xyzw([0.0, 0.0, 1.0], math.pi / 2)
+        b = _quat_xyzw([1.0, 0.0, 0.0], math.pi / 2)
+        expected = _quat_to_matrix(a) @ _quat_to_matrix(b)
+        assert (
+            float(np.linalg.norm(_quat_to_matrix(_quat_mul(a, b)) - expected)) < 1e-12
         )
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=(0.5, -0.3, 0.7))
-        r.compute(inputs, outputs, _make_context())
+
+
+class TestEngageRelativeClutchSeeding:
+    """The constructor latches home from the supplied startup EE pose -- both blocks."""
+
+    def test_engage_frame_returns_seeded_home_position(self):
+        """Engaging at any controller pose returns exactly the seeded home -- no teleport."""
+        c = _Driver(_make_home_transform((0.1, 0.2, 0.3)))
         np.testing.assert_allclose(
-            _read_pose(outputs)[:3], np.array(home_xyz), atol=1e-6
+            c.engage((5.0, -3.0, 2.0))[:3], [0.1, 0.2, 0.3], atol=1e-6
         )
 
-    def test_reengage_resumes_from_last_commanded_pose(self):
-        """A mid-task re-clutch resumes from the last commanded pose (no snap), then accumulates.
-
-        The clutch keeps its own running home internally. After a plain Stop, the next Play
-        latches the origin to the new controller pose but keeps the home at the last commanded
-        pose, so the arm stays put and tracks fresh delta from there.
-        """
-        r = SO101ClutchRetargeter(name="ee_pose")
-        home = np.array(_CLUTCH_HOME_EE_POS)
-        p0 = np.array([0.5, -0.3, 0.7])
-
-        # Engage (seeds home from config) and move +d1 -> last commanded is home + d1.
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
-        r.compute(inputs, outputs, _make_context())
-        d1 = np.array([0.05, -0.02, 0.10])
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0 + d1)
-        r.compute(inputs, outputs, _make_context())
-        np.testing.assert_allclose(_read_pose(outputs)[:3], home + d1, atol=1e-5)
-
-        # Disengage (STOPPED) -> hold last commanded pose, re-arm the origin.
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=(9.0, 9.0, 9.0))
-        r.compute(inputs, outputs, _make_context(state=ExecutionState.STOPPED))
-        np.testing.assert_allclose(_read_pose(outputs)[:3], home + d1, atol=1e-5)
-        assert r._origin is None
-
-        # Re-engage at a new controller pose -> resume from the running home (home + d1): no jump.
-        p1 = np.array([1.0, 1.0, 1.0])
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p1)
-        r.compute(inputs, outputs, _make_context())
-        np.testing.assert_allclose(_read_pose(outputs)[:3], home + d1, atol=1e-5)
-
-        # Fresh delta from the re-engage origin accumulates on top of the resumed pose.
-        d2 = np.array([0.0, 0.10, -0.03])
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p1 + d2)
-        r.compute(inputs, outputs, _make_context())
-        np.testing.assert_allclose(_read_pose(outputs)[:3], home + d1 + d2, atol=1e-5)
-
-    def test_reset_returns_home_to_config(self):
-        """An explicit reset returns the running home to the configured home.
-
-        Unlike a plain Stop (which freezes the running home so re-engage resumes), a reset
-        re-zeros the clutch to the configured home for a fresh episode.
-        """
-        r = SO101ClutchRetargeter(name="ee_pose")
-        home = np.array(_CLUTCH_HOME_EE_POS)
-        p0 = np.array([0.5, -0.3, 0.7])
-
-        # Engage and move so the running home is no longer the configured home.
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
-        r.compute(inputs, outputs, _make_context())
-        d1 = np.array([0.05, -0.02, 0.10])
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0 + d1)
-        r.compute(inputs, outputs, _make_context())
-
-        # Reset (controller steady at p0) -> re-zeros the home to config and re-latches the
-        # origin at p0, so the emitted pose is the configured home, not the pre-reset pose.
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
-        r.compute(inputs, outputs, _make_context(reset=True))
-        np.testing.assert_allclose(_read_pose(outputs)[:3], home, atol=1e-6)
-
-        # Subsequent motion is measured from the config home (not the pre-reset commanded pose).
-        d2 = np.array([0.0, 0.10, -0.03])
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0 + d2)
-        r.compute(inputs, outputs, _make_context())
-        np.testing.assert_allclose(_read_pose(outputs)[:3], home + d2, atol=1e-6)
-
-    def test_dropped_frame_holds_last_pose(self):
-        """An absent controller frame holds the last commanded pose."""
-        r = SO101ClutchRetargeter(name="ee_pose")
-        p0 = np.array([0.5, -0.3, 0.7])
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
-        r.compute(inputs, outputs, _make_context())
-        first = _read_pose(outputs)
-
-        inputs2, outputs2 = _build_io(r)  # controller absent
-        r.compute(inputs2, outputs2, _make_context())
-        np.testing.assert_allclose(_read_pose(outputs2), first, atol=1e-9)
-
-    def test_calibration_offset_composed_into_orientation(self):
-        """The fixed orientation offset right-multiplies (body frame) the grip orientation.
-
-        The default offset is ``Rz(pi)`` (a roll about the shared approach axis), composed as a
-        body-frame right multiply (``grip (x) offset``) and renormalized to unit. An explicit
-        identity offset passes the grip orientation through unchanged.
-        """
-        grip = _quat_xyzw([0.0, 1.0, 0.0], 0.4).astype(np.float32)
-
-        # Explicit identity offset: passthrough.
-        r = SO101ClutchRetargeter(
-            name="ee_pose", orientation_offset=np.array([0.0, 0.0, 0.0, 1.0])
+    def test_engage_frame_returns_seeded_home_orientation(self):
+        """Same no-teleport guarantee for orientation, whatever the controller orientation."""
+        home_rot = _quat_to_matrix(_quat_xyzw([0.0, 1.0, 0.0], math.pi / 3))
+        c = _Driver(_make_home_transform((0.0, 0.0, 0.0), home_rot))
+        grip = _quat_xyzw([1.0, 0.0, 0.0], math.pi / 5)
+        assert (
+            _rot_dist(c.engage((0.0, 0.0, 0.0), grip)[3:7], _mat_to_quat_xyzw(home_rot))
+            < 1e-6
         )
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(
-            grip_pos=(0.5, -0.3, 0.7), grip_ori=grip
-        )
-        r.compute(inputs, outputs, _make_context())
-        np.testing.assert_allclose(_read_pose(outputs)[3:], grip, atol=1e-6)
 
-        # Default offset: emitted == grip (x) Rz(pi) (body-frame right multiply), unit.
-        r_def = SO101ClutchRetargeter(name="ee_pose")
-        inputs_def, outputs_def = _build_io(r_def)
-        inputs_def[ControllersSource.RIGHT] = _make_controller(
-            grip_pos=(0.5, -0.3, 0.7), grip_ori=grip
-        )
-        r_def.compute(inputs_def, outputs_def, _make_context())
-        rz_pi = np.array([0.0, 0.0, 1.0, 0.0])  # Rz(pi), xyzw
-        expected_def = _quat_mul(grip.astype(np.float64), rz_pi)
-        expected_def = expected_def / np.linalg.norm(expected_def)
-        np.testing.assert_allclose(_read_pose(outputs_def)[3:], expected_def, atol=1e-6)
+    def test_home_transform_rotation_block_is_used(self):
+        """The rotation block is NOT discarded: it seeds the home orientation."""
+        home_rot = _quat_to_matrix(_quat_xyzw([0.0, 0.0, 1.0], math.pi / 2))
+        c = _Driver(_make_home_transform((0.0, 0.0, 0.0), home_rot))
+        assert _rot_dist(c.frame(squeeze=0.0)[3:7], _mat_to_quat_xyzw(home_rot)) < 1e-6
 
-        # Non-identity offset: emitted == grip (x) offset (right multiply), renormalized to unit.
-        offset = _quat_xyzw([0.0, 0.0, 1.0], 0.9)
-        r2 = SO101ClutchRetargeter(name="ee_pose", orientation_offset=offset)
-        inputs2, outputs2 = _build_io(r2)
-        inputs2[ControllersSource.RIGHT] = _make_controller(
-            grip_pos=(0.5, -0.3, 0.7), grip_ori=grip
+
+class TestEngageRelativeClutchPosition:
+    """Controller -> EE translation is measured from the engage origin, scaled."""
+
+    def test_position_delta_is_one_to_one(self):
+        c = _Driver(_make_home_transform((1.0, 1.0, 1.0)))
+        c.engage((0.0, 0.0, 0.0))
+        pose = c.frame((0.3, -0.2, 0.0))
+        np.testing.assert_allclose(pose[:3], [1.3, 0.8, 1.0], atol=1e-6)
+
+    def test_position_is_relative_to_origin_not_absolute(self):
+        """A nonzero engage origin does not leak into the output -- only the change from it."""
+        c = _Driver()
+        c.engage((10.0, 10.0, 10.0))
+        np.testing.assert_allclose(
+            c.frame((10.5, 10.0, 10.0))[:3], [0.5, 0.0, 0.0], atol=1e-6
         )
-        r2.compute(inputs2, outputs2, _make_context())
-        emitted = _read_pose(outputs2)[3:]
-        expected = _quat_mul(grip.astype(np.float64), offset)
-        expected = expected / np.linalg.norm(expected)
-        np.testing.assert_allclose(emitted, expected, atol=1e-6)
-        assert np.linalg.norm(emitted) == pytest.approx(1.0, abs=1e-6)
+
+
+class TestEngageRelativeClutchOrientation:
+    """Base-frame (left-composed) orientation delta."""
+
+    def test_orientation_delta_is_base_frame_left_composed(self):
+        """R_out = Rz(90) @ Rx(90), NOT the body-frame Rx(90) @ Rz(90) a right-composition gives."""
+        home_rot = _quat_to_matrix(_quat_xyzw([1.0, 0.0, 0.0], math.pi / 2))
+        c = _Driver(_make_home_transform((0.0, 0.0, 0.0), home_rot))
+        c.engage()
+        ctrl = _quat_xyzw([0.0, 0.0, 1.0], math.pi / 2)
+        out = c.frame((0.0, 0.0, 0.0), ctrl)[3:7]
+        expected = _quat_to_matrix(ctrl) @ home_rot
+        assert float(np.linalg.norm(_quat_to_matrix(out) - expected)) < 1e-6
+        # And it is NOT the right-composed alternative, which differs by O(1).
+        assert (
+            float(
+                np.linalg.norm(_quat_to_matrix(out) - home_rot @ _quat_to_matrix(ctrl))
+            )
+            > 1.0
+        )
+
+    def test_orientation_is_relative_to_origin_orientation(self):
+        """A nonzero controller origin orientation cancels on the engage frame."""
+        c = _Driver()
+        origin = _quat_xyzw([0.0, 0.0, 1.0], math.pi / 4)
+        assert _rot_dist(c.engage((0.0, 0.0, 0.0), origin)[3:7], _ID_QUAT) < 1e-6
+
+    def test_orientation_delta_is_always_one_to_one_regardless_of_scale(self):
+        """``position_scale`` applies to translation only."""
+        c = _Driver(position_scale=0.25)
+        c.engage()
+        ctrl = _quat_xyzw([0.0, 1.0, 0.0], math.pi / 3)
+        assert _rot_dist(c.frame((0.0, 0.0, 0.0), ctrl)[3:7], ctrl) < 1e-6
+
+
+class TestEngageRelativeClutchReclutch:
+    """A fresh engage resumes from the LAST COMMANDED pose."""
+
+    def test_reclutch_resumes_from_last_commanded_position(self):
+        c = _Driver()
+        c.engage((0.0, 0.0, 0.0))
+        c.frame((1.0, 0.0, 0.0))
+        # Re-engage with the controller somewhere else entirely: no jump to its absolute position.
+        np.testing.assert_allclose(
+            c.engage((5.0, 5.0, 5.0))[:3], [1.0, 0.0, 0.0], atol=1e-6
+        )
+        np.testing.assert_allclose(
+            c.frame((6.0, 5.0, 5.0))[:3], [2.0, 0.0, 0.0], atol=1e-6
+        )
+
+    def test_reclutch_resumes_from_last_commanded_orientation(self):
+        c = _Driver()
+        c.engage()
+        ctrl = _quat_xyzw([0.0, 0.0, 1.0], math.pi / 2)
+        c.frame((0.0, 0.0, 0.0), ctrl)
+        reengage = _quat_xyzw([1.0, 0.0, 0.0], math.pi / 3)
+        out = c.engage((0.0, 0.0, 0.0), reengage)[3:7]
+        assert _rot_dist(out, ctrl) < 1e-6
+
+    def test_disengaged_gap_does_not_change_commanded_pose(self):
+        """Only engaged frames advance the commanded pose; disengaged frames hold it."""
+        c = _Driver()
+        c.engage()
+        pose_a = c.frame((0.4, 0.1, -0.2)).copy()
+        for _ in range(5):
+            c.frame((7.0, 7.0, 7.0), squeeze=0.0)
+        pose_b = c.engage((9.0, 9.0, 9.0))
+        np.testing.assert_allclose(pose_a[:3], pose_b[:3], atol=1e-6)
+        assert _rot_dist(pose_a[3:7], pose_b[3:7]) < 1e-6
+
+
+class TestEngageRelativeClutchEngageSignal:
+    """``engaged == RUNNING and squeeze > squeeze_threshold``, latched on the rising edge."""
+
+    def test_squeeze_below_threshold_does_not_engage(self):
+        c = _Driver(squeeze_threshold=0.5)
+        c.frame((1.0, 0.0, 0.0), squeeze=0.5)  # strictly greater, so 0.5 is NOT engaged
+        assert not c.r.is_engaged
+        np.testing.assert_allclose(
+            c.frame((1.0, 0.0, 0.0), squeeze=0.51)[:3], [0.0, 0.0, 0.0], atol=1e-6
+        )
+        assert c.r.is_engaged
 
     @pytest.mark.parametrize(
-        "bad_grip_ori",
-        [
-            # valid-flagged but zero-norm composed quaternion
-            np.zeros(4, dtype=np.float32),
-            # valid-flagged but non-finite grip quaternion
-            np.full(4, np.nan, dtype=np.float32),
-        ],
+        "state",
+        [ExecutionState.STOPPED, ExecutionState.PAUSED, ExecutionState.UNKNOWN],
     )
-    def test_degenerate_grip_orientation_emits_finite_pose(self, bad_grip_ori):
-        """Defense-in-depth: a valid-flagged but degenerate grip quaternion must not emit NaN.
-
-        Even when the grip pose is flagged valid (so the ``GRIP_IS_VALID`` gate passes), a source
-        that emits a zero or non-finite grip quaternion would, after composing the calibration
-        offset, normalize to NaN and poison the downstream SE3 IK (``svdvals`` -> ``LinAlgError``
-        -> PhysX non-finite bounds). The clutch must instead emit a finite, unit-norm orientation,
-        holding the last good one (the seeded identity on the first frame).
-        """
-        r = SO101ClutchRetargeter(name="ee_pose")
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(
-            grip_pos=(0.5, -0.3, 0.7), grip_ori=bad_grip_ori
-        )
-        r.compute(inputs, outputs, _make_context())
-        pose = _read_pose(outputs)
-        assert np.all(np.isfinite(pose)), f"non-finite pose emitted: {pose}"
-        np.testing.assert_allclose(pose[3:], _ID_QUAT, atol=1e-6)
-        assert np.linalg.norm(pose[3:]) == pytest.approx(1.0, abs=1e-6)
-
-    def test_invalid_grip_pose_holds_last_without_latching(self):
-        """An invalid grip pose (OpenXR validity bits clear) is treated like a dropped frame.
-
-        When the controller is present but its grip pose is not localizable, the source flags
-        ``GRIP_IS_VALID`` False and passes through an untrusted (often all-zero) pose. The clutch
-        must hold the last commanded pose and must NOT latch its origin off that garbage pose, so
-        the first *valid* RUNNING frame still latches cleanly at the configured home.
-        """
-        r = SO101ClutchRetargeter(name="ee_pose")
-        home = np.array(_CLUTCH_HOME_EE_POS)
-
-        # Invalid grip pose on the first RUNNING frame: hold home + identity, do not latch.
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(
-            grip_pos=(9.0, 9.0, 9.0),
-            grip_ori=np.zeros(4, dtype=np.float32),
-            grip_is_valid=False,
-        )
-        r.compute(inputs, outputs, _make_context())
-        pose = _read_pose(outputs)
-        np.testing.assert_allclose(pose[:3], home, atol=1e-6)
-        np.testing.assert_allclose(pose[3:], _ID_QUAT, atol=1e-6)
-        assert r._origin is None  # not latched off the invalid pose
-
-        # A subsequent valid frame latches cleanly at home (no jump from the garbage pose).
-        inputs2, outputs2 = _build_io(r)
-        inputs2[ControllersSource.RIGHT] = _make_controller(grip_pos=(0.5, -0.3, 0.7))
-        r.compute(inputs2, outputs2, _make_context())
-        np.testing.assert_allclose(_read_pose(outputs2)[:3], home, atol=1e-6)
-        assert r._origin is not None
-
-    def test_position_scale_scales_delta(self):
-        """A non-unity ``position_scale`` scales the clutch delta without teleporting on engage."""
-        scale = 0.5
-        r = SO101ClutchRetargeter(name="ee_pose", position_scale=scale)
-        home = np.array(_CLUTCH_HOME_EE_POS)
-        p0 = np.array([0.5, -0.3, 0.7])
-
-        # Engage frame: p_ctrl == origin, so the EE sits exactly at home even at non-unity scale.
-        inputs, outputs = _build_io(r)
-        inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
-        r.compute(inputs, outputs, _make_context())
-        np.testing.assert_allclose(_read_pose(outputs)[:3], home, atol=1e-6)
-
-        # A controller delta after engage advances the EE by scale * delta from home.
-        delta = np.array([0.05, -0.02, 0.10])
-        inputs2, outputs2 = _build_io(r)
-        inputs2[ControllersSource.RIGHT] = _make_controller(grip_pos=p0 + delta)
-        r.compute(inputs2, outputs2, _make_context())
+    def test_non_running_state_blocks_engagement(self, state):
+        """The RUNNING conjunct is a real readiness interlock, not a vacuous term."""
+        c = _Driver()
+        c.frame((1.0, 0.0, 0.0), squeeze=1.0, state=state)
+        assert not c.r.is_engaged
         np.testing.assert_allclose(
-            _read_pose(outputs2)[:3], home + scale * delta, atol=1e-5
+            _read_pose(c.outputs)[:3], [0.0, 0.0, 0.0], atol=1e-6
         )
 
-    @pytest.mark.parametrize("bad_scale", [0.0, -1.0, float("nan"), float("inf")])
-    def test_invalid_position_scale_rejected(self, bad_scale):
-        """A non-positive or non-finite ``position_scale`` is rejected at construction."""
+    def test_is_engaged_rising_edge_is_the_latch_frame(self):
+        """The loop derives the engage edge from ``is_engaged``; it must equal the latch."""
+        c = _Driver()
+        assert not c.r.is_engaged  # False before the first compute
+        c.frame((1.0, 0.0, 0.0), squeeze=1.0)
+        assert c.r.is_engaged
+        c.frame((2.0, 0.0, 0.0), squeeze=0.0)
+        assert not c.r.is_engaged
+
+    def test_squeeze_held_across_a_stop_relatches_on_resume(self):
+        """Leaving RUNNING disarms, so returning with squeeze held is a fresh rising edge."""
+        c = _Driver()
+        c.frame((0.0, 0.0, 0.0), squeeze=1.0)
+        c.frame((1.0, 0.0, 0.0), squeeze=1.0)
+        c.frame((5.0, 0.0, 0.0), squeeze=1.0, state=ExecutionState.STOPPED)
+        assert not c.r.is_engaged
+        # Re-latches here rather than rebasing against the pre-stop origin.
+        np.testing.assert_allclose(
+            c.frame((5.0, 0.0, 0.0), squeeze=1.0)[:3], [1.0, 0.0, 0.0], atol=1e-6
+        )
+
+
+class TestEngageRelativeClutchDisarm:
+    """Dropped / invalid / degenerate frames hold the pose AND re-arm the pending latch.
+
+    The happy-path tests never exercise these branches, so without this class the disarm logic --
+    the half of the latch structure that a plain rising-edge boolean gets wrong -- would ship
+    unverified behind a green suite.
+    """
+
+    def test_dropped_frame_holds_last_pose(self):
+        c = _Driver()
+        c.engage()
+        held = c.frame((0.5, 0.0, 0.0)).copy()
+        np.testing.assert_allclose(c.frame(present=False)[:3], held[:3], atol=1e-9)
+        assert not c.r.is_engaged
+
+    def test_invalid_grip_frame_holds_last_pose(self):
+        c = _Driver()
+        c.engage()
+        held = c.frame((0.5, 0.0, 0.0)).copy()
+        np.testing.assert_allclose(
+            c.frame((9.0, 9.0, 9.0), grip_is_valid=False)[:3], held[:3], atol=1e-9
+        )
+        assert not c.r.is_engaged
+
+    def test_degenerate_quaternion_frame_holds_last_pose(self):
+        """A source that flags the pose valid yet emits a zero quaternion must not reach the IK."""
+        c = _Driver()
+        c.engage()
+        held = c.frame((0.5, 0.0, 0.0)).copy()
+        pose = c.frame((9.0, 9.0, 9.0), np.zeros(4))
+        np.testing.assert_allclose(pose[:3], held[:3], atol=1e-9)
+        assert np.all(np.isfinite(pose))
+        assert not c.r.is_engaged
+
+    def test_non_finite_grip_position_frame_holds_last_pose(self):
+        """A NaN position on a valid-flagged frame must never reach the commanded pose.
+
+        Once NaN enters the held pose it is unrecoverable: the hold path re-emits it, and the
+        last-commanded home fallback re-latches it on the next engage. NaN comparisons are all
+        False, so no downstream bounds check rejects it either.
+        """
+        c = _Driver()
+        c.engage()
+        held = c.frame((0.5, 0.0, 0.0)).copy()
+        for bad in ((np.nan, 0.0, 0.0), (0.0, np.inf, 0.0), (0.0, 0.0, -np.inf)):
+            pose = c.frame(bad)
+            assert np.all(np.isfinite(pose)), f"non-finite output for grip_pos={bad}"
+            np.testing.assert_allclose(pose[:3], held[:3], atol=1e-9)
+            assert not c.r.is_engaged
+        # ...and the clutch still works afterwards, from the pose it held.
+        np.testing.assert_allclose(c.engage((5.0, 0.0, 0.0))[:3], held[:3], atol=1e-6)
+        assert np.all(np.isfinite(c.r._last_commanded_pos))
+
+    def test_invalid_frame_on_the_rising_edge_still_latches_next_frame(self):
+        """An unusable frame defers the latch rather than consuming it."""
+        c = _Driver()
+        c.frame((0.0, 0.0, 0.0), squeeze=1.0)
+        c.frame((1.0, 0.0, 0.0), squeeze=1.0)
+        c.frame((1.0, 0.0, 0.0), squeeze=0.0)
+        # The re-engage frame is invalid, so the latch stays owed...
+        c.frame((9.0, 0.0, 0.0), squeeze=1.0, grip_is_valid=False)
+        assert not c.r.is_engaged
+        # ...and fires on the next good frame, holding rather than jumping to the controller.
+        np.testing.assert_allclose(
+            c.frame((9.0, 0.0, 0.0), squeeze=1.0)[:3], [1.0, 0.0, 0.0], atol=1e-6
+        )
+
+    def test_release_and_resqueeze_across_a_dropout_does_not_jump(self):
+        """The case a plain rising-edge boolean gets wrong.
+
+        The squeeze is unobservable during a dropout, so if the operator releases and re-squeezes
+        inside the gap, no falling edge is ever *seen*. Keeping the old origin would rebase against
+        the pre-dropout engagement and jump the arm by the whole accumulated hand motion. Disarming
+        on the dropped frames keeps the latch owed, so the first good frame re-latches in place.
+        """
+        c = _Driver()
+        c.frame((0.0, 0.0, 0.0), squeeze=1.0)
+        c.frame((1.0, 0.0, 0.0), squeeze=1.0)
+        for pos in ((3.0, 0.0, 0.0), (6.0, 0.0, 0.0), (9.0, 0.0, 0.0)):
+            c.frame(pos, present=False)
+        np.testing.assert_allclose(
+            c.frame((9.0, 0.0, 0.0), squeeze=1.0)[:3], [1.0, 0.0, 0.0], atol=1e-6
+        )
+
+
+class TestEngageRelativeClutchMeasuredHome:
+    """The asymmetric home latch: position from the measurement, orientation never."""
+
+    def test_measured_pose_supplies_the_home_position(self):
+        """An arm that sagged while disengaged is not snapped back to the stale command."""
+        c = _Driver()
+        c.engage()
+        c.frame((1.0, 0.0, 0.0))
+        pose = c.engage((5.0, 5.0, 5.0), measured=(0.30, 0.05, 0.09))
+        np.testing.assert_allclose(pose[:3], [0.30, 0.05, 0.09], atol=1e-6)
+
+    def test_measured_pose_does_not_supply_the_home_orientation(self):
+        """Orientation always comes from the last commanded rotation -- never the measurement.
+
+        The 5-DOF wrist tracks orientation softly, so latching the measured orientation would
+        inject that tracking offset into the command on every re-clutch.
+        """
+        c = _Driver()
+        c.engage()
+        ctrl = _quat_xyzw([0.0, 0.0, 1.0], math.pi / 2)
+        c.frame((0.0, 0.0, 0.0), ctrl)
+        measured_rot = _quat_to_matrix(_quat_xyzw([1.0, 0.0, 0.0], math.pi / 3))
+        tg = TensorGroup(TransformMatrix())
+        tg[0] = _make_home_transform((0.4, 0.0, 0.0), measured_rot).astype(np.float32)
+        c.frame((0.0, 0.0, 0.0), ctrl, squeeze=0.0)
+        c.inputs[SO101ClutchRetargeter.MEASURED_BASE_T_EE_INPUT] = tg
+        c.inputs[ControllersSource.RIGHT] = _make_controller(grip_ori=ctrl, squeeze=1.0)
+        c.r.compute(c.inputs, c.outputs, _make_context())
+        pose = _read_pose(c.outputs)
+        np.testing.assert_allclose(
+            pose[:3], [0.4, 0.0, 0.0], atol=1e-6
+        )  # position: measured
+        assert _rot_dist(pose[3:7], ctrl) < 1e-6  # orientation: last commanded
+
+    def test_absent_measured_input_falls_back_to_the_last_commanded_position(self):
+        """An unwired measured input lands on the last-commanded home, silently and repeatedly.
+
+        This is a *designed* path, not degraded mode: a consumer whose owning task slews the arm
+        to a known configured home on reset (Isaac Lab) legitimately leaves
+        ``MEASURED_BASE_T_EE_INPUT`` unconnected, so the retargeter must not editorialize about
+        it. The fallback is exercised across several re-clutches to pin that it stays stable
+        rather than drifting or firing only once.
+        """
+        c = _Driver()
+        c.engage()
+        c.frame((1.0, 0.0, 0.0))
+        np.testing.assert_allclose(
+            c.engage((5.0, 5.0, 5.0))[:3], [1.0, 0.0, 0.0], atol=1e-6
+        )
+        c.frame((6.0, 5.0, 5.0))
+        np.testing.assert_allclose(
+            c.engage((7.0, 5.0, 5.0))[:3], [2.0, 0.0, 0.0], atol=1e-6
+        )
+
+
+class TestEngageRelativeClutchSetHome:
+    """``set_home_base_T_ee`` -- the late-seeding path used when the graph is built before the
+    arm is homed, and the transform a subsequent ``reset`` re-seeds to. Public API, so it is
+    covered directly."""
+
+    def test_set_home_reseeds_the_held_pose(self):
+        c = _Driver(_make_home_transform((0.0, 0.0, 0.0)))
+        home_rot = _quat_to_matrix(_quat_xyzw([0.0, 0.0, 1.0], math.pi / 2))
+        c.r.set_home_base_T_ee(_make_home_transform((0.22, 0.0, 0.12), home_rot))
+        pose = c.frame(squeeze=0.0)
+        np.testing.assert_allclose(pose[:3], [0.22, 0.0, 0.12], atol=1e-6)
+        assert _rot_dist(pose[3:7], _mat_to_quat_xyzw(home_rot)) < 1e-6
+
+    def test_set_home_while_engaged_rearms_instead_of_jumping(self):
+        """Re-seeding mid-engagement must not leave the OLD origin latched against the NEW home.
+
+        Without the re-arm the next frame would command ``new_home + scale*(grip - old_origin)``,
+        i.e. a jump of ``new_home - old_home`` at servo speed.
+        """
+        c = _Driver(_make_home_transform((0.0, 0.0, 0.0)))
+        c.frame((0.0, 0.0, 0.0), squeeze=1.0)
+        c.frame((1.0, 0.0, 0.0), squeeze=1.0)
+        assert c.r.is_engaged
+
+        c.r.set_home_base_T_ee(_make_home_transform((5.0, 0.0, 0.0)))
+        assert not c.r.is_engaged, "set_home_base_T_ee must re-arm the pending latch"
+        # The next engaged frame re-latches in place at the new home -- no accumulated delta.
+        np.testing.assert_allclose(
+            c.frame((1.0, 0.0, 0.0), squeeze=1.0)[:3], [5.0, 0.0, 0.0], atol=1e-6
+        )
+
+
+class TestEngageRelativeClutchPositionScale:
+    """``position_scale`` validation and effect."""
+
+    def test_scale_halves_the_delta_but_the_engage_frame_still_returns_home(self):
+        c = _Driver(_make_home_transform((0.1, 0.2, 0.3)), position_scale=0.5)
+        np.testing.assert_allclose(
+            c.engage((5.0, -3.0, 2.0))[:3], [0.1, 0.2, 0.3], atol=1e-6
+        )
+        np.testing.assert_allclose(
+            c.frame((5.4, -3.0, 2.0))[:3], [0.3, 0.2, 0.3], atol=1e-6
+        )
+
+    @pytest.mark.parametrize("scale", [0.0, -1.0, float("inf"), float("nan")])
+    def test_invalid_scale_raises(self, scale):
+        with pytest.raises(
+            ValueError, match="position_scale must be positive and finite"
+        ):
+            SO101ClutchRetargeter(
+                "c", _make_home_transform((0.0, 0.0, 0.0)), position_scale=scale
+            )
+
+
+class TestEngageRelativeClutchSqueezeThreshold:
+    """``squeeze_threshold`` validation. Every rejected value fails the SAME way -- silently."""
+
+    @pytest.mark.parametrize("threshold", [0.0, 0.5, 0.999])
+    def test_valid_threshold_accepted(self, threshold):
+        """The usable range is ``[0, 1)``; ``0`` engages on any non-zero squeeze."""
+        c = _Driver(squeeze_threshold=threshold)
+        c.frame((0.0, 0.0, 0.0), squeeze=1.0)
+        assert c.r.is_engaged
+
+    @pytest.mark.parametrize(
+        "threshold", [float("nan"), 1.0, 1.5, float("inf"), -0.1, float("-inf")]
+    )
+    def test_invalid_threshold_raises(self, threshold):
+        """A threshold outside ``[0, 1)`` can never be exceeded -- the clutch would never engage.
+
+        ``NaN`` is the nastiest of these: every ``squeeze > NaN`` comparison is False, so the
+        clutch stays disengaged forever with no error, no warning and a perfectly healthy-looking
+        graph. A threshold of ``1.0`` or above is the same defect by a different route, since the
+        squeeze axis is normalized to ``[0, 1]`` and the comparison is strict.
+        """
+        with pytest.raises(
+            ValueError, match=r"squeeze_threshold must be finite and in \[0, 1\)"
+        ):
+            SO101ClutchRetargeter(
+                "c",
+                _make_home_transform((0.0, 0.0, 0.0)),
+                squeeze_threshold=threshold,
+            )
+
+
+class TestEngageRelativeClutchHomeValidation:
+    """``home_base_T_ee`` must be a 4x4 with a *proper* rotation block.
+
+    A scaled or reflected block still converts to a unit quaternion, so it would command a quietly
+    wrong home orientation with nothing downstream to reject it -- the one failure mode this class
+    exists to make loud.
+    """
+
+    def test_scaled_rotation_block_rejected(self):
+        home = _make_home_transform((0.1, 0.2, 0.3), 2.0 * np.eye(3))
+        with pytest.raises(ValueError, match="orthonormal"):
+            SO101ClutchRetargeter("c", home)
+
+    def test_reflected_rotation_block_rejected(self):
+        """Orthonormal but ``det == -1``: a reflection, not a rotation."""
+        home = _make_home_transform((0.1, 0.2, 0.3), np.diag([1.0, 1.0, -1.0]))
+        with pytest.raises(ValueError, match="proper rotation"):
+            SO101ClutchRetargeter("c", home)
+
+    def test_shear_rotation_block_rejected(self):
+        home = _make_home_transform(
+            (0.1, 0.2, 0.3),
+            np.array([[1.0, 0.2, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]),
+        )
+        with pytest.raises(ValueError, match="orthonormal"):
+            SO101ClutchRetargeter("c", home)
+
+    def test_wrong_shape_rejected(self):
+        with pytest.raises(ValueError, match="4x4"):
+            SO101ClutchRetargeter("c", np.eye(3))
+
+    def test_non_finite_rejected(self):
+        home = _make_home_transform((np.nan, 0.2, 0.3))
+        with pytest.raises(ValueError, match="finite"):
+            SO101ClutchRetargeter("c", home)
+
+    def test_legacy_positional_call_fails_loudly(self):
+        """The retired signature put ``input_device`` second; that call must not silently work."""
         with pytest.raises(ValueError):
-            SO101ClutchRetargeter(name="ee_pose", position_scale=bad_scale)
+            SO101ClutchRetargeter("ee_pose", ControllersSource.RIGHT)
 
-    def test_reengage_ratchets_scaled_delta_per_cycle(self):
-        """N re-clutch cycles accumulate ``scale * delta`` each, ratcheting by ``N * scale * delta``.
+    def test_float32_rotation_block_accepted(self):
+        """Callers routinely build the transform in float32; the tolerance must not reject it.
 
-        This is the issue's motivating regression: at 1:1 motion (``scale == 1``) each re-engage
-        ratchets a full delta onto the running home, driving the target out of reach; a sub-unity
-        scale attenuates each cycle's advance so the same operator motion stays in the workspace.
+        Swept rather than sampled once: a single lucky draw would not show that the tolerance
+        clears the *worst* float32 residual, and the check refusing a legitimate measured home is
+        the failure this class would otherwise cause.
         """
-        home = np.array(_CLUTCH_HOME_EE_POS)
-        delta = np.array([0.05, -0.02, 0.10])
-        n_cycles = 3
+        rng = np.random.default_rng(20260727)
+        for _ in range(200):
+            q = rng.standard_normal(4)
+            rot = _quat_to_matrix(q / np.linalg.norm(q))
+            home = _make_home_transform((0.1, 0.2, 0.3), rot).astype(np.float32)
+            c = _Driver(home)
+            np.testing.assert_allclose(
+                c.frame(squeeze=0.0)[:3], [0.1, 0.2, 0.3], atol=1e-6
+            )
 
-        def _run_cycles(scale):
-            r = SO101ClutchRetargeter(name="ee_pose", position_scale=scale)
-            outputs = None
-            for i in range(n_cycles):
-                p0 = np.array(
-                    [float(i), float(i), float(i)]
-                )  # fresh origin each engage
-                # Engage: latch the origin at p0 and resume from the running home.
-                inputs, outputs = _build_io(r)
-                inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
-                r.compute(inputs, outputs, _make_context())
-                # Move +delta: the running home advances by scale * delta.
-                inputs, outputs = _build_io(r)
-                inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0 + delta)
-                r.compute(inputs, outputs, _make_context())
-                # Disengage (STOPPED): freeze the running home, re-arm the origin.
-                inputs, outputs = _build_io(r)
-                inputs[ControllersSource.RIGHT] = _make_controller(grip_pos=p0)
-                r.compute(inputs, outputs, _make_context(state=ExecutionState.STOPPED))
-            return _read_pose(outputs)[:3]
+    def test_hand_typed_rotation_block_accepted(self):
+        """A matrix hand-typed at 5 decimal places must not be rejected as "not orthonormal".
 
-        # Sub-unity scale ratchets N * scale * delta over the N cycles.
-        scale = 0.5
-        np.testing.assert_allclose(
-            _run_cycles(scale), home + n_cycles * scale * delta, atol=1e-5
+        Hand-typed 4x4s are a supported caller input -- a home transform read off a sensor once and
+        pasted into a config file is the ordinary way a task pins its seated pose -- so a tolerance
+        that policed precision rather than structure would reject a legitimate home. 5 decimals is
+        the documented floor (see ``_ROTATION_ATOL``); 4 is NOT covered and is rejected ~16% of the
+        time.
+
+        Swept rather than sampled once, for the same reason as
+        :meth:`test_float32_rotation_block_accepted`: a single lucky draw says nothing about the
+        worst rounding residual, which is the number the tolerance is actually sized against.
+        """
+        rng = np.random.default_rng(20260727)
+        for _ in range(200):
+            q = rng.standard_normal(4)
+            rot = np.round(_quat_to_matrix(q / np.linalg.norm(q)), 5)
+            c = _Driver(_make_home_transform((0.1, 0.2, 0.3), rot))
+            np.testing.assert_allclose(
+                c.frame(squeeze=0.0)[:3], [0.1, 0.2, 0.3], atol=1e-6
+            )
+
+    def test_transposed_transform_rejected(self):
+        """``base_T_ee.T`` passes every other check, so the bottom row is the only guard.
+
+        Its rotation block is ``R.T`` -- orthonormal, ``det == +1`` -- and the translation moves to
+        the bottom row, leaving column 3 zeroed. Without this check the clutch would home at the
+        base origin with the inverse orientation and report nothing.
+        """
+        rot = _quat_to_matrix(_quat_xyzw([1.0, 2.0, 3.0], 0.9))
+        home = _make_home_transform((0.1, 0.2, 0.3), rot)
+        with pytest.raises(ValueError, match="bottom row"):
+            SO101ClutchRetargeter("c", home.T)
+
+    def test_set_home_validates_too(self):
+        """The late-seeding path is the one a live loop calls -- it gets the same guard."""
+        c = _Driver()
+        with pytest.raises(ValueError, match="orthonormal"):
+            c.r.set_home_base_T_ee(
+                _make_home_transform((0.0, 0.0, 0.0), np.zeros((3, 3)))
+            )
+
+
+class TestEngageRelativeClutchStatePrecision:
+    """The float64 internal state, asserted white-box on purpose.
+
+    The ``ee_pose`` output is float32 by contract, and that contract structurally HIDES this
+    defect: an implementation that reads its running home back out of the emitted float32 pose --
+    the obvious shortcut, since the pose is right there -- is pinned at ~1 float32 ULP in that
+    same output under either state layout, so no black-box assertion can discriminate. Reaching
+    into the
+    float64 state attribute is the only instrument that can, and the error it catches grows with
+    re-clutch count whenever no measured pose re-seeds the home.
+    """
+
+    def test_repeated_reclutch_does_not_quantize_the_commanded_pose(self):
+        """50 re-clutches of an exactly-cancelling excursion must leave the state where it began.
+
+        Both channels are exercised with values that MOVE: each cycle latches a different engage
+        orientation and swings out through a non-identity rotation and an off-float32-grid
+        translation before returning to the engage pose, so the commanded pose is analytically
+        unchanged only after passing through states float32 cannot represent.
+
+        Scope: the measured-EE input is deliberately absent throughout. ``TransformMatrix`` is
+        float32 *by tensor type*, so feeding it would re-seed the home at float32 resolution and
+        this assertion would measure that quantization rather than the state layout. The
+        orientation channel has no measured re-seed path at all -- it always comes from the last
+        commanded rotation -- which is exactly why float64 state is load-bearing there.
+
+        This test's whole job is to catch the float32-state defect, so it is written to be capable
+        of failing: driving the same sequence through a state that round-trips via the float32
+        output scores ~1e-07 m and ~1e-06 in these metrics, orders above both thresholds.
+        """
+        start = np.array([0.1234567890123, -0.9876543210987, 0.5555555555555])
+        # The seeded home rotation must NOT be float32-representable, or the orientation half of
+        # this test is vacuous: identity survives a float32 round-trip exactly, so a quantizing
+        # state layout would score zero against it.
+        start_rot = _quat_to_matrix(
+            _quat_xyzw([0.31234567, -0.7654321, 0.5555511], 0.9876543)
         )
-        # Unit-scale contrast: each cycle ratchets a full delta -> N * delta.
-        np.testing.assert_allclose(_run_cycles(1.0), home + n_cycles * delta, atol=1e-5)
+        c = _Driver(_make_home_transform(start, start_rot))
+        home_rot0 = c.r._last_commanded_rot.copy()
+        assert not np.array_equal(
+            home_rot0, home_rot0.astype(np.float32).astype(np.float64)
+        ), "seed rotation must not be exactly float32-representable"
+        delta = np.array([math.pi, math.e, math.sqrt(2)]) * 1e-3
+
+        for k in range(50):
+            # A different engage orientation every cycle, so _home_rot re-latches onto a moving
+            # target instead of sitting on identity (which would assert nothing).
+            engage_q = _quat_xyzw([1.0, 2.0, 3.0], 0.017 * (k + 1))
+            swing_q = _quat_xyzw([-2.0, 1.0, 0.5], 0.023 * (k + 1))
+            c.frame((0.0, 0.0, 0.0), engage_q, squeeze=0.0)
+            c.frame((0.0, 0.0, 0.0), engage_q, squeeze=1.0)
+            c.frame(tuple(delta), swing_q)  # out, through an unrepresentable pose
+            c.frame((0.0, 0.0, 0.0), engage_q)  # and exactly back
+
+        assert float(np.max(np.abs(c.r._last_commanded_pos - start))) == 0.0
+        # Each cycle ends on q_engage (x) q_engage^-1 (x) R_home == R_home, and R_home is
+        # re-latched from that same value next cycle -- so the rotation returns to the seed.
+        assert _rot_dist(c.r._last_commanded_rot, home_rot0) < 1e-12
+
+
+class TestEngageRelativeClutchPipelineShape:
+    """The in-pipeline wiring contract the LeRobot example depends on.
+
+    That example cannot be exercised by this suite (different repo, and its pinned ``isaacteleop``
+    predates this retargeter), so the graph shape it builds is covered here instead.
+    """
+
+    def _build_graph(self, retargeter):
+        controllers = ValueInput("controllers", OptionalType(ControllerInput()))
+        measured = ValueInput("measured_ee", OptionalType(TransformMatrix()))
+        sub = retargeter.connect(
+            {
+                ControllersSource.RIGHT: controllers.output("value"),
+                SO101ClutchRetargeter.MEASURED_BASE_T_EE_INPUT: measured.output(
+                    "value"
+                ),
+            }
+        )
+        # The raw controller stays on the combiner: the device derives is_tracking and the analog
+        # trigger from it, and both would be lost if only ee_pose were published.
+        return OutputCombiner(
+            {
+                "ee_pose": sub.output("ee_pose"),
+                "controller": controllers.output("value"),
+            }
+        )
+
+    def test_graph_executes_and_publishes_both_outputs(self):
+        r = SO101ClutchRetargeter(
+            "clutch", _make_home_transform((0.0, 0.0, 0.0)), position_scale=0.5
+        )
+        graph = self._build_graph(r)
+        result = graph.execute_pipeline(
+            {
+                "controllers": {"value": _make_controller(squeeze=1.0)},
+                "measured_ee": {"value": _make_measured((0.30, 0.05, 0.09))},
+            },
+            context=_make_context(),
+        )
+        np.testing.assert_allclose(
+            np.from_dlpack(result["ee_pose"][0])[:3], [0.30, 0.05, 0.09], atol=1e-6
+        )
+        assert r.is_engaged
+        # is_tracking regression: the device re-derives it from this group's is_none. If that
+        # derivation is lost, the example's connect-wait loop never returns.
+        assert result["controller"].is_none is False
+        assert float(result["controller"][ControllerInputIndex.TRIGGER_VALUE]) == 0.0
+
+    def test_untracked_controller_holds_pose_and_reports_is_none(self):
+        r = SO101ClutchRetargeter("clutch", _make_home_transform((0.2, 0.0, 0.1)))
+        graph = self._build_graph(r)
+        result = graph.execute_pipeline(
+            {"controllers": {"value": OptionalTensorGroup(ControllerInput())}},
+            context=_make_context(),
+        )
+        np.testing.assert_allclose(
+            np.from_dlpack(result["ee_pose"][0])[:3], [0.2, 0.0, 0.1], atol=1e-6
+        )
+        assert result["controller"].is_none is True
+        assert not r.is_engaged
+
+    def test_measured_value_input_must_be_declared_optional(self):
+        """A plain ``ValueInput`` leaf is REQUIRED and raises inside the retargeting worker.
+
+        ``ValueInput.input_spec`` returns a plain ``TensorGroupType``, so a leaf that is not fed
+        every step fails the graph rather than degrading. Declaring it ``OptionalType`` is what
+        makes a skipped feed land on the documented last-commanded fallback instead of a
+        ``RuntimeError`` at frame rate with the arm live.
+        """
+        r = SO101ClutchRetargeter("clutch", _make_home_transform((0.0, 0.0, 0.0)))
+        controllers = ValueInput("controllers", OptionalType(ControllerInput()))
+        strict = ValueInput("measured_ee", TransformMatrix())  # NOT OptionalType
+        graph = OutputCombiner(
+            {
+                "ee_pose": r.connect(
+                    {
+                        ControllersSource.RIGHT: controllers.output("value"),
+                        SO101ClutchRetargeter.MEASURED_BASE_T_EE_INPUT: strict.output(
+                            "value"
+                        ),
+                    }
+                ).output("ee_pose")
+            }
+        )
+        with pytest.raises(ValueError, match="not found in cache"):
+            graph.execute_pipeline(
+                {"controllers": {"value": _make_controller(squeeze=1.0)}},
+                context=_make_context(),
+            )
+        # The optional form, by contrast, runs clean when unfed.
+        optional_graph = self._build_graph(
+            SO101ClutchRetargeter("clutch2", _make_home_transform((0.2, 0.0, 0.1)))
+        )
+        result = optional_graph.execute_pipeline(
+            {"controllers": {"value": _make_controller(squeeze=1.0)}},
+            context=_make_context(),
+        )
+        np.testing.assert_allclose(
+            np.from_dlpack(result["ee_pose"][0])[:3], [0.2, 0.0, 0.1], atol=1e-6
+        )

--- a/src/retargeters/SO101/clutch_retargeter.py
+++ b/src/retargeters/SO101/clutch_retargeter.py
@@ -1,63 +1,81 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""SO-101 clutch (relative-origin) EE-pose retargeter for the absolute-pose XR teleop pipeline.
+"""Engage-relative full-pose clutch retargeter for the SO-101 5-DOF arm.
 
-The shared :class:`~isaacteleop.retargeters.Se3AbsRetargeter` maps the controller's absolute
-position directly to the EE target, so engaging teleop teleports the arm to wherever the
-controller happens to be in the (anchor-transformed) world frame. For comfortable bring-up we
-want clutch-style rebasing: capture the controller position at engage and drive the EE from
-the *delta* relative to that captured origin, while keeping position-control IK
-(``use_relative_mode=False``).
+Clutches the **full pose**: on every engage it re-latches *both* the home position and the home
+orientation, so the operator can disengage, reposition their hand, and re-engage without the arm
+moving. Each engaged frame emits::
 
-:class:`SO101ClutchRetargeter` therefore emits an **absolute** 7D ``ee_pose`` (position
-``[x, y, z]`` [m] + orientation quaternion ``[x, y, z, w]``) with the exact same output
-contract as :class:`~isaacteleop.retargeters.Se3AbsRetargeter` (node ``name="ee_pose"``, output
-key ``"ee_pose"``, ``NDArrayType("pose", shape=(7,))``), so the downstream reorderer and the
-8D action contract are untouched. The orientation is the controller grip orientation composed
-with a fixed calibration offset; it **drives the SE3 IK** that solves all 5 SO-101 arm joints.
+    pos = home_pos + position_scale * (grip_pos - origin_pos)   # scaled translation
+    rot = (R_ctrl @ R_origin^-1) @ R_home                       # base-frame delta, 1:1
 
-Frame contract: the controller stream reaching this retargeter is already expressed in the
-robot **base** frame -- the Isaac Lab device rebases it upstream via its
-``target_frame_prim_path`` (set to the robot base), composing ``base_T_world`` onto the XR
-anchor before the controllers are transformed. The clutch therefore applies the controller
-delta to the home directly, with no world->base rotation of its own. The emitted position is
-in the same base frame as the downstream absolute-position IK command.
+On the engage frame ``grip_pos == origin_pos`` and ``R_ctrl == R_origin``, so the output is
+*exactly* the home pose whatever the scale -- no teleport. Because the orientation delta is
+**left**-composed (base frame), a hand rotation about base Z maps to an EE rotation about base Z.
 
-Clutch behavior:
+Engagement is ``execution_state == RUNNING`` **and** ``squeeze > squeeze_threshold``. The two
+conjuncts are different things and both are load-bearing: ``squeeze`` is *operator intent*, while
+``execution_state`` is *system readiness*. An owning application that is still homing the arm
+holds ``STOPPED`` so a squeeze cannot latch a home the arm has not reached yet.
 
-- The origin is **re-armed** (``self._origin = None``) whenever teleop is not ``RUNNING``
-  (i.e. on Stop, and on an explicit reset); the first ``RUNNING`` frame thereafter (the moment
-  the headset "Play" engages) latches the controller origin ``p0`` in the (base-frame)
-  controller stream. Connecting the client does **not** latch the origin, and every Play
-  re-zeroes it to the controller's current pose.
-- The clutch keeps its own **running home** internally. Because it commands the EE, it knows
-  the last target it emitted; on a mid-task re-clutch (disengage to reposition the hand,
-  re-engage to continue) it latches the home to that last commanded pose, so the EE stays put
-  and tracks fresh delta from where it was left -- the live end-effector is *not* re-read on a
-  re-clutch.
-- The home is **seeded from the configured reset-origin** on reset / first engage: the
-  :paramref:`home_base_T_ee` ``base_T_ee`` transform -- the gripper's pose relative to the robot
-  base at the reset pose. No live end-effector is read; the owning task resets the arm to this
-  pose, so the engage after a reset latches the home there and the arm sits exactly where it
-  already is (no snap on Play). The clutch never needs to read the robot back: the base rebase is
-  done upstream by ``target_frame_prim_path``, and the EE state going forward is the running home
-  (what the clutch itself commanded).
-- Each frame the emitted position is ``output_pos = home + s * (p_ctrl - p0)`` with scale
-  ``s = position_scale`` (the constructor parameter, defaulting to
-  :data:`_CLUTCH_POSITION_SCALE`; see :func:`_rebased_position`). On the latching frame
-  ``p_ctrl == p0`` so ``output_pos == home`` exactly (no teleport on engage).
-- A plain Stop **freezes** the running home, so the next Play resumes from the last commanded
-  pose. An explicit **reset** re-seeds the home from the configured reset-origin for a fresh
-  episode.
-- The reset-origin home is supplied as a ``base_T_ee`` 4x4 transform at construction; only its
-  translation drives the position command (the orientation is the live controller grip
-  orientation composed with the fixed calibration offset, not read from this home transform). It
-  is **never** ``(0, 0, 0)`` (that would command the EE into the robot base / floor).
-- The last pose is held on a dropped frame, and likewise on a frame whose controller grip pose
-  is flagged invalid (the OpenXR location-validity bits are clear): the untrusted pose is
-  ignored and the clutch origin is not latched off it.
+Latching uses a **pending-latch sentinel**: ``_origin is None`` means "a latch is owed". The
+sentinel is cleared (re-armed) on every disengaged, dropped, invalid or degenerate frame, so the
+latch stays owed until a frame arrives that can be trusted to latch off. Both halves are
+necessary -- arm-then-fire *without* the re-arm silently jumps when the operator releases and
+re-squeezes across a tracking dropout, because the squeeze is unobservable inside the gap.
+
+Home latching is deliberately **asymmetric**:
+
+* the home **position** comes from the arm's measured EE pose when
+  :data:`MEASURED_BASE_T_EE_INPUT` is connected, so an arm that sagged or was pushed while
+  disengaged is not snapped back to a stale command;
+* the home **orientation** is *always* the last commanded rotation, never the measurement. The
+  5-DOF SO-101 tracks orientation only softly, so its measured wrist orientation persistently
+  differs from the command; latching the measurement would inject that offset into the commanded
+  signal on **every** re-clutch. Position has no such tracking gap.
+
+On ``execution_events.reset`` the held pose is re-seeded from the **configured** home -- the
+transform most recently supplied to the constructor or to :meth:`set_home_base_T_ee` -- and the
+latch is re-armed. Seeding from a *static configured* transform rather than from live arm state is
+what makes this safe: the reset pulse can reach this retargeter on either side of the owner's
+actual teleport, so anything read from the arm at reset time is stale on one of those orderings.
+The owning task is expected to slew the arm to that same configured pose on reset (Isaac Lab's
+``init_state`` does exactly that), which is what makes the re-seed jump-free. An owner whose reset
+does *not* move the arm should keep the configured home up to date with
+:meth:`set_home_base_T_ee`, or simply not fire ``reset``.
+
+That "never from live arm state" scopes to the **re-seed**, not to the whole frame. A frame that
+carries ``reset`` can also latch the clutch, and the latch is unchanged by the re-seed having just
+happened: the normal engage rule still applies, so on such a frame the home **position** comes from
+:data:`MEASURED_BASE_T_EE_INPUT` when it is connected, not from the re-seed. Note that this does
+not escape the ordering problem above -- ``GRIP_IS_VALID`` and the squeeze qualify the *controller*
+pose, and say nothing about whether the arm has been teleported yet, so on a reset-before-teleport
+ordering that measurement is the previous episode's arm state. No consumer wires both today. One
+that does should either not fire ``reset`` on a frame it also engages, or leave the measured input
+unwired. The re-seed's own job is unaffected: it defines what the retargeter holds, and re-latches
+*from*, when nothing engages.
+
+.. note::
+   There is deliberately **no** ``orientation_offset`` parameter. It is not merely unnecessary
+   here, it is *wrong*: appending a fixed offset gives ``(R_ctrl . R_origin^-1 . R_home) . R_off``,
+   and on the engage frame ``R_ctrl == R_origin``, so the output is ``R_home . R_off != R_home`` --
+   which breaks the no-teleport invariant. Worse, because ``_home_rot`` re-latches from the last
+   *commanded* rotation, the error compounds as ``R_off``, ``R_off^2``, ``R_off^3`` over successive
+   re-clutches. Do not re-add it.
+
+.. note::
+   Orientation **wind-up** is a real property of this algebra and is intentionally preserved: the
+   commanded rotation is unbounded in SO(3) across repeated re-clutches, and ``wrist_roll`` sits in
+   the null space of the 5-DOF position objective. Mitigating it would change behaviour.
+
+Quaternion helpers are inlined below rather than imported: the equivalents in
+``retargeting_engine/python/utilities/transform_utils.py`` (``_rotation_matrix_to_quat_xyzw`` at
+``:116``, ``_quat_multiply_xyzw`` at ``:158``) are private to the engine layer. No SciPy either,
+so this retargeter needs nothing beyond NumPy at install time.
 """
+
+from __future__ import annotations
 
 import numpy as np
 from isaacteleop.retargeting_engine.deviceio_source_nodes import ControllersSource
@@ -76,45 +94,51 @@ from isaacteleop.retargeting_engine.tensor_types import (
     ControllerInputIndex,
     DLDataType,
     NDArrayType,
+    TransformMatrix,
 )
 
-# Default home EE position [m] in the IK command (base) frame, used to build the fallback
-# ``base_T_ee`` home when no ``home_base_T_ee`` transform is supplied (e.g. sim-free tests). A
-# generic, non-degenerate bring-up value (approximately where a small tabletop arm's gripper
-# sits at a neutral pose); it is intentionally arm-scale geometry, not a task-specific
-# placement. Must never be the base origin (that would command the EE into the robot base /
-# floor). TODO(verify-in-sim)
-_CLUTCH_HOME_EE_POS: tuple[float, float, float] = (0.22, 0.0, 0.12)
-# Default controller-to-EE translation gain (1.0 = 1:1 motion) for the ``position_scale``
-# constructor parameter. TODO(verify-in-sim)
-_CLUTCH_POSITION_SCALE = 1.0
-# Identity orientation quaternion [x, y, z, w], emitted before any valid frame / on reset.
-_IDENTITY_QUAT = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
-# Default fixed orientation calibration offset [x, y, z, w], right-multiplied (body frame) onto
-# the controller grip orientation so a neutrally-held controller maps to a sensible neutral
-# gripper orientation. The OpenXR grip frame and the SO-101 gripper_link frame share their tool
-# axis (both point/approach along their own -Z), so the only fixed convention offset between them
-# is a roll about that shared approach (Z) axis; the default is Rz(pi) == [0, 0, 1, 0] (xyzw), the
-# body-frame equivalent of the ~pi wrist-roll calibration the deleted SO101WristRetargeter applied.
-# TODO(tune-in-sim): confirm the angle/sign (pi vs pi +/- pi/2) -- it sets which way the single
-# moving jaw faces relative to the hand.
-_DEFAULT_ORIENTATION_OFFSET = np.array(
-    [0.0, 0.0, 1.0, 0.0], dtype=np.float64
-)  # Rz(pi), xyzw
-# Minimum norm below which the composed command quaternion is treated as degenerate. The
-# ``GRIP_IS_VALID`` gate in :meth:`SO101ClutchRetargeter._compute_fn` is the primary guard against
-# untracked poses; this is a secondary "never divide by zero" net for the unlikely case of a
-# source that flags the grip pose valid yet still emits a zero/non-finite quaternion (normalizing
-# which would feed NaN into the downstream SE3 IK -> svdvals LinAlgError -> PhysX non-finite bounds).
+# Identity orientation quaternion [x, y, z, w].
+_IDENTITY_QUAT = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+# Element index of the 4x4 matrix inside a ``TransformMatrix()`` tensor group.
+_MATRIX_INDEX = 0
+# Minimum norm below which an incoming grip quaternion is treated as degenerate. The
+# ``GRIP_IS_VALID`` gate is the primary guard against untracked poses; this is the secondary
+# "never divide by zero" net for a source that flags the pose valid yet emits a zero /
+# non-finite quaternion (normalizing which would feed NaN into the downstream SE3 IK).
 _MIN_QUAT_NORM = 1e-6
+# Absolute tolerance for the ``home_base_T_ee`` rotation-block orthonormality check. This check
+# exists to reject a *scale, shear or reflection*, which are O(0.1) errors or worse; it is
+# emphatically NOT a precision policy, so the tolerance is set generously.
+#
+# Measured worst cases over 2000 random SO(3) samples: a rotation round-tripped through float32
+# lands at 8.1e-08 (callers routinely build the transform as a float32 matrix, and
+# ``TransformMatrix`` is float32 by tensor type), and a float32 quaternion converted to a matrix --
+# the path a caller takes when reading a measured EE orientation off a sensor -- reaches 4.5e-07.
+# A matrix hand-typed from rounded decimal literals is coarser still, and coarse enough to matter:
+# over 20000 random SO(3), rounding to **4** decimals reaches ``max|R.T @ R - I| == 1.6e-4`` and so
+# is rejected ~16% of the time, whereas **5** decimals peaks at 1.6e-5 and is never rejected. Hence
+# 1e-4, and hence: type at least 5 decimals. Against that, 1e-4 leaves room for every legitimate
+# input while the smallest defect worth catching (a 0.2 shear) fails by 2000x.
+_ROTATION_ATOL = 1e-4
+
+
+def _normalize_quat(q: np.ndarray) -> np.ndarray:
+    """Return ``q`` scaled to unit norm (``[x, y, z, w]``); a zero quaternion is returned as-is.
+
+    Every composition step normalizes, mirroring the reference implementation this retargeter
+    reproduces, whose rotation type normalizes on construction.
+    """
+    norm = float(np.linalg.norm(q))
+    return q / norm if norm > 0.0 else q
 
 
 def _quat_mul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     """Hamilton product ``a (x) b`` of two ``[x, y, z, w]`` quaternions (scalar-last).
 
-    Follows the SciPy ``Rotation`` composition convention (``(Ra * Rb).as_quat()`` equals
-    ``_quat_mul(Ra.as_quat(), Rb.as_quat())``), but is inlined here to avoid a SciPy /
-    cross-module dependency for this single product.
+    Verbatim equivalent of ``transform_utils._quat_multiply_xyzw`` (``:158``), inlined to avoid
+    depending on an engine-private helper from the retargeter layer. Follows the SciPy
+    ``Rotation`` composition convention: ``(Ra * Rb).as_quat() == _quat_mul(Ra.as_quat(),
+    Rb.as_quat())``.
     """
     ax, ay, az, aw = a
     bx, by, bz, bw = b
@@ -129,141 +153,317 @@ def _quat_mul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
     )
 
 
-def _rebased_position(
-    p_ctrl: np.ndarray,
-    origin: np.ndarray,
-    home: np.ndarray,
-    scale: float,
-) -> np.ndarray:
-    """Rebase a controller position onto the EE home via the clutch origin and scale.
+def _quat_inv(q: np.ndarray) -> np.ndarray:
+    """Inverse of an ``[x, y, z, w]`` quaternion: normalize, then conjugate.
 
-    Returns ``home + scale * (p_ctrl - origin)`` [m]. With ``p_ctrl == origin`` (the latching
-    frame) this is exactly ``home``; subsequent controller motion ``delta = p_ctrl - origin``
-    is scaled by ``scale`` and applied to the home.
-
-    The controller stream is already in the robot base frame (the Lab device rebases it
-    upstream), so ``home`` and the downstream absolute-position IK command share that frame and
-    the delta is applied without any further rotation.
-
-    Args:
-        p_ctrl: Current controller position [m], shape ``(3,)``, in the (base-frame) controller
-            stream.
-        origin: Latched controller origin ``p0`` [m], shape ``(3,)``, same frame.
-        home: EE home position [m], shape ``(3,)``, in the IK command (base) frame.
-        scale: Dimensionless translation gain applied to the controller delta.
-
-    Returns:
-        The rebased EE target position [m], shape ``(3,)``.
+    The conjugate is the inverse only for a *unit* quaternion, hence the normalize first. This
+    matches the reference implementation, whose ``inv()`` conjugates a value its constructor has
+    already normalized.
     """
-    return home + scale * (p_ctrl - origin)
+    x, y, z, w = _normalize_quat(q)
+    return np.array([-x, -y, -z, w], dtype=np.float64)
+
+
+def _mat_to_quat_xyzw(matrix: np.ndarray) -> np.ndarray:
+    """Convert a 3x3 rotation matrix to a unit ``[x, y, z, w]`` quaternion (Shepperd's method).
+
+    Verbatim equivalent of ``transform_utils._rotation_matrix_to_quat_xyzw`` (``:116``), inlined
+    for the same reason as :func:`_quat_mul`, **plus a normalize** of the result that the engine
+    copy omits -- everything downstream of the home latch assumes unit quaternions.
+
+    Branch-on-trace conversions are not eyeball-verifiable, so this is pinned numerically against
+    an independent reference over random SO(3) in
+    ``retargeting_engine_tests/python/test_so101_retargeters.py``.
+    """
+    m00, m01, m02 = matrix[0, 0], matrix[0, 1], matrix[0, 2]
+    m10, m11, m12 = matrix[1, 0], matrix[1, 1], matrix[1, 2]
+    m20, m21, m22 = matrix[2, 0], matrix[2, 1], matrix[2, 2]
+    trace = m00 + m11 + m22
+
+    if trace > 0:
+        s = 0.5 / np.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (m21 - m12) * s
+        y = (m02 - m20) * s
+        z = (m10 - m01) * s
+    elif m00 > m11 and m00 > m22:
+        s = 2.0 * np.sqrt(1.0 + m00 - m11 - m22)
+        w = (m21 - m12) / s
+        x = 0.25 * s
+        y = (m01 + m10) / s
+        z = (m02 + m20) / s
+    elif m11 > m22:
+        s = 2.0 * np.sqrt(1.0 + m11 - m00 - m22)
+        w = (m02 - m20) / s
+        x = (m01 + m10) / s
+        y = 0.25 * s
+        z = (m12 + m21) / s
+    else:
+        s = 2.0 * np.sqrt(1.0 + m22 - m00 - m11)
+        w = (m10 - m01) / s
+        x = (m02 + m20) / s
+        y = (m12 + m21) / s
+        z = 0.25 * s
+
+    return _normalize_quat(np.array([x, y, z, w], dtype=np.float64))
 
 
 class SO101ClutchRetargeter(BaseRetargeter):
-    """Retargets an XR controller to an absolute SO-101 EE pose with clutch-style rebasing.
+    """Clutch-rebases an XR controller onto an absolute SO-101 EE pose, re-latching every engage.
 
-    Emits an absolute 7D ``ee_pose`` (position [m] + grip orientation quaternion ``[x,y,z,w]``)
-    identical in contract to :class:`~isaacteleop.retargeters.Se3AbsRetargeter`, but rebases the
-    controller motion around a captured origin: the EE position is
-    ``home + scale * (p_ctrl - p0)`` where ``p0`` is latched on the first valid frame after each
-    engage. The controller stream is already in the robot base frame (rebased upstream by the
-    Lab device's ``target_frame_prim_path``), so no world->base rotation is applied here. This
-    keeps position-control IK (``use_relative_mode=False``) while avoiding an engage-time
-    teleport (see the module docstring). The orientation drives the SE3 IK: it is the controller
-    grip orientation right-multiplied (body frame) by the fixed :paramref:`orientation_offset`
-    calibration rotation, then renormalized -- a rigid "tool mount" between the controller grip
-    frame and the gripper, so a controller rotation maps 1:1 onto the gripper.
+    Emits an absolute 7D ``ee_pose`` (position ``[x, y, z]`` [m] + orientation quaternion
+    ``[x, y, z, w]``) with the exact same output contract as
+    :class:`~isaacteleop.retargeters.Se3AbsRetargeter` (node ``name="ee_pose"``, output key
+    ``"ee_pose"``, ``NDArrayType("pose", shape=(7,))``), so a downstream reorderer is unaffected.
 
-    The clutch keeps its own running home: on a mid-task re-clutch it latches the home to the
-    last EE pose it commanded, so it resumes from where the arm was left (no jump). On reset /
-    first engage it seeds the home from the configured :paramref:`home_base_T_ee` reset-origin
-    (the gripper's pose relative to the base at the reset pose), so the arm sits where it already
-    is without reading the robot back each frame.
+    Frame contract: the controller stream reaching this retargeter must already be expressed in the
+    robot **base** frame (rebase it upstream, e.g. via ``ControllersSource.transformed``). The
+    engage-relative delta is applied directly, with no world->base rotation of its own. Under an
+    upstream rigid rebase ``p -> R @ p + t``, the rebase's translation ``t`` cancels exactly in
+    ``grip_pos - origin_pos``. Its rotation ``R`` does not: it **rotates the translation delta**
+    and conjugates the orientation delta, so a wrong rebase rotation mis-maps *both* channels --
+    a hand push along +X can come out as EE motion along +Y.
+
+    .. warning::
+       The upstream rebase is a **static configuration** encoding an assumption about where the
+       operator's XR anchor sits relative to the robot base. Nothing here can validate it: this
+       retargeter's own correctness says nothing about whether that frame is right, and a wrong
+       rebase rotation shows up as an intuitive-but-wrong hand-to-EE mapping, not as an error.
+
+    Inputs:
+        - ``input_device`` -- Optional :func:`ControllerInput` grip pose, validity and squeeze.
+        - :data:`MEASURED_BASE_T_EE_INPUT` -- Optional ``base_T_ee`` 4x4 transform of the arm's
+          *measured* EE pose. Only its translation block is read, and only on the engage frame.
+          When absent, the home position falls back to the last commanded position.
+
+    Outputs:
+        - ``ee_pose`` -- a single 7D ``[x, y, z, qx, qy, qz, qw]`` float32 ``NDArray``.
+
+    Reset: ``execution_events.reset`` re-seeds the held pose from the configured home and re-arms
+    the latch -- see :meth:`set_home_base_T_ee` and the module docstring. Nothing else in the
+    frame path is stateful, so that is the whole of the reset contract.
+
+    See the module docstring for the algebra, the asymmetric home latch, and why there is no
+    ``orientation_offset``.
     """
+
+    #: Input key for the arm's measured ``base_T_ee`` pose, used to latch the home position. The
+    #: symbol names the frame because the frame is the whole point:
+    #: deliberately **not** ``JointStateRetargeter.ROBOT_EE_POS_INPUT``, which carries a
+    #: ``world_T_ee`` while this is a ``base_T_ee``. Same tensor type, different frame -- so a
+    #: mis-wire would be a silently wrong home with no type error to catch it. Producers should
+    #: reference this attribute rather than re-declaring the string.
+    #:
+    #: The input is ``OptionalType``, and a consumer **may omit it entirely** from
+    #: :meth:`~isaacteleop.retargeting_engine.interface.BaseRetargeter.connect` -- optional inputs
+    #: are exempt from the missing-input check (``base_retargeter.py:213``). A consumer whose owning
+    #: task slews the arm to a known configured home (Isaac Lab) legitimately leaves it unwired and
+    #: rides the last-commanded fallback.
+    #:
+    #: What ``OptionalType`` does **not** buy is the right to skip a key you *did* wire. If this
+    #: input is connected to a ``ValueInput`` leaf, that leaf is an external graph input, and
+    #: ``TeleopSession`` validates every external leaf name is present in ``external_inputs`` on
+    #: every step, independently of ``OptionalType``. Such a producer must send the key
+    #: unconditionally, carrying an absent ``OptionalTensorGroup`` on frames with no pose.
+    MEASURED_BASE_T_EE_INPUT = "measured_base_T_ee"
 
     def __init__(
         self,
         name: str,
+        home_base_T_ee: np.ndarray,  # noqa: N803
+        *,
         input_device: str = ControllersSource.RIGHT,
-        home_base_T_ee: np.ndarray | None = None,
-        position_scale: float = _CLUTCH_POSITION_SCALE,
-        orientation_offset: np.ndarray | None = None,
-        debug_log_engage: bool = False,
+        position_scale: float = 1.0,
+        squeeze_threshold: float = 0.5,
     ) -> None:
-        """Initialize the clutch EE-pose retargeter.
+        """Initialize the clutch retargeter.
 
         Args:
             name: Name identifier for this retargeter node.
+            home_base_T_ee: Required ``base_T_ee`` 4x4 transform [m] giving the EE pose in the
+                robot base frame that seeds the held pose. **Both** blocks are used: the
+                translation seeds the home position, the rotation seeds the home orientation. Pass
+                the arm's measured startup pose so the first engage is jump-free. It is also the
+                pose a ``reset`` re-seeds to. When the pose is not known until after construction
+                (e.g. the graph is built before the arm is homed), pass a placeholder and call
+                :meth:`set_home_base_T_ee` before the first ``RUNNING`` frame.
             input_device: Controller source key to read the grip pose from.
-            home_base_T_ee: Optional ``base_T_ee`` 4x4 reset-origin home transform [m] giving the
-                EE pose in the robot base frame at the reset pose. The clutch seeds its home from
-                this on reset / first engage, so the owning task must reset the arm to this pose to
-                avoid a jump on engage. Only its translation block drives the position command (the
-                orientation is the live controller grip orientation composed with
-                :paramref:`orientation_offset`, not read from this transform). When ``None``, falls
-                back to :data:`_CLUTCH_HOME_EE_POS`.
-            position_scale: Dimensionless controller-to-EE translation gain applied to the clutch
-                delta: ``output_pos = home + position_scale * (p_ctrl - p0)``. ``1.0`` is 1:1
-                motion. A value ``< 1`` shrinks robot travel relative to hand travel: the SO-101's
-                ~0.35 m reach is roughly half a comfortable ~0.7 m arm sweep, so 1:1 motion plus
-                clutch re-engage cycles can ratchet the commanded target out of reach -- e.g.
-                ``0.5`` keeps a full operator sweep inside reach in a single engaged segment.
-                Applies to **translation only**; the orientation is always 1:1. A value ``> 1``
-                amplifies the commanded EE velocity and jitter toward the joint-rate limits (no
-                upper clamp is enforced). Must be positive and finite. Defaults to
-                :data:`_CLUTCH_POSITION_SCALE` (1:1 motion).
-            orientation_offset: Optional fixed calibration quaternion ``[x, y, z, w]``
-                right-multiplied (body frame) onto the controller grip orientation
-                (``q_cmd = q_grip (x) offset``) so a neutrally-held controller maps to a neutral
-                gripper orientation for the SE3 IK; a controller rotation then maps 1:1 onto the
-                gripper. When ``None``, defaults to a roll of ``pi`` about the approach axis
-                (``Rz(pi)``); see :data:`_DEFAULT_ORIENTATION_OFFSET`.
-            debug_log_engage: When ``True``, prints the controller grip orientation (xyzw, base
-                frame) and the active offset on each engage, to capture the calibration offset
-                ``R_off = quat_inv(q_grip) (x) q_G0``. Leave ``False`` outside tuning sessions.
+            position_scale: Dimensionless controller-to-EE translation gain applied to the
+                engage-relative delta. ``1.0`` is 1:1 motion; a value ``< 1`` shrinks robot travel
+                relative to hand travel, which is what lets a comfortable operator arm sweep
+                (~0.7 m) stay inside the SO-101's ~0.35 m reach. Applies to **translation only** --
+                the orientation delta is always 1:1, since a scaled rotation is disorienting and
+                the 5-DOF wrist tracks orientation softly anyway. Must be positive and finite:
+                ``0`` freezes the EE, a negative value inverts the hand->EE mapping, and the finite
+                check closes the ``inf * 0 = nan`` path before it reaches the IK.
+            squeeze_threshold: Squeeze value above which the clutch is engaged, combined by AND
+                with ``execution_state == RUNNING``. This is the **only** place the threshold is
+                compared; owning loops should read :attr:`is_engaged` rather than re-deriving it.
+                Must be finite and in ``[0, 1)``: the squeeze axis is normalized to ``[0, 1]``, so
+                a threshold of ``1.0`` or above can never be exceeded and ``NaN`` makes every
+                comparison False -- either way the clutch would silently never engage.
+
+        Raises:
+            ValueError: If ``position_scale`` is not positive and finite, if
+                ``squeeze_threshold`` is not finite or lies outside ``[0, 1)``, or if
+                ``home_base_T_ee`` is not a 4x4 transform with an orthonormal rotation block.
         """
         self._input_device = input_device
-        super().__init__(name=name)
-        # Fixed calibration offset [x, y, z, w], right-multiplied (body frame) onto the grip
-        # orientation before it is emitted. Defaults to Rz(pi) about the approach axis.
-        if orientation_offset is None:
-            self._orientation_offset = _DEFAULT_ORIENTATION_OFFSET.copy()
-        else:
-            self._orientation_offset = np.asarray(
-                orientation_offset, dtype=np.float64
-            ).copy()
-        self._debug_log_engage = bool(debug_log_engage)
-        # Controller-to-EE translation gain applied to the clutch delta. Strictly positive and
-        # finite: scale == 0 freezes the EE, scale < 0 inverts the hand->EE mapping, and the finite
-        # check closes the ``inf * 0 = nan`` path before it can reach the SE3 IK.
+
         position_scale = float(position_scale)
         if not np.isfinite(position_scale) or position_scale <= 0.0:
             raise ValueError(
                 f"position_scale must be positive and finite, got: {position_scale!r}"
             )
         self._position_scale = position_scale
-        # Reset-origin home [m] in the base frame: the translation of the ``base_T_ee`` transform,
-        # or the constant. Seeds the home on reset / first engage.
-        if home_base_T_ee is None:
-            self._home_config = np.array(_CLUTCH_HOME_EE_POS, dtype=np.float64)
-        else:
-            self._home_config = np.asarray(home_base_T_ee, dtype=np.float64)[
-                :3, 3
-            ].copy()
-        # Running home [m] in the base frame. ``None`` means "re-seed from the reset-origin on the
-        # next engage"; set at construction and on reset. Otherwise it holds the last commanded
-        # pose so a mid-task re-clutch resumes there.
-        self._home: np.ndarray | None = None
+
+        squeeze_threshold = float(squeeze_threshold)
+        if not np.isfinite(squeeze_threshold) or not (0.0 <= squeeze_threshold < 1.0):
+            raise ValueError(
+                "squeeze_threshold must be finite and in [0, 1), got: "
+                f"{squeeze_threshold!r}"
+            )
+        self._squeeze_threshold = squeeze_threshold
+
+        # All clutch state is float64. The float32 ``_last_pose`` below is a write-only mirror for
+        # emission: it is NEVER read back into state. Reading the running home out of the float32
+        # output would quantize both channels on every re-clutch. The two channels differ in how
+        # much that matters: the home POSITION is re-seeded from the measured input on most
+        # engages (and that input is float32 by tensor type anyway, so its own resolution is the
+        # floor), but the home ORIENTATION is always taken from the last commanded rotation and
+        # has no measured re-seed path at all -- so there the error genuinely compounds across
+        # re-clutches, without bound.
+        self._last_commanded_pos = np.zeros(3, dtype=np.float64)
+        self._last_commanded_rot = _IDENTITY_QUAT.copy()
+        self._home_pos = np.zeros(3, dtype=np.float64)
+        self._home_rot = _IDENTITY_QUAT.copy()
+        # Latched controller origin, and the pending-latch sentinel: ``None`` means "a latch is
+        # owed on the next usable engaged frame". Set ONLY by the latch, cleared by every disarm --
+        # which is what makes :attr:`is_engaged` exactly track the latch.
         self._origin: np.ndarray | None = None
-        # Pose held while not running and on dropped frames: the reset-origin home at identity
-        # orientation until the first command refreshes it.
-        self._last_pose = np.concatenate([self._home_config, _IDENTITY_QUAT]).astype(
-            np.float32
-        )
+        self._origin_rot = _IDENTITY_QUAT.copy()
+        self._last_pose = np.zeros(7, dtype=np.float32)
+        # The configured home a ``reset`` re-seeds to; owned by set_home_base_T_ee.
+        self._configured_home = np.eye(4, dtype=np.float64)
+        self.set_home_base_T_ee(home_base_T_ee)
+
+        # LAST: BaseRetargeter.__init__ calls input_spec(), which reads self._input_device.
+        super().__init__(name=name)
+
+    # ------------------------------------------------------------------ state
+
+    def set_home_base_T_ee(self, home_base_T_ee: np.ndarray) -> None:  # noqa: N803
+        """Re-seed the held pose from a ``base_T_ee`` 4x4 transform.
+
+        For owners that cannot know the arm's pose at construction time (the retargeting graph is
+        built before the arm is homed). Both blocks are used, exactly as in the constructor. The
+        supplied transform also becomes the **configured home** that a subsequent ``reset``
+        re-seeds to, so an owner that re-homes its arm mid-session should call this rather than
+        letting reset drag the arm back to the construction-time pose.
+
+        Call this only while the clutch is not engaged -- typically while the session holds
+        ``STOPPED``, which makes latching impossible and so makes the ordering unambiguous: the new
+        home takes effect before the first ``RUNNING`` frame.
+
+        The pending latch is re-armed as a safety net rather than the call being rejected. Without
+        it, a call made while engaged would leave the *old* controller origin latched against the
+        *new* home, and the very next frame would command
+        ``new_home + scale * (grip_pos - old_origin)`` -- a jump of ``new_home - old_home`` at
+        servo speed. Re-arming bounds that: the next engaged frame re-latches rather than applying
+        a stale delta. It does **not** make the call free. The re-latch still homes on whatever
+        this call supplied, so the commanded pose still steps to the new home -- measured at
+        0.0100 m with the measured-EE input connected versus 1.3398 m without it on the same
+        sequence -- and the ORIENTATION snaps to the new home rotation either way, since it has no
+        measured rescue path at all (90.00 deg in a single frame, measured). Raising would still
+        be worse: this sits one call away from a frame-rate loop, where turning a jump into an
+        unhandled exception leaves the arm uncommanded. Call it while disengaged.
+
+        That is not in tension with the ``ValueError``\\ s below, which draw the line elsewhere: a
+        **malformed argument** raises, because there is no pose to command from it and continuing
+        would only defer the same failure to a wrong orientation nobody can trace. **Bad timing**
+        never raises -- the transform is well-formed, the retargeter can keep commanding, and the
+        cost is a bounded jump rather than an uncommanded arm.
+
+        Args:
+            home_base_T_ee: ``base_T_ee`` 4x4 transform [m]; its rotation block must be a proper
+                rotation (orthonormal, ``det == +1``) and its bottom row ``[0, 0, 0, 1]``.
+
+        Raises:
+            ValueError: If the transform is not 4x4, is not finite, has a bottom row other than
+                ``[0, 0, 0, 1]``, or its rotation block is not a proper rotation. A scaled or
+                reflected block would still normalize to a unit quaternion and command a quietly
+                *wrong* orientation, with nothing downstream to catch it; the bottom-row check
+                additionally catches a **transposed** transform, which is otherwise indistinguishable
+                from a valid one. None of this can catch an inverted transform -- an ``ee_T_base``
+                passed here is a perfectly well-formed 4x4 and is accepted.
+        """
+        home = np.asarray(home_base_T_ee, dtype=np.float64)
+        if home.shape != (4, 4):
+            raise ValueError(
+                f"home_base_T_ee must be a 4x4 transform, got shape {home.shape}"
+            )
+        rot = home[:3, :3]
+        if not np.all(np.isfinite(home)):
+            raise ValueError("home_base_T_ee must be finite")
+        # Bottom row, checked before the rotation block so the message names the real fault. This
+        # is what catches a TRANSPOSED transform, which every other check here waves through: the
+        # rotation block of ``base_T_ee.T`` is ``R.T``, still orthonormal with ``det == +1``, and
+        # the translation ends up in the bottom row, leaving column 3 zeroed -- so the clutch would
+        # silently home at the base origin with the inverse orientation.
+        if not np.allclose(home[3], [0.0, 0.0, 0.0, 1.0], atol=_ROTATION_ATOL):
+            raise ValueError(
+                "home_base_T_ee bottom row must be [0, 0, 0, 1] (a transposed transform is the "
+                f"usual cause); got: {home[3]}"
+            )
+        if not np.allclose(rot.T @ rot, np.eye(3), atol=_ROTATION_ATOL):
+            raise ValueError(
+                "home_base_T_ee rotation block must be orthonormal (R.T @ R == I within "
+                f"{_ROTATION_ATOL}); got:\n{rot}"
+            )
+        det = float(np.linalg.det(rot))
+        if abs(det - 1.0) > _ROTATION_ATOL:
+            raise ValueError(
+                "home_base_T_ee rotation block must be a proper rotation (det == +1 within "
+                f"{_ROTATION_ATOL}); got det == {det!r}"
+            )
+        # Store the configured home FIRST, and as a copy: the reset path calls this method with
+        # ``self._configured_home`` itself, so reading from an aliased buffer would be a trap.
+        self._configured_home = home.copy()
+        self._last_commanded_pos = home[:3, 3].copy()
+        self._last_commanded_rot = _mat_to_quat_xyzw(rot)
+        self._home_pos = self._last_commanded_pos.copy()
+        self._home_rot = self._last_commanded_rot.copy()
+        self._last_pose = np.concatenate(
+            [self._last_commanded_pos, self._last_commanded_rot]
+        ).astype(np.float32)
+        # Re-arm: never leave a stale origin latched against a fresh home. Idempotent on the
+        # constructor path, where the sentinel is already None. MUST stay last -- the reset path
+        # relies on this call re-arming the latch as its final act.
+        self._origin = None
+
+    @property
+    def is_engaged(self) -> bool:
+        """Whether the clutch was engaged and tracking on the **last computed frame**.
+
+        Exactly ``self._origin is not None``, so its rising edge *is* the latch frame: the sentinel
+        is set only by the latch and cleared by every disarm. An owning loop can therefore derive
+        the engage edge as ``is_engaged and not prev_is_engaged`` without re-deriving engagement
+        from ``squeeze`` -- which it could not do correctly anyway, since the latch can be deferred
+        by an unusable frame or a stale session frame that the loop cannot observe.
+
+        Only meaningful after a ``compute()``; ``False`` before the first one. Anything that
+        changes engagement -- a squeeze, an ``execution_state`` change, a re-seeded home -- takes
+        effect on the **next** ``compute()``, not at the moment it happens.
+        """
+        return self._origin is not None
+
+    # ------------------------------------------------------------------ specs
 
     def input_spec(self) -> RetargeterIOType:
-        """Requires only the controller grip pose; the stream is already in the base frame."""
+        """Controller grip pose (base frame) plus the optional measured EE pose for the home."""
         return {
             self._input_device: OptionalType(ControllerInput()),
+            self.MEASURED_BASE_T_EE_INPUT: OptionalType(TransformMatrix()),
         }
 
     def output_spec(self) -> RetargeterIOType:
@@ -279,90 +479,101 @@ class SO101ClutchRetargeter(BaseRetargeter):
             )
         }
 
+    # ---------------------------------------------------------------- compute
+
+    def _latch(
+        self, inputs: RetargeterIO, grip_pos: np.ndarray, grip_rot: np.ndarray
+    ) -> None:
+        """Latch the engage home (where the arm is now) and the controller origin."""
+        measured = inputs.get(self.MEASURED_BASE_T_EE_INPUT)
+        if measured is not None and not measured.is_none:
+            base_T_ee = np.from_dlpack(measured[_MATRIX_INDEX]).astype(np.float64)  # noqa: N806
+            self._home_pos = base_T_ee[:3, 3].copy()
+        else:
+            # Documented fallback, and the *designed* path for a consumer that leaves
+            # MEASURED_BASE_T_EE_INPUT unwired because its owning task slews the arm to a known
+            # configured home on reset. Not degraded mode, so it is deliberately silent.
+            self._home_pos = self._last_commanded_pos.copy()
+        # ALWAYS the last commanded rotation, never the measurement -- see the module docstring.
+        self._home_rot = self._last_commanded_rot.copy()
+        self._origin = grip_pos.copy()
+        self._origin_rot = _normalize_quat(grip_rot)
+
     def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
-        """Computes the clutch-rebased absolute EE pose; holds last on a dropped frame."""
-        # Teleop is only "engaged" when the session is RUNNING (the headset "Play").
-        running = context.execution_events.execution_state == ExecutionState.RUNNING
+        """Computes the engage-relative clutch pose; holds the last commanded pose otherwise."""
+        ee_pose = outputs["ee_pose"]
 
         if context.execution_events.reset:
-            # A reset starts a fresh episode: re-arm the origin and mark the home for re-seeding
-            # from the configured reset-origin (the arm is reset to that pose) on the next engage.
-            self._origin = None
-            self._home = None
-            self._last_pose = np.concatenate(
-                [self._home_config, _IDENTITY_QUAT]
-            ).astype(np.float32)
-        elif not running:
-            # A plain Stop re-arms the origin but FREEZES the running home and last pose, so the
-            # next Play resumes from the last commanded pose instead of snapping to home.
-            self._origin = None
+            # Re-seed the held pose from the CONFIGURED home and re-arm the latch (the re-arm is
+            # set_home_base_T_ee's last act). The seed is a static configured transform, never live
+            # arm state: the reset pulse can reach this retargeter on either side of the owner's
+            # actual teleport, so anything read from the arm at reset time is stale on one of those
+            # orderings. Re-seeding also refreshes the held pose, so the value emitted on a
+            # disengaged frame after a reset matches the physically-homed arm instead of leaking
+            # the previous episode's last commanded pose.
+            self.set_home_base_T_ee(self._configured_home)
 
-        ee_pose = outputs["ee_pose"]
+        running = context.execution_events.execution_state == ExecutionState.RUNNING
         inp = inputs[self._input_device]
+
         if inp.is_none:
-            # Dropped frame: hold the last commanded pose.
+            # Dropped frame: hold, and re-arm so the latch stays owed. Re-arming matters because
+            # the squeeze is unobservable across the gap -- if the operator released and
+            # re-squeezed inside it, keeping the old origin would rebase against a stale engagement
+            # and jump the arm by the whole accumulated hand motion.
+            self._origin = None
             ee_pose[0] = self._last_pose
             return
+
         if not bool(inp[ControllerInputIndex.GRIP_IS_VALID]):
-            # Controller present but its grip pose is not localizable this frame: the OpenXR
-            # XR_SPACE_LOCATION_{POSITION,ORIENTATION}_VALID_BIT are clear (just engaged, or
-            # tracking briefly lost), so the source passes through an untrusted pose -- the
-            # orientation typically arrives as the all-zero quaternion. Treat it like a dropped
-            # frame: hold the last commanded pose and do NOT latch the clutch origin off a garbage
-            # position.
+            # Controller present but its grip pose is not localizable this frame (the OpenXR
+            # XR_SPACE_LOCATION_*_VALID_BITs are clear), so the source passes through an untrusted
+            # pose. Treat it like a dropped frame and never latch the clutch origin off it.
+            self._origin = None
             ee_pose[0] = self._last_pose
             return
 
         grip_pos = np.from_dlpack(inp[ControllerInputIndex.GRIP_POSITION]).astype(
             np.float64
         )
-        grip_ori = np.from_dlpack(inp[ControllerInputIndex.GRIP_ORIENTATION]).astype(
+        grip_rot = np.from_dlpack(inp[ControllerInputIndex.GRIP_ORIENTATION]).astype(
             np.float64
         )  # XYZW
-        # Compose the fixed calibration offset as a body-frame right multiply (q_grip (x) offset)
-        # and renormalize, so a controller rotation maps 1:1 onto the commanded gripper orientation
-        # that drives the SE3 IK.
-        cmd_ori = _quat_mul(grip_ori, self._orientation_offset)
-        cmd_ori_norm = float(np.linalg.norm(cmd_ori))
-        if not np.isfinite(cmd_ori_norm) or cmd_ori_norm < _MIN_QUAT_NORM:
-            # Defense-in-depth: the GRIP_IS_VALID gate above already drops untrusted poses, but
-            # never divide by zero -- if a source ever reports a valid-flagged yet degenerate
-            # (zero / non-finite) quaternion, hold the last emitted (unit) orientation rather than
-            # feeding NaN into the downstream SE3 IK. See _MIN_QUAT_NORM.
-            cmd_ori = self._last_pose[3:7].astype(np.float64)
-        else:
-            cmd_ori = cmd_ori / cmd_ori_norm
-        cmd_ori = cmd_ori.astype(np.float32)
+        squeeze = float(inp[ControllerInputIndex.SQUEEZE_VALUE])
+
+        grip_norm = float(np.linalg.norm(grip_rot))
+        if (
+            not np.all(np.isfinite(grip_pos))
+            or not np.isfinite(grip_norm)
+            or grip_norm < _MIN_QUAT_NORM
+        ):
+            # Defense in depth behind GRIP_IS_VALID, on BOTH channels of the same ``XrPosef``. A
+            # degenerate quaternion cannot produce a meaningful orientation delta, and a non-finite
+            # position would propagate into the commanded pose -- from where it never recovers,
+            # because the held pose and the last-commanded home fallback are then NaN too, and NaN
+            # comparisons are False so no downstream bounds check rejects it.
+            self._origin = None
+            ee_pose[0] = self._last_pose
+            return
+
+        if not (running and squeeze > self._squeeze_threshold):
+            # Disengaged: hold the last commanded pose and re-arm.
+            self._origin = None
+            ee_pose[0] = self._last_pose
+            return
 
         if self._origin is None:
-            if not running:
-                # Connected but not playing yet: hold the last pose and do not latch. The origin
-                # latches on the first RUNNING frame (the moment Play starts).
-                ee_pose[0] = self._last_pose
-                return
-            # First RUNNING frame (Play just started): latch the controller origin. Seed the home
-            # from the configured reset-origin on a reset / first engage, else resume the running
-            # home (the last commanded pose) so a mid-task re-clutch stays put.
-            self._origin = grip_pos.copy()
-            if self._home is None:
-                self._home = self._home_config.copy()
-            else:
-                self._home = self._last_pose[:3].astype(np.float64)
-            if self._debug_log_engage:
-                # Tuning aid: capture the controller orientation at engage so the calibration
-                # offset can be set to R_off = quat_inv(q_grip) (x) q_G0. q_G0 is the gripper_link
-                # orientation in the base frame at the reset pose -- read it once (it is constant)
-                # from the env's "ee_frame" FrameTransformer: scene["ee_frame"].data
-                # .target_quat_source[0, 0] (wxyz -> reorder to xyzw before composing R_off).
-                print(
-                    "[SO101ClutchRetargeter] engage capture (xyzw):\n"
-                    f"  q_grip (controller, base frame) = {grip_ori.tolist()}\n"
-                    f"  orientation_offset              = {self._orientation_offset.tolist()}\n"
-                    f"  emitted cmd_ori                 = {cmd_ori.tolist()}"
-                )
+            self._latch(inputs, grip_pos, grip_rot)
 
-        pos = _rebased_position(
-            grip_pos, self._origin, self._home, self._position_scale
+        pos = self._home_pos + self._position_scale * (grip_pos - self._origin)
+        # Left-composed (base frame): (R_ctrl . R_origin^-1) . R_home. Operand order is
+        # load-bearing -- the plausible wrong orderings diverge by O(1), not by a rounding.
+        rot = _normalize_quat(
+            _quat_mul(_normalize_quat(grip_rot), _quat_inv(self._origin_rot))
         )
-        self._last_pose = np.concatenate([pos, cmd_ori]).astype(np.float32)
+        rot = _normalize_quat(_quat_mul(rot, self._home_rot))
+
+        self._last_commanded_pos = pos
+        self._last_commanded_rot = rot
+        self._last_pose = np.concatenate([pos, rot]).astype(np.float32)
         ee_pose[0] = self._last_pose

--- a/src/retargeters/SO101/clutch_retargeter.py
+++ b/src/retargeters/SO101/clutch_retargeter.py
@@ -44,7 +44,8 @@ Clutch behavior:
   done upstream by ``target_frame_prim_path``, and the EE state going forward is the running home
   (what the clutch itself commanded).
 - Each frame the emitted position is ``output_pos = home + s * (p_ctrl - p0)`` with scale
-  ``s = _CLUTCH_POSITION_SCALE`` (see :func:`_rebased_position`). On the latching frame
+  ``s = position_scale`` (the constructor parameter, defaulting to
+  :data:`_CLUTCH_POSITION_SCALE`; see :func:`_rebased_position`). On the latching frame
   ``p_ctrl == p0`` so ``output_pos == home`` exactly (no teleport on engage).
 - A plain Stop **freezes** the running home, so the next Play resumes from the last commanded
   pose. An explicit **reset** re-seeds the home from the configured reset-origin for a fresh
@@ -84,7 +85,8 @@ from isaacteleop.retargeting_engine.tensor_types import (
 # placement. Must never be the base origin (that would command the EE into the robot base /
 # floor). TODO(verify-in-sim)
 _CLUTCH_HOME_EE_POS: tuple[float, float, float] = (0.22, 0.0, 0.12)
-# Controller-to-EE translation gain (1.0 = 1:1 motion). TODO(verify-in-sim)
+# Default controller-to-EE translation gain (1.0 = 1:1 motion) for the ``position_scale``
+# constructor parameter. TODO(verify-in-sim)
 _CLUTCH_POSITION_SCALE = 1.0
 # Identity orientation quaternion [x, y, z, w], emitted before any valid frame / on reset.
 _IDENTITY_QUAT = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
@@ -183,6 +185,7 @@ class SO101ClutchRetargeter(BaseRetargeter):
         name: str,
         input_device: str = ControllersSource.RIGHT,
         home_base_T_ee: np.ndarray | None = None,
+        position_scale: float = _CLUTCH_POSITION_SCALE,
         orientation_offset: np.ndarray | None = None,
         debug_log_engage: bool = False,
     ) -> None:
@@ -198,6 +201,16 @@ class SO101ClutchRetargeter(BaseRetargeter):
                 orientation is the live controller grip orientation composed with
                 :paramref:`orientation_offset`, not read from this transform). When ``None``, falls
                 back to :data:`_CLUTCH_HOME_EE_POS`.
+            position_scale: Dimensionless controller-to-EE translation gain applied to the clutch
+                delta: ``output_pos = home + position_scale * (p_ctrl - p0)``. ``1.0`` is 1:1
+                motion. A value ``< 1`` shrinks robot travel relative to hand travel: the SO-101's
+                ~0.35 m reach is roughly half a comfortable ~0.7 m arm sweep, so 1:1 motion plus
+                clutch re-engage cycles can ratchet the commanded target out of reach -- e.g.
+                ``0.5`` keeps a full operator sweep inside reach in a single engaged segment.
+                Applies to **translation only**; the orientation is always 1:1. A value ``> 1``
+                amplifies the commanded EE velocity and jitter toward the joint-rate limits (no
+                upper clamp is enforced). Must be positive and finite. Defaults to
+                :data:`_CLUTCH_POSITION_SCALE` (1:1 motion).
             orientation_offset: Optional fixed calibration quaternion ``[x, y, z, w]``
                 right-multiplied (body frame) onto the controller grip orientation
                 (``q_cmd = q_grip (x) offset``) so a neutrally-held controller maps to a neutral
@@ -219,6 +232,15 @@ class SO101ClutchRetargeter(BaseRetargeter):
                 orientation_offset, dtype=np.float64
             ).copy()
         self._debug_log_engage = bool(debug_log_engage)
+        # Controller-to-EE translation gain applied to the clutch delta. Strictly positive and
+        # finite: scale == 0 freezes the EE, scale < 0 inverts the hand->EE mapping, and the finite
+        # check closes the ``inf * 0 = nan`` path before it can reach the SE3 IK.
+        position_scale = float(position_scale)
+        if not np.isfinite(position_scale) or position_scale <= 0.0:
+            raise ValueError(
+                f"position_scale must be positive and finite, got: {position_scale!r}"
+            )
+        self._position_scale = position_scale
         # Reset-origin home [m] in the base frame: the translation of the ``base_T_ee`` transform,
         # or the constant. Seeds the home on reset / first engage.
         if home_base_T_ee is None:
@@ -340,7 +362,7 @@ class SO101ClutchRetargeter(BaseRetargeter):
                 )
 
         pos = _rebased_position(
-            grip_pos, self._origin, self._home, _CLUTCH_POSITION_SCALE
+            grip_pos, self._origin, self._home, self._position_scale
         )
         self._last_pose = np.concatenate([pos, cmd_ori]).astype(np.float32)
         ee_pose[0] = self._last_pose

--- a/src/retargeters/__init__.py
+++ b/src/retargeters/__init__.py
@@ -16,7 +16,9 @@ Available Retargeters:
     - LocomotionRootCmdRetargeter: Locomotion from controller inputs
     - FootPedalRootCmdRetargeter: Root command from 3-axis foot pedal (horizontal/vertical + rudder)
     - GripperRetargeter: Pinch-based gripper control
-    - SO101ClutchRetargeter: Clutch-rebased absolute EE pose for the SO-101 5-DOF arm
+    - SO101ClutchRetargeter: Clutch-rebased absolute EE pose for the SO-101 5-DOF arm --
+      re-latches BOTH home position and orientation on every engage, base-frame left-composed, no
+      fixed offset
     - SO101GripperRetargeter: Proportional (analog) jaw closedness for the SO-101 gripper
     - JointStateRetargeter: Generic joint-space device (leader arm, exoskeleton) -> joint or EE action
     - SharpaHandRetargeter: Pinocchio/Pink IK-based retargeting for Sharpa hand
@@ -101,7 +103,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str, str | None]] = {
     # .gripper_retargeter
     "GripperRetargeter": (".gripper_retargeter", "GripperRetargeter", None),
     "GripperRetargeterConfig": (".gripper_retargeter", "GripperRetargeterConfig", None),
-    # .SO101 (SO-101 5-DOF arm: full-pose clutch EE pose, analog gripper)
+    # .SO101 (SO-101 5-DOF arm: clutch EE-pose, analog gripper)
     "SO101ClutchRetargeter": (
         ".SO101.clutch_retargeter",
         "SO101ClutchRetargeter",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Consolidates the SO-101 clutch retargeter so the Isaac Lab and LeRobot paths share one
implementation, and adds the motion scale requested in #733.

V1 clutched **position only** with a fixed `orientation_offset`; the LeRobot XR path had
meanwhile grown a **full-pose**, squeeze-gated clutch that re-centers on every engage — the
behaviour this repository's own docs already promise. Both are now one
`SO101ClutchRetargeter`:

```
pos = home_pos + position_scale * (grip_pos - origin_pos)
rot = (R_ctrl · R_origin⁻¹) · R_home
```

On the engage frame this is exactly the home pose whatever the scale — no teleport.
`position_scale` (default `1.0`) maps an operator's ~0.7 m arm travel into the SO-101's
~0.35 m reach; at 1:1, re-engage cycles ratchet the target out of the workspace.

Fixes #733

### Breaking changes

* `home_base_T_ee` — required 2nd positional, both blocks used (was optional, translation only)
* `input_device`, `position_scale`, `squeeze_threshold` — keyword-only
* engaging now needs `squeeze > squeeze_threshold` as well as `RUNNING`
* `orientation_offset`, `debug_log_engage` — removed; put the gripper's base-frame orientation in `home_base_T_ee`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

82 unit tests pass; verified against the reference implementation (position bit-exact,
orientation 1.116e-15). Hardware validation on a physical SO-101 is still pending.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
