### PR TITLE
docs: derive install version specifiers from VERSION

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,13 +16,19 @@ copyright += f", last updated on {build_time.strftime('%B %d, %Y')}"
 author = "NVIDIA"
 
 _version_file = os.path.join(os.path.dirname(__file__), "..", "..", "VERSION")
+# ``VERSION`` is ``MAJOR.MINOR.x`` on main and on every release branch and tag, so its
+# first two components name the release series a given build of the docs describes.
+# ``_pip_version_pin`` turns that into a specifier (``1.5.x`` -> ``~=1.5.0``, i.e.
+# >=1.5.0 <1.6.0) so each versioned docs build shows how to install its own series.
 if os.path.exists(_version_file):
     with open(_version_file) as f:
         full_version = f.read().strip()
     version = full_version
     release = full_version
+    _pip_version_pin = "~={}.0".format(".".join(full_version.split(".")[:2]))
 else:
     version = release = "0.0.0"
+    _pip_version_pin = "~=1.0"
 
 # -- General configuration -----------------------------------------------------
 
@@ -34,6 +40,12 @@ extensions = [
 ]
 
 exclude_patterns = ["build", "_templates", "Thumbs.db", ".DS_Store"]
+
+# sphinx-copybutton only targets highlighted blocks (``div.highlight pre``) by default,
+# which skips ``parsed-literal`` (rendered as a bare ``pre.literal-block``).  Commands
+# that interpolate a substitution have to use ``parsed-literal``, so widen the selector
+# to keep the copy button on them.
+copybutton_selector = "div.highlight pre, pre.literal-block"
 
 templates_path = ["_templates"]
 
@@ -85,12 +97,14 @@ _icons = _VERSION_ICON_MAP.get(_smv_name, _DEFAULT_ICONS)
 _client_slug = (_smv_name or "main").replace("/", "-")
 _web_client_url = f"https://nvidia.github.io/IsaacTeleop/client/{_client_slug}/"
 
-# Shared substitution + link targets injected into every page, so the
-# branch-specific web client URL lives in one place.  ``|web_client_url|``
-# expands the bare URL (usable in prose and ``parsed-literal`` blocks); the
+# Shared substitutions + link targets injected into every page, so the
+# branch-specific web client URL and version pin live in one place.
+# ``|web_client_url|`` expands the bare URL and ``|pip_version_pin|`` the
+# version specifier (both usable in prose and ``parsed-literal`` blocks); the
 # named targets back ```...`_`` references in the prose.
 rst_epilog = f"""
 .. |web_client_url| replace:: {_web_client_url}
+.. |pip_version_pin| replace:: {_pip_version_pin}
 .. _`nvidia.github.io/IsaacTeleop/client`: {_web_client_url}
 .. _`Isaac Teleop Web Client`: {_web_client_url}
 """

--- a/docs/source/getting_started/lerobot/data_collection_real.rst
+++ b/docs/source/getting_started/lerobot/data_collection_real.rst
@@ -36,14 +36,17 @@ Follow the necessary one-time steps to set up your environment and hardware:
    LeRobot extras cover the SO-101 motor bus (``feetech``), the IK solver for the XR path
    (``kinematics``), and dataset recording (``dataset``). For Isaac Teleop, ``cloudxr`` brings the
    CloudXR runtime bindings and ``retargeters-lite`` is the default retargeter path on both
-   x86_64 and aarch64; the full ``retargeters`` extra is optional:
+   x86_64 and aarch64; the full ``retargeters`` extra is optional. The ``isaacteleop`` pin follows
+   the release series this page documents — see :ref:`install-isaacteleop-pip-package` for the
+   other install options:
 
-   .. code-block:: bash
+   .. parsed-literal::
 
       uv venv --python 3.12 .venv
       source .venv/bin/activate
       uv pip install -e ".[feetech,kinematics,dataset]" "huggingface_hub>=1.5"
-      uv pip install "isaacteleop[cloudxr,retargeters-lite]~=1.3.131" "scipy>=1.14"
+      uv pip install "isaacteleop[cloudxr,retargeters-lite]\ |pip_version_pin|\ " "scipy>=1.14" \\
+            --extra-index-url https://pypi.nvidia.com --prerelease=allow
 
 #. Log in to the Hugging Face Hub — recorded datasets are pushed to the Hub by default (pass
    ``--dataset.push_to_hub=false`` to keep them local):

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -70,13 +70,28 @@ to clone the repository for a couple quick samples to run.
 2. Install the ``isaacteleop`` pip package
 -------------------------------------------
 
-In a new terminal, activate your preferred virtual or conda environment, then install the package
-from PyPI (or from a local wheel if you built from source):
+In a new terminal, activate your preferred virtual or conda environment, then install the latest
+stable release from PyPI:
 
 .. code-block:: bash
 
