### PR TITLE
Rename ee_pose back to ee_poses

### DIFF
--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -60,7 +60,7 @@ Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
 
 - `xr_teleop/hand` (`teleop_ros2_interfaces/msg/NamedPoseArray`)
   - Named OpenXR hand joint poses; always contains 25 `left_` entries followed by 25 `right_` entries, including `WRIST` and omitting `PALM`; missing or invalid joints use zero poses with `is_valid=false`
-- `xr_teleop/ee_pose` (`teleop_ros2_interfaces/msg/NamedPoseArray`)
+- `xr_teleop/ee_poses` (`teleop_ros2_interfaces/msg/NamedPoseArray`)
   - Named hand/controller EE poses; always contains `left` and `right` entries, with zero poses and `is_valid=false` for invalid sides
 - `xr_teleop/root_twist` (`geometry_msgs/TwistStamped`)
 - `xr_teleop/root_pose` (`geometry_msgs/PoseStamped`)
@@ -119,14 +119,14 @@ docker run --rm --gpus all --net=host --ipc=host \
   teleop_ros2_ref --ros-args -p cloudxr_accept_eula:=true \
   -p world_frame:=odom -p rate_hz:=30.0 \
   -r xr_teleop/hand:=my_robot/hand \
-  -r xr_teleop/ee_pose:=my_robot/ee_pose
+  -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
 Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 
-Available topics for remapping: `xr_teleop/hand`, `xr_teleop/ee_pose`, `xr_teleop/root_twist`, `xr_teleop/root_pose`, `xr_teleop/head_pose`, `xr_teleop/controller_data`, `xr_teleop/full_body`, `xr_teleop/finger_joints`. Active remaps can be inspected with `ros2 node info /teleop_ros2_node`.
+Available topics for remapping: `xr_teleop/hand`, `xr_teleop/ee_poses`, `xr_teleop/root_twist`, `xr_teleop/root_pose`, `xr_teleop/head_pose`, `xr_teleop/controller_data`, `xr_teleop/full_body`, `xr_teleop/finger_joints`. Active remaps can be inspected with `ros2 node info /teleop_ros2_node`.
 
 ### Mode
 
@@ -134,8 +134,8 @@ The `mode` parameter selects the teleoperation scenario and which topics are pub
 
 | Mode | Topics published |
 |------|------------------|
-| `controller_teleop` (default) | `ee_pose` (from controller aim poses), `root_twist`, `root_pose`, `head_pose`, `finger_joints` (TriHand by default; Sharpa from Manus/OpenXR hands when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`), `controller_data`, `tf` (from controller aim poses and head pose), and `hand` only for the explicit Sharpa retargeter path |
-| `hand_teleop` | `ee_pose` (from hand tracking wrists), `hand` (named left and right joint poses), `finger_joints` (finger joints in joint space), `root_twist`, `root_pose`, `head_pose`, `tf` (from hand tracking wrists and head pose); locomotion comes from the configured foot pedal collection |
+| `controller_teleop` (default) | `ee_poses` (from controller aim poses), `root_twist`, `root_pose`, `head_pose`, `finger_joints` (TriHand by default; Sharpa from Manus/OpenXR hands when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`), `controller_data`, `tf` (from controller aim poses and head pose), and `hand` only for the explicit Sharpa retargeter path |
+| `hand_teleop` | `ee_poses` (from hand tracking wrists), `hand` (named left and right joint poses), `finger_joints` (finger joints in joint space), `root_twist`, `root_pose`, `head_pose`, `tf` (from hand tracking wrists and head pose); locomotion comes from the configured foot pedal collection |
 | `controller_raw` | `controller_data` only |
 | `full_body` | `full_body` and `controller_data` |
 
@@ -191,7 +191,7 @@ coverage.
 docker exec -it teleop_ros2_ref /bin/bash
 
 ros2 topic echo /xr_teleop/hand teleop_ros2_interfaces/msg/NamedPoseArray
-ros2 topic echo /xr_teleop/ee_pose teleop_ros2_interfaces/msg/NamedPoseArray
+ros2 topic echo /xr_teleop/ee_poses teleop_ros2_interfaces/msg/NamedPoseArray
 ros2 topic echo /xr_teleop/root_twist geometry_msgs/msg/TwistStamped
 ros2 topic echo /xr_teleop/root_pose geometry_msgs/msg/PoseStamped
 ros2 topic echo /xr_teleop/head_pose geometry_msgs/msg/PoseStamped

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -89,7 +89,7 @@ def _assert_nonzero_pose_positions(msg: NamedPoseArray, label: str) -> None:
         raise ValueError(f"{label} positions are all zero")
 
 
-def _assert_ee_pose_array(msg: NamedPoseArray) -> None:
+def _assert_ee_poses_array(msg: NamedPoseArray) -> None:
     _assert_named_pose_array(msg, ["left", "right"])
     if not all(bool(is_valid) for is_valid in msg.is_valid):
         raise ValueError("EE pose array contains an invalid entry")
@@ -263,10 +263,10 @@ class TopicVerifier(Node):
         if mode == "controller_teleop":
             return [
                 (
-                    "ee_pose",
-                    "xr_teleop/ee_pose",
+                    "ee_poses",
+                    "xr_teleop/ee_poses",
                     NamedPoseArray,
-                    _assert_ee_pose_array,
+                    _assert_ee_poses_array,
                 ),
                 ("root_twist", "xr_teleop/root_twist", TwistStamped, _assert_twist),
                 ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_pose_stamped),
