### PR TITLE
fix: align CloudXR quick start requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,10 @@ pre-commit install --hook-type commit-msg
   SKIP=check-copyright-year pre-commit run --all-files
   ```
 
+- On Windows, verify `git submodule` and `python` resolve before running
+  pre-commit. Pre-commit updates submodules while cloning hook repositories,
+  and repository hooks invoke Python directly. For sparse checkouts, also
+  include `.reuse/` and `LICENSES/` so REUSE can resolve declared licenses.
 - **REUSE:** files covered by the REUSE hook need **`SPDX-FileCopyrightText`** and **`SPDX-License-Identifier`** in the form the repo already uses (for example the HTML comment block at the top of `README.md` also applies to **`AGENTS.md`** and similar docs).
 - **C++ formatting is enforced by CI, not pre-commit.** The hook set runs `ruff` for Python but does **not** run `clang-format`; CI (`build-ubuntu.yml`) installs **`clang-format-14`** and rejects unformatted C++ as `-Wclang-format-violations`. Before pushing, format touched C++ with the system `clang-format` (match CI's version 14) and verify:
 

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -40,6 +40,10 @@ the list of dependencies. On **Ubuntu**, install build tools and clang-format:
 
 Runtime-only dependencies (needed to actually run teleop, not to build):
 
+The normal Wi-Fi workflow does not require either package below. Install
+``adb`` only for USB headset automation with ``--setup-oob``, and install
+``coturn`` only for the fully USB-local ``--setup-oob --usb-local`` mode.
+
 .. code-block:: bash
 
    # adb — required for OOB teleop (``--setup-oob``) to talk to the headset over USB.

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -76,7 +76,7 @@ from PyPI (or from a local wheel if you built from source):
 .. code-block:: bash
 
    # From PyPI
-   pip install 'isaacteleop[cloudxr,retargeters]~=1.0.0' --extra-index-url https://pypi.nvidia.com
+   pip install 'isaacteleop[cloudxr,retargeters]~=1.3.131' --extra-index-url https://pypi.nvidia.com
 
 Instead of installing the package from PyPI, you can build from source and install the local wheel.
 See :doc:`build_from_source/index` for more details.
@@ -92,6 +92,13 @@ need to start the runtime in a separate terminal or source any environment file.
 The first launch downloads the CloudXR Web Client SDK and asks you to review and
 accept the EULA on the terminal; answer the prompt once and the acceptance is
 remembered for subsequent runs.
+
+.. important::
+
+   Run only one CloudXR runtime at a time. When a teleop example auto-launches
+   CloudXR, do not also run ``python -m isaacteleop.cloudxr`` in another
+   terminal. Competing runtimes use the same backend port and interrupt the
+   active session.
 
 The CloudXR runtime uses the ``auto-webrtc`` device profile by default
 (Pico & Quest). For Apple Vision Pro it defaults to ``auto-native``. To
@@ -119,7 +126,8 @@ To inspect the resolved settings after startup:
    If you prefer to run the runtime yourself in its own terminal — e.g. to keep
    the headset connection alive across example restarts, or to use launch modes
    like ``--host-client`` and ``--setup-oob`` — see
-   :doc:`/references/cloudxr`.
+   :doc:`/references/cloudxr`. Stop the auto-launched runtime before switching
+   to the standalone launcher.
 
 .. list-table:: Environment variables
    :header-rows: 1
@@ -252,6 +260,12 @@ running the CloudXR runtime and wss proxy in containerized environment; or using
             :alt: Certificate accepted page
 
             **Figure:** Certificate accepted page
+
+   .. important::
+
+      Complete the certificate-acceptance step before clicking **Connect**.
+      Otherwise, the headset's secure WebSocket connection can fail without a
+      visible error.
 
    As illustrated in the figure above, there are 3 steps to connect to your headset:
 

--- a/examples/cloudxr_mujoco_teleop/pyproject.toml
+++ b/examples/cloudxr_mujoco_teleop/pyproject.toml
@@ -11,4 +11,5 @@ dependencies = [
     "mujoco>=3.0",
     "numpy>=1.22.2",
     "scipy>=1.10",
+    "websockets>=14",
 ]


### PR DESCRIPTION
## Summary

- clarify single-runtime, certificate-acceptance, and mode-specific `adb`/`coturn` requirements
- declare the MuJoCo CloudXR example's WebSockets dependency
- document Windows and sparse-checkout prerequisites for running the repository hook set

## Validation

- `SKIP=check-copyright-year pre-commit run --all-files`