### PR TITLE
Zero-copy joint access from Python

### DIFF
--- a/cmake/GenerateFlatBuffers.cmake
+++ b/cmake/GenerateFlatBuffers.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # CMake function to generate C++ headers from FlatBuffer schema files.
@@ -51,12 +51,16 @@ function(generate_flatbuffer_headers OUT_VAR INPUT_DIR OUTPUT_DIR)
               --gen-mutable
               --schema
               --bfbs-gen-embed
+              # Mini-reflect type tables with field names. Supersedes --reflect-types, which
+              # sets the same flatc option to a names-less value.
               --reflect-names
-              --reflect-types
               -I ${INPUT_DIR}
               -o ${OUTPUT_DIR}
               ${INPUT_DIR}/${SCHEMA_FILE}
-      DEPENDS ${INPUT_DIR}/${SCHEMA_FILE} flatc
+      # Depend on this file too: the flatc flags live here, and generators that compare
+      # timestamps rather than command lines would otherwise keep stale headers after a
+      # flag change.
+      DEPENDS ${INPUT_DIR}/${SCHEMA_FILE} flatc ${CMAKE_CURRENT_FUNCTION_LIST_FILE}
       COMMENT "Generating FlatBuffers C++ for ${SCHEMA_FILE}"
       VERBATIM
     )

--- a/src/core/deviceio_trackers/python/tracker_bindings.cpp
+++ b/src/core/deviceio_trackers/python/tracker_bindings.cpp
@@ -256,7 +256,10 @@ PYBIND11_MODULE(_deviceio_trackers, m)
             "get_body_pose",
             [](const core::FullBodyTracker& self, const core::ITrackerSession& session)
             { return share_tracked(self.get_body_pose(session)); },
-            py::arg("session"), "Get full body pose tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC);
+            // No lifetime note here: the full-body impls install freshly allocated joint storage
+            // each frame rather than refilling it, so the result is a snapshot of the frame it was
+            // read on. Call again to see newer body data.
+            py::arg("session"), "Get full body pose tracked state (data is None if inactive)");
 
     m.attr("NUM_JOINTS") = static_cast<int>(core::HandJoint_NUM_JOINTS);
     m.attr("JOINT_PALM") = static_cast<int>(core::HandJoint_PALM);

--- a/src/core/deviceio_trackers/python/tracker_bindings.cpp
+++ b/src/core/deviceio_trackers/python/tracker_bindings.cpp
@@ -19,9 +19,40 @@
 
 #include <array>
 #include <cstring>
+#include <memory>
 #include <stdexcept>
 
 namespace py = pybind11;
+
+namespace
+{
+
+// Hand a tracker's tracked snapshot to Python without cloning its payload.
+//
+// Every Tracked wrapper holds its payload behind a shared_ptr, but flatc gives each generated
+// -T a deep-copying copy constructor, so returning one by value clones the whole payload on
+// every call: for a hand that is two allocations and 936 bytes of joints, twice per frame.
+// Copying the shared_ptr instead costs one small wrapper allocation and a refcount bump, which
+// is also what the .data property on these wrappers has always done.
+//
+// The payload is therefore live tracker storage. Most impls refill it in place on the next
+// session.update(), so the returned object is a view valid until that call, not a snapshot --
+// see the note repeated on each accessor below.
+template <typename TrackedT>
+std::shared_ptr<TrackedT> share_tracked(const TrackedT& tracked)
+{
+    auto shared = std::make_shared<TrackedT>();
+    shared->data = tracked.data;
+    return shared;
+}
+
+} // namespace
+
+// Appended to the docstring of every accessor that returns a Tracked wrapper. A macro so it
+// concatenates with the surrounding literal at compile time; pybind11 takes a const char*.
+#define TRACKED_LIFETIME_DOC                                                                                           \
+    "\n\nThe returned wrapper shares the tracker's storage rather than copying it: its contents are "                  \
+    "refilled by the next session.update(). Read what you need before that call, or copy it."
 
 PYBIND11_MODULE(_deviceio_trackers, m)
 {
@@ -38,35 +69,35 @@ PYBIND11_MODULE(_deviceio_trackers, m)
         .def(py::init<>())
         .def(
             "get_left_hand",
-            [](const core::HandTracker& self, const core::ITrackerSession& session) -> core::HandPoseTrackedT
-            { return self.get_left_hand(session); },
-            py::arg("session"))
+            [](const core::HandTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_left_hand(session)); },
+            py::arg("session"), "Get the left hand tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC)
         .def(
             "get_right_hand",
-            [](const core::HandTracker& self, const core::ITrackerSession& session) -> core::HandPoseTrackedT
-            { return self.get_right_hand(session); },
-            py::arg("session"));
+            [](const core::HandTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_right_hand(session)); },
+            py::arg("session"), "Get the right hand tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC);
 
     py::class_<core::HeadTracker, core::ITracker, std::shared_ptr<core::HeadTracker>>(m, "HeadTracker")
         .def(py::init<>())
         .def(
             "get_head",
-            [](const core::HeadTracker& self, const core::ITrackerSession& session) -> core::HeadPoseTrackedT
-            { return self.get_head(session); },
-            py::arg("session"));
+            [](const core::HeadTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_head(session)); },
+            py::arg("session"), "Get the head tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC);
 
     py::class_<core::ControllerTracker, core::ITracker, std::shared_ptr<core::ControllerTracker>>(m, "ControllerTracker")
         .def(py::init<>())
         .def(
             "get_left_controller",
-            [](const core::ControllerTracker& self, const core::ITrackerSession& session) -> core::ControllerSnapshotTrackedT
-            { return self.get_left_controller(session); },
-            py::arg("session"), "Get the left controller tracked state (data is None if inactive)")
+            [](const core::ControllerTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_left_controller(session)); },
+            py::arg("session"), "Get the left controller tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC)
         .def(
             "get_right_controller",
-            [](const core::ControllerTracker& self, const core::ITrackerSession& session) -> core::ControllerSnapshotTrackedT
-            { return self.get_right_controller(session); },
-            py::arg("session"), "Get the right controller tracked state (data is None if inactive)")
+            [](const core::ControllerTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_right_controller(session)); },
+            py::arg("session"), "Get the right controller tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC)
         .def(
             "apply_left_haptic_feedback",
             [](const core::ControllerTracker& self, const core::ITrackerSession& session, float amplitude,
@@ -111,10 +142,9 @@ PYBIND11_MODULE(_deviceio_trackers, m)
              "Construct a MessageChannelTracker for XR_NV_opaque_data_channel")
         .def(
             "get_messages",
-            [](const core::MessageChannelTracker& self,
-               const core::ITrackerSession& session) -> core::MessageChannelMessagesTrackedT
-            { return self.get_messages(session); },
-            py::arg("session"), "Get all messages drained during the last update (possibly empty)")
+            [](const core::MessageChannelTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_messages(session)); },
+            py::arg("session"), "Get all messages drained during the last update (possibly empty)" TRACKED_LIFETIME_DOC)
         .def(
             "get_status",
             [](const core::MessageChannelTracker& self, const core::ITrackerSession& session) -> core::MessageChannelStatus
@@ -134,11 +164,11 @@ PYBIND11_MODULE(_deviceio_trackers, m)
              "Construct a multi-stream FrameMetadataTrackerOak")
         .def(
             "get_stream_data",
-            [](const core::FrameMetadataTrackerOak& self, const core::ITrackerSession& session,
-               size_t stream_index) -> core::FrameMetadataOakTrackedT
-            { return self.get_stream_data(session, stream_index); },
+            [](const core::FrameMetadataTrackerOak& self, const core::ITrackerSession& session, size_t stream_index)
+            { return share_tracked(self.get_stream_data(session, stream_index)); },
             py::arg("session"), py::arg("stream_index"),
-            "Get FrameMetadataOakTrackedT for a specific stream by index; .data is None until first frame arrives")
+            "Get FrameMetadataOakTrackedT for a specific stream by index; .data is None until first frame "
+            "arrives" TRACKED_LIFETIME_DOC)
         .def_property_readonly("stream_count", &core::FrameMetadataTrackerOak::get_stream_count,
                                "Number of streams this tracker is configured for");
 