-   # From PyPI
-   pip install 'isaacteleop[cloudxr,retargeters]~=1.0.0' --extra-index-url https://pypi.nvidia.com
+   pip install 'isaacteleop[cloudxr,retargeters]~=1.0'
+
+Pre-release builds are published between stable releases. Picking one up takes the NVIDIA index
+and an opt-in to pre-release versions — shown here with `uv <https://docs.astral.sh/uv/>`__:
+
+.. code-block:: bash
+
+   uv pip install 'isaacteleop[cloudxr,retargeters]~=1.0' \
+         --extra-index-url https://pypi.nvidia.com --prerelease=allow
+
+The two commands above track the newest 1.x release. To follow this version of the documentation
+(|version|) exactly, pin to the series it describes instead:
+
+.. parsed-literal::
+
+   uv pip install 'isaacteleop[cloudxr,retargeters]\ |pip_version_pin|\ ' \\
+         --extra-index-url https://pypi.nvidia.com --prerelease=allow
 
 Instead of installing the package from PyPI, you can build from source and install the local wheel.
 See :doc:`build_from_source/index` for more details.


### PR DESCRIPTION
## Description

The quick start hardcoded `pip install 'isaacteleop[cloudxr,retargeters]~=1.0.0' --extra-index-url https://pypi.nvidia.com`, so every published docs version — `main` included — sends readers to the 1.0 series no matter what the page around it describes.

The install step now offers three commands:

| Intent | Command |
| --- | --- |
| Latest stable | `pip install 'isaacteleop[cloudxr,retargeters]~=1.0'` |
| Latest pre-release | `uv pip install 'isaacteleop[cloudxr,retargeters]~=1.0' --extra-index-url https://pypi.nvidia.com --prerelease=allow` |
| The series this page documents | `uv pip install 'isaacteleop[cloudxr,retargeters]~=1.5.0' --extra-index-url https://pypi.nvidia.com --prerelease=allow` |

The third one is not written by hand. `conf.py` reads the `VERSION` file it already reads for `version`/`release`, turns `MAJOR.MINOR.x` into `~=MAJOR.MINOR.0`, and exposes it as the `|pip_version_pin|` substitution. Each sphinx-multiversion build therefore advertises its own series: `main` renders `~=1.5.0` today, and every release branch and tag cut from this commit onward renders its own (`release/1.6.x` -> `~=1.6.0`) with no follow-up edit at release time. Already-published versions are unaffected — sphinx-multiversion builds each ref from that ref's own `docs/`, which is exactly why the site keeps serving old docs for old versions.

Two things that came out of that:

- `docs/source/getting_started/lerobot/data_collection_real.rst` carried its own hardcoded `~=1.3.131`. It now uses the same substitution — same defect, and leaving a stale literal pin next to the new mechanism would just recreate the issue on the next branch cut. Shout if you would rather keep that page pinned to a known-good build.
- Substitutions only expand in `parsed-literal`, which Sphinx renders as a bare `pre.literal-block` rather than `div.highlight pre` — sphinx-copybutton's default selector, so the version-pinned command would have silently lost its copy button. `copybutton_selector` is widened to cover both. Across a full build the only pages containing `pre.literal-block` are the two touched here plus the two pre-existing blocks in `references/oob_teleop_control.rst`, which gain a copy button they should have had already.

Fixes #837

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

**Docs build.** `sphinx-build -W --keep-going` is clean. Because `conf.py` reaches outside the source dir for `VERSION`, and sphinx-multiversion builds each ref from an extracted tree, the real publishing path was exercised too:

```
SMV_BRANCH_WHITELIST='^jiwenc/docs-install-version-spec$' SMV_TAG_WHITELIST='^v1\.3\.131$' \
  python -m sphinx_multiversion source build/mv
```

The branch output renders `~=1.5.0` (i.e. `VERSION` is reachable in the extracted tree and the pin does not silently degrade to the `~=1.0` fallback), the `v1.3.131` output is unchanged, and neither contains an unresolved `|substitution|` marker. Rendered install step on this branch:

```
pip install 'isaacteleop[cloudxr,retargeters]~=1.0'

uv pip install 'isaacteleop[cloudxr,retargeters]~=1.0' \
      --extra-index-url https://pypi.nvidia.com --prerelease=allow

uv pip install 'isaacteleop[cloudxr,retargeters]~=1.5.0' \
      --extra-index-url https://pypi.nvidia.com --prerelease=allow
```

**Command resolution.** The issue is "broken install guide", so each command was resolved for real in a scratch venv on aarch64 (`--dry-run`, so nothing was installed):

| Command | Resolves to |
| --- | --- |
| `pip install 'isaacteleop[cloudxr,retargeters]~=1.0'` | `isaacteleop-1.3.131` — confirms the latest stable is reachable on public PyPI with no extra index, and that the `retargeters` extra (`dex-retargeting`, `pin`, `cmeel-*`) resolves alongside it |
| same spec `+ --prerelease=allow` `+` NVIDIA index | `isaacteleop==1.5.5rc1` |
| `~=1.5.0` `+ --prerelease=allow` `+` NVIDIA index | `isaacteleop==1.5.5rc1` |
| LeRobot page's `isaacteleop[cloudxr,retargeters-lite]~=1.5.0` + `scipy>=1.14` | `isaacteleop==1.5.5rc1` |

Note that `~=1.5.0` needs `--prerelease=allow` on `main` today because 1.5 has only `rc` builds so far; on a release branch with stable builds the same rendered command resolves to a stable release, so the surrounding prose is kept version-neutral.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not) — docs-only; verified by building with `-W` through both the plain and multiversion paths and resolving every command, as above
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
