### PR TITLE
fix(ci): add curl retry policy to CloudXR SDK download scripts

### DIFF
--- a/scripts/download_cloudxr_runtime_sdk.sh
+++ b/scripts/download_cloudxr_runtime_sdk.sh
@@ -91,7 +91,9 @@ download_ngc_file() {
     [[ -s "$out_path" ]] && return 0
 
     echo -e "${YELLOW}Downloading ${label}...${NC}"
-    local -a curl_args=(--fail --location --output "$out_path")
+    local -a curl_args=(--fail --location --output "$out_path"
+        --connect-timeout 10 --max-time 120
+        --retry 3 --retry-delay 5)
     if [[ -n "$auth_bearer" ]]; then
         curl_args+=(-H "Authorization: Bearer ${auth_bearer}" -H "Content-Type: application/json")
     fi

--- a/scripts/download_cloudxr_sdk.sh
+++ b/scripts/download_cloudxr_sdk.sh
@@ -110,6 +110,8 @@ install_from_public_ngc() {
 
     echo -e "${YELLOW}Downloading CloudXR Web SDK from NGC...${NC}"
     if ! curl --fail --location \
+        --connect-timeout 10 --max-time 120 \
+        --retry 3 --retry-delay 5 \
         --output "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
         "$NGC_URL"; then
         echo -e "${RED}Error: Failed to download CloudXR Web SDK from NGC${NC}"
@@ -151,6 +153,8 @@ install_from_private_ngc() {
 
     echo -e "${YELLOW}Downloading CloudXR Web SDK from private NGC...${NC}"
     if ! curl --fail --location \
+        --connect-timeout 10 --max-time 120 \
+        --retry 3 --retry-delay 5 \
         -H "Authorization: Bearer $NGC_API_KEY" \
         -H "Content-Type: application/json" \
         --output "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Network flakes during NGC downloads caused transient CI failures. Add --retry 3 --retry-delay 5 --connect-timeout 10 --max-time 120 to all curl calls in the download scripts. Intentionally omit --retry-all-errors so permanent HTTP errors (404, 403) fail fast instead of being retried.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SDK download reliability with connection timeouts and automatic retries.
  * Added maximum download time limits to prevent stalled downloads.
  * Applied more resilient network handling to both public and private package downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->