### PR TITLE
docs: fix broken Isaac Lab documentation links

### DIFF
--- a/docs/source/references/requirements.rst
+++ b/docs/source/references/requirements.rst
@@ -67,7 +67,7 @@ The recommended workstation configuration for Sim-based Teleop is:
       - 580.95.05 or newer
 
 If you are only using XR headsets for teleoperation, you can host the workstation in the cloud.
-See `Isaac Lab Cloud Deployment <https://isaac-sim.github.io/IsaacLab/develop/source/deployment/index.html>`_
+See `Isaac Lab Cloud Deployment <https://isaac-sim.github.io/IsaacLab/develop/source/features/docker_cloud.html#cloud-workstations>`_
 for more details.
 
 Human-centric Data Collection
@@ -108,5 +108,5 @@ to device peripherals. The minimum requirements for the laptop/workstation are:
 .. [#isaacsim-req] Please refer to `Isaac Sim System Requirements <https://docs.isaacsim.omniverse.nvidia.com/latest/installation/requirements.html>`_
    for more details.
 
-.. [#isaaclab-req] Please refer to `Isaac Lab System Requirements <https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html#general-requirements>`_
+.. [#isaaclab-req] Please refer to `Isaac Lab System Requirements <https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html#system-requirements>`_
    for more details.


### PR DESCRIPTION
## Problem

The **Teleoperation with Isaac Sim and Isaac Lab** section of our
[requirements page](https://nvidia.github.io/IsaacTeleop/main/references/requirements.html#teleoperation-with-isaac-sim-and-isaac-lab)
links to `https://isaac-sim.github.io/IsaacLab/develop/source/deployment/index.html`,
which now 404s — the Isaac Lab docs reorganized that page away.

The same reorg also broke a second link in the same file: the *Isaac Lab System
Requirements* footnote points at `installation/index.html#general-requirements`,
and that anchor no longer exists on the page. The page still returns 200, so the
browser silently lands the reader at the top instead of the requirements section.

## Fix

Two link updates in `docs/source/references/requirements.rst`:

| Old | New |
| --- | --- |
| `source/deployment/index.html` | `source/features/docker_cloud.html#cloud-workstations` |
| `source/setup/installation/index.html#general-requirements` | `source/setup/installation/index.html#system-requirements` |

The `#cloud-workstations` anchor lands the reader directly on the "Cloud Deployment"
material (Isaac Automator, cloud workstation setup) rather than the top of the Docker
guide, which matches the intent of the surrounding sentence about hosting the
workstation in the cloud.

The `#system-requirements` section is the current home of the Ubuntu 22.04 / Python
3.12 / driver 580.95.05 requirements that the footnote's table cites.

## Verification

- Old cloud URL → **404**; new URL → **200** with `id="cloud-workstations"` present.
- `installation/index.html` → **200**, but `id="general-requirements"` is **absent**
  and `id="system-requirements"` is present.
- Every other `isaac-sim.github.io/IsaacLab` and Isaac Sim docs link under `docs/`
  and `README.md` was checked for both HTTP status and anchor presence
  (`#isaaclab-installation-root`, `#teleoperation-imitation-learning`) — all resolve.
- Repo-wide grep confirms `source/deployment` appeared in exactly one place.

Closes #826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CloudXR and Isaac Lab cloud-workstation documentation links.
  * Refined the Isaac Lab system requirements reference to point directly to the relevant section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->