### PR TITLE
ci: increase artifact retention days from 1 to 7

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -241,7 +241,7 @@ jobs:
         name: viz-tests-${{ matrix.arch }}
         path: viz-tests.tar.gz
         if-no-files-found: error
-        retention-days: 1
+        retention-days: 7
 
     - name: Install (Release only)
       if: matrix.build_type == 'Release'
@@ -282,7 +282,7 @@ jobs:
       with:
         name: isaacteleop-install-release-${{ matrix.arch }}-py${{ matrix.python_version }}
         path: isaacteleop-install.tar
-        retention-days: 1
+        retention-days: 7
     - name: Upload wheel artifacts
       if: matrix.build_type == 'Release'
       uses: actions/upload-artifact@v6
@@ -290,7 +290,7 @@ jobs:
         name: isaacteleop-wheels-${{ matrix.arch }}-py${{ matrix.python_version }}
         path: install/wheels/*.whl
         if-no-files-found: error
-        retention-days: 1
+        retention-days: 7
 
   test-viz-gpu:
     # Runs [gpu]-tagged Catch2 tests for the Televiz module on a self-hosted


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Increase artifacts renention period to allow incremental workflow re-runs for longer.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended retention for Ubuntu build artifacts from 1 day to 7 days.
  * Release install packages, wheel artifacts, and visualization test binaries are now available for download longer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->