@@ -293,10 +293,10 @@ class TopicVerifier(Node):
                     _assert_hand_pose_array,
                 ),
                 (
-                    "ee_pose",
-                    "xr_teleop/ee_pose",
+                    "ee_poses",
+                    "xr_teleop/ee_poses",
                     NamedPoseArray,
-                    _assert_ee_pose_array,
+                    _assert_ee_poses_array,
                 ),
                 ("root_twist", "xr_teleop/root_twist", TwistStamped, _assert_twist),
                 ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_pose_stamped),

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -10,11 +10,11 @@ Publishes teleoperation data over ROS2 topics using isaacteleop TeleopSession.
 The `mode` parameter selects the teleoperation scenario and which topics are
 published:
 
-  - controller_teleop (default): ee_pose (from controller aim poses),
+  - controller_teleop (default): ee_poses (from controller aim poses),
                        root_twist, root_pose, finger_joints
                        (retargeted TriHand angles), controller_data, head_pose,
                        and TF transforms for left/right wrists and head
-  - hand_teleop: ee_pose (from hand tracking wrists), hand (named left and
+  - hand_teleop: ee_poses (from hand tracking wrists), hand (named left and
                  right joint poses),
                  finger_joints (retargeted Sharpa joint angles),
                  root_twist/root_pose (from foot pedal locomotion), head_pose,
@@ -24,7 +24,7 @@ published:
 
 Topic names (remappable via ROS 2 remapping):
   - xr_teleop/hand (NamedPoseArray): named left and right hand joint poses
-  - xr_teleop/ee_pose (NamedPoseArray): named left and right EE poses
+  - xr_teleop/ee_poses (NamedPoseArray): named left and right EE poses
   - xr_teleop/root_twist (TwistStamped): root velocity command
   - xr_teleop/root_pose (PoseStamped): root pose command (height only)
   - xr_teleop/head_pose (PoseStamped): head pose
@@ -91,8 +91,8 @@ class TeleopRos2Node(Node):
 
     def _create_publishers(self) -> None:
         self._pub_hand = self.create_publisher(NamedPoseArray, "xr_teleop/hand", 10)
-        self._pub_ee_pose = self.create_publisher(
-            NamedPoseArray, "xr_teleop/ee_pose", 10
+        self._pub_ee_poses = self.create_publisher(
+            NamedPoseArray, "xr_teleop/ee_poses", 10
         )
         self._pub_root_twist = self.create_publisher(
             TwistStamped, "xr_teleop/root_twist", 10
@@ -111,8 +111,8 @@ class TeleopRos2Node(Node):
         )
         self._pub_head = self.create_publisher(PoseStamped, "xr_teleop/head_pose", 10)
 
-    def _publish_ee_pose_from_controllers(self, result: SessionResult, now) -> None:
-        ee_pose_msg, wrist_tfs = build_ee_output_from_controllers(
+    def _publish_ee_poses_from_controllers(self, result: SessionResult, now) -> None:
+        ee_poses_msg, wrist_tfs = build_ee_output_from_controllers(
             result["controller_left"],
             result["controller_right"],
             now,
@@ -123,7 +123,7 @@ class TeleopRos2Node(Node):
             self._params.transform_translation,
             self._params.controller_uses_hands_source,
         )
-        self._pub_ee_pose.publish(ee_pose_msg)
+        self._pub_ee_poses.publish(ee_poses_msg)
         if wrist_tfs:
             self._tf_broadcaster.sendTransform(wrist_tfs)
 
@@ -161,8 +161,8 @@ class TeleopRos2Node(Node):
         )
         self._pub_hand.publish(hand_msg)
 
-    def _publish_ee_pose_from_hands(self, result: SessionResult, now) -> None:
-        ee_pose_msg, wrist_tfs = build_ee_output_from_hands(
+    def _publish_ee_poses_from_hands(self, result: SessionResult, now) -> None:
+        ee_poses_msg, wrist_tfs = build_ee_output_from_hands(
             result["hand_left"],
             result["hand_right"],
             now,
@@ -172,7 +172,7 @@ class TeleopRos2Node(Node):
             self._params.transform_rotation,
             self._params.transform_translation,
         )
-        self._pub_ee_pose.publish(ee_pose_msg)
+        self._pub_ee_poses.publish(ee_poses_msg)
         if wrist_tfs:
             self._tf_broadcaster.sendTransform(wrist_tfs)
 
@@ -239,12 +239,12 @@ class TeleopRos2Node(Node):
                             PublishType.EE_FROM_HANDS
                             in self._profile_spec.publish_types
                         ):
-                            self._publish_ee_pose_from_hands(result, now)
+                            self._publish_ee_poses_from_hands(result, now)
                         if (
                             PublishType.EE_FROM_CONTROLLERS
                             in self._profile_spec.publish_types
                         ):
-                            self._publish_ee_pose_from_controllers(result, now)
+                            self._publish_ee_poses_from_controllers(result, now)
                         if PublishType.HAND_POSES in self._profile_spec.publish_types:
                             self._publish_hand_poses(result, now)
                         if PublishType.ROOT_COMMAND in self._profile_spec.publish_types:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Rename ee_pose back to ee_poses

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Teleop ROS2 end-effector output topic to `xr_teleop/ee_poses`.
  - Ensured controller and hand teleoperation modes publish and validate end-effector pose arrays correctly.

- **Documentation**
  - Updated topic lists, remapping examples, mode references, and echo commands to use the new topic name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->