### PR TITLE
feat(cloudxr): add webclient CLI to open the teleop page on a headset

### DIFF
--- a/docs/source/references/cloudxr.rst
+++ b/docs/source/references/cloudxr.rst
@@ -94,6 +94,26 @@ headset connects and how the web client is delivered.
 ``--usb-local`` requires ``--setup-oob``. See
 :doc:`/references/oob_teleop_control` for full OOB documentation.
 
+Re-open the client on the headset
+---------------------------------
+
+If the headset browser is closed or navigated away, re-open the client from a
+second terminal without restarting the runtime:
+
+.. code-block:: bash
+
+   python -m isaacteleop.cloudxr.webclient
+
+This opens the versioned client over USB ``adb`` with this host's ``serverIP``
+and ``port`` pre-filled. Pass a URL to override the target — one already
+containing ``oobEnable=`` is opened verbatim, which is how to restore an OOB or
+USB-local session from the URL the launcher printed. ``--print-only`` resolves
+the URL without touching ``adb``. Run with ``--help`` for the full argument
+handling.
+
+It only *opens* the page; accepting the certificate and clicking CONNECT remain
+``--setup-oob``'s CDP automation.
+
 .. _load-cloudxr-environment-variables:
 
 Load CloudXR environment variables

--- a/docs/source/references/oob_teleop_control.rst
+++ b/docs/source/references/oob_teleop_control.rst
@@ -166,7 +166,9 @@ Prerequisites:
 
 If any step fails, the hub still starts.  Fall back to
 ``chrome://inspect/#devices`` from the PC or tap CONNECT on the headset
-directly.
+directly.  To re-open the page later without restarting the launcher, pass the
+bookmark URL above to ``python -m isaacteleop.cloudxr.webclient`` (see
+:doc:`/references/cloudxr`).
 
 Architecture
 ------------

--- a/src/core/cloudxr/python/CMakeLists.txt
+++ b/src/core/cloudxr/python/CMakeLists.txt
@@ -156,6 +156,7 @@ add_custom_target(cloudxr_python ALL
         "${CMAKE_CURRENT_SOURCE_DIR}/launcher.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/runtime.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/wss.py"
+        "${CMAKE_CURRENT_SOURCE_DIR}/webclient.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/oob_teleop_adb.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/oob_teleop_env.py"
         "${CMAKE_CURRENT_SOURCE_DIR}/oob_teleop_hub.py"

--- a/src/core/cloudxr/python/oob_teleop_adb.py
+++ b/src/core/cloudxr/python/oob_teleop_adb.py
@@ -39,6 +39,7 @@ from .oob_teleop_env import (
     build_headset_bookmark_url,
     client_ui_fields_from_env,
     oob_progress,
+    redact_control_token,
     resolve_lan_host_for_oob,
     web_client_base_override_from_env,
 )
@@ -88,13 +89,14 @@ def oob_adb_automation_message(rc: int, detail: str, hint: str) -> str:
     ]
     if hint.strip():
         lines.extend(["", hint])
-    lines.extend(
-        [
-            "",
-            "To run the WSS proxy and OOB hub without adb, omit --setup-oob and open the teleop URL on the headset yourself.",
-        ]
-    )
+    lines.extend(["", MANUAL_FALLBACK_HINT])
     return "\n".join(lines)
+
+
+# Remediation appended to adb failures. Deliberately names no CLI flag: both
+# the launcher (--setup-oob) and the standalone opener raise these, and manual
+# navigation is the correct fallback for either.
+MANUAL_FALLBACK_HINT = "Or open the teleop URL on the headset yourself."
 
 
 def require_adb_on_path() -> None:
@@ -102,9 +104,9 @@ def require_adb_on_path() -> None:
     if shutil.which("adb"):
         return
     raise OobAdbError(
-        "Cannot use --setup-oob: `adb` was not found on PATH.\n\n"
-        "Install Android Platform Tools and ensure `adb` is available, or omit --setup-oob and open "
-        "the teleop bookmark URL on the headset yourself."
+        "`adb` was not found on PATH.\n\n"
+        "Install Android Platform Tools and ensure `adb` is available. "
+        f"{MANUAL_FALLBACK_HINT}"
     )
 
 
@@ -391,13 +393,14 @@ def assert_exactly_one_adb_device() -> None:
         )
     except FileNotFoundError as e:
         raise OobAdbError(
-            "Cannot use --setup-oob: `adb` was not found on PATH.\n\n"
-            "Install Android Platform Tools and ensure `adb` is available, or omit --setup-oob."
+            "`adb` was not found on PATH.\n\n"
+            "Install Android Platform Tools and ensure `adb` is available. "
+            f"{MANUAL_FALLBACK_HINT}"
         ) from e
     except subprocess.TimeoutExpired as e:
         raise OobAdbError(
             "adb command timed out; ensure Android Platform Tools are installed and adb is callable.\n\n"
-            "Try `adb kill-server` and reconnect the USB cable, or omit --setup-oob."
+            f"Try `adb kill-server` and reconnect the USB cable. {MANUAL_FALLBACK_HINT}"
         ) from e
     if proc.returncode != 0:
         diag = _adb_output_text(proc)
@@ -417,9 +420,9 @@ def assert_exactly_one_adb_device() -> None:
             ready.append(parts[0])
     if len(ready) == 0:
         raise OobAdbError(
-            "No adb device found for --setup-oob.\n\n"
+            "No adb device found.\n\n"
             "Plug in the USB cable, enable USB debugging on the headset, and check `adb devices`. "
-            "Or omit --setup-oob and open the teleop URL on the headset yourself."
+            f"{MANUAL_FALLBACK_HINT}"
         )
 
     # If the operator pinned a specific device, validate it is ready and stop.
@@ -441,18 +444,32 @@ def assert_exactly_one_adb_device() -> None:
     if len(ready) > 1:
         listed = ", ".join(ready)
         raise OobAdbError(
-            "Too many adb devices for --setup-oob.\n\n"
+            "Too many adb devices.\n\n"
             f"Currently connected: {listed}\n\n"
             "Unplug extras so only one headset is connected, OR set "
             "ANDROID_SERIAL=<serial> to pin the one you want, then retry. "
-            "(Or omit --setup-oob and open the teleop URL manually.)"
+            f"({MANUAL_FALLBACK_HINT})"
         )
 
 
 def build_teleop_url(
-    *, resolved_port: int, usb_local: bool = False, host_client: bool = False
+    *,
+    resolved_port: int,
+    usb_local: bool = False,
+    host_client: bool = False,
+    web_client_base: str | None = None,
+    oob_enable: bool = True,
 ) -> str:
-    """Build the headset teleop bookmark URL for ``am start`` and CDP automation."""
+    """Build the headset teleop bookmark URL for ``am start`` and CDP automation.
+
+    *web_client_base* overrides the WebXR client origin and takes precedence
+    over :envvar:`TELEOP_WEB_CLIENT_BASE` (an explicit argument outranks the
+    environment); the streaming query params are computed the same way either
+    way.
+
+    *oob_enable* forwards to :func:`~.oob_teleop_env.build_headset_bookmark_url`;
+    pass ``False`` only when the OOB control hub is not running.
+    """
     env_port = os.environ.get("TELEOP_STREAM_PORT", "").strip()
     signaling_port = (
         parse_env_port("TELEOP_STREAM_PORT", env_port) if env_port else resolved_port
@@ -479,7 +496,7 @@ def build_teleop_url(
             "iceRelayOnly": True,
             **client_ui_fields_from_env(),
         }
-        ovr = web_client_base_override_from_env()
+        ovr = web_client_base or web_client_base_override_from_env()
         web_base = ovr if ovr else f"https://localhost:{usb_ui_port()}"
     else:
         stream_cfg = {
@@ -487,7 +504,7 @@ def build_teleop_url(
             "port": signaling_port,
             **client_ui_fields_from_env(),
         }
-        ovr = web_client_base_override_from_env()
+        ovr = web_client_base or web_client_base_override_from_env()
         if host_client:
             from .oob_teleop_env import guess_lan_ipv4, wss_proxy_port  # noqa: PLC0415
 
@@ -502,6 +519,7 @@ def build_teleop_url(
         web_client_base=web_base,
         stream_config=stream_cfg,
         control_token=token,
+        oob_enable=oob_enable,
     )
 
 
@@ -585,15 +603,17 @@ def headset_browser_package() -> str | None:
     return None
 
 
-def run_adb_headset_bookmark(
-    *, resolved_port: int, usb_local: bool = False, host_client: bool = False
-) -> tuple[int, str]:
-    """Launch the browser on the headset via ``am start`` (used when browser is not yet running).
+def open_url_on_headset(url: str) -> tuple[int, str]:
+    """Open *url* on the connected headset via ``am start``.
 
     When a known vendor browser is detected (Meta / PICO), launches into it
     explicitly via ``-p <package>`` so the URL opens in the full Chromium
     (with working WebXR controller input), not Android WebLayer.  Falls
     back to the generic VIEW intent on unknown vendors.
+
+    Takes the URL as an argument rather than deriving it, so callers that
+    already have one (``python -m isaacteleop.cloudxr.webclient``) share the
+    vendor-browser selection and token redaction with the OOB launcher path.
 
     Returns ``(exit_code, diagnostic)``.
     """
@@ -602,9 +622,6 @@ def run_adb_headset_bookmark(
     except OobAdbError as exc:
         return 99, str(exc)
 
-    url = build_teleop_url(
-        resolved_port=resolved_port, usb_local=usb_local, host_client=host_client
-    )
     package = headset_browser_package()
     if package:
         log.info("ADB automation: launching into %s (bypass WebLayer)", package)
@@ -615,9 +632,10 @@ def run_adb_headset_bookmark(
     else:
         shell_cmd = "am start -a android.intent.action.VIEW -d " + shlex.quote(url)
     full = ["adb", "shell", shell_cmd]
-    redacted = " ".join(shlex.quote(c) for c in full)
-    redacted = re.sub(r"(controlToken=)[^&\s'\"]+", r"\1<REDACTED>", redacted)
-    log.info("ADB automation: %s", redacted)
+    log.info(
+        "ADB automation: %s",
+        redact_control_token(" ".join(shlex.quote(c) for c in full)),
+    )
     try:
         proc = subprocess.run(full, capture_output=True, text=True, timeout=30)
     except subprocess.TimeoutExpired as e:
@@ -635,6 +653,23 @@ def run_adb_headset_bookmark(
         return proc.returncode, diag
     log.info("ADB automation: am start completed")
     return 0, ""
+
+
+def run_adb_headset_bookmark(
+    *, resolved_port: int, usb_local: bool = False, host_client: bool = False
+) -> tuple[int, str]:
+    """Open the computed teleop bookmark URL on the headset (browser not yet running).
+
+    Thin wrapper: :func:`build_teleop_url` for the URL,
+    :func:`open_url_on_headset` for the ``am start``.
+
+    Returns ``(exit_code, diagnostic)``.
+    """
+    return open_url_on_headset(
+        build_teleop_url(
+            resolved_port=resolved_port, usb_local=usb_local, host_client=host_client
+        )
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/core/cloudxr/python/oob_teleop_env.py
+++ b/src/core/cloudxr/python/oob_teleop_env.py
@@ -473,11 +473,20 @@ def build_headset_bookmark_url(
     web_client_base: str,
     stream_config: dict | None = None,
     control_token: str | None = None,
+    oob_enable: bool = True,
 ) -> str:
-    """Full WebXR page URL with OOB query params (``oobEnable=1``, stream fields, optional token).
+    """Full WebXR page URL with stream query params, and OOB params when enabled.
 
     The client derives ``wss://{serverIP}:{port}/oob/v1/ws`` from ``serverIP`` + ``port`` in the query
     when ``oobEnable=1``.
+
+    Set *oob_enable* to ``False`` to omit ``oobEnable`` (and the control token,
+    which only authenticates hub operations).  The remaining params —
+    ``serverIP``, ``port``, ``codec``, ``panelHiddenAtStart`` — are plain form
+    overrides the client honours either way, so the headset still lands with
+    the right streaming target pre-filled.  Callers must not disable OOB while
+    the control hub is down: without a hub, ``/oob/v1/ws`` is proxied to the
+    CloudXR streaming backend rather than refused.
 
     A HashRouter fragment is appended at the end when ``TELEOP_CLIENT_ROUTE``
     is set (e.g. ``#/real/gear/dexmate``); by default no fragment is added
@@ -488,9 +497,11 @@ def build_headset_bookmark_url(
         raise ValueError(
             "build_headset_bookmark_url requires stream_config with serverIP and port"
         )
-    params: dict[str, str] = {"oobEnable": "1"}
-    if control_token:
-        params["controlToken"] = control_token
+    params: dict[str, str] = {}
+    if oob_enable:
+        params["oobEnable"] = "1"
+        if control_token:
+            params["controlToken"] = control_token
     params["serverIP"] = str(cfg["serverIP"])
     params["port"] = str(int(cfg["port"]))
     v = cfg.get("codec")
@@ -518,6 +529,16 @@ def build_headset_bookmark_url(
     if route:
         url = f"{url}#{route}"
     return url
+
+
+def redact_control_token(text: str) -> str:
+    """Mask ``controlToken`` values in *text* for display or logging.
+
+    Shared by every path that surfaces a bookmark URL — the startup banner,
+    the ``am start`` log line, and the standalone opener — so a token can
+    never reach a terminal or log file through one of them.
+    """
+    return re.sub(r"(controlToken=)[^&\s'\"]+", r"\1<REDACTED>", text)
 
 
 def resolve_lan_host_for_oob() -> str:
@@ -605,7 +626,9 @@ def print_oob_hub_startup_banner(
         control_token=None,
     )
     if token:
-        bookmark_display += "&controlToken=<REDACTED>"
+        bookmark_display = redact_control_token(
+            f"{bookmark_display}&controlToken={token}"
+        )
     wss_primary = f"wss://{primary_host}:{port}{OOB_WS_PATH}"
 
     bar = "=" * 72

--- a/src/core/cloudxr/python/webclient.py
+++ b/src/core/cloudxr/python/webclient.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Open the Isaac Teleop WebXR client on a USB-connected headset.
+
+``python -m isaacteleop.cloudxr.webclient [CLIENT_URL]``
+
+Re-opens the teleop page on the headset without restarting the launcher —
+useful when the headset browser was closed, navigated away, or needs to point
+at a different client build.
+
+URL building, adb preflight, vendor-browser selection and token redaction are
+all reused from :mod:`~.oob_teleop_adb` / :mod:`~.oob_teleop_env`; this module
+only adds argument handling and the summary block.
+
+Scope is deliberately narrow: it opens a page over WiFi with this host's
+streaming target pre-filled.  Out-of-band control, USB-local and host-client
+topologies stay with the launcher, which owns the servers they need — pass a
+URL explicitly to target one of them.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from urllib.parse import parse_qs, urlsplit
+
+from .oob_teleop_adb import (
+    OobAdbError,
+    adb_automation_failure_hint,
+    assert_exactly_one_adb_device,
+    assert_headset_awake,
+    build_teleop_url,
+    headset_browser_package,
+    oob_adb_automation_message,
+    open_url_on_headset,
+    require_adb_on_path,
+)
+from .oob_teleop_env import (
+    TELEOP_CLIENT_ROUTE_ENV,
+    redact_control_token,
+    teleop_client_route_from_env,
+    wss_proxy_port,
+)
+
+# Query param the WebXR client keys off for out-of-band control. Its presence
+# in a user-supplied URL means that URL is already a full bookmark.
+_OOB_MARKER = "oobEnable="
+
+
+def resolve_client_url(override: str | None) -> tuple[str, str]:
+    """Return ``(url, source)`` for the page to open on the headset.
+
+    *source* is a short human-readable label for the summary block.
+
+    Three cases:
+
+    * *override* is ``None`` — the computed default: the versioned client with
+      ``serverIP`` / ``port`` pre-filled.
+    * *override* already contains ``oobEnable=`` — opened verbatim.  This is
+      the paste-back case: copy the URL the launcher's banner printed, tweak a
+      param, re-open it.  Appending our own params would duplicate the
+      existing ones, and it is how you reach an OOB / USB-local / host-client
+      session from here.
+    * *override* is anything else — treated as the WebXR client *base*, with
+      the query params appended.  Same semantics as
+      :envvar:`TELEOP_WEB_CLIENT_BASE`, which the argument outranks.
+
+    The computed URL never sets ``oobEnable``: the control hub only exists
+    when the launcher runs with ``--setup-oob``, and without one the client's
+    control WebSocket would reach the CloudXR streaming backend instead.
+    """
+    if override is not None and _OOB_MARKER in override:
+        return override, "verbatim"
+
+    url = build_teleop_url(
+        resolved_port=wss_proxy_port(),
+        web_client_base=override,
+        oob_enable=False,
+    )
+    return url, ("client base override" if override else "computed default")
+
+
+def stream_target(url: str) -> str:
+    """``serverIP:port`` parsed out of *url*, or ``"<unknown>"``.
+
+    Read back from the URL rather than recomputed, so the summary always
+    describes the page actually being opened — a verbatim URL may well point
+    somewhere the local defaults would not.
+    """
+    query = parse_qs(urlsplit(url).query)
+    server_ip = (query.get("serverIP") or [""])[0]
+    port = (query.get("port") or [""])[0]
+    return f"{server_ip}:{port}" if server_ip and port else "<unknown>"
+
+
+def _paint(out, code: str, text: str) -> str:
+    """Wrap *text* in ANSI *code*, or return it bare for non-TTY / ``NO_COLOR``."""
+    if os.environ.get("NO_COLOR") or not getattr(out, "isatty", lambda: False)():
+        return text
+    return f"\033[{code}m{text}\033[0m"
+
+
+def _field(out, label: str, value: str, note: str = "") -> str:
+    """Format one aligned ``label   value  (note)`` row of the summary block."""
+    row = f"  {_paint(out, '90', label.ljust(7))} {value}"
+    return f"{row}  {_paint(out, '90', f'({note})')}" if note else row
+
+
+def print_summary(*, url: str, source: str, probe_device: bool, stream=None) -> None:
+    """Print the resolved-configuration block and the URL.
+
+    *probe_device* controls whether the browser row is filled in from adb;
+    ``--print-only`` skips it so the command works with no headset attached.
+    """
+    out = stream if stream is not None else sys.stdout
+    bar = "━" * 64
+
+    print(bar, file=out)
+    print(f" {_paint(out, '1', 'Isaac Teleop')} · web client → headset", file=out)
+    print(bar, file=out)
+    print(file=out)
+
+    if probe_device:
+        # Which browser matters: WebLayer accepts requestSession() but does not
+        # fully plumb controller input through to the client.
+        print(
+            _field(out, "browser", headset_browser_package() or "system default"),
+            file=out,
+        )
+
+    # Parsed from the URL, so a verbatim URL reports its own target.
+    print(_field(out, "stream", stream_target(url)), file=out)
+
+    # Only worth a row when set — the client picks its own landing route otherwise.
+    route = teleop_client_route_from_env()
+    if route:
+        print(_field(out, "route", f"#{route}", TELEOP_CLIENT_ROUTE_ENV), file=out)
+
+    print(_field(out, "source", source), file=out)
+    print(file=out)
+    # Unwrapped and on its own line so terminal double-click / drag copies it whole.
+    print(f"  {_paint(out, '36', redact_control_token(url))}", file=out)
+    print(file=out)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments for the web client opener."""
+    parser = argparse.ArgumentParser(
+        prog="python -m isaacteleop.cloudxr.webclient",
+        description=(
+            "Open the Isaac Teleop WebXR client on a USB-connected headset. "
+            "With no argument, opens the versioned client with this host's "
+            "streaming target pre-filled."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "CLIENT_URL handling:\n"
+            "  omitted                     the computed default URL\n"
+            "  contains 'oobEnable='       opened verbatim (paste back a printed URL)\n"
+            "  anything else               used as the client base; params appended\n"
+            "                              (outranks TELEOP_WEB_CLIENT_BASE)\n"
+            "\n"
+            "To open an OOB, USB-local or host-client session, pass the URL the\n"
+            "launcher printed for it.\n"
+        ),
+    )
+    parser.add_argument(
+        "client_url",
+        nargs="?",
+        default=None,
+        metavar="CLIENT_URL",
+        help="Optional WebXR client URL, or client base URL, to open.",
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Resolve and print the URL without touching adb (no headset required).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Resolve the client URL and open it on the headset. Returns an exit code."""
+    args = _parse_args(argv)
+
+    try:
+        url, source = resolve_client_url(args.client_url)
+        # Preflight before the summary so its browser row describes a headset
+        # we have actually validated, and so failures surface without a banner.
+        if not args.print_only:
+            require_adb_on_path()
+            assert_exactly_one_adb_device()
+            assert_headset_awake()
+    except (OobAdbError, RuntimeError, ValueError) as exc:
+        print(f"\n{exc}\n", file=sys.stderr)
+        return 1
+
+    print_summary(url=url, source=source, probe_device=not args.print_only)
+
+    if args.print_only:
+        return 0
+
+    rc, diag = open_url_on_headset(url)
+    if rc != 0:
+        print(f"  {_paint(sys.stdout, '31', '✖')} adb failed\n")
+        print(
+            oob_adb_automation_message(rc, diag, adb_automation_failure_hint(diag)),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"  {_paint(sys.stdout, '32', '✔')} opened on headset\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/core/cloudxr_tests/python/conftest.py
+++ b/src/core/cloudxr_tests/python/conftest.py
@@ -42,6 +42,7 @@ def _ensure_cloudxr_package() -> None:
     load("oob_teleop_hub")
     load("oob_teleop_env")
     load("oob_teleop_adb")
+    load("webclient")
 
 
 _ensure_cloudxr_package()

--- a/src/core/cloudxr_tests/python/test_oob_teleop_adb.py
+++ b/src/core/cloudxr_tests/python/test_oob_teleop_adb.py
@@ -53,7 +53,7 @@ def test_oob_adb_automation_message() -> None:
     assert "exit code 1" in msg
     assert "device offline" in msg
     assert "Device offline hint." in msg
-    assert "omit --setup-oob" in msg
+    assert "open the teleop URL on the headset" in msg
 
 
 def test_oob_adb_automation_message_empty_detail() -> None:

--- a/src/core/cloudxr_tests/python/test_webclient.py
+++ b/src/core/cloudxr_tests/python/test_webclient.py
@@ -1,0 +1,279 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for :mod:`webclient` (URL resolution, redaction, arg parsing, pretty output)."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cloudxr_py_test_ns.oob_teleop_env import redact_control_token
+from cloudxr_py_test_ns.webclient import (
+    _parse_args,
+    main,
+    print_summary,
+    resolve_client_url,
+)
+
+_LAN = "cloudxr_py_test_ns.oob_teleop_adb.resolve_lan_host_for_oob"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep URL building independent of the developer's shell env."""
+    for var in (
+        "TELEOP_WEB_CLIENT_BASE",
+        "TELEOP_CLIENT_ROUTE",
+        "TELEOP_STREAM_PORT",
+        "CONTROL_TOKEN",
+        "PROXY_PORT",
+        "NO_COLOR",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# URL resolution -------------------------------------------------------------
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_resolve_default_is_not_oob(_mock_lan: MagicMock) -> None:
+    """OOB is opt-in: the hub only runs under the launcher's --setup-oob."""
+    url, source = resolve_client_url(None)
+    assert "oobEnable" not in url
+    assert "serverIP=10.0.0.1" in url
+    assert "port=48322" in url
+    assert "nvidia.github.io" in url
+    assert "default" in source.lower()
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_control_token_never_in_computed_url(
+    _mock_lan: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The token authenticates hub operations, so it is meaningless without OOB."""
+    monkeypatch.setenv("CONTROL_TOKEN", "sup3rs3cret")
+    assert "controlToken" not in resolve_client_url(None)[0]
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_resolve_base_override_appends_params(_mock_lan: MagicMock) -> None:
+    url, source = resolve_client_url("https://192.168.1.5:8080")
+    assert url.startswith("https://192.168.1.5:8080?")
+    assert "serverIP=10.0.0.1" in url
+    assert "nvidia.github.io" not in url
+    assert "base" in source.lower()
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_resolve_base_override_outranks_env(
+    _mock_lan: MagicMock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("TELEOP_WEB_CLIENT_BASE", "https://from-env.example")
+    url, _ = resolve_client_url("https://from-arg.example")
+    assert url.startswith("https://from-arg.example?")
+    assert "from-env" not in url
+
+
+def test_resolve_full_url_is_verbatim() -> None:
+    """A URL already carrying OOB params must not get a second set appended."""
+    given = "https://example.test/client/?oobEnable=1&serverIP=10.0.0.9&port=48322"
+    url, source = resolve_client_url(given)
+    assert url == given
+    assert url.count("oobEnable=") == 1
+    assert url.count("serverIP=") == 1
+    assert "verbatim" in source.lower()
+
+
+# Token redaction ------------------------------------------------------------
+
+
+def test_redact_token_masks_value() -> None:
+    masked = redact_control_token("https://x.test/?controlToken=s3cret&port=48322")
+    assert "s3cret" not in masked
+    assert "controlToken=<REDACTED>" in masked
+    assert "port=48322" in masked
+
+
+def test_redact_token_noop_without_token() -> None:
+    url = "https://x.test/?oobEnable=1&port=48322"
+    assert redact_control_token(url) == url
+
+
+def test_summary_hides_token_but_url_keeps_it() -> None:
+    """A pasted OOB URL can carry a token; it must not reach the terminal."""
+    url, source = resolve_client_url(
+        "https://x.test/?oobEnable=1&controlToken=sup3rs3cret&serverIP=10.0.0.9&port=48322"
+    )
+    assert "sup3rs3cret" in url
+
+    buf = io.StringIO()
+    print_summary(
+        url=url,
+        source=source,
+        probe_device=False,
+        stream=buf,
+    )
+    printed = buf.getvalue()
+    assert "sup3rs3cret" not in printed
+    assert "controlToken=<REDACTED>" in printed
+
+
+# Pretty output --------------------------------------------------------------
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_summary_is_plain_text_when_not_a_tty(_mock_lan: MagicMock) -> None:
+    """StringIO is not a tty, so no escape sequences should be emitted."""
+    buf = io.StringIO()
+    url, source = resolve_client_url(None)
+    print_summary(
+        url=url,
+        source=source,
+        probe_device=False,
+        stream=buf,
+    )
+    printed = buf.getvalue()
+    assert "\033[" not in printed
+    assert "10.0.0.1:48322" in printed
+    assert url in printed
+
+
+def test_summary_reports_verbatim_urls_own_target() -> None:
+    """The summary must describe the URL being opened, not the local defaults."""
+    given = "https://example.test/client/?oobEnable=1&serverIP=203.0.113.7&port=1234"
+    url, source = resolve_client_url(given)
+    buf = io.StringIO()
+    print_summary(
+        url=url,
+        source=source,
+        probe_device=False,
+        stream=buf,
+    )
+    printed = buf.getvalue()
+    assert "203.0.113.7:1234" in printed
+    assert "48322" not in printed
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_summary_skips_adb_when_not_probing(_mock_lan: MagicMock) -> None:
+    """--print-only must not shell out to adb."""
+    buf = io.StringIO()
+    with patch("cloudxr_py_test_ns.webclient.headset_browser_package") as probe:
+        url, source = resolve_client_url(None)
+        print_summary(
+            url=url,
+            source=source,
+            probe_device=False,
+            stream=buf,
+        )
+    probe.assert_not_called()
+
+
+# Argument parsing -----------------------------------------------------------
+
+
+def test_parse_args_defaults() -> None:
+    args = _parse_args([])
+    assert args.client_url is None
+    assert args.print_only is False
+
+
+def test_parse_args_positional_and_flag() -> None:
+    args = _parse_args(["https://x.test", "--print-only"])
+    assert args.client_url == "https://x.test"
+    assert args.print_only is True
+
+
+# main() ---------------------------------------------------------------------
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_main_print_only_skips_adb(_mock_lan: MagicMock, capsys) -> None:
+    with (
+        patch("cloudxr_py_test_ns.webclient.require_adb_on_path") as req,
+        patch("cloudxr_py_test_ns.webclient.open_url_on_headset") as opener,
+    ):
+        rc = main(["--print-only"])
+    assert rc == 0
+    req.assert_not_called()
+    opener.assert_not_called()
+    assert "serverIP=10.0.0.1" in capsys.readouterr().out
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_main_opens_resolved_url(_mock_lan: MagicMock, capsys) -> None:
+    with (
+        patch("cloudxr_py_test_ns.webclient.require_adb_on_path"),
+        patch("cloudxr_py_test_ns.webclient.assert_exactly_one_adb_device"),
+        patch("cloudxr_py_test_ns.webclient.assert_headset_awake"),
+        patch(
+            "cloudxr_py_test_ns.webclient.headset_browser_package",
+            return_value="com.pico.browser",
+        ),
+        patch(
+            "cloudxr_py_test_ns.webclient.open_url_on_headset", return_value=(0, "")
+        ) as opener,
+    ):
+        rc = main([])
+    assert rc == 0
+    opened = opener.call_args[0][0]
+    assert "serverIP=10.0.0.1" in opened
+    assert "oobEnable" not in opened
+    out = capsys.readouterr().out
+    assert "com.pico.browser" in out
+    assert "opened on headset" in out
+
+
+@patch(_LAN, return_value="10.0.0.1")
+def test_main_reports_adb_failure_with_hint(_mock_lan: MagicMock, capsys) -> None:
+    with (
+        patch("cloudxr_py_test_ns.webclient.require_adb_on_path"),
+        patch("cloudxr_py_test_ns.webclient.assert_exactly_one_adb_device"),
+        patch("cloudxr_py_test_ns.webclient.assert_headset_awake"),
+        patch(
+            "cloudxr_py_test_ns.webclient.headset_browser_package", return_value=None
+        ),
+        patch(
+            "cloudxr_py_test_ns.webclient.open_url_on_headset",
+            return_value=(1, "no devices/emulators found"),
+        ),
+    ):
+        rc = main([])
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "no devices/emulators found" in captured.err
+    assert "No adb device" in captured.err
+
+
+def test_main_reports_preflight_failure_without_traceback() -> None:
+    """An adb preflight failure is a clean exit code, not an escaping OobAdbError."""
+    from cloudxr_py_test_ns.oob_teleop_adb import OobAdbError as _Err
+
+    with patch(
+        "cloudxr_py_test_ns.webclient.require_adb_on_path",
+        side_effect=_Err("no adb"),
+    ):
+        rc = main([])
+    assert rc == 1
+
+
+def test_main_preflight_hint_does_not_mention_setup_oob(capsys) -> None:
+    """Shared adb advice must name no CLI flag — this tool has no --setup-oob."""
+    with patch("cloudxr_py_test_ns.oob_teleop_adb.shutil.which", return_value=None):
+        rc = main([])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "not found on PATH" in err
+    assert "--setup-oob" not in err
+    assert "open the teleop URL on the headset" in err
+
+
+def test_main_returns_1_when_lan_unresolvable(capsys) -> None:
+    """No LAN IP and no override is a clean error, not a traceback."""
+    with patch(_LAN, side_effect=RuntimeError("no LAN IP")):
+        rc = main([])
+    assert rc == 1
+    assert "no LAN IP" in capsys.readouterr().err


### PR DESCRIPTION
## What

`python -m isaacteleop.cloudxr.webclient [CLIENT_URL]` re-opens the WebXR client on a USB-connected headset without restarting the launcher — for when the headset browser gets closed or navigated away mid-session.

With no argument it opens the versioned client with this host's `serverIP` and `port` pre-filled:

```
  stream  10.112.219.208:48322
  source  computed default

  https://…/client/main?serverIP=10.112.219.208&port=48322
```

A URL containing `oobEnable=` is opened verbatim — paste back what the launcher printed to restore an OOB or USB-local session. Anything else is treated as the client base, outranking `TELEOP_WEB_CLIENT_BASE`. `--print-only` resolves the URL without touching adb.

It never sets `oobEnable` itself: the control hub only exists under `--setup-oob`, and without one the client's control WebSocket reaches the streaming backend rather than being refused.

## Supporting changes

- Extract `open_url_on_headset()` from `run_adb_headset_bookmark()`, so both share vendor-browser selection and token redaction.
- Add `web_client_base` / `oob_enable` kwargs to the URL builders; defaults leave every launcher URL unchanged.
- Share `redact_control_token()` across the three places that each had a copy.

## Testing

123 tests pass, 19 new. Lint, format and pre-commit clean. Not verified on hardware — `am start` is untested against a real headset.