@@ -149,10 +179,10 @@ PYBIND11_MODULE(_deviceio_trackers, m)
              "Construct a Generic3AxisPedalTracker for the given tensor collection ID")
         .def(
             "get_pedal_data",
-            [](const core::Generic3AxisPedalTracker& self,
-               const core::ITrackerSession& session) -> core::Generic3AxisPedalOutputTrackedT
-            { return self.get_data(session); },
-            py::arg("session"), "Get the current foot pedal tracked state (data is None when no data available)");
+            [](const core::Generic3AxisPedalTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_data(session)); },
+            py::arg("session"),
+            "Get the current foot pedal tracked state (data is None when no data available)" TRACKED_LIFETIME_DOC);
 
     py::class_<core::OgloTactileTracker, core::ITracker, std::shared_ptr<core::OgloTactileTracker>>(
         m, "OgloTactileTracker")
@@ -162,9 +192,10 @@ PYBIND11_MODULE(_deviceio_trackers, m)
              "(e.g. 'oglo/left' / 'oglo/right', matching the oglo_tactile plugin's --collection-prefix)")
         .def(
             "get_glove_data",
-            [](const core::OgloTactileTracker& self, const core::ITrackerSession& session) -> core::OgloGloveSampleTrackedT
-            { return self.get_data(session); },
-            py::arg("session"), "Get the current tactile glove tracked state (data is None when no data available)");
+            [](const core::OgloTactileTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_data(session)); },
+            py::arg("session"),
+            "Get the current tactile glove tracked state (data is None when no data available)" TRACKED_LIFETIME_DOC);
 
     py::class_<core::TensorPushTracker, core::ITracker, std::shared_ptr<core::TensorPushTracker>> tensor_push_tracker(
         m, "TensorPushTracker");
@@ -192,9 +223,10 @@ PYBIND11_MODULE(_deviceio_trackers, m)
              "joint-space device: leader arm, exoskeleton, ...)")
         .def(
             "get_data",
-            [](const core::JointStateTracker& self, const core::ITrackerSession& session) -> core::JointStateOutputTrackedT
-            { return self.get_data(session); },
-            py::arg("session"), "Get the current joint-state tracked snapshot (data is None when no data available)");
+            [](const core::JointStateTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_data(session)); },
+            py::arg("session"),
+            "Get the current joint-state tracked state (data is None when no data available)" TRACKED_LIFETIME_DOC);
 
     py::class_<core::Se3Tracker, core::ITracker, std::shared_ptr<core::Se3Tracker>>(m, "Se3Tracker")
         .def(py::init<const std::string&, size_t>(), py::arg("collection_id"),
@@ -203,11 +235,11 @@ PYBIND11_MODULE(_deviceio_trackers, m)
              "6-DoF pose source: tracker puck, mocap rigid body, logical tracker, ...)")
         .def(
             "get_data",
-            [](const core::Se3Tracker& self, const core::ITrackerSession& session) -> core::Se3TrackerPoseTrackedT
-            { return self.get_data(session); },
+            [](const core::Se3Tracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_data(session)); },
             py::arg("session"),
-            "Get the current SE3 tracked snapshot (data is None when no data available; gate on "
-            "data.is_valid before consuming the pose)");
+            "Get the current SE3 tracked state (data is None when no data available; gate on "
+            "data.is_valid before consuming the pose)" TRACKED_LIFETIME_DOC);
 
     py::class_<core::FullBodyTracker, core::ITracker, std::shared_ptr<core::FullBodyTracker>>(m, "FullBodyTracker")
         .def(py::init<>(),
@@ -215,9 +247,9 @@ PYBIND11_MODULE(_deviceio_trackers, m)
              "vendor via VendorConfig (default: native PICO XR_BD_body_tracking); replay is vendor-neutral.")
         .def(
             "get_body_pose",
-            [](const core::FullBodyTracker& self, const core::ITrackerSession& session) -> core::FullBodyPoseTrackedT
-            { return self.get_body_pose(session); },
-            py::arg("session"), "Get full body pose tracked state (data is None if inactive)");
+            [](const core::FullBodyTracker& self, const core::ITrackerSession& session)
+            { return share_tracked(self.get_body_pose(session)); },
+            py::arg("session"), "Get full body pose tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC);
 
     m.attr("NUM_JOINTS") = static_cast<int>(core::HandJoint_NUM_JOINTS);
     m.attr("JOINT_PALM") = static_cast<int>(core::HandJoint_PALM);

--- a/src/core/deviceio_trackers/python/tracker_bindings.cpp
+++ b/src/core/deviceio_trackers/python/tracker_bindings.cpp
@@ -41,6 +41,11 @@ namespace
 template <typename TrackedT>
 std::shared_ptr<TrackedT> share_tracked(const TrackedT& tracked)
 {
+    // Only `data` is carried over, so a Tracked wrapper that grows a second field (the parallel
+    // Record wrappers already carry a timestamp) would be silently dropped here with nothing to
+    // flag it. NativeTable is empty, so a one-field wrapper is exactly as wide as its member.
+    static_assert(sizeof(TrackedT) == sizeof(decltype(TrackedT::data)),
+                  "Tracked wrapper has fields beyond .data; share_tracked() would drop them");
     auto shared = std::make_shared<TrackedT>();
     shared->data = tracked.data;
     return shared;
@@ -144,7 +149,9 @@ PYBIND11_MODULE(_deviceio_trackers, m)
             "get_messages",
             [](const core::MessageChannelTracker& self, const core::ITrackerSession& session)
             { return share_tracked(self.get_messages(session)); },
-            py::arg("session"), "Get all messages drained during the last update (possibly empty)" TRACKED_LIFETIME_DOC)
+            // No lifetime note here: this payload is a vector, so share_tracked() copies the list
+            // itself, and every drained message is freshly allocated. The result is a snapshot.
+            py::arg("session"), "Get all messages drained during the last update (possibly empty)")
         .def(
             "get_status",
             [](const core::MessageChannelTracker& self, const core::ITrackerSession& session) -> core::MessageChannelStatus

--- a/src/core/deviceio_trackers/python/tracker_bindings.cpp
+++ b/src/core/deviceio_trackers/python/tracker_bindings.cpp
@@ -76,12 +76,15 @@ PYBIND11_MODULE(_deviceio_trackers, m)
             "get_left_hand",
             [](const core::HandTracker& self, const core::ITrackerSession& session)
             { return share_tracked(self.get_left_hand(session)); },
-            py::arg("session"), "Get the left hand tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC)
+            // No lifetime note on either hand: like full body, the impls install freshly allocated
+            // joint storage each frame rather than refilling it, so the result is a snapshot of the
+            // frame it was read on. Call again to see newer hand data.
+            py::arg("session"), "Get the left hand tracked state (data is None if inactive)")
         .def(
             "get_right_hand",
             [](const core::HandTracker& self, const core::ITrackerSession& session)
             { return share_tracked(self.get_right_hand(session)); },
-            py::arg("session"), "Get the right hand tracked state (data is None if inactive)" TRACKED_LIFETIME_DOC);
+            py::arg("session"), "Get the right hand tracked state (data is None if inactive)");
 
     py::class_<core::HeadTracker, core::ITracker, std::shared_ptr<core::HeadTracker>>(m, "HeadTracker")
         .def(py::init<>())

--- a/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.cpp
+++ b/src/core/live_trackers/cpp/live_full_body_tracker_pico_impl.cpp
@@ -130,17 +130,12 @@ void LiveFullBodyTrackerPicoImpl::update(int64_t monotonic_time_ns)
         throw std::runtime_error("[FullBodyTracker] xrLocateBodyJointsBD failed: " + std::to_string(result));
     }
 
-    if (!tracked_.data)
-    {
-        tracked_.data = std::make_shared<FullBodyPoseT>();
-    }
-
-    tracked_.data->all_joint_poses_tracked = locations.allJointPosesTracked;
-
-    if (!tracked_.data->joints)
-    {
-        tracked_.data->joints = std::make_shared<BodyJoints>();
-    }
+    // Publish freshly allocated joint storage each frame instead of refilling the previous
+    // frame's. The query API hands the pose out by reference and callers may still hold an
+    // earlier frame's joints, so an in-place refill would change data already handed out.
+    auto data = std::make_shared<FullBodyPoseT>();
+    data->all_joint_poses_tracked = locations.allJointPosesTracked;
+    data->joints = std::make_shared<BodyJoints>();
 
     for (uint32_t i = 0; i < XR_BODY_JOINT_COUNT_BD; ++i)
     {
@@ -155,8 +150,10 @@ void LiveFullBodyTrackerPicoImpl::update(int64_t monotonic_time_ns)
                         (joint_loc.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT);
 
         BodyJointPose joint_pose(pose, is_valid);
-        tracked_.data->joints->mutable_joints()->Mutate(i, joint_pose);
+        data->joints->mutable_joints()->Mutate(i, joint_pose);
     }
+
+    tracked_.data = std::move(data);
 
     if (mcap_channels_)
     {

--- a/src/core/live_trackers/cpp/live_hand_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_hand_tracker_impl.cpp
@@ -408,15 +408,11 @@ bool LiveHandTrackerImpl::try_update_hand(XrHandTrackerEXT tracker, XrTime time,
         return false;
     }
 
-    if (!tracked.data)
-    {
-        tracked.data = std::make_shared<HandPoseT>();
-    }
-
-    if (!tracked.data->joints)
-    {
-        tracked.data->joints = std::make_shared<HandJoints>();
-    }
+    // Publish freshly allocated joint storage each frame instead of refilling the previous
+    // frame's. The query API hands the pose out by reference and callers may still hold an
+    // earlier frame's joints, so an in-place refill would change data already handed out.
+    auto data = std::make_shared<HandPoseT>();
+    data->joints = std::make_shared<HandJoints>();
 
     for (uint32_t i = 0; i < XR_HAND_JOINT_COUNT_EXT; ++i)
     {
@@ -431,9 +427,10 @@ bool LiveHandTrackerImpl::try_update_hand(XrHandTrackerEXT tracker, XrTime time,
                         (joint_loc.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT);
 
         HandJointPose joint_pose(pose, is_valid, joint_loc.radius);
-        tracked.data->joints->mutable_poses()->Mutate(i, joint_pose);
+        data->joints->mutable_poses()->Mutate(i, joint_pose);
     }
 
+    tracked.data = std::move(data);
     return true;
 }
 

--- a/src/core/schema/python/CMakeLists.txt
+++ b/src/core/schema/python/CMakeLists.txt
@@ -13,6 +13,7 @@ pybind11_add_module(schema_py
     oglo_tactile_bindings.h
     pedals_bindings.h
     pose_bindings.h
+    schema_array_views.h
     se3_tracker_bindings.h
     schema_module.cpp
 )

--- a/src/core/schema/python/full_body_bindings.h
+++ b/src/core/schema/python/full_body_bindings.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Python bindings for the FullBodyPose FlatBuffer schema.
@@ -6,12 +6,16 @@
 
 #pragma once
 
+#include "schema_array_views.h"
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <schema/full_body_generated.h>
 #include <schema/timestamp_generated.h>
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <vector>
@@ -20,6 +24,21 @@ namespace py = pybind11;
 
 namespace core
 {
+
+// First joint of a BodyJoints, i.e. the origin of the strided views below.
+inline const BodyJointPose& first_body_joint(const py::object& self)
+{
+    return *(*self.cast<const BodyJoints&>().joints())[0];
+}
+
+// Row stride of the joint array; see the matching HandJoints constants.
+constexpr py::ssize_t BODY_JOINT_STRIDE = static_cast<py::ssize_t>(sizeof(BodyJointPose));
+constexpr py::ssize_t BODY_JOINT_COUNT = static_cast<py::ssize_t>(BodyJoint_NUM_JOINTS);
+
+// The views span BODY_JOINT_COUNT rows of raw storage, so the enum count and the fixed array
+// length declared in full_body.fbs must agree; otherwise the views would run off the struct.
+static_assert(sizeof(BodyJoints) == sizeof(BodyJointPose) * static_cast<size_t>(BodyJoint_NUM_JOINTS),
+              "BodyJoints.joints length must equal BodyJoint::NUM_JOINTS");
 
 inline void bind_full_body(py::module& m)
 {
@@ -85,6 +104,36 @@ inline void bind_full_body(py::module& m)
             },
             py::arg("index"), py::return_value_policy::reference_internal,
             "Get the BodyJointPose at the specified index (0 to NUM_JOINTS-1).")
+        // Zero-copy bulk accessors, one per joint field; see the matching note on HandJoints.
+        // One fewer than the hand, since BodyJointPose has no radius.
+        .def_property_readonly(
+            "positions",
+            [](py::object self)
+            {
+                const auto* first = reinterpret_cast<const float*>(&first_body_joint(self).pose().position());
+                return strided_field_view<float>(self, first, BODY_JOINT_STRIDE, BODY_JOINT_COUNT, 3);
+            },
+            "Joint positions as a (NUM_JOINTS, 3) float32 view in BodyJoint order. Strided (not contiguous) "
+            "and aliasing this object's storage: writing to it modifies the schema object; call .copy() for "
+            "packed data you own.")
+        .def_property_readonly(
+            "orientations",
+            [](py::object self)
+            {
+                const auto* first = reinterpret_cast<const float*>(&first_body_joint(self).pose().orientation());
+                return strided_field_view<float>(self, first, BODY_JOINT_STRIDE, BODY_JOINT_COUNT, 4);
+            },
+            "Joint orientation quaternions (XYZW) as a (NUM_JOINTS, 4) float32 view. See positions for the "
+            "aliasing and stride caveats.")
+        .def_property_readonly(
+            "is_valid",
+            [offset = FBS_FIELD_OFFSET(BodyJointPose, is_valid)](py::object self)
+            {
+                const auto* first = fbs_field_address<uint8_t>(first_body_joint(self), offset);
+                return strided_field_view<uint8_t>(self, first, BODY_JOINT_STRIDE, BODY_JOINT_COUNT, 0);
+            },
+            "Per-joint validity as a (NUM_JOINTS,) uint8 view. See positions for the aliasing and stride "
+            "caveats.")
         .def("__repr__", [](const BodyJoints&) { return "BodyJoints(joints=[...24 BodyJointPose entries...])"; });
 
     // Bind FullBodyPoseT class (FlatBuffers object API for tables).

--- a/src/core/schema/python/hand_bindings.h
+++ b/src/core/schema/python/hand_bindings.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Python bindings for the HandPose FlatBuffer schema.
@@ -6,12 +6,16 @@
 
 #pragma once
 
+#include "schema_array_views.h"
+
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <schema/hand_generated.h>
 #include <schema/timestamp_generated.h>
 
 #include <array>
+#include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <string>
@@ -21,6 +25,22 @@ namespace py = pybind11;
 
 namespace core
 {
+
+// First joint of a HandJoints, i.e. the origin of the strided views below.
+inline const HandJointPose& first_hand_joint(const py::object& self)
+{
+    return *(*self.cast<const HandJoints&>().poses())[0];
+}
+
+// Row stride of the joint array: the joints are a contiguous array of structs, so one whole
+// HandJointPose separates a field from the same field of the next joint.
+constexpr py::ssize_t HAND_JOINT_STRIDE = static_cast<py::ssize_t>(sizeof(HandJointPose));
+constexpr py::ssize_t HAND_JOINT_COUNT = static_cast<py::ssize_t>(HandJoint_NUM_JOINTS);
+
+// The views span HAND_JOINT_COUNT rows of raw storage, so the enum count and the fixed array
+// length declared in hand.fbs must agree; otherwise the views would run off the struct.
+static_assert(sizeof(HandJoints) == sizeof(HandJointPose) * static_cast<size_t>(HandJoint_NUM_JOINTS),
+              "HandJoints.poses length must equal HandJoint::NUM_JOINTS");
 
 inline void bind_hand(py::module& m)
 {
@@ -92,6 +112,49 @@ inline void bind_hand(py::module& m)
             py::arg("index"), py::return_value_policy::reference_internal,
             "Get the HandJointPose at the specified index. Valid indices: 0 <= index < HandJoint.NUM_JOINTS "
             "(OpenXR hand joint order).")
+        // Zero-copy bulk accessors, one per joint field: strided views aliasing this object's
+        // storage. See schema_array_views.h for the mechanics and for why they are writable.
+        // Rows are in HandJoint / OpenXR joint order.
+        //
+        // positions and orientations take the address of the generated accessor, so the
+        // compiler derives the location and a schema rename breaks the build. radius and
+        // is_valid are returned by value by flatc and have no address, so those two resolve
+        // an offset once here via FBS_FIELD_OFFSET, which keeps the name compile-time checked.
+        .def_property_readonly(
+            "positions",
+            [](py::object self)
+            {
+                const auto* first = reinterpret_cast<const float*>(&first_hand_joint(self).pose().position());
+                return strided_field_view<float>(self, first, HAND_JOINT_STRIDE, HAND_JOINT_COUNT, 3);
+            },
+            "Joint positions as a (NUM_JOINTS, 3) float32 view. Strided (not contiguous) and aliasing this "
+            "object's storage: writing to it modifies the schema object; call .copy() for packed data you own.")
+        .def_property_readonly(
+            "orientations",
+            [](py::object self)
+            {
+                const auto* first = reinterpret_cast<const float*>(&first_hand_joint(self).pose().orientation());
+                return strided_field_view<float>(self, first, HAND_JOINT_STRIDE, HAND_JOINT_COUNT, 4);
+            },
+            "Joint orientation quaternions (XYZW) as a (NUM_JOINTS, 4) float32 view. See positions for the "
+            "aliasing and stride caveats.")
+        .def_property_readonly(
+            "radii",
+            [offset = FBS_FIELD_OFFSET(HandJointPose, radius)](py::object self)
+            {
+                const auto* first = fbs_field_address<float>(first_hand_joint(self), offset);
+                return strided_field_view<float>(self, first, HAND_JOINT_STRIDE, HAND_JOINT_COUNT, 0);
+            },
+            "Joint radii as a (NUM_JOINTS,) float32 view. See positions for the aliasing and stride caveats.")
+        .def_property_readonly(
+            "is_valid",
+            [offset = FBS_FIELD_OFFSET(HandJointPose, is_valid)](py::object self)
+            {
+                const auto* first = fbs_field_address<uint8_t>(first_hand_joint(self), offset);
+                return strided_field_view<uint8_t>(self, first, HAND_JOINT_STRIDE, HAND_JOINT_COUNT, 0);
+            },
+            "Per-joint validity as a (NUM_JOINTS,) uint8 view. See positions for the aliasing and stride "
+            "caveats.")
         .def("__repr__",
              [](const HandJoints&) { return "HandJoints(poses=[...HandJoint.NUM_JOINTS HandJointPose entries...])"; });
 

--- a/src/core/schema/python/schema_array_views.h
+++ b/src/core/schema/python/schema_array_views.h
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Helpers for exposing fixed-size FlatBuffers struct arrays to Python as NumPy views.
+//
+// A FlatBuffers struct array is interleaved (array of structs), so a field is exposed as a
+// strided view rather than a packed buffer; NumPy and DLPack both carry strides natively,
+// so such views satisfy the retargeting engine's NDArrayType tensor contract without a copy.
+//
+// Two ways to reach a field, in order of preference:
+//
+//   1. Take its address through the generated accessor. flatc returns nested structs by
+//      const reference, so &joint.pose().position() is an ordinary member address: the
+//      compiler does the arithmetic, and renaming or removing the field in the .fbs breaks
+//      the build. No offset is involved.
+//   2. Only when 1 is impossible: FBS_FIELD_OFFSET below. flatc returns scalars *by value*
+//      (through EndianScalar), so scalar fields have no addressable accessor and their
+//      offset has to be looked up.
+
+#pragma once
+
+#include <flatbuffers/flatbuffers.h>
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+#include <cstddef>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
+namespace py = pybind11;
+
+namespace core
+{
+
+// These views hand NumPy a raw pointer into FlatBuffers storage, so they bypass the
+// EndianScalar() conversion the generated accessors apply. FlatBuffers stores scalars
+// little-endian and NumPy reads them in host order, so the two agree only on a
+// little-endian host — as do all supported targets (x86_64, ARM64), where EndianScalar()
+// compiles to a no-op. Fail the build rather than silently byte-swapped data if that ever
+// stops being true; a big-endian port would need packed copies, not views.
+static_assert(FLATBUFFERS_LITTLEENDIAN == 1,
+              "Strided FlatBuffers views assume a little-endian host; on big-endian the "
+              "generated accessors byte-swap and these raw-pointer views would not");
+
+// Byte offset of a struct field. Call it through FBS_FIELD_OFFSET rather than directly — the
+// accessor argument is what makes the field name compile-time checked.
+//
+// The offset comes from flatc's reflection table, emitted under --reflect-names (see
+// cmake/GenerateFlatBuffers.cmake), so reordering or inserting schema fields cannot shift
+// what gets read. A fully compile-time offset is not reachable for these types:
+// MiniReflectTypeTable() is not constexpr, and the generated members are private so offsetof
+// cannot name them. Hence a runtime lookup, resolved once at binding time, that throws on
+// miss rather than returning a sentinel.
+template <typename StructT, typename Accessor>
+inline py::ssize_t fbs_field_offset(const char* field_name, Accessor /*compile-time probe*/)
+{
+    const ::flatbuffers::TypeTable* type_table = StructT::MiniReflectTypeTable();
+    if (type_table->names == nullptr)
+    {
+        throw std::runtime_error(
+            "FlatBuffers headers were generated without --reflect-names; "
+            "schema field offsets cannot be resolved by name");
+    }
+    // values holds byte offsets only for structs; tables leave it null (their fields live behind
+    // a vtable and have no fixed offset), so reject those before indexing it.
+    if (type_table->st != ::flatbuffers::ST_STRUCT || type_table->values == nullptr)
+    {
+        throw std::runtime_error(
+            std::string("field offsets are only defined for FlatBuffers structs, not for the type owning: ") + field_name);
+    }
+    for (size_t i = 0; i < type_table->num_elems; ++i)
+    {
+        if (std::strcmp(type_table->names[i], field_name) == 0)
+        {
+            return static_cast<py::ssize_t>(type_table->values[i]);
+        }
+    }
+    throw std::runtime_error(std::string("no such field in FlatBuffers struct: ") + field_name);
+}
+
+// Byte offset of `field` within FlatBuffers struct `StructT`, naming the field exactly once.
+//
+// The name reaches fbs_field_offset() two ways: stringified for the reflection lookup, and
+// as &StructT::field. The second is a compile-time probe with no runtime effect — rename or
+// remove the field in the .fbs and the generated accessor goes with it, so this stops
+// COMPILING instead of throwing at import or, worse, reading the wrong bytes.
+#define FBS_FIELD_OFFSET(StructT, field) (::core::fbs_field_offset<StructT>(#field, &StructT::field))
+
+// Address of a scalar field that has no addressable accessor, given its offset. Only needed
+// for case 2 above; prefer taking the accessor's address directly.
+template <typename T, typename StructT>
+inline const T* fbs_field_address(const StructT& value, py::ssize_t field_offset)
+{
+    return reinterpret_cast<const T*>(reinterpret_cast<const std::byte*>(&value) + field_offset);
+}
+
+// Strided view of one field across an array of `count` structs, starting at `first` and
+// repeating every `stride` bytes. `width` is the trailing dimension (0 for a scalar field).
+// `owner` becomes the array's base, so the storage it aliases stays alive.
+//
+// The view is writable, and writes go straight back into the schema object. Marking it
+// read-only would be the safer contract, but NumPy cannot export a read-only array over
+// DLPack before 2.1 (BufferError), and the retargeting engine reaches every tensor through
+// np.from_dlpack — so a read-only view would break the wheel's declared numpy>=1.23 floor.
+// Callers that intend to modify the data must .copy() first.
+template <typename T>
+inline py::array_t<T> strided_field_view(
+    py::object owner, const T* first, py::ssize_t stride, py::ssize_t count, py::ssize_t width)
+{
+    if (width > 0)
+    {
+        return py::array_t<T>({ count, width }, { stride, static_cast<py::ssize_t>(sizeof(T)) }, first, owner);
+    }
+    return py::array_t<T>({ count }, { stride }, first, owner);
+}
+
+} // namespace core

--- a/src/core/schema_tests/python/test_full_body.py
+++ b/src/core/schema_tests/python/test_full_body.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Unit tests for FullBodyPoseT and related types in isaacteleop.schema.
@@ -21,6 +21,9 @@ Joint indices follow XrBodyJointBD enum:
   18-19: Left/Right Elbow, 20-21: Left/Right Wrist, 22-23: Left/Right Hand
 """
 
+import gc
+
+import numpy as np
 import pytest
 
 from isaacteleop.schema import (
@@ -115,6 +118,110 @@ class TestBodyJointsStruct:
 
         with pytest.raises(IndexError):
             _ = body_joints.joints(24)
+
+
+class TestBodyJointsFieldViews:
+    """Tests for the bulk per-field BodyJoints array accessors."""
+
+    def test_shapes_and_dtypes(self):
+        """The field views carry the layout FullBodyInput declares."""
+        joints = BodyJoints()
+        positions, orientations, is_valid = (
+            joints.positions,
+            joints.orientations,
+            joints.is_valid,
+        )
+
+        assert positions.shape == (BodyJoint.NUM_JOINTS, 3)
+        assert orientations.shape == (BodyJoint.NUM_JOINTS, 4)
+        assert is_valid.shape == (BodyJoint.NUM_JOINTS,)
+        assert positions.dtype == np.float32
+        assert orientations.dtype == np.float32
+        assert is_valid.dtype == np.uint8
+
+    def test_matches_per_joint_accessor(self):
+        """Every row agrees with the corresponding joints(i) read.
+
+        Each field gets its own value range so a view pointed at the wrong
+        offset, or rows read at the wrong stride, cannot still compare equal.
+        """
+        num_joints = int(BodyJoint.NUM_JOINTS)
+        body_joints = BodyJoints()
+        positions, orientations = body_joints.positions, body_joints.orientations
+        is_valid = body_joints.is_valid
+
+        positions[:] = np.arange(num_joints * 3, dtype=np.float32).reshape(-1, 3)
+        orientations[:] = np.arange(
+            1000, 1000 + num_joints * 4, dtype=np.float32
+        ).reshape(-1, 4)
+        is_valid[:] = np.arange(num_joints, dtype=np.uint8) % 2
+
+        for i in range(num_joints):
+            joint = body_joints.joints(i)
+            assert positions[i].tolist() == [
+                joint.pose.position.x,
+                joint.pose.position.y,
+                joint.pose.position.z,
+            ]
+            assert positions[i].tolist() == [3 * i, 3 * i + 1, 3 * i + 2]
+            assert orientations[i].tolist() == [
+                joint.pose.orientation.x,
+                joint.pose.orientation.y,
+                joint.pose.orientation.z,
+                joint.pose.orientation.w,
+            ]
+            assert orientations[i].tolist() == [
+                1000 + 4 * i,
+                1000 + 4 * i + 1,
+                1000 + 4 * i + 2,
+                1000 + 4 * i + 3,
+            ]
+            assert is_valid[i] == (1 if joint.is_valid else 0) == i % 2
+
+    def test_returns_strided_views(self):
+        """Arrays alias the interleaved joint storage instead of copying it."""
+        body_joints = BodyJoints()
+        positions, orientations = body_joints.positions, body_joints.orientations
+        is_valid = body_joints.is_valid
+
+        stride = positions.strides[0]
+        for array in (positions, orientations, is_valid):
+            assert not array.flags.owndata
+            # Row stride is one whole BodyJointPose, not the packed field width.
+            assert array.strides[0] == stride
+            assert not array.flags.c_contiguous
+
+    def test_views_write_through_to_schema(self):
+        """Views are writable and alias schema state; callers must copy to detach."""
+        body_joints = BodyJoints()
+        positions = body_joints.positions
+
+        positions[0, 0] = 42.0
+
+        assert body_joints.joints(0).pose.position.x == 42.0
+
+    def test_views_keep_owner_alive(self):
+        """A view outlives the last direct reference to the table it came from."""
+        pose = FullBodyPoseT()
+        positions = pose.joints.positions
+        expected = np.arange(int(BodyJoint.NUM_JOINTS) * 3, dtype=np.float32).reshape(
+            -1, 3
+        )
+        positions[:] = expected
+
+        del pose
+        gc.collect()
+
+        # Would read freed memory if the base object chain were not held.
+        assert positions.shape == (BodyJoint.NUM_JOINTS, 3)
+        assert np.array_equal(np.asarray(positions), expected)
+
+    def test_copy_yields_packed_writable_array(self):
+        """The documented escape hatch produces contiguous, writable data."""
+        packed = BodyJoints().positions.copy()
+
+        assert packed.flags.c_contiguous
+        assert packed.flags.writeable
 
 
 class TestBodyJointsRepr:

--- a/src/core/schema_tests/python/test_hand.py
+++ b/src/core/schema_tests/python/test_hand.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Unit tests for HandPoseT and related types in isaacteleop.schema.
@@ -16,6 +16,9 @@ HandJointPose is a struct containing:
 Timestamps are carried by HandPoseRecord, not HandPoseT.
 """
 
+import gc
+
+import numpy as np
 import pytest
 
 from isaacteleop.schema import (
@@ -128,6 +131,111 @@ class TestHandJointsStruct:
 
         with pytest.raises(IndexError):
             _ = hand_joints.poses(HandJoint.NUM_JOINTS)
+
+
+class TestHandJointsFieldViews:
+    """Tests for the bulk per-field HandJoints array accessors."""
+
+    def test_shapes_and_dtypes(self):
+        """The field views carry the layout HandInput declares."""
+        joints = HandJoints()
+        positions, orientations = joints.positions, joints.orientations
+        radii, is_valid = joints.radii, joints.is_valid
+
+        assert positions.shape == (HandJoint.NUM_JOINTS, 3)
+        assert orientations.shape == (HandJoint.NUM_JOINTS, 4)
+        assert radii.shape == (HandJoint.NUM_JOINTS,)
+        assert is_valid.shape == (HandJoint.NUM_JOINTS,)
+        assert positions.dtype == np.float32
+        assert orientations.dtype == np.float32
+        assert radii.dtype == np.float32
+        assert is_valid.dtype == np.uint8
+
+    def test_matches_per_joint_accessor(self):
+        """Every row agrees with the corresponding poses(i) read.
+
+        Each field gets its own value range so a view pointed at the wrong
+        offset, or rows read at the wrong stride, cannot still compare equal.
+        """
+        num_joints = int(HandJoint.NUM_JOINTS)
+        hand_joints = HandJoints()
+        positions, orientations = hand_joints.positions, hand_joints.orientations
+        radii, is_valid = hand_joints.radii, hand_joints.is_valid
+
+        positions[:] = np.arange(num_joints * 3, dtype=np.float32).reshape(-1, 3)
+        orientations[:] = np.arange(
+            1000, 1000 + num_joints * 4, dtype=np.float32
+        ).reshape(-1, 4)
+        radii[:] = np.arange(5000, 5000 + num_joints, dtype=np.float32)
+        is_valid[:] = np.arange(num_joints, dtype=np.uint8) % 2
+
+        for i in range(num_joints):
+            joint = hand_joints.poses(i)
+            assert positions[i].tolist() == [
+                joint.pose.position.x,
+                joint.pose.position.y,
+                joint.pose.position.z,
+            ]
+            assert positions[i].tolist() == [3 * i, 3 * i + 1, 3 * i + 2]
+            assert orientations[i].tolist() == [
+                joint.pose.orientation.x,
+                joint.pose.orientation.y,
+                joint.pose.orientation.z,
+                joint.pose.orientation.w,
+            ]
+            assert orientations[i].tolist() == [
+                1000 + 4 * i,
+                1000 + 4 * i + 1,
+                1000 + 4 * i + 2,
+                1000 + 4 * i + 3,
+            ]
+            assert radii[i] == joint.radius == 5000 + i
+            assert is_valid[i] == (1 if joint.is_valid else 0) == i % 2
+
+    def test_returns_strided_views(self):
+        """Arrays alias the interleaved joint storage instead of copying it."""
+        hand_joints = HandJoints()
+        positions, orientations = hand_joints.positions, hand_joints.orientations
+        radii, is_valid = hand_joints.radii, hand_joints.is_valid
+
+        stride = positions.strides[0]
+        for array in (positions, orientations, radii, is_valid):
+            assert not array.flags.owndata
+            # Row stride is one whole HandJointPose, not the packed field width.
+            assert array.strides[0] == stride
+            assert not array.flags.c_contiguous
+
+    def test_views_write_through_to_schema(self):
+        """Views are writable and alias schema state; callers must copy to detach."""
+        hand_joints = HandJoints()
+        positions = hand_joints.positions
+
+        positions[0, 0] = 42.0
+
+        assert hand_joints.poses(0).pose.position.x == 42.0
+
+    def test_views_keep_owner_alive(self):
+        """A view outlives the last direct reference to the table it came from."""
+        pose = HandPoseT()
+        positions = pose.joints.positions
+        expected = np.arange(int(HandJoint.NUM_JOINTS) * 3, dtype=np.float32).reshape(
+            -1, 3
+        )
+        positions[:] = expected
+
+        del pose
+        gc.collect()
+
+        # Would read freed memory if the base object chain were not held.
+        assert positions.shape == (HandJoint.NUM_JOINTS, 3)
+        assert np.array_equal(np.asarray(positions), expected)
+
+    def test_copy_yields_packed_writable_array(self):
+        """The documented escape hatch produces contiguous, writable data."""
+        packed = HandJoints().positions.copy()
+
+        assert packed.flags.c_contiguous
+        assert packed.flags.writeable
 
 
 class TestHandJointsRepr:

--- a/src/python/isaacteleop/retargeting_engine/deviceio_source_nodes/full_body_source.py
+++ b/src/python/isaacteleop/retargeting_engine/deviceio_source_nodes/full_body_source.py
@@ -121,25 +121,16 @@ class FullBodySource(IDeviceIOSource):
 
         group = outputs["full_body"]
 
-        positions = np.zeros((NUM_BODY_JOINTS, 3), dtype=np.float32)
-        orientations = np.zeros((NUM_BODY_JOINTS, 4), dtype=np.float32)
-        valid = np.zeros(NUM_BODY_JOINTS, dtype=np.uint8)
-
-        if body_pose.joints is not None:
-            for i in range(NUM_BODY_JOINTS):
-                joint = body_pose.joints.joints(i)
-                positions[i] = [
-                    joint.pose.position.x,
-                    joint.pose.position.y,
-                    joint.pose.position.z,
-                ]
-                orientations[i] = [
-                    joint.pose.orientation.x,
-                    joint.pose.orientation.y,
-                    joint.pose.orientation.z,
-                    joint.pose.orientation.w,
-                ]
-                valid[i] = 1 if joint.is_valid else 0
+        joints = body_pose.joints
+        if joints is not None:
+            # Strided views over the joint array, in the layout FullBodyInput declares.
+            positions = joints.positions
+            orientations = joints.orientations
+            valid = joints.is_valid
+        else:
+            positions = np.zeros((NUM_BODY_JOINTS, 3), dtype=np.float32)
+            orientations = np.zeros((NUM_BODY_JOINTS, 4), dtype=np.float32)
+            valid = np.zeros(NUM_BODY_JOINTS, dtype=np.uint8)
 
         group[FullBodyInputIndex.JOINT_POSITIONS] = positions
         group[FullBodyInputIndex.JOINT_ORIENTATIONS] = orientations

--- a/src/python/isaacteleop/retargeting_engine/deviceio_source_nodes/hands_source.py
+++ b/src/python/isaacteleop/retargeting_engine/deviceio_source_nodes/hands_source.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -7,7 +7,6 @@ Hands Source Node - DeviceIO to Retargeting Engine converter.
 Converts raw HandPoseT flatbuffer data to standard HandInput tensor format.
 """
 
-import numpy as np
 from typing import Any, TYPE_CHECKING
 from .interface import IDeviceIOSource
 from ..interface.retargeter_core_types import (
@@ -17,7 +16,7 @@ from ..interface.retargeter_core_types import (
 )
 from ..interface.retargeter_subgraph import RetargeterSubgraph
 from ..interface.tensor_group import OptionalTensorGroup, TensorGroup
-from ..tensor_types import HandInput, HandInputIndex, NUM_HAND_JOINTS
+from ..tensor_types import HandInput, HandInputIndex
 from ..interface.tensor_group_type import OptionalType
 from .deviceio_tensor_types import DeviceIOHandPoseTracked
 
@@ -134,31 +133,12 @@ class HandsSource(IDeviceIOSource):
             group.set_none()
             return
 
-        positions = np.zeros((NUM_HAND_JOINTS, 3), dtype=np.float32)
-        orientations = np.zeros((NUM_HAND_JOINTS, 4), dtype=np.float32)
-        radii = np.zeros(NUM_HAND_JOINTS, dtype=np.float32)
-        valid = np.zeros(NUM_HAND_JOINTS, dtype=np.uint8)
-
-        for i in range(NUM_HAND_JOINTS):
-            joint = hand_data.joints.poses(i)
-            positions[i] = [
-                joint.pose.position.x,
-                joint.pose.position.y,
-                joint.pose.position.z,
-            ]
-            orientations[i] = [
-                joint.pose.orientation.x,
-                joint.pose.orientation.y,
-                joint.pose.orientation.z,
-                joint.pose.orientation.w,
-            ]
-            radii[i] = joint.radius
-            valid[i] = 1 if joint.is_valid else 0
-
-        group[HandInputIndex.JOINT_POSITIONS] = positions
-        group[HandInputIndex.JOINT_ORIENTATIONS] = orientations
-        group[HandInputIndex.JOINT_RADII] = radii
-        group[HandInputIndex.JOINT_VALID] = valid
+        # Strided views over the joint array, in the layout HandInput declares.
+        joints = hand_data.joints
+        group[HandInputIndex.JOINT_POSITIONS] = joints.positions
+        group[HandInputIndex.JOINT_ORIENTATIONS] = joints.orientations
+        group[HandInputIndex.JOINT_RADII] = joints.radii
+        group[HandInputIndex.JOINT_VALID] = joints.is_valid
 
     def transformed(self, transform_input: OutputSelector) -> RetargeterSubgraph:
         """


### PR DESCRIPTION
Reading hand and body joints from Python cost a Python→C++ round trip per field per joint, plus a full deep copy of the payload on every tracker call. This removes both.

## What changed

**Joint arrays reach Python as zero-copy NumPy views.** `HandJoints` and `BodyJoints` gain per-field accessors — `positions`, `orientations`, `radii`, `is_valid` — returning strided arrays that alias the FlatBuffers joint storage. Reading all joints through `poses(i)`/`joints(i)` cost one round trip per field per joint; the views cost one call and no copy. `HandsSource` and `FullBodySource` now feed the retargeting graph directly from them.

The joints are an interleaved array of structs, so each field is strided rather than packed. NumPy and DLPack both carry strides natively, so the views satisfy the `NDArrayType` tensor contract as-is.

Field locations are derived, not restated: nested struct fields are reached through the generated accessors, so a schema rename fails the build. The two scalar fields have no addressable accessor — flatc returns scalars by value through `EndianScalar` — and instead resolve an offset from flatc's reflection table once at binding time, with the name compile-time checked via `FBS_FIELD_OFFSET`. This also fixes a latent flatc flag bug: `--reflect-names` and `--reflect-types` assign the same option, so passing both silently dropped the names and left the reflection tables empty.

**Tracker accessors share their payload instead of deep-copying it.** Every accessor returned the generated `-T` wrapper by value, and flatc gives each `-T` a deep-copying copy constructor even though the payload sits behind a `shared_ptr`. `get_left_hand()` cloned 936 bytes of joints plus two allocations on every call, twice per frame; `get_messages()` cloned every drained payload. The accessors now copy the data pointer into a fresh wrapper: one small allocation and a refcount bump, which is what the `.data` property has always done. The Python-visible type is unchanged, so call sites and `isinstance` checks are untouched.

**The joint trackers publish fresh storage each frame.** Sharing payloads turns the views into views over live tracker storage, so anything emitting them must not refill in place. The PICO full-body impl did, and now builds a fresh `FullBodyPoseT` per frame. The hand impl was already fresh, but only because `update_hand` happened to pass an empty local — folding that away would have silently reintroduced the aliasing, so the allocation is now unconditional and the invariant is stated in both impls.

## Lifetime contract

Accessors fall into two groups, and each docstring says which:

- **Snapshot** — hand, full body, and message channel. Safe to retain; call again for newer data.
- **Aliased**, refilled by the next `session.update()` — head, controller, and the six schema-backed trackers. Read before that call, or copy.

`TeleopSession` runs update, tracker polling, and graph execution together inside one step — deliberately, to avoid passing raw DeviceIO state across threads — so the in-repo consumer path reads before any refill.

## Known trade-offs

- The views are **writable** and alias schema storage; callers that modify data must `.copy()` first. Read-only would be safer, but NumPy cannot export a read-only array over DLPack before 2.1 and the wheel declares `numpy>=1.23`. In-repo transform nodes copy before mutating; nothing enforces it for external nodes.
- `hands_source.py` does not None-check the optional `joints` struct, while `full_body_source.py` does. Replaying a `HandPose` serialized without `joints` raises `AttributeError`. Pre-existing rather than introduced here — the prior `joints.poses(i)` path had the same gap — but the asymmetry is worth closing separately.

## Testing

Full suite green (297/297) at each commit. Schema tests cover the view mechanics: layout and offsets, stride correctness, aliasing, and DLPack export on all seven properties.

Not covered: the per-frame-fresh invariant for the live trackers needs real XR runtimes (`XR_BD_body_tracking`, `XR_EXT_hand_tracking`), and the existing joint coverage runs through the replay path, which allocates fresh regardless. That invariant rests on the comments in the two live impls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
