### PR TITLE
[TeleViz] native OpenXR composition layers — cylinder/equirect, native-by-default quads, per-layer alpha

### DIFF
--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -65,8 +65,9 @@ Four layer types are available:
   ``(color, depth)`` buffers. Use it to present a rendered 3D scene from the current head pose.
 
 A session holds **either** one ``ProjectionLayer`` **or** any number of texture layers
-(``QuadLayer`` / ``CylinderLayer`` / ``EquirectLayer``), not both: quads composite into a shared
-render target, while a projection layer is presented directly (see `ProjectionLayer`_).
+(``QuadLayer`` / ``CylinderLayer`` / ``EquirectLayer``), not both. Texture layers are composited
+natively by the XR runtime (or by Televiz's own compositor as the fallback and in window /
+offscreen modes), while a projection layer is presented directly (see `ProjectionLayer`_).
 
 All symbols are imported from the top-level module::
 
@@ -218,8 +219,8 @@ A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
    * - ``native_composition``
      - ``True``
      - In XR, submit as a native ``XrCompositionLayerQuad``. ``False`` composites through
-       Televiz — needed to z-compose with a ``ProjectionLayer``. See
-       `Native OpenXR composition layers`_.
+       Televiz's shared render target, where 3D-placed quads depth-test against each other.
+       See `Native OpenXR composition layers`_.
    * - ``alpha_blend``
      - ``False``
      - Honor the texture's alpha channel (translucent content). See
@@ -268,8 +269,8 @@ composition from the layer geometry — lower bandwidth, sharper reprojection.
      - Native
    * - ``QuadLayer``
      - ``XrCompositionLayerQuad``
-     - Default. ``native_composition = False`` composites through Televiz instead — needed to
-       z-compose with a ``ProjectionLayer``. Window / offscreen always composite.
+     - Default. ``native_composition = False`` composites through Televiz instead (quads then
+       depth-test against each other). Window / offscreen always composite.
    * - ``CylinderLayer``
      - ``XrCompositionLayerCylinderKHR``
      - Always (native-only).

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -55,19 +55,19 @@ Four layer types are available:
 * :code-file:`QuadLayer <src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp>` — a CUDA-fed 2D texture
   plane (mono or stereo), optionally placed in 3D space. Use it for camera feeds.
 * :code-file:`CylinderLayer <src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp>` — the same
-  CUDA-fed texture curved onto the inside of a cylinder arc. XR-only; composited natively by the
-  OpenXR runtime (see `Native OpenXR composition layers`_).
+  CUDA-fed texture curved onto the inside of a cylinder arc, so wide-FOV feeds keep a constant
+  viewing distance edge to edge. XR-only.
 * :code-file:`EquirectLayer <src/viz/layers/cpp/inc/viz/layers/equirect_layer.hpp>` — an
   equirectangular texture mapped onto the inside of a sphere, for 360°/180° panorama and VR-video
-  sources. XR-only; composited natively by the OpenXR runtime.
+  sources. XR-only.
 * :code-file:`ProjectionLayer <src/viz/layers/cpp/inc/viz/layers/projection_layer.hpp>` — a full-view
   RGBD layer for external renderers (gsplat, nvblox, neural reconstruction) that produce per-view
   ``(color, depth)`` buffers. Use it to present a rendered 3D scene from the current head pose.
 
 A session holds **either** one ``ProjectionLayer`` **or** any number of texture layers
-(``QuadLayer`` / ``CylinderLayer`` / ``EquirectLayer``), not both. Texture layers are composited
-natively by the XR runtime (or by Televiz's own compositor as the fallback and in window /
-offscreen modes), while a projection layer is presented directly (see `ProjectionLayer`_).
+(``QuadLayer`` / ``CylinderLayer`` / ``EquirectLayer``), not both. The texture layers share one
+submission API and differ only in the surface the texture is mapped onto; a projection layer is
+presented directly (see `ProjectionLayer`_).
 
 All symbols are imported from the top-level module::
 
@@ -221,11 +221,11 @@ A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
      - Who composites the quad in XR: ``True`` = the OpenXR runtime (submitted as an
        ``XrCompositionLayerQuad``), ``False`` = Televiz's built-in compositor (shared render
        target, where 3D-placed quads depth-test against each other). See
-       `Native OpenXR composition layers`_.
+       `OpenXR composition layers`_.
    * - ``alpha_blend``
      - ``False``
-     - Honor the texture's alpha channel (translucent content). Native path only; ignored on
-       the compositor path. See `Native OpenXR composition layers`_.
+     - Honor the texture's alpha channel (translucent content). OpenXR composition only;
+       ignored on the built-in compositor path.
 
 Submit and place a frame:
 
@@ -251,51 +251,17 @@ For a stereo layer both buffers are copied on the same stream and signaled toget
 never sees a half-matched pair. Lock-mode placement strategies (``world`` / ``head`` / ``lazy`` / ``gimbal``) are
 **application policy** and ship in the sample, not in the module.
 
-.. _native-openxr-composition-layers:
+CylinderLayer
+^^^^^^^^^^^^^
 
-Native OpenXR composition layers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+The same CUDA-fed texture, curved onto the inside of a vertical cylinder arc. Every point on the
+surface sits at the same distance from the cylinder's axis, which makes it the natural surface for
+wide-FOV camera feeds — a flat quad wide enough for a 110° image would put its edges much farther
+from the eye than its center.
 
-In XR mode, texture layers are handed straight to the OpenXR runtime as **native composition
-layers**: the runtime places, samples, and reprojects them itself. When every visible layer is
-native (and opaque), CloudXR streams color-only video and the headset reconstructs the
-composition from the layer geometry — lower bandwidth, sharper reprojection.
-
-.. list-table::
-   :header-rows: 1
-   :widths: 22 36 42
-
-   * - Layer
-     - OpenXR type
-     - Native
-   * - ``QuadLayer``
-     - ``XrCompositionLayerQuad``
-     - Default. ``openxr_composition = False`` hands the quad to Televiz's compositor instead
-       (quads then depth-test against each other). Window / offscreen are always
-       Televiz-composited.
-   * - ``CylinderLayer``
-     - ``XrCompositionLayerCylinderKHR``
-     - Always (native-only).
-   * - ``EquirectLayer``
-     - ``XrCompositionLayerEquirect2KHR``
-     - Always (native-only).
-
-Rules of thumb:
-
-* ``CylinderLayer`` / ``EquirectLayer`` need ``DisplayMode.kXr`` and a runtime with the matching
-  ``XR_KHR_composition_layer_*`` extension (CloudXR has both); ``add_cylinder_layer`` /
-  ``add_equirect_layer`` raise ``ValueError`` otherwise.
-* Native layers carry no depth: they composite in insertion order. Add backgrounds first.
-* ``alpha_blend`` (default off) makes the runtime honor the texture's alpha channel — use for
-  translucent HUDs. Leave it off for opaque feeds: alpha-blended layers disable CloudXR's
-  per-layer streaming for the frame.
-* Stereo = per-eye textures on the same surface (the VR-video convention).
-  ``stereo_baseline_mm`` adds a per-eye pose shift on top; it has no effect on an
-  infinite-radius equirect sphere.
-
-``CylinderLayerConfig`` — ``name`` / ``resolution`` / ``stereo`` / ``stereo_baseline_mm`` /
-``alpha_blend`` as ``QuadLayerConfig``, plus a
-``CylinderLayerPlacement``:
+``CylinderLayerConfig`` carries the same ``name`` / ``resolution`` / ``format`` / ``stereo`` /
+``stereo_baseline_mm`` / ``alpha_blend`` fields as ``QuadLayerConfig``, plus a
+``CylinderLayerPlacement`` describing the arc:
 
 .. list-table::
    :header-rows: 1
@@ -317,8 +283,22 @@ Rules of thumb:
      - ``0``
      - Arc width / height. ``0`` derives it from ``resolution`` (square texels).
 
-``EquirectLayerConfig`` — same common fields, plus an ``EquirectLayerPlacement``. The defaults are
-a full 360°×180° sphere at infinite radius, so a panorama needs no placement at all:
+Cylinder layers exist only in XR: they are composited by the OpenXR runtime (see
+`OpenXR composition layers`_), so they require ``DisplayMode.kXr`` and a runtime with
+``XR_KHR_composition_layer_cylinder`` (CloudXR supports it). ``add_cylinder_layer`` raises
+``ValueError`` otherwise. ``submit`` and ``set_visible`` work exactly as on ``QuadLayer``.
+
+EquirectLayer
+^^^^^^^^^^^^^
+
+An equirectangular texture mapped onto the inside of a sphere centered on (by default) the
+operator, for 360°/180° panoramas and VR-video sources. Like ``CylinderLayer`` it is XR-only and
+composited by the OpenXR runtime — here the required extension is
+``XR_KHR_composition_layer_equirect2``.
+
+``EquirectLayerConfig`` carries the same common fields plus an ``EquirectLayerPlacement``. The
+defaults describe a full 360°×180° sphere at infinite radius, so a panorama needs no placement at
+all:
 
 .. list-table::
    :header-rows: 1
@@ -340,9 +320,10 @@ a full 360°×180° sphere at infinite radius, so a panorama needs no placement 
      - ``π/2`` / ``−π/2``
      - Vertical span from the horizon, upper > lower.
 
+Combining the two — a panorama background with a camera feed on an arc in front of it:
+
 .. code-block:: python
 
-   # 360 panorama background + a camera feed on a cylinder arc.
    eq_cfg = televiz.EquirectLayerConfig()
    eq_cfg.name = "sky"
    eq_cfg.resolution = televiz.Resolution(4096, 2048)
@@ -358,6 +339,34 @@ a full 360°×180° sphere at infinite radius, so a panorama needs no placement 
        sky.submit(panorama_rgba)
        cam.submit(camera_rgba)
        session.render()
+
+.. _openxr-composition-layers:
+
+OpenXR composition layers
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In XR mode, texture layers are not drawn by Televiz — each one is submitted to the OpenXR runtime
+as its own composition layer (``XrCompositionLayerQuad`` / ``CylinderKHR`` / ``Equirect2KHR``),
+and the runtime places, samples, and reprojects it at display rate. This keeps text and fine
+detail sharp under head motion, and it lets CloudXR stream color-only video when every visible
+layer is runtime-composited and opaque — the headset then rebuilds the composition from the layer
+geometry at lower bandwidth.
+
+Two things follow from handing composition to the runtime:
+
+* Runtime-composited layers carry no depth; they blend in **insertion order**. Add backgrounds
+  (e.g. an ``EquirectLayer`` panorama) before foreground layers.
+* ``alpha_blend`` (default off) makes the runtime honor the texture's alpha channel — use it for
+  translucent HUDs. Leave it off for opaque feeds so CloudXR's color-only streaming stays
+  available.
+
+``QuadLayer`` is the one layer with a choice: set ``openxr_composition = False`` to draw the quad
+with Televiz's built-in compositor instead, where 3D-placed quads depth-test against each other in
+a shared render target. Window and offscreen modes always use the built-in compositor.
+
+For stereo, all texture layers follow the VR-video convention: per-eye textures on the *same*
+surface, with ``stereo_baseline_mm`` adding an optional per-eye pose shift on top (no effect on an
+infinite-radius equirect sphere).
 
 ProjectionLayer
 ^^^^^^^^^^^^^^^
@@ -388,7 +397,7 @@ that produce per-view ``(color, depth)`` buffers. Configure it with ``Projection
 
 Unlike ``QuadLayer``, a projection layer is **direct-present**: each view's ``(color, depth)`` is
 copied straight into the presentation swapchains (no shared render target). Because of that a session
-holds *either* one ``ProjectionLayer`` *or* any number of ``QuadLayer`` s, never both.
+holds *either* one ``ProjectionLayer`` *or* any number of texture layers, never both.
 
 The renderer runs **in-loop** with the frame loop: read the predicted view poses from the
 ``FrameInfo`` returned by ``begin_frame()``, render against them, then ``submit()`` before
@@ -523,7 +532,7 @@ VizSession
 - ``begin_frame() -> FrameInfo`` / ``end_frame()`` — explicit two-phase frame loop.
 - ``add_quad_layer(config) -> QuadLayer`` — construct + register a layer; returns a non-owning handle.
 - ``add_cylinder_layer(config) -> CylinderLayer`` / ``add_equirect_layer(config) -> EquirectLayer`` —
-  native OpenXR shaped layers (``kXr`` only; raise ``ValueError`` elsewhere).
+  shaped texture layers (``kXr`` only; raise ``ValueError`` elsewhere).
 - ``readback_to_host() -> HostImage`` — most recent frame as RGBA8 host pixels (``kOffscreen`` only).
 - ``get_state() -> SessionState``, ``should_close() -> bool``, ``is_xr_mode() -> bool``.
 - ``get_recommended_resolution() -> Resolution`` — runtime per-eye resolution (XR).

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -223,8 +223,8 @@ A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
        See `Native OpenXR composition layers`_.
    * - ``alpha_blend``
      - ``False``
-     - Honor the texture's alpha channel (translucent content). See
-       `Native OpenXR composition layers`_.
+     - Honor the texture's alpha channel (translucent content). Native path only; ignored on
+       the compositor path. See `Native OpenXR composition layers`_.
 
 Submit and place a frame:
 
@@ -291,7 +291,8 @@ Rules of thumb:
   ``stereo_baseline_mm`` adds a per-eye pose shift on top; it has no effect on an
   infinite-radius equirect sphere.
 
-``CylinderLayerConfig`` — ``name`` / ``resolution`` / ``stereo`` as ``QuadLayerConfig``, plus a
+``CylinderLayerConfig`` — ``name`` / ``resolution`` / ``stereo`` / ``stereo_baseline_mm`` /
+``alpha_blend`` as ``QuadLayerConfig``, plus a
 ``CylinderLayerPlacement``:
 
 .. list-table::

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -216,11 +216,12 @@ A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
    * - ``generate_mipmaps``
      - ``True``
      - Allocate + regenerate a capped mip chain each frame; sampler uses trilinear filtering.
-   * - ``native_composition``
+   * - ``openxr_composition``
      - ``True``
-     - In XR, submit as a native ``XrCompositionLayerQuad``. ``False`` composites through
-       Televiz's shared render target, where 3D-placed quads depth-test against each other.
-       See `Native OpenXR composition layers`_.
+     - Who composites the quad in XR: ``True`` = the OpenXR runtime (submitted as an
+       ``XrCompositionLayerQuad``), ``False`` = Televiz's built-in compositor (shared render
+       target, where 3D-placed quads depth-test against each other). See
+       `Native OpenXR composition layers`_.
    * - ``alpha_blend``
      - ``False``
      - Honor the texture's alpha channel (translucent content). Native path only; ignored on
@@ -269,8 +270,9 @@ composition from the layer geometry — lower bandwidth, sharper reprojection.
      - Native
    * - ``QuadLayer``
      - ``XrCompositionLayerQuad``
-     - Default. ``native_composition = False`` composites through Televiz instead (quads then
-       depth-test against each other). Window / offscreen always composite.
+     - Default. ``openxr_composition = False`` hands the quad to Televiz's compositor instead
+       (quads then depth-test against each other). Window / offscreen are always
+       Televiz-composited.
    * - ``CylinderLayer``
      - ``XrCompositionLayerCylinderKHR``
      - Always (native-only).

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -248,7 +248,7 @@ Submit and place a frame:
 ``submit(left, right=None, stream=0)`` accepts a ``VizBuffer`` or any
 ``__cuda_array_interface__`` object; the binding converts it and releases the GIL across the copy.
 For a stereo layer both buffers are copied on the same stream and signaled together, so the renderer
-never sees a half-matched pair. Lock-mode placement strategies (``world`` / ``head`` / ``lazy``) are
+never sees a half-matched pair. Lock-mode placement strategies (``world`` / ``head`` / ``lazy`` / ``gimbal``) are
 **application policy** and ship in the sample, not in the module.
 
 .. _native-openxr-composition-layers:

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -292,9 +292,11 @@ Trade-offs shared by all native layers:
 * **No per-frame placement strategies** — the runtime owns placement between submissions, so
   head-lock / lazy-follow strategies that rewrite the pose every frame defeat the purpose (each
   ``set_placement`` still takes effect on the next frame).
-* In **passthrough** blend modes the source-alpha flag keeps layers compositing correctly but
-  excludes them from CloudXR's client-reconstructed optimization; opaque VR sessions get the fast
-  path.
+* **Alpha is per-layer opt-in** (``alpha_blend``, default off). Opaque layers composite fully
+  within their bounds — passthrough still shows around them — and keep the frame eligible for
+  CloudXR's client-reconstructed streaming. Setting ``alpha_blend`` on a layer makes the runtime
+  honor its texture's alpha channel (translucent HUDs), at the cost of excluding the frame from
+  that optimization.
 
 ``CylinderLayerConfig`` — ``name`` / ``resolution`` / ``format`` / ``stereo`` as ``QuadLayerConfig``,
 plus a ``CylinderLayerPlacement``:

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -50,17 +50,23 @@ which owns the Vulkan context, the display target, the OpenXR session (in XR mod
 of **layers**. Content producers submit GPU buffers to layers; the session composites every layer
 into one frame each time you call ``render()``.
 
-Two layer types are available:
+Four layer types are available:
 
 * :code-file:`QuadLayer <src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp>` — a CUDA-fed 2D texture
   plane (mono or stereo), optionally placed in 3D space. Use it for camera feeds.
+* :code-file:`CylinderLayer <src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp>` — the same
+  CUDA-fed texture curved onto the inside of a cylinder arc. XR-only; composited natively by the
+  OpenXR runtime (see `Native OpenXR composition layers`_).
+* :code-file:`EquirectLayer <src/viz/layers/cpp/inc/viz/layers/equirect_layer.hpp>` — an
+  equirectangular texture mapped onto the inside of a sphere, for 360°/180° panorama and VR-video
+  sources. XR-only; composited natively by the OpenXR runtime.
 * :code-file:`ProjectionLayer <src/viz/layers/cpp/inc/viz/layers/projection_layer.hpp>` — a full-view
   RGBD layer for external renderers (gsplat, nvblox, neural reconstruction) that produce per-view
   ``(color, depth)`` buffers. Use it to present a rendered 3D scene from the current head pose.
 
-A session holds **either** one ``ProjectionLayer`` **or** any number of ``QuadLayer`` s, not both:
-quads composite into a shared render target, while a projection layer is presented directly (see
-`ProjectionLayer`_).
+A session holds **either** one ``ProjectionLayer`` **or** any number of texture layers
+(``QuadLayer`` / ``CylinderLayer`` / ``EquirectLayer``), not both: quads composite into a shared
+render target, while a projection layer is presented directly (see `ProjectionLayer`_).
 
 All symbols are imported from the top-level module::
 
@@ -209,6 +215,11 @@ A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
    * - ``generate_mipmaps``
      - ``True``
      - Allocate + regenerate a capped mip chain each frame; sampler uses trilinear filtering.
+   * - ``use_openxr_quad_layer``
+     - ``False``
+     - Submit as a native ``XrCompositionLayerQuad`` instead of compositing into the shared render
+       target (XR only; ignored in window / offscreen). See
+       `Native OpenXR composition layers`_.
 
 Submit and place a frame:
 
@@ -233,6 +244,128 @@ Submit and place a frame:
 For a stereo layer both buffers are copied on the same stream and signaled together, so the renderer
 never sees a half-matched pair. Lock-mode placement strategies (``world`` / ``head`` / ``lazy``) are
 **application policy** and ship in the sample, not in the module.
+
+.. _native-openxr-composition-layers:
+
+Native OpenXR composition layers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In XR mode a texture layer can bypass Televiz's compositor entirely and be handed to the OpenXR
+runtime as a **native composition layer** — the runtime places and samples the texture itself. This
+unlocks the runtime's layer fast path: with CloudXR, frames whose visible layers are *all* native
+drop the projection layer from the submission, letting the runtime's client-reconstructed streaming
+engage (each layer is streamed and reprojected on-device instead of being flattened into the eye
+buffers on the server).
+
+Three shapes map 1:1 onto OpenXR composition-layer types:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 34 44
+
+   * - Layer
+     - OpenXR type
+     - Enabled by
+   * - ``QuadLayer``
+     - ``XrCompositionLayerQuad``
+     - ``QuadLayerConfig.use_openxr_quad_layer = True`` (opt-in; the compositor draw path stays
+       the default and the window / offscreen fallback)
+   * - ``CylinderLayer``
+     - ``XrCompositionLayerCylinderKHR``
+     - Always — the layer is native-only
+   * - ``EquirectLayer``
+     - ``XrCompositionLayerEquirect2KHR``
+     - Always — the layer is native-only
+
+``CylinderLayer`` and ``EquirectLayer`` have **no compositor fallback**: they require
+``DisplayMode.kXr`` *and* a runtime that advertises the matching
+``XR_KHR_composition_layer_cylinder`` / ``XR_KHR_composition_layer_equirect2`` extension
+(CloudXR advertises both). ``add_cylinder_layer`` / ``add_equirect_layer`` raise ``ValueError``
+up front otherwise.
+
+Trade-offs shared by all native layers:
+
+* **No depth** — OpenXR composition layers carry no depth buffer, so they composite in submission
+  order (insertion order of the layers) rather than z-testing against 3D content. Add background
+  layers (an equirect sky) first.
+* **No per-frame placement strategies** — the runtime owns placement between submissions, so
+  head-lock / lazy-follow strategies that rewrite the pose every frame defeat the purpose (each
+  ``set_placement`` still takes effect on the next frame).
+* In **passthrough** blend modes the source-alpha flag keeps layers compositing correctly but
+  excludes them from CloudXR's client-reconstructed optimization; opaque VR sessions get the fast
+  path.
+
+``CylinderLayerConfig`` — ``name`` / ``resolution`` / ``format`` / ``stereo`` as ``QuadLayerConfig``,
+plus a ``CylinderLayerPlacement``:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 14 60
+
+   * - Field
+     - Default
+     - Description
+   * - ``pose``
+     - identity
+     - Center of the cylinder; the arc is centered on the pose's ``-z`` axis, cylinder axis
+       is ``+y``.
+   * - ``radius``
+     - ``1.0``
+     - Cylinder radius in meters (finite, > 0).
+   * - ``central_angle``
+     - ``π/2``
+     - Visible arc in radians, ``(0, 2π]``.
+   * - ``aspect_ratio``
+     - ``0``
+     - Width / height of the visible arc. ``0`` derives it from ``resolution`` (square texels).
+
+``EquirectLayerConfig`` — same common fields, plus an ``EquirectLayerPlacement`` whose defaults
+describe a **full 360°×180° sphere at infinite radius** (a mono panorama works out of the box):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 14 56
+
+   * - Field
+     - Default
+     - Description
+   * - ``pose``
+     - identity
+     - Sphere center; the texture's horizontal center maps to the pose's ``-z``.
+   * - ``radius``
+     - ``0``
+     - Sphere radius in meters; ``0`` or ``+inf`` = infinite sphere.
+   * - ``central_horizontal_angle``
+     - ``2π``
+     - Horizontal span in radians (``2π`` = full 360°; use ``π`` for VR180).
+   * - ``upper_vertical_angle`` / ``lower_vertical_angle``
+     - ``π/2`` / ``−π/2``
+     - Vertical span as angles from the horizon, ``[−π/2, π/2]``, upper > lower.
+
+Stereo on all three shapes follows the VR-video convention: per-eye textures on the **same** surface
+(one composition layer per eye via ``eyeVisibility``) — the depth cue comes from the image pair.
+Only ``QuadLayer`` additionally supports a per-eye pose shift (``stereo_baseline_mm``).
+
+.. code-block:: python
+
+   # 360 panorama background + a camera feed on a cylinder arc.
+   eq_cfg = televiz.EquirectLayerConfig()
+   eq_cfg.name = "sky"
+   eq_cfg.resolution = televiz.Resolution(4096, 2048)
+   sky = session.add_equirect_layer(eq_cfg)          # default = full sphere
+
+   cyl_cfg = televiz.CylinderLayerConfig()
+   cyl_cfg.name = "cam"
+   cyl_cfg.resolution = televiz.Resolution(1920, 1080)
+   placement = televiz.CylinderLayerPlacement()
+   placement.radius = 2.0                            # 2 m arc in front of the user
+   cyl_cfg.placement = placement
+   cam = session.add_cylinder_layer(cyl_cfg)
+
+   while running:
+       sky.submit(panorama_rgba)
+       cam.submit(camera_rgba)
+       session.render()
 
 ProjectionLayer
 ^^^^^^^^^^^^^^^
@@ -397,6 +530,8 @@ VizSession
 - ``render() -> FrameInfo`` — wait + composite + present.
 - ``begin_frame() -> FrameInfo`` / ``end_frame()`` — explicit two-phase frame loop.
 - ``add_quad_layer(config) -> QuadLayer`` — construct + register a layer; returns a non-owning handle.
+- ``add_cylinder_layer(config) -> CylinderLayer`` / ``add_equirect_layer(config) -> EquirectLayer`` —
+  native OpenXR shaped layers (``kXr`` only; raise ``ValueError`` elsewhere).
 - ``readback_to_host() -> HostImage`` — most recent frame as RGBA8 host pixels (``kOffscreen`` only).
 - ``get_state() -> SessionState``, ``should_close() -> bool``, ``is_xr_mode() -> bool``.
 - ``get_recommended_resolution() -> Resolution`` — runtime per-eye resolution (XR).
@@ -407,13 +542,15 @@ VizSession
 - Properties ``vk_device`` / ``vk_physical_device`` / ``vk_queue_family_index`` — raw handles for
   wiring Televiz into a foreign Vulkan app. Most users won't touch these.
 
-QuadLayer
-^^^^^^^^^
+QuadLayer / CylinderLayer / EquirectLayer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - ``submit(left, right=None, stream=0)`` — submit a frame (mono: ``left`` only; stereo: both).
-- ``set_placement(placement)`` / ``placement()`` — 3D placement (``None`` → fullscreen, window mode).
+- ``set_placement(placement)`` / ``placement()`` — placement swap, thread-safe vs the frame loop.
+  ``QuadLayer`` accepts ``None`` (fullscreen, window mode); the shaped layers validate and raise
+  ``ValueError`` on bad shape parameters.
 - ``set_visible(visible)`` / ``is_visible()``.
-- Properties ``resolution``, ``format``, ``aspect_ratio``, ``name``.
+- Properties ``resolution``, ``format``, ``name`` (plus ``aspect_ratio`` on ``QuadLayer``).
 
 Data types
 ^^^^^^^^^^
@@ -455,7 +592,8 @@ symbols live in ``namespace viz``, and headers use nested include paths::
      - Core types (``VizBuffer``, ``Pose3D``, ``HostImage``, ``DeviceImage``) and Vulkan / CUDA infrastructure
    * - ``viz_layers``
      - ``viz::layers``
-     - ``LayerBase`` and the built-in layers (``QuadLayer``, …)
+     - The built-in layers (``QuadLayer``, ``CylinderLayer``, ``EquirectLayer``,
+       ``ProjectionLayer``) and their shared ``ImageLayerBase`` mailbox
    * - ``viz_session``
      - ``viz::session``
      - ``VizSession``, the compositor, ``FrameInfo``, window / offscreen backends

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -215,10 +215,11 @@ A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
    * - ``generate_mipmaps``
      - ``True``
      - Allocate + regenerate a capped mip chain each frame; sampler uses trilinear filtering.
-   * - ``use_openxr_quad_layer``
-     - ``False``
-     - Submit as a native ``XrCompositionLayerQuad`` instead of compositing into the shared render
-       target (XR only; ignored in window / offscreen). See
+   * - ``native_composition``
+     - ``True``
+     - In XR, submit as a native ``XrCompositionLayerQuad`` (the default). Set ``False`` to
+       composite into the shared render target instead — needed to z-compose with
+       ``ProjectionLayer`` content. Ignored in window / offscreen (always composited). See
        `Native OpenXR composition layers`_.
 
 Submit and place a frame:
@@ -268,8 +269,8 @@ Three shapes map 1:1 onto OpenXR composition-layer types:
      - Enabled by
    * - ``QuadLayer``
      - ``XrCompositionLayerQuad``
-     - ``QuadLayerConfig.use_openxr_quad_layer = True`` (opt-in; the compositor draw path stays
-       the default and the window / offscreen fallback)
+     - Default (``QuadLayerConfig.native_composition``); set ``False`` to opt back into the
+       compositor draw path — the only path with depth, and always used in window / offscreen
    * - ``CylinderLayer``
      - ``XrCompositionLayerCylinderKHR``
      - Always — the layer is native-only
@@ -314,7 +315,7 @@ plus a ``CylinderLayerPlacement``:
      - Cylinder radius in meters; ``0`` or ``+inf`` = infinite cylinder.
    * - ``central_angle_rad``
      - ``π/2``
-     - Visible arc in radians, ``(0, 2π]``.
+     - Visible arc in radians, ``(0, 2π)`` — the spec excludes a full wrap.
    * - ``aspect_ratio``
      - ``0``
      - Width / height of the visible arc. ``0`` derives it from ``resolution`` (square texels).

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -217,9 +217,12 @@ A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
      - Allocate + regenerate a capped mip chain each frame; sampler uses trilinear filtering.
    * - ``native_composition``
      - ``True``
-     - In XR, submit as a native ``XrCompositionLayerQuad`` (the default). Set ``False`` to
-       composite into the shared render target instead — needed to z-compose with
-       ``ProjectionLayer`` content. Ignored in window / offscreen (always composited). See
+     - In XR, submit as a native ``XrCompositionLayerQuad``. ``False`` composites through
+       Televiz — needed to z-compose with a ``ProjectionLayer``. See
+       `Native OpenXR composition layers`_.
+   * - ``alpha_blend``
+     - ``False``
+     - Honor the texture's alpha channel (translucent content). See
        `Native OpenXR composition layers`_.
 
 Submit and place a frame:
@@ -251,55 +254,44 @@ never sees a half-matched pair. Lock-mode placement strategies (``world`` / ``he
 Native OpenXR composition layers
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In XR mode a texture layer can bypass Televiz's compositor entirely and be handed to the OpenXR
-runtime as a **native composition layer** — the runtime places and samples the texture itself. This
-unlocks the runtime's layer fast path: with CloudXR, frames whose visible layers are *all* native
-drop the projection layer from the submission, letting the runtime's client-reconstructed streaming
-engage (each layer is streamed and reprojected on-device instead of being flattened into the eye
-buffers on the server).
-
-Three shapes map 1:1 onto OpenXR composition-layer types:
+In XR mode, texture layers are handed straight to the OpenXR runtime as **native composition
+layers**: the runtime places, samples, and reprojects them itself. When every visible layer is
+native (and opaque), CloudXR streams color-only video and the headset reconstructs the
+composition from the layer geometry — lower bandwidth, sharper reprojection.
 
 .. list-table::
    :header-rows: 1
-   :widths: 22 34 44
+   :widths: 22 36 42
 
    * - Layer
      - OpenXR type
-     - Enabled by
+     - Native
    * - ``QuadLayer``
      - ``XrCompositionLayerQuad``
-     - Default (``QuadLayerConfig.native_composition``); set ``False`` to opt back into the
-       compositor draw path — the only path with depth, and always used in window / offscreen
+     - Default. ``native_composition = False`` composites through Televiz instead — needed to
+       z-compose with a ``ProjectionLayer``. Window / offscreen always composite.
    * - ``CylinderLayer``
      - ``XrCompositionLayerCylinderKHR``
-     - Always — the layer is native-only
+     - Always (native-only).
    * - ``EquirectLayer``
      - ``XrCompositionLayerEquirect2KHR``
-     - Always — the layer is native-only
+     - Always (native-only).
 
-``CylinderLayer`` and ``EquirectLayer`` have **no compositor fallback**: they require
-``DisplayMode.kXr`` *and* a runtime that advertises the matching
-``XR_KHR_composition_layer_cylinder`` / ``XR_KHR_composition_layer_equirect2`` extension
-(CloudXR advertises both). ``add_cylinder_layer`` / ``add_equirect_layer`` raise ``ValueError``
-up front otherwise.
+Rules of thumb:
 
-Trade-offs shared by all native layers:
+* ``CylinderLayer`` / ``EquirectLayer`` need ``DisplayMode.kXr`` and a runtime with the matching
+  ``XR_KHR_composition_layer_*`` extension (CloudXR has both); ``add_cylinder_layer`` /
+  ``add_equirect_layer`` raise ``ValueError`` otherwise.
+* Native layers carry no depth: they composite in insertion order. Add backgrounds first.
+* ``alpha_blend`` (default off) makes the runtime honor the texture's alpha channel — use for
+  translucent HUDs. Leave it off for opaque feeds: alpha-blended layers disable CloudXR's
+  per-layer streaming for the frame.
+* Stereo = per-eye textures on the same surface (the VR-video convention).
+  ``stereo_baseline_mm`` adds a per-eye pose shift on top; it has no effect on an
+  infinite-radius equirect sphere.
 
-* **No depth** — OpenXR composition layers carry no depth buffer, so they composite in submission
-  order (insertion order of the layers) rather than z-testing against 3D content. Add background
-  layers (an equirect sky) first.
-* **No per-frame placement strategies** — the runtime owns placement between submissions, so
-  head-lock / lazy-follow strategies that rewrite the pose every frame defeat the purpose (each
-  ``set_placement`` still takes effect on the next frame).
-* **Alpha is per-layer opt-in** (``alpha_blend``, default off). Opaque layers composite fully
-  within their bounds — passthrough still shows around them — and keep the frame eligible for
-  CloudXR's client-reconstructed streaming. Setting ``alpha_blend`` on a layer makes the runtime
-  honor its texture's alpha channel (translucent HUDs), at the cost of excluding the frame from
-  that optimization.
-
-``CylinderLayerConfig`` — ``name`` / ``resolution`` / ``format`` / ``stereo`` as ``QuadLayerConfig``,
-plus a ``CylinderLayerPlacement``:
+``CylinderLayerConfig`` — ``name`` / ``resolution`` / ``stereo`` as ``QuadLayerConfig``, plus a
+``CylinderLayerPlacement``:
 
 .. list-table::
    :header-rows: 1
@@ -310,20 +302,19 @@ plus a ``CylinderLayerPlacement``:
      - Description
    * - ``pose``
      - identity
-     - Center of the cylinder; the arc is centered on the pose's ``-z`` axis, cylinder axis
-       is ``+y``.
+     - Cylinder center; the arc bows out along the pose's ``-z``, cylinder axis is ``+y``.
    * - ``radius_m``
      - ``1.0``
-     - Cylinder radius in meters; ``0`` or ``+inf`` = infinite cylinder.
+     - Radius in meters — the viewing distance to the surface. ``0`` / ``+inf`` = infinite.
    * - ``central_angle_rad``
      - ``π/2``
-     - Visible arc in radians, ``(0, 2π)`` — the spec excludes a full wrap.
+     - Visible arc in radians, ``(0, 2π)``.
    * - ``aspect_ratio``
      - ``0``
-     - Width / height of the visible arc. ``0`` derives it from ``resolution`` (square texels).
+     - Arc width / height. ``0`` derives it from ``resolution`` (square texels).
 
-``EquirectLayerConfig`` — same common fields, plus an ``EquirectLayerPlacement`` whose defaults
-describe a **full 360°×180° sphere at infinite radius** (a mono panorama works out of the box):
+``EquirectLayerConfig`` — same common fields, plus an ``EquirectLayerPlacement``. The defaults are
+a full 360°×180° sphere at infinite radius, so a panorama needs no placement at all:
 
 .. list-table::
    :header-rows: 1
@@ -337,20 +328,13 @@ describe a **full 360°×180° sphere at infinite radius** (a mono panorama work
      - Sphere center; the texture's horizontal center maps to the pose's ``-z``.
    * - ``radius_m``
      - ``0``
-     - Sphere radius in meters; ``0`` or ``+inf`` = infinite sphere.
+     - Radius in meters; ``0`` / ``+inf`` = infinite sphere.
    * - ``central_horizontal_angle_rad``
      - ``2π``
-     - Horizontal span in radians (``2π`` = full 360°; use ``π`` for VR180).
+     - Horizontal span (``π`` for VR180).
    * - ``upper_vertical_angle_rad`` / ``lower_vertical_angle_rad``
      - ``π/2`` / ``−π/2``
-     - Vertical span as angles from the horizon, ``[−π/2, π/2]``, upper > lower.
-
-Stereo on all three shapes follows the VR-video convention by default: per-eye textures on the
-**same** surface (one composition layer per eye via ``eyeVisibility``) — the depth cue comes from
-the image pair. All three configs also accept ``stereo_baseline_mm``, which shifts each eye's layer
-by ``±baseline/2`` along the placement's local ``+x`` for additional geometric disparity. Note it
-only has a visible effect where the surface is at *finite* distance: the viewing direction to a
-sphere of radius R changes by ~shift/R, so it is a no-op on an infinite-radius equirect sphere.
+     - Vertical span from the horizon, upper > lower.
 
 .. code-block:: python
 

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -309,10 +309,10 @@ plus a ``CylinderLayerPlacement``:
      - identity
      - Center of the cylinder; the arc is centered on the pose's ``-z`` axis, cylinder axis
        is ``+y``.
-   * - ``radius``
+   * - ``radius_m``
      - ``1.0``
-     - Cylinder radius in meters (finite, > 0).
-   * - ``central_angle``
+     - Cylinder radius in meters; ``0`` or ``+inf`` = infinite cylinder.
+   * - ``central_angle_rad``
      - ``π/2``
      - Visible arc in radians, ``(0, 2π]``.
    * - ``aspect_ratio``
@@ -332,19 +332,22 @@ describe a **full 360°×180° sphere at infinite radius** (a mono panorama work
    * - ``pose``
      - identity
      - Sphere center; the texture's horizontal center maps to the pose's ``-z``.
-   * - ``radius``
+   * - ``radius_m``
      - ``0``
      - Sphere radius in meters; ``0`` or ``+inf`` = infinite sphere.
-   * - ``central_horizontal_angle``
+   * - ``central_horizontal_angle_rad``
      - ``2π``
      - Horizontal span in radians (``2π`` = full 360°; use ``π`` for VR180).
-   * - ``upper_vertical_angle`` / ``lower_vertical_angle``
+   * - ``upper_vertical_angle_rad`` / ``lower_vertical_angle_rad``
      - ``π/2`` / ``−π/2``
      - Vertical span as angles from the horizon, ``[−π/2, π/2]``, upper > lower.
 
-Stereo on all three shapes follows the VR-video convention: per-eye textures on the **same** surface
-(one composition layer per eye via ``eyeVisibility``) — the depth cue comes from the image pair.
-Only ``QuadLayer`` additionally supports a per-eye pose shift (``stereo_baseline_mm``).
+Stereo on all three shapes follows the VR-video convention by default: per-eye textures on the
+**same** surface (one composition layer per eye via ``eyeVisibility``) — the depth cue comes from
+the image pair. All three configs also accept ``stereo_baseline_mm``, which shifts each eye's layer
+by ``±baseline/2`` along the placement's local ``+x`` for additional geometric disparity. Note it
+only has a visible effect where the surface is at *finite* distance: the viewing direction to a
+sphere of radius R changes by ~shift/R, so it is a no-op on an infinite-radius equirect sphere.
 
 .. code-block:: python
 
@@ -357,9 +360,7 @@ Only ``QuadLayer`` additionally supports a per-eye pose shift (``stereo_baseline
    cyl_cfg = televiz.CylinderLayerConfig()
    cyl_cfg.name = "cam"
    cyl_cfg.resolution = televiz.Resolution(1920, 1080)
-   placement = televiz.CylinderLayerPlacement()
-   placement.radius = 2.0                            # 2 m arc in front of the user
-   cyl_cfg.placement = placement
+   cyl_cfg.placement = televiz.CylinderLayerPlacement(radius_m=2.0)   # 2 m arc in front of the user
    cam = session.add_cylinder_layer(cyl_cfg)
 
    while running:

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -173,6 +173,10 @@ In XR, how a plane follows the operator's head is the per-camera ``lock_mode`` u
      - Follows your head every frame. Head-locked content updates its pose at application
        rate, so it trails fast head motion by roughly a frame — expected for any head-locked
        OpenXR layer; prefer ``lazy`` unless you need a true HUD.
+   * - ``gimbal``
+     - Follows your position but not your rotation: the surface stays pointed where you first
+       looked, walks with you, and turning your head looks around it. The natural mode for
+       wide cylinder feeds (a "virtual gimbal").
    * - ``lazy``
      - World-locked, but re-snaps in front of you when you look away (default).
 
@@ -299,7 +303,7 @@ its own plane (and, in split mode, its own RTP port). Abbreviated:
      clear_color: [r, g, b, a]
      placements:
        cam:
-         lock_mode: lazy         # world | head | lazy
+         lock_mode: lazy         # world | head | lazy | gimbal
          distance: 1.5
          # size: [w_m, h_m]
          # stereo_baseline_mm: 0
@@ -344,7 +348,7 @@ Televiz as the compositor at the end of the chain:
    ├── camera_viz.py        — receiver / viewer (drives a Televiz VizSession)
    ├── camera_streamer.py   — robot-side RTP sender (per-camera supervisor)
    ├── pipeline/            — source ABC + threaded runner
-   ├── placements/          — XR lock-mode strategies (world / head / lazy)
+   ├── placements/          — XR lock-mode strategies (world / head / lazy / gimbal)
    ├── sources/             — V4L2 / OAK-D / ZED / video replay / synthetic / rtp_h264
    ├── transports/          — RTP sender + receiver (native + GStreamer)
    ├── codec/               — native NVENC / NVDEC pybind module

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -100,7 +100,7 @@ In XR mode the viewer first brings up the CloudXR runtime (accept the EULA on fi
 pass ``--accept-eula``), then **you should see** the terminal report the session and the source
 coming up::
 
-   camera_viz: source=local, mode=xr, xr=True, shape=quad, 1 layer(s)
+   camera_viz: source=local, mode=xr, xr=True, shapes=quad, 1 layer(s)
    [video] opening...
    [video] connected
    [video] streaming
@@ -302,7 +302,7 @@ its own plane (and, in split mode, its own RTP port). Abbreviated:
          distance: 1.5
          # size: [w_m, h_m]
          # stereo_baseline_mm: 0
-         # shape: quad           # quad | cylinder | equirect (native-only shapes)
+         # shape: quad           # quad | cylinder | equirect (cylinder/equirect are XR-only)
          # native: true          # quads: native OpenXR layer (default) vs compositor
          # cylinder_radius_m: 2.0
          # cylinder_angle_deg: 90

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -203,7 +203,7 @@ Each camera renders on a flat plane by default. Per-camera keys under
        don't apply.
    * - ``native: false``
      - Quads only: composite server-side through Televiz instead of submitting a native
-       OpenXR layer (needed to z-compose with a ``ProjectionLayer``).
+       OpenXR layer.
 
 ``cylinder`` and ``equirect`` require XR mode — the viewer exits with an error in window mode.
 Stereo sources render per-eye textures on the same surface; ``stereo_baseline_mm`` adds a

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -183,36 +183,38 @@ In XR, how a plane follows the operator's head is the per-camera ``lock_mode`` u
 Lazy-mode knobs live under ``placements.<name>``: ``look_away_angle_deg``,
 ``reposition_distance``, ``reposition_delay_s``, ``transition_duration_s``.
 
-Surface shapes and native composition layers
---------------------------------------------
+Display surfaces
+----------------
 
-Each camera renders on a flat plane by default. Per-camera keys under
-``display.placements.<name>`` pick the surface (XR mode only; details in
-:ref:`Native OpenXR composition layers <native-openxr-composition-layers>`):
+By default each camera renders on a flat plane, which suits normal-FOV feeds. Wide-FOV and
+panoramic sources look better on a curved surface: set ``shape`` per camera under
+``display.placements.<name>``:
 
 .. list-table::
    :header-rows: 1
    :widths: 30 70
 
-   * - Key
-     - Effect
-   * - ``shape: quad`` (default)
+   * - Shape
+     - Behavior
+   * - ``quad`` (default)
      - Flat plane. All lock modes apply.
-   * - ``shape: cylinder``
-     - Curved arc facing the operator; ``cylinder_radius_m`` (default 2.0) sets the viewing
-       distance, ``cylinder_angle_deg`` (default 90) the arc width. All lock modes apply
-       (``head`` = gaze-tracking curved visor).
-   * - ``shape: equirect``
-     - Full 360°×180° sphere, for equirectangular panorama / VR-video sources. Lock modes
-       don't apply.
-   * - ``compositor: televiz``
-     - Quads only: Televiz's built-in compositor draws the quad server-side instead of
-       handing it to the OpenXR runtime (the ``openxr`` default). Cylinder / equirect are
-       runtime-composited always.
+   * - ``cylinder``
+     - Curved arc facing the operator, so the image stays at a constant viewing distance edge
+       to edge. ``cylinder_radius_m`` (default 2.0) sets that distance, ``cylinder_angle_deg``
+       (default 90) the arc width. All lock modes apply (``head`` = gaze-tracking curved
+       visor).
+   * - ``equirect``
+     - Full 360°×180° sphere around the operator, for equirectangular panorama / VR-video
+       sources. Lock modes don't apply.
 
-``cylinder`` and ``equirect`` require XR mode — the viewer exits with an error in window mode.
-Stereo sources render per-eye textures on the same surface; ``stereo_baseline_mm`` adds a
-per-eye pose shift (no effect on the equirect sphere at its default infinite radius).
+Curved shapes exist only in XR mode — the viewer exits with an error in window mode. Stereo
+sources render per-eye textures on the same surface, and ``stereo_baseline_mm`` adds a per-eye
+pose shift (no effect on the equirect sphere at its default infinite radius).
+
+Surfaces are composited by the OpenXR runtime, which keeps them sharp under head motion and lets
+CloudXR stream them efficiently (see
+:ref:`OpenXR composition layers <openxr-composition-layers>`). For flat planes only,
+``compositor: televiz`` opts a camera back into Televiz's built-in compositor.
 
 CloudXR runtime flags
 ---------------------

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -172,7 +172,9 @@ In XR, how a plane follows the operator's head is the per-camera ``lock_mode`` u
    * - ``world``
      - Placed once in front of you and stays put.
    * - ``head``
-     - Follows your head every frame.
+     - Follows your head every frame. Head-locked content updates its pose at application
+       rate, so it trails fast head motion by roughly a frame — expected for any head-locked
+       OpenXR layer; prefer ``lazy`` unless you need a true HUD.
    * - ``lazy``
      - World-locked, but re-snaps in front of you when you look away (default).
 
@@ -182,30 +184,35 @@ Lazy-mode knobs live under ``placements.<name>``: ``look_away_angle_deg``,
 Surface shapes and native composition layers
 --------------------------------------------
 
-By default each camera renders on a flat plane composited by Televiz. Two CLI flags change how
-the feed reaches the headset (XR mode only; see
-:ref:`Native OpenXR composition layers <native-openxr-composition-layers>` for the underlying
-mechanics and trade-offs):
+By default each camera renders on a flat plane submitted as a native ``XrCompositionLayerQuad``.
+Per-camera keys under ``display.placements.<name>`` change how the feed reaches the headset
+(XR mode only; see :ref:`Native OpenXR composition layers <native-openxr-composition-layers>`
+for the underlying mechanics and trade-offs):
 
 .. list-table::
    :header-rows: 1
-   :widths: 26 74
+   :widths: 30 70
 
-   * - Flag
+   * - Key
      - Effect
-   * - ``--native-quad`` / ``--no-native-quad``
-     - Flat planes submit as native ``XrCompositionLayerQuad`` **by default**: when every visible
-       layer is native, CloudXR can stream each layer separately and reproject it on-device.
-       Placement lock modes still apply. ``--no-native-quad`` falls back to server-side
-       compositing (e.g. for runtimes that mishandle native quad layers).
-   * - ``--layer-shape cylinder``
-     - Wrap each feed onto a cylinder arc facing the operator (native
-       ``XrCompositionLayerCylinderKHR``). ``--cylinder-radius METERS`` (default 2.0) and
-       ``--cylinder-angle-deg DEGREES`` (default 90) size the arc; its width/height ratio follows
-       the source resolution. Placement lock modes don't apply — the arc is fixed in the space.
-   * - ``--layer-shape equirect``
-     - Map each feed onto a full 360°×180° sphere (native ``XrCompositionLayerEquirect2KHR``) —
-       for equirectangular panorama / VR-video sources, not regular camera frames.
+   * - ``shape: quad`` (default)
+     - Flat plane, native ``XrCompositionLayerQuad``: when every visible layer is native, CloudXR
+       can stream each layer separately and reproject it on-device. Placement lock modes apply.
+   * - ``native: false``
+     - Quads only: fall back to server-side compositing through Televiz's shared render target
+       (e.g. for runtimes that mishandle native quad layers, or to z-compose with a
+       ``ProjectionLayer``).
+   * - ``shape: cylinder``
+     - Wrap the feed onto a cylinder arc facing the operator (native
+       ``XrCompositionLayerCylinderKHR``). ``cylinder_radius_m`` (default 2.0) and
+       ``cylinder_angle_deg`` (default 90) size the arc; its width/height ratio follows the
+       source resolution. All three lock modes apply, repositioning the cylinder around the
+       operator just like a quad (the surface distance stays ``cylinder_radius_m``); ``head``
+       turns it into a gaze-tracking curved visor.
+   * - ``shape: equirect``
+     - Map the feed onto a full 360°×180° sphere (native ``XrCompositionLayerEquirect2KHR``) —
+       for equirectangular panorama / VR-video sources, not regular camera frames. Lock modes
+       don't apply (a full sphere has nothing to re-snap).
 
 Both shaped layers are **native-only**: they require XR mode and a runtime advertising the
 matching ``XR_KHR_composition_layer_*`` extension (CloudXR advertises both), and the viewer exits
@@ -309,6 +316,10 @@ its own plane (and, in split mode, its own RTP port). Abbreviated:
          distance: 1.5
          # size: [w_m, h_m]
          # stereo_baseline_mm: 0
+         # shape: quad           # quad | cylinder | equirect (native-only shapes)
+         # native: true          # quads: native OpenXR layer (default) vs compositor
+         # cylinder_radius_m: 2.0
+         # cylinder_angle_deg: 90
 
 See the :code-dir:`configs/ <examples/camera_viz/configs>` directory for a complete, commented
 YAML per source kind.

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -208,7 +208,9 @@ mechanics and trade-offs):
 
 Both shaped layers are **native-only**: they require XR mode and a runtime advertising the
 matching ``XR_KHR_composition_layer_*`` extension (CloudXR advertises both), and the viewer exits
-with an error otherwise. Stereo sources render per-eye textures on the same surface.
+with an error otherwise. Stereo sources render per-eye textures on the same surface;
+``placements.<name>.stereo_baseline_mm`` shifts each eye's surface laterally for extra
+geometric disparity (no effect on the infinite-radius equirect sphere).
 
 CloudXR runtime flags
 ---------------------

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -48,7 +48,7 @@ run the sample's one-time setup:
    source examples/camera_viz/.venv/bin/activate
 
 There is no need to install the ``isaacteleop`` pip package yourself — ``setup`` creates the
-sample's own environment: it installs ``isaacteleop`` (which bundles Televiz) and every other
+sample's own environment: it installs ``isaacteleop>=1.4`` (which bundles Televiz) and every other
 Python dependency from PyPI into ``.venv/`` via ``uv``, builds the native NVENC/NVDEC codec, and
 probes system packages (GStreamer plugins, cairo / girepository headers, JetPack ``cuda-nvrtc`` +
 ``ld.so`` wiring). When something is missing it prints the exact ``apt-get`` line and prompts

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -193,10 +193,11 @@ mechanics and trade-offs):
 
    * - Flag
      - Effect
-   * - ``--native-quad``
-     - Keep the flat plane, but submit it as a native ``XrCompositionLayerQuad`` instead of
-       compositing it server-side. When every visible layer is native, CloudXR can stream each
-       layer separately and reproject it on-device. Placement lock modes still apply.
+   * - ``--native-quad`` / ``--no-native-quad``
+     - Flat planes submit as native ``XrCompositionLayerQuad`` **by default**: when every visible
+       layer is native, CloudXR can stream each layer separately and reproject it on-device.
+       Placement lock modes still apply. ``--no-native-quad`` falls back to server-side
+       compositing (e.g. for runtimes that mishandle native quad layers).
    * - ``--layer-shape cylinder``
      - Wrap each feed onto a cylinder arc facing the operator (native
        ``XrCompositionLayerCylinderKHR``). ``--cylinder-radius METERS`` (default 2.0) and

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -31,10 +31,12 @@ Requirements
 
 - A workstation meeting the :doc:`system requirements </references/requirements>` (Ubuntu, NVIDIA
   GPU, CUDA driver) — every source hands frames to the renderer GPU-resident via CuPy.
-- For the default XR mode, a running CloudXR server with a connected headset — follow the
-  :doc:`quick start </getting_started/quick_start>` steps :ref:`run-cloudxr-server` and
-  :ref:`connect-xr-headset`. No headset handy? ``--mode window`` renders to a desktop window
-  instead and only needs a local display.
+- For the default XR mode, a headset to connect as the CloudXR client — follow the
+  :doc:`quick start </getting_started/quick_start>` step :ref:`connect-xr-headset`. The CloudXR
+  **runtime itself is launched by the viewer**: ``camera_viz.py`` starts the bundled in-process
+  runtime and WSS proxy before creating its XR session (pass ``--no-launch-cloudxr-runtime`` when
+  one is already running, e.g. after sourcing ``~/.cloudxr/run/cloudxr.env``). No headset handy?
+  ``--mode window`` renders to a desktop window instead and only needs a local display.
 
 Setup
 -----
@@ -96,15 +98,17 @@ at it:
    ./camera_viz.sh run configs/replay.yaml                 # XR headset (default)
    ./camera_viz.sh run configs/replay.yaml --mode window   # desktop window instead
 
-**You should see** the terminal report the session and the source coming up::
+In XR mode the viewer first brings up the CloudXR runtime (accept the EULA on first launch, or
+pass ``--accept-eula``), then **you should see** the terminal report the session and the source
+coming up::
 
-   camera_viz: source=local, mode=xr, xr=True, 1 layer(s)
+   camera_viz: source=local, mode=xr, xr=True, shape=quad, 1 layer(s)
    [video] opening...
    [video] connected
    [video] streaming
 
-and the clip looping on a plane in the headset — or in a desktop window (``mode=window,
-xr=False``) with the ``--mode window`` override.
+and the clip looping on a plane in the headset once it connects — or in a desktop window
+(``mode=window, xr=False``) with the ``--mode window`` override, which starts no runtime.
 
 To replay your own video, set a custom ``path:`` in :code-file:`configs/replay.yaml
 <examples/camera_viz/configs/replay.yaml>` — relative paths resolve against the YAML's directory.
@@ -174,6 +178,51 @@ In XR, how a plane follows the operator's head is the per-camera ``lock_mode`` u
 
 Lazy-mode knobs live under ``placements.<name>``: ``look_away_angle_deg``,
 ``reposition_distance``, ``reposition_delay_s``, ``transition_duration_s``.
+
+Surface shapes and native composition layers
+--------------------------------------------
+
+By default each camera renders on a flat plane composited by Televiz. Two CLI flags change how
+the feed reaches the headset (XR mode only; see
+:ref:`Native OpenXR composition layers <native-openxr-composition-layers>` for the underlying
+mechanics and trade-offs):
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 74
+
+   * - Flag
+     - Effect
+   * - ``--native-quad``
+     - Keep the flat plane, but submit it as a native ``XrCompositionLayerQuad`` instead of
+       compositing it server-side. When every visible layer is native, CloudXR can stream each
+       layer separately and reproject it on-device. Placement lock modes still apply.
+   * - ``--layer-shape cylinder``
+     - Wrap each feed onto a cylinder arc facing the operator (native
+       ``XrCompositionLayerCylinderKHR``). ``--cylinder-radius METERS`` (default 2.0) and
+       ``--cylinder-angle-deg DEGREES`` (default 90) size the arc; its width/height ratio follows
+       the source resolution. Placement lock modes don't apply — the arc is fixed in the space.
+   * - ``--layer-shape equirect``
+     - Map each feed onto a full 360°×180° sphere (native ``XrCompositionLayerEquirect2KHR``) —
+       for equirectangular panorama / VR-video sources, not regular camera frames.
+
+Both shaped layers are **native-only**: they require XR mode and a runtime advertising the
+matching ``XR_KHR_composition_layer_*`` extension (CloudXR advertises both), and the viewer exits
+with an error otherwise. Stereo sources render per-eye textures on the same surface.
+
+CloudXR runtime flags
+---------------------
+
+In XR mode the viewer owns the runtime lifecycle. All the standard launcher flags are available:
+
+- ``--launch-cloudxr-runtime`` / ``--no-launch-cloudxr-runtime`` — start (default) or reuse an
+  already-running runtime.
+- ``--launch-wss-proxy`` / ``--no-launch-wss-proxy`` — the WSS TLS proxy headset clients connect
+  through (default: on). Disable for headless smoke tests.
+- ``--accept-eula`` — accept the NVIDIA CloudXR EULA non-interactively (first run only).
+- ``--cloudxr-install-dir PATH`` / ``--cloudxr-device-profile PROFILE`` /
+  ``--cloudxr-env-config PATH`` — install dir (default ``~/.cloudxr``), ``NV_DEVICE_PROFILE``
+  (default ``Quest3``), and a KEY=value env-override file.
 
 Split mode — robot → workstation over RTP
 -----------------------------------------
@@ -264,9 +313,10 @@ YAML per source kind.
 Troubleshooting
 ---------------
 
-- **The XR session fails to create** — the default mode needs the CloudXR server running and a
-  headset connected (quick start steps :ref:`run-cloudxr-server` and :ref:`connect-xr-headset`);
-  pass ``--mode window`` to render to a desktop window instead.
+- **The XR session fails to create** — the viewer launches the CloudXR runtime itself; check
+  ``~/.cloudxr/logs/cxr_server.*.log`` and ``runtime_stderr.log`` for the startup failure. If a
+  runtime is already running from another app, pass ``--no-launch-cloudxr-runtime``. Pass
+  ``--mode window`` to render to a desktop window instead (no runtime involved).
 - **No window appears over SSH** — ``--mode window`` needs a local display; run on the machine
   you're sitting at, or use a video-capable remote desktop.
 - **"video source: no such file"** — relative ``path:`` values resolve against the YAML's

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -201,9 +201,10 @@ Each camera renders on a flat plane by default. Per-camera keys under
    * - ``shape: equirect``
      - Full 360°×180° sphere, for equirectangular panorama / VR-video sources. Lock modes
        don't apply.
-   * - ``native: false``
-     - Quads only: composite server-side through Televiz instead of submitting a native
-       OpenXR layer.
+   * - ``compositor: televiz``
+     - Quads only: Televiz's built-in compositor draws the quad server-side instead of
+       handing it to the OpenXR runtime (the ``openxr`` default). Cylinder / equirect are
+       runtime-composited always.
 
 ``cylinder`` and ``equirect`` require XR mode — the viewer exits with an error in window mode.
 Stereo sources render per-eye textures on the same surface; ``stereo_baseline_mm`` adds a
@@ -303,7 +304,7 @@ its own plane (and, in split mode, its own RTP port). Abbreviated:
          # size: [w_m, h_m]
          # stereo_baseline_mm: 0
          # shape: quad           # quad | cylinder | equirect (cylinder/equirect are XR-only)
-         # native: true          # quads: native OpenXR layer (default) vs compositor
+         # compositor: openxr    # openxr (default) | televiz — quads only
          # cylinder_radius_m: 2.0
          # cylinder_angle_deg: 90
 

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -32,11 +32,9 @@ Requirements
 - A workstation meeting the :doc:`system requirements </references/requirements>` (Ubuntu, NVIDIA
   GPU, CUDA driver) — every source hands frames to the renderer GPU-resident via CuPy.
 - For the default XR mode, a headset to connect as the CloudXR client — follow the
-  :doc:`quick start </getting_started/quick_start>` step :ref:`connect-xr-headset`. The CloudXR
-  **runtime itself is launched by the viewer**: ``camera_viz.py`` starts the bundled in-process
-  runtime and WSS proxy before creating its XR session (pass ``--no-launch-cloudxr-runtime`` when
-  one is already running, e.g. after sourcing ``~/.cloudxr/run/cloudxr.env``). No headset handy?
-  ``--mode window`` renders to a desktop window instead and only needs a local display.
+  :doc:`quick start </getting_started/quick_start>` step :ref:`connect-xr-headset`. The viewer
+  launches the CloudXR runtime itself; nothing to start separately. No headset handy?
+  ``--mode window`` renders to a desktop window instead.
 
 Setup
 -----
@@ -184,10 +182,9 @@ Lazy-mode knobs live under ``placements.<name>``: ``look_away_angle_deg``,
 Surface shapes and native composition layers
 --------------------------------------------
 
-By default each camera renders on a flat plane submitted as a native ``XrCompositionLayerQuad``.
-Per-camera keys under ``display.placements.<name>`` change how the feed reaches the headset
-(XR mode only; see :ref:`Native OpenXR composition layers <native-openxr-composition-layers>`
-for the underlying mechanics and trade-offs):
+Each camera renders on a flat plane by default. Per-camera keys under
+``display.placements.<name>`` pick the surface (XR mode only; details in
+:ref:`Native OpenXR composition layers <native-openxr-composition-layers>`):
 
 .. list-table::
    :header-rows: 1
@@ -196,43 +193,32 @@ for the underlying mechanics and trade-offs):
    * - Key
      - Effect
    * - ``shape: quad`` (default)
-     - Flat plane, native ``XrCompositionLayerQuad``: when every visible layer is native, CloudXR
-       can stream each layer separately and reproject it on-device. Placement lock modes apply.
-   * - ``native: false``
-     - Quads only: fall back to server-side compositing through Televiz's shared render target
-       (e.g. for runtimes that mishandle native quad layers, or to z-compose with a
-       ``ProjectionLayer``).
+     - Flat plane. All lock modes apply.
    * - ``shape: cylinder``
-     - Wrap the feed onto a cylinder arc facing the operator (native
-       ``XrCompositionLayerCylinderKHR``). ``cylinder_radius_m`` (default 2.0) and
-       ``cylinder_angle_deg`` (default 90) size the arc; its width/height ratio follows the
-       source resolution. All three lock modes apply, repositioning the cylinder around the
-       operator just like a quad (the surface distance stays ``cylinder_radius_m``); ``head``
-       turns it into a gaze-tracking curved visor.
+     - Curved arc facing the operator; ``cylinder_radius_m`` (default 2.0) sets the viewing
+       distance, ``cylinder_angle_deg`` (default 90) the arc width. All lock modes apply
+       (``head`` = gaze-tracking curved visor).
    * - ``shape: equirect``
-     - Map the feed onto a full 360°×180° sphere (native ``XrCompositionLayerEquirect2KHR``) —
-       for equirectangular panorama / VR-video sources, not regular camera frames. Lock modes
-       don't apply (a full sphere has nothing to re-snap).
+     - Full 360°×180° sphere, for equirectangular panorama / VR-video sources. Lock modes
+       don't apply.
+   * - ``native: false``
+     - Quads only: composite server-side through Televiz instead of submitting a native
+       OpenXR layer (needed to z-compose with a ``ProjectionLayer``).
 
-Both shaped layers are **native-only**: they require XR mode and a runtime advertising the
-matching ``XR_KHR_composition_layer_*`` extension (CloudXR advertises both), and the viewer exits
-with an error otherwise. Stereo sources render per-eye textures on the same surface;
-``placements.<name>.stereo_baseline_mm`` shifts each eye's surface laterally for extra
-geometric disparity (no effect on the infinite-radius equirect sphere).
+``cylinder`` and ``equirect`` require XR mode — the viewer exits with an error in window mode.
+Stereo sources render per-eye textures on the same surface; ``stereo_baseline_mm`` adds a
+per-eye pose shift (no effect on the equirect sphere at its default infinite radius).
 
 CloudXR runtime flags
 ---------------------
 
-In XR mode the viewer owns the runtime lifecycle. All the standard launcher flags are available:
+In XR mode the viewer launches the CloudXR runtime and WSS proxy itself. Useful flags:
 
-- ``--launch-cloudxr-runtime`` / ``--no-launch-cloudxr-runtime`` — start (default) or reuse an
-  already-running runtime.
-- ``--launch-wss-proxy`` / ``--no-launch-wss-proxy`` — the WSS TLS proxy headset clients connect
-  through (default: on). Disable for headless smoke tests.
-- ``--accept-eula`` — accept the NVIDIA CloudXR EULA non-interactively (first run only).
-- ``--cloudxr-install-dir PATH`` / ``--cloudxr-device-profile PROFILE`` /
-  ``--cloudxr-env-config PATH`` — install dir (default ``~/.cloudxr``), ``NV_DEVICE_PROFILE``
-  (default ``Quest3``), and a KEY=value env-override file.
+- ``--no-launch-cloudxr-runtime`` — reuse an already-running runtime.
+- ``--accept-eula`` — accept the CloudXR EULA non-interactively (first run only).
+- ``--cloudxr-device-profile PROFILE`` — ``NV_DEVICE_PROFILE`` (default ``Quest3``).
+
+Run ``camera_viz.py --help`` for the rest (install dir, env-config file, WSS proxy toggle).
 
 Split mode — robot → workstation over RTP
 -----------------------------------------

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -33,7 +33,7 @@ examples/camera_viz/camera_viz.sh setup
 source examples/camera_viz/.venv/bin/activate
 ```
 
-`setup` installs `isaacteleop` (which bundles Televiz) and every other Python dep from PyPI into `.venv/` via `uv` (no `--system-site-packages`), builds the native NVENC/NVDEC codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts. No need to build IsaacTeleop from source.
+`setup` installs `isaacteleop>=1.4` (which bundles Televiz) and every other Python dep from PyPI into `.venv/` via `uv` (no `--system-site-packages`), builds the native NVENC/NVDEC codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts. No need to build IsaacTeleop from source.
 
 Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`. Pass `--venv PATH` to install into an existing venv (symlinks `.venv` → PATH so `run` / `loopback` pick it up too).
 

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: Apache-2.0
 | `zed`       | ZED 2 / Mini / X One; mono or `stereo: true` (per-eye SDK retrieve, zero-copy GPU) |
 | `video`     | Video-file replay (anything OpenCV/FFmpeg reads) — preview / testing without a camera. Loops by default; `stereo: true` splits side-by-side files into eyes (viewer only) |
 
-Output: XR headset (default) or desktop window (`run CONFIG --mode window`); one surface per camera — a flat plane (default), a cylinder arc, or an equirect sphere (`placements.<name>.shape`, XR only for the curved shapes). Stereo cameras render true SBS in XR; window mode shows the left eye. XR placements: `world` / `head` / `lazy`.
+In XR mode the viewer **launches the CloudXR runtime + WSS proxy itself** — nothing to start separately (`--no-launch-cloudxr-runtime` reuses an external one; `--accept-eula` for the first run; `camera_viz.py --help` for the rest). Output: XR headset (default) or desktop window (`run CONFIG --mode window`); one surface per camera — a flat plane (default), a cylinder arc, or an equirect sphere (`placements.<name>.shape`, XR only for the curved shapes). Stereo cameras render true SBS in XR; window mode shows the left eye. XR placements: `world` / `head` / `lazy`.
 
 ---
 
@@ -123,7 +123,7 @@ display:                      # camera_viz only
                                # (parallax from the frames); ~65 = virtual IPD push
       # shape: quad            # quad (default) | cylinder | equirect — XR only for
                                # the curved shapes
-      # native: true           # quads: native OpenXR layer (default) vs compositor
+      # compositor: openxr     # openxr (default) | televiz — quads only
       # cylinder_radius_m: 2.0 # cylinder: viewing distance to the arc
       # cylinder_angle_deg: 90 # cylinder: visible arc width
 ```

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: Apache-2.0
 | `zed`       | ZED 2 / Mini / X One; mono or `stereo: true` (per-eye SDK retrieve, zero-copy GPU) |
 | `video`     | Video-file replay (anything OpenCV/FFmpeg reads) — preview / testing without a camera. Loops by default; `stereo: true` splits side-by-side files into eyes (viewer only) |
 
-In XR mode the viewer **launches the CloudXR runtime + WSS proxy itself** — nothing to start separately (`--no-launch-cloudxr-runtime` reuses an external one; `--accept-eula` for the first run; `camera_viz.py --help` for the rest). Output: XR headset (default) or desktop window (`run CONFIG --mode window`); one surface per camera — a flat plane (default), a cylinder arc, or an equirect sphere (`placements.<name>.shape`, XR only for the curved shapes). Stereo cameras render true SBS in XR; window mode shows the left eye. XR placements: `world` / `head` / `lazy`.
+In XR mode the viewer **launches the CloudXR runtime + WSS proxy itself** — nothing to start separately (`--no-launch-cloudxr-runtime` reuses an external one; `--accept-eula` for the first run; `camera_viz.py --help` for the rest). Output: XR headset (default) or desktop window (`run CONFIG --mode window`); one surface per camera — a flat plane (default), a cylinder arc, or an equirect sphere (`placements.<name>.shape`, XR only for the curved shapes). Stereo cameras render true SBS in XR; window mode shows the left eye. XR placements: `world` / `head` / `lazy` / `gimbal`.
 
 ---
 
@@ -114,7 +114,7 @@ display:                      # camera_viz only
   clear_color: [r, g, b, a]
   placements:
     cam:
-      lock_mode: lazy         # world | head | lazy
+      lock_mode: lazy         # world | head | lazy | gimbal
       distance: 1.5
       offset_x: 0.0
       offset_y: 0.0

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: Apache-2.0
 | `zed`       | ZED 2 / Mini / X One; mono or `stereo: true` (per-eye SDK retrieve, zero-copy GPU) |
 | `video`     | Video-file replay (anything OpenCV/FFmpeg reads) — preview / testing without a camera. Loops by default; `stereo: true` splits side-by-side files into eyes (viewer only) |
 
-Output: XR headset (default) or desktop window (`run CONFIG --mode window`); one plane per camera, aspect-fit. Stereo cameras render true SBS in XR; window mode shows the left eye. XR placements: `world` / `head` / `lazy`.
+Output: XR headset (default) or desktop window (`run CONFIG --mode window`); one surface per camera — a flat plane (default), a cylinder arc, or an equirect sphere (`placements.<name>.shape`, XR only for the curved shapes). Stereo cameras render true SBS in XR; window mode shows the left eye. XR placements: `world` / `head` / `lazy`.
 
 ---
 
@@ -121,6 +121,11 @@ display:                      # camera_viz only
       # size: [w_m, h_m]
       # stereo_baseline_mm: 0  # stereo cams: 0 = both eyes share the world quad
                                # (parallax from the frames); ~65 = virtual IPD push
+      # shape: quad            # quad (default) | cylinder | equirect — XR only for
+                               # the curved shapes
+      # native: true           # quads: native OpenXR layer (default) vs compositor
+      # cylinder_radius_m: 2.0 # cylinder: viewing distance to the arc
+      # cylinder_angle_deg: 90 # cylinder: visible arc width
 ```
 
 Multiple cameras → multiple `cameras:` entries; each gets its own `rtp.port` (plus `port_right` if stereo) and renders as its own plane.

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -41,6 +41,17 @@ from sources import (
     set_verbose,
 )
 
+# camera_viz tracks the in-repo isaacteleop; a PyPI wheel that predates
+# this example lacks the CloudXR launcher helpers and the shaped-layer /
+# compositor-choice APIs. Detect once and either degrade (launcher) or
+# fail with the remedy (layer APIs) instead of stack-tracing.
+_HAS_LAUNCHER_HELPERS = hasattr(CloudXRLauncher, "add_launcher_arguments")
+_UPGRADE_HINT = (
+    "your installed isaacteleop is too old for this camera_viz — install the "
+    "matching wheel (./camera_viz.sh setup --wheel <path-to-built-wheel>) or "
+    "point PYTHONPATH at an IsaacTeleop build's python_package/."
+)
+
 
 @dataclass
 class SourceEntry:
@@ -52,15 +63,17 @@ class SourceEntry:
     stereo_baseline_mm: float = 0.0
     # display.placements.<name>.shape: quad | cylinder | equirect.
     shape: str = "quad"
-    # Quads only: native XrCompositionLayerQuad (default) vs the built-in
-    # compositor (display.placements.<name>.native: false).
-    native: bool = True
+    # Who composites the layer (display.placements.<name>.compositor):
+    # "openxr" (default — the OpenXR runtime) or "televiz" (built-in
+    # compositor; quads only).
+    compositor: str = "openxr"
     # Cylinder shape parameters (display.placements.<name>).
     cylinder_radius_m: float = 2.0
     cylinder_angle_deg: float = 90.0
 
 
 _VALID_SHAPES = ("quad", "cylinder", "equirect")
+_VALID_COMPOSITORS = ("openxr", "televiz")
 
 # Every key the placements.<name> block understands (lock-mode strategy
 # knobs + surface-shape keys). Unknown keys warn instead of silently
@@ -79,7 +92,7 @@ _KNOWN_PLACEMENT_KEYS = frozenset(
         "size",
         "stereo_baseline_mm",
         "shape",
-        "native",
+        "compositor",
         "cylinder_radius_m",
         "cylinder_angle_deg",
     }
@@ -104,9 +117,9 @@ def _warn_unknown_placement_keys(cam_name: str, pspec: dict) -> None:
 
 def _shape_for(cam_name: str, placements_cfg: dict) -> Tuple[str, bool, float, float]:
     """Per-camera surface config from ``display.placements.<name>``:
-    ``shape`` (quad | cylinder | equirect, default quad), ``native``
-    (quads only, default true), ``cylinder_radius_m`` / ``cylinder_angle_deg``
-    (cylinder only)."""
+    ``shape`` (quad | cylinder | equirect, default quad), ``compositor``
+    (openxr — the default — or televiz; quads only), ``cylinder_radius_m``
+    / ``cylinder_angle_deg`` (cylinder only)."""
     pspec = placements_cfg.get(cam_name) or {}
     _warn_unknown_placement_keys(cam_name, pspec)
     shape = str(pspec.get("shape", "quad")).lower()
@@ -115,10 +128,21 @@ def _shape_for(cam_name: str, placements_cfg: dict) -> Tuple[str, bool, float, f
             f"camera_viz: placements.{cam_name}.shape must be one of "
             f"{'|'.join(_VALID_SHAPES)}, got {shape!r}"
         )
-    native = bool(pspec.get("native", True))
+    compositor = str(pspec.get("compositor", "openxr")).lower()
+    if compositor not in _VALID_COMPOSITORS:
+        raise ValueError(
+            f"camera_viz: placements.{cam_name}.compositor must be "
+            f"{'|'.join(_VALID_COMPOSITORS)}, got {compositor!r}"
+        )
+    if compositor == "televiz" and shape != "quad":
+        raise ValueError(
+            f"camera_viz: placements.{cam_name}: compositor: televiz only "
+            f"applies to shape: quad — {shape} layers are composited by the "
+            "OpenXR runtime always."
+        )
     radius_m = float(pspec.get("cylinder_radius_m", 2.0))
     angle_deg = float(pspec.get("cylinder_angle_deg", 90.0))
-    return shape, native, radius_m, angle_deg
+    return shape, compositor, radius_m, angle_deg
 
 
 def _build_placement(spec: Optional[dict], is_xr: bool) -> Optional[PlacementStrategy]:
@@ -187,7 +211,7 @@ def _build_local_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
             placements_cfg.get(cam["name"]), first.width, first.height, is_xr
         )
         stereo, baseline_mm = _stereo_for(cam, placements_cfg)
-        shape, native, radius_m, angle_deg = _shape_for(cam["name"], placements_cfg)
+        shape, compositor, radius_m, angle_deg = _shape_for(cam["name"], placements_cfg)
         for source in cam_sources:
             entries.append(
                 SourceEntry(
@@ -196,7 +220,7 @@ def _build_local_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
                     stereo=stereo,
                     stereo_baseline_mm=baseline_mm,
                     shape=shape,
-                    native=native,
+                    compositor=compositor,
                     cylinder_radius_m=radius_m,
                     cylinder_angle_deg=angle_deg,
                 )
@@ -265,7 +289,7 @@ def _build_rtp_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
                 gpu_id=int(rtp.get("gpu_id", 0)),
             )
 
-        shape, native, radius_m, angle_deg = _shape_for(cam["name"], placements_cfg)
+        shape, compositor, radius_m, angle_deg = _shape_for(cam["name"], placements_cfg)
         entries.append(
             SourceEntry(
                 source=source,
@@ -273,7 +297,7 @@ def _build_rtp_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
                 stereo=stereo,
                 stereo_baseline_mm=baseline_mm,
                 shape=shape,
-                native=native,
+                compositor=compositor,
                 cylinder_radius_m=radius_m,
                 cylinder_angle_deg=angle_deg,
             )
@@ -310,14 +334,14 @@ def _add_layer(session: viz.VizSession, entry: SourceEntry):
     """Register one layer for ``entry`` per its ``shape`` (from
     ``display.placements.<name>`` in the YAML).
 
-    quad     → QuadLayer (native XrCompositionLayerQuad by default;
-               ``native: false`` opts back into the compositor); the
-               placement strategy positions it per frame.
-    cylinder → native CylinderLayer: the feed wrapped on an arc facing the
-               user (``cylinder_radius_m`` / ``cylinder_angle_deg``, aspect
-               from the source).
-    equirect → native EquirectLayer: full 360x180 sphere (the source is
-               expected to be an equirect panorama).
+    quad     → QuadLayer, composited by the OpenXR runtime by default
+               (``compositor: televiz`` opts into the built-in compositor);
+               the placement strategy positions it per frame.
+    cylinder → CylinderLayer: the feed wrapped on an arc facing the user
+               (``cylinder_radius_m`` / ``cylinder_angle_deg``, aspect from
+               the source). Runtime-composited always.
+    equirect → EquirectLayer: full 360x180 sphere (the source is expected
+               to be an equirect panorama). Runtime-composited always.
     """
     spec = entry.source.spec
     if entry.shape == "cylinder":
@@ -349,10 +373,20 @@ def _add_layer(session: viz.VizSession, entry: SourceEntry):
     if entry.stereo:
         layer_cfg.stereo = True
         layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
-    # Native OpenXR quad path is the default (kXr only; window mode always
-    # composites). Requires a placement, which the placement strategy
-    # applies below.
-    layer_cfg.native_composition = entry.native
+    # OpenXR-runtime composition is the default (kXr only; window mode is
+    # always composited by Televiz). Requires a placement, which the
+    # placement strategy applies below.
+    want_openxr = entry.compositor == "openxr"
+    if hasattr(layer_cfg, "openxr_composition"):
+        layer_cfg.openxr_composition = want_openxr
+    elif want_openxr:
+        # Old isaacteleop wheel: quads are Televiz-composited only.
+        print(
+            f"camera_viz: warning: {_UPGRADE_HINT} Falling back to "
+            "compositor: televiz for quads.",
+            file=sys.stderr,
+            flush=True,
+        )
     return session.add_quad_layer(layer_cfg)
 
 
@@ -366,7 +400,8 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="Override display.mode from the config "
         "(default: the config's value, or xr when the config omits it).",
     )
-    CloudXRLauncher.add_launcher_arguments(parser)
+    if _HAS_LAUNCHER_HELPERS:
+        CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv)
 
     with open(args.config) as f:
@@ -386,16 +421,24 @@ def main(argv: Optional[list[str]] = None) -> int:
         raise ValueError(f"camera_viz: source must be local|rtp, got {source_mode!r}")
 
     effective_mode = (args.mode or cfg.get("display", {}).get("mode", "xr")).lower()
-    # Shaped layers (display.placements.<name>.shape) are native-only —
-    # fail fast, before launching the runtime, when the mode can't host them.
+    # Shaped layers (display.placements.<name>.shape) are composited by
+    # the OpenXR runtime, so they need XR mode and a current isaacteleop —
+    # fail fast, before launching the runtime, when either is missing.
     placements_cfg = cfg.get("display", {}).get("placements", {})
     for cam in _enabled_cameras(cfg):
         shape, _, _, _ = _shape_for(cam["name"], placements_cfg)
-        if shape != "quad" and effective_mode != "xr":
+        if shape == "quad":
+            continue
+        if effective_mode != "xr":
             raise SystemExit(
                 f"camera_viz: placements.{cam['name']}.shape: {shape} is "
-                "native-only (XrCompositionLayer*KHR) and requires XR mode; "
+                "composited by the OpenXR runtime and requires XR mode; "
                 "use --mode xr or shape: quad in window mode."
+            )
+        if not hasattr(viz, "CylinderLayerConfig"):
+            raise SystemExit(
+                f"camera_viz: placements.{cam['name']}.shape: {shape} needs "
+                f"cylinder/equirect layer support — {_UPGRADE_HINT}"
             )
 
     # In XR mode, launch the in-process CloudXR runtime (+ WSS proxy for
@@ -410,9 +453,17 @@ def main(argv: Optional[list[str]] = None) -> int:
     # under a live xrWaitFrame — the same hazard the skip-destroy
     # mitigation exists for. The launcher registers an atexit stop, which
     # fires once the stuck (non-daemon) thread finally exits.
+    if effective_mode == "xr" and not _HAS_LAUNCHER_HELPERS:
+        print(
+            f"camera_viz: warning: {_UPGRADE_HINT} Continuing WITHOUT "
+            "launching the CloudXR runtime — start it yourself if one "
+            "isn't already running.",
+            file=sys.stderr,
+            flush=True,
+        )
     launch_ctx = (
         CloudXRLauncher.launch_context(args)
-        if effective_mode == "xr"
+        if effective_mode == "xr" and _HAS_LAUNCHER_HELPERS
         else contextlib.nullcontext(None)
     )
     launch_ctx.__enter__()

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -44,12 +44,41 @@ from sources import (
 
 @dataclass
 class SourceEntry:
-    """source + placement + stereo cfg; drives QuadLayer construction."""
+    """source + placement + stereo + shape cfg; drives layer construction."""
 
     source: FrameSource
     placement: Optional[PlacementStrategy]
     stereo: bool = False
     stereo_baseline_mm: float = 0.0
+    # display.placements.<name>.shape: quad | cylinder | equirect.
+    shape: str = "quad"
+    # Quads only: native XrCompositionLayerQuad (default) vs the built-in
+    # compositor (display.placements.<name>.native: false).
+    native: bool = True
+    # Cylinder shape parameters (display.placements.<name>).
+    cylinder_radius_m: float = 2.0
+    cylinder_angle_deg: float = 90.0
+
+
+_VALID_SHAPES = ("quad", "cylinder", "equirect")
+
+
+def _shape_for(cam_name: str, placements_cfg: dict) -> Tuple[str, bool, float, float]:
+    """Per-camera surface config from ``display.placements.<name>``:
+    ``shape`` (quad | cylinder | equirect, default quad), ``native``
+    (quads only, default true), ``cylinder_radius_m`` / ``cylinder_angle_deg``
+    (cylinder only)."""
+    pspec = placements_cfg.get(cam_name) or {}
+    shape = str(pspec.get("shape", "quad")).lower()
+    if shape not in _VALID_SHAPES:
+        raise ValueError(
+            f"camera_viz: placements.{cam_name}.shape must be one of "
+            f"{'|'.join(_VALID_SHAPES)}, got {shape!r}"
+        )
+    native = bool(pspec.get("native", True))
+    radius_m = float(pspec.get("cylinder_radius_m", 2.0))
+    angle_deg = float(pspec.get("cylinder_angle_deg", 90.0))
+    return shape, native, radius_m, angle_deg
 
 
 def _build_placement(spec: Optional[dict], is_xr: bool) -> Optional[PlacementStrategy]:
@@ -118,6 +147,7 @@ def _build_local_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
             placements_cfg.get(cam["name"]), first.width, first.height, is_xr
         )
         stereo, baseline_mm = _stereo_for(cam, placements_cfg)
+        shape, native, radius_m, angle_deg = _shape_for(cam["name"], placements_cfg)
         for source in cam_sources:
             entries.append(
                 SourceEntry(
@@ -125,6 +155,10 @@ def _build_local_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
                     placement=placement,
                     stereo=stereo,
                     stereo_baseline_mm=baseline_mm,
+                    shape=shape,
+                    native=native,
+                    cylinder_radius_m=radius_m,
+                    cylinder_angle_deg=angle_deg,
                 )
             )
     return entries
@@ -191,12 +225,17 @@ def _build_rtp_entries(cfg: dict, is_xr: bool) -> List[SourceEntry]:
                 gpu_id=int(rtp.get("gpu_id", 0)),
             )
 
+        shape, native, radius_m, angle_deg = _shape_for(cam["name"], placements_cfg)
         entries.append(
             SourceEntry(
                 source=source,
                 placement=placement,
                 stereo=stereo,
                 stereo_baseline_mm=baseline_mm,
+                shape=shape,
+                native=native,
+                cylinder_radius_m=radius_m,
+                cylinder_angle_deg=angle_deg,
             )
         )
     return entries
@@ -227,18 +266,21 @@ def _make_session(cfg: dict, mode_override: Optional[str] = None) -> viz.VizSess
     return viz.VizSession.create(session_cfg)
 
 
-def _add_layer(session: viz.VizSession, entry: SourceEntry, args: argparse.Namespace):
-    """Register one layer for ``entry`` per --layer-shape.
+def _add_layer(session: viz.VizSession, entry: SourceEntry):
+    """Register one layer for ``entry`` per its ``shape`` (from
+    ``display.placements.<name>`` in the YAML).
 
-    quad     → QuadLayer (compositor path, or native when --native-quad);
-               the placement strategy positions it per frame.
+    quad     → QuadLayer (native XrCompositionLayerQuad by default;
+               ``native: false`` opts back into the compositor); the
+               placement strategy positions it per frame.
     cylinder → native CylinderLayer: the feed wrapped on an arc facing the
-               user (radius / angle from the CLI, aspect from the source).
+               user (``cylinder_radius_m`` / ``cylinder_angle_deg``, aspect
+               from the source).
     equirect → native EquirectLayer: full 360x180 sphere (the source is
                expected to be an equirect panorama).
     """
     spec = entry.source.spec
-    if args.layer_shape == "cylinder":
+    if entry.shape == "cylinder":
         layer_cfg = viz.CylinderLayerConfig()
         layer_cfg.name = spec.name
         layer_cfg.resolution = viz.Resolution(spec.width, spec.height)
@@ -246,11 +288,11 @@ def _add_layer(session: viz.VizSession, entry: SourceEntry, args: argparse.Names
         layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
         # aspect_ratio 0 = derived from the source resolution (square texels).
         layer_cfg.placement = viz.CylinderLayerPlacement(
-            radius_m=args.cylinder_radius,
-            central_angle_rad=math.radians(args.cylinder_angle_deg),
+            radius_m=entry.cylinder_radius_m,
+            central_angle_rad=math.radians(entry.cylinder_angle_deg),
         )
         return session.add_cylinder_layer(layer_cfg)
-    if args.layer_shape == "equirect":
+    if entry.shape == "equirect":
         layer_cfg = viz.EquirectLayerConfig()
         layer_cfg.name = spec.name
         layer_cfg.resolution = viz.Resolution(spec.width, spec.height)
@@ -270,7 +312,7 @@ def _add_layer(session: viz.VizSession, entry: SourceEntry, args: argparse.Names
     # Native OpenXR quad path is the default (kXr only; window mode always
     # composites). Requires a placement, which the placement strategy
     # applies below.
-    layer_cfg.native_composition = args.native_quad
+    layer_cfg.native_composition = entry.native
     return session.add_quad_layer(layer_cfg)
 
 
@@ -283,44 +325,6 @@ def main(argv: Optional[list[str]] = None) -> int:
         default=None,
         help="Override display.mode from the config "
         "(default: the config's value, or xr when the config omits it).",
-    )
-    parser.add_argument(
-        "--native-quad",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Submit each camera as a native OpenXR quad layer "
-        "(XrCompositionLayerQuad) — the default in XR mode; window mode "
-        "always composites. When every layer is native the projection "
-        "layer is dropped, letting the runtime engage its quad fast path / "
-        "client-reconstructed streaming. Pass --no-native-quad to fall "
-        "back to the built-in compositor (e.g. for runtimes that "
-        "mishandle native quad layers).",
-    )
-    parser.add_argument(
-        "--layer-shape",
-        choices=("quad", "cylinder", "equirect"),
-        default="quad",
-        help="Surface each camera is mapped onto (default: quad). "
-        "cylinder wraps the feed onto a native XrCompositionLayerCylinderKHR "
-        "arc; equirect maps it onto a native XrCompositionLayerEquirect2KHR "
-        "sphere (for 360/180 panorama sources). Both are native-only and "
-        "require XR mode + a runtime advertising the matching "
-        "XR_KHR_composition_layer_* extension; placement lock modes from the "
-        "config apply to quads only.",
-    )
-    parser.add_argument(
-        "--cylinder-radius",
-        type=float,
-        default=2.0,
-        metavar="METERS",
-        help="Cylinder radius when --layer-shape cylinder (default: 2.0).",
-    )
-    parser.add_argument(
-        "--cylinder-angle-deg",
-        type=float,
-        default=90.0,
-        metavar="DEGREES",
-        help="Cylinder visible arc when --layer-shape cylinder (default: 90).",
     )
     CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv)
@@ -342,12 +346,17 @@ def main(argv: Optional[list[str]] = None) -> int:
         raise ValueError(f"camera_viz: source must be local|rtp, got {source_mode!r}")
 
     effective_mode = (args.mode or cfg.get("display", {}).get("mode", "xr")).lower()
-    if args.layer_shape != "quad" and effective_mode != "xr":
-        raise SystemExit(
-            f"camera_viz: --layer-shape {args.layer_shape} is native-only "
-            "(XrCompositionLayer*KHR) and requires XR mode; use --mode xr "
-            "or drop the flag in window mode."
-        )
+    # Shaped layers (display.placements.<name>.shape) are native-only —
+    # fail fast, before launching the runtime, when the mode can't host them.
+    placements_cfg = cfg.get("display", {}).get("placements", {})
+    for cam in _enabled_cameras(cfg):
+        shape, _, _, _ = _shape_for(cam["name"], placements_cfg)
+        if shape != "quad" and effective_mode != "xr":
+            raise SystemExit(
+                f"camera_viz: placements.{cam['name']}.shape: {shape} is "
+                "native-only (XrCompositionLayer*KHR) and requires XR mode; "
+                "use --mode xr or shape: quad in window mode."
+            )
 
     # In XR mode, launch the in-process CloudXR runtime (+ WSS proxy for
     # headset clients) before creating the session — VizSession's OpenXR
@@ -381,14 +390,18 @@ def main(argv: Optional[list[str]] = None) -> int:
         sources, layers, strategies = [], [], []
         for entry in entries:
             sources.append(entry.source)
-            layers.append(_add_layer(session, entry, args))
-            # Placement lock-mode strategies drive QuadLayer.set_placement;
-            # cylinder/equirect placements are fixed at add time.
-            strategies.append(entry.placement if args.layer_shape == "quad" else None)
+            layers.append(_add_layer(session, entry))
+            # Placement lock-mode strategies reposition quads AND cylinders
+            # (the runner adapts the pose to the cylinder's head-anchored
+            # center); an equirect sphere has nothing to re-snap.
+            strategies.append(
+                entry.placement if entry.shape in ("quad", "cylinder") else None
+            )
 
+        shapes = ",".join(sorted({e.shape for e in entries})) or "quad"
         print(
             f"camera_viz: source={source_mode}, mode={effective_mode}, "
-            f"xr={is_xr}, shape={args.layer_shape}, {len(sources)} layer(s)",
+            f"xr={is_xr}, shapes={shapes}, {len(sources)} layer(s)",
             flush=True,
         )
 

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -134,7 +134,19 @@ def _shape_for(cam_name: str, placements_cfg: dict) -> Tuple[str, bool, float, f
     return shape, compositor, radius_m, angle_deg
 
 
+_VALID_LOCK_MODES = ("world", "head", "lazy", "gimbal")
+
+
 def _build_placement(spec: Optional[dict], is_xr: bool) -> Optional[PlacementStrategy]:
+    if spec is not None:
+        # Validate in every display mode — a typo'd lock_mode shouldn't
+        # silently become lazy (XR) or pass unnoticed (window).
+        lock_mode = str(spec.get("lock_mode", "lazy")).lower()
+        if lock_mode not in _VALID_LOCK_MODES:
+            raise ValueError(
+                f"camera_viz: lock_mode must be {'|'.join(_VALID_LOCK_MODES)}, "
+                f"got {lock_mode!r}"
+            )
     if not is_xr or spec is None:
         return None
     cfg_kwargs = {}

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -243,18 +243,21 @@ def _add_layer(session: viz.VizSession, entry: SourceEntry, args: argparse.Names
         layer_cfg.name = spec.name
         layer_cfg.resolution = viz.Resolution(spec.width, spec.height)
         layer_cfg.stereo = entry.stereo
-        placement = viz.CylinderLayerPlacement()
-        placement.radius = args.cylinder_radius
-        placement.central_angle = math.radians(args.cylinder_angle_deg)
+        layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
         # aspect_ratio 0 = derived from the source resolution (square texels).
-        layer_cfg.placement = placement
+        layer_cfg.placement = viz.CylinderLayerPlacement(
+            radius_m=args.cylinder_radius,
+            central_angle_rad=math.radians(args.cylinder_angle_deg),
+        )
         return session.add_cylinder_layer(layer_cfg)
     if args.layer_shape == "equirect":
         layer_cfg = viz.EquirectLayerConfig()
         layer_cfg.name = spec.name
         layer_cfg.resolution = viz.Resolution(spec.width, spec.height)
         layer_cfg.stereo = entry.stereo
-        # Default placement = full 360x180 sphere at infinite radius.
+        # Baseline only matters at finite sphere radius; harmless at the
+        # default infinite-radius placement (full 360x180 sphere).
+        layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
         return session.add_equirect_layer(layer_cfg)
 
     layer_cfg = viz.QuadLayerConfig()

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -62,6 +62,45 @@ class SourceEntry:
 
 _VALID_SHAPES = ("quad", "cylinder", "equirect")
 
+# Every key the placements.<name> block understands (lock-mode strategy
+# knobs + surface-shape keys). Unknown keys warn instead of silently
+# falling back to defaults — a typo'd `cylinder_radius` should not run
+# with a 2 m default and no hint.
+_KNOWN_PLACEMENT_KEYS = frozenset(
+    {
+        "lock_mode",
+        "distance",
+        "offset_x",
+        "offset_y",
+        "look_away_angle_deg",
+        "reposition_distance",
+        "reposition_delay_s",
+        "transition_duration_s",
+        "size",
+        "stereo_baseline_mm",
+        "shape",
+        "native",
+        "cylinder_radius_m",
+        "cylinder_angle_deg",
+    }
+)
+
+
+def _warn_unknown_placement_keys(cam_name: str, pspec: dict) -> None:
+    import difflib
+
+    for key in pspec:
+        if key in _KNOWN_PLACEMENT_KEYS:
+            continue
+        hint = difflib.get_close_matches(key, _KNOWN_PLACEMENT_KEYS, n=1)
+        suggestion = f" (did you mean {hint[0]!r}?)" if hint else ""
+        print(
+            f"camera_viz: warning: placements.{cam_name}: unknown key "
+            f"{key!r}{suggestion} — ignored",
+            file=sys.stderr,
+            flush=True,
+        )
+
 
 def _shape_for(cam_name: str, placements_cfg: dict) -> Tuple[str, bool, float, float]:
     """Per-camera surface config from ``display.placements.<name>``:
@@ -69,6 +108,7 @@ def _shape_for(cam_name: str, placements_cfg: dict) -> Tuple[str, bool, float, f
     (quads only, default true), ``cylinder_radius_m`` / ``cylinder_angle_deg``
     (cylinder only)."""
     pspec = placements_cfg.get(cam_name) or {}
+    _warn_unknown_placement_keys(cam_name, pspec)
     shape = str(pspec.get("shape", "quad")).lower()
     if shape not in _VALID_SHAPES:
         raise ValueError(

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -18,6 +18,8 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import contextlib
+import math
 import signal
 import sys
 from dataclasses import dataclass
@@ -27,6 +29,7 @@ from typing import List, Optional, Tuple
 import yaml
 
 import isaacteleop.viz as viz
+from isaacteleop.cloudxr import CloudXRLauncher
 
 from pipeline import FrameSource, VizRunner
 from placements import PlacementConfig, PlacementStrategy, build as build_placement
@@ -224,6 +227,49 @@ def _make_session(cfg: dict, mode_override: Optional[str] = None) -> viz.VizSess
     return viz.VizSession.create(session_cfg)
 
 
+def _add_layer(session: viz.VizSession, entry: SourceEntry, args: argparse.Namespace):
+    """Register one layer for ``entry`` per --layer-shape.
+
+    quad     → QuadLayer (compositor path, or native when --native-quad);
+               the placement strategy positions it per frame.
+    cylinder → native CylinderLayer: the feed wrapped on an arc facing the
+               user (radius / angle from the CLI, aspect from the source).
+    equirect → native EquirectLayer: full 360x180 sphere (the source is
+               expected to be an equirect panorama).
+    """
+    spec = entry.source.spec
+    if args.layer_shape == "cylinder":
+        layer_cfg = viz.CylinderLayerConfig()
+        layer_cfg.name = spec.name
+        layer_cfg.resolution = viz.Resolution(spec.width, spec.height)
+        layer_cfg.stereo = entry.stereo
+        placement = viz.CylinderLayerPlacement()
+        placement.radius = args.cylinder_radius
+        placement.central_angle = math.radians(args.cylinder_angle_deg)
+        # aspect_ratio 0 = derived from the source resolution (square texels).
+        layer_cfg.placement = placement
+        return session.add_cylinder_layer(layer_cfg)
+    if args.layer_shape == "equirect":
+        layer_cfg = viz.EquirectLayerConfig()
+        layer_cfg.name = spec.name
+        layer_cfg.resolution = viz.Resolution(spec.width, spec.height)
+        layer_cfg.stereo = entry.stereo
+        # Default placement = full 360x180 sphere at infinite radius.
+        return session.add_equirect_layer(layer_cfg)
+
+    layer_cfg = viz.QuadLayerConfig()
+    layer_cfg.name = spec.name
+    layer_cfg.resolution = viz.Resolution(spec.width, spec.height)
+    layer_cfg.format = viz.PixelFormat.kRGBA8
+    if entry.stereo:
+        layer_cfg.stereo = True
+        layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
+    # Native OpenXR quad path (kXr only; a no-op fallback in window mode).
+    # Requires a placement, which the placement strategy applies below.
+    layer_cfg.use_openxr_quad_layer = args.native_quad
+    return session.add_quad_layer(layer_cfg)
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     parser = argparse.ArgumentParser(description="Televiz camera_viz — display side")
     parser.add_argument("config", type=Path, help="YAML config file")
@@ -243,6 +289,33 @@ def main(argv: Optional[list[str]] = None) -> int:
         "quad the projection layer is dropped, letting the runtime engage "
         "its quad fast path / client-reconstructed streaming.",
     )
+    parser.add_argument(
+        "--layer-shape",
+        choices=("quad", "cylinder", "equirect"),
+        default="quad",
+        help="Surface each camera is mapped onto (default: quad). "
+        "cylinder wraps the feed onto a native XrCompositionLayerCylinderKHR "
+        "arc; equirect maps it onto a native XrCompositionLayerEquirect2KHR "
+        "sphere (for 360/180 panorama sources). Both are native-only and "
+        "require XR mode + a runtime advertising the matching "
+        "XR_KHR_composition_layer_* extension; placement lock modes from the "
+        "config apply to quads only.",
+    )
+    parser.add_argument(
+        "--cylinder-radius",
+        type=float,
+        default=2.0,
+        metavar="METERS",
+        help="Cylinder radius when --layer-shape cylinder (default: 2.0).",
+    )
+    parser.add_argument(
+        "--cylinder-angle-deg",
+        type=float,
+        default=90.0,
+        metavar="DEGREES",
+        help="Cylinder visible arc when --layer-shape cylinder (default: 90).",
+    )
+    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv)
 
     with open(args.config) as f:
@@ -262,67 +335,76 @@ def main(argv: Optional[list[str]] = None) -> int:
         raise ValueError(f"camera_viz: source must be local|rtp, got {source_mode!r}")
 
     effective_mode = (args.mode or cfg.get("display", {}).get("mode", "xr")).lower()
-    session = _make_session(cfg, mode_override=args.mode)
-    is_xr = session.is_xr_mode()
-
-    if source_mode == "local":
-        entries = _build_local_entries(cfg, is_xr)
-    else:
-        entries = _build_rtp_entries(cfg, is_xr)
-
-    # Build sources, layers, and placement strategies in parallel arrays.
-    sources, layers, strategies = [], [], []
-    for entry in entries:
-        sources.append(entry.source)
-        layer_cfg = viz.QuadLayerConfig()
-        layer_cfg.name = entry.source.spec.name
-        layer_cfg.resolution = viz.Resolution(
-            entry.source.spec.width, entry.source.spec.height
+    if args.layer_shape != "quad" and effective_mode != "xr":
+        raise SystemExit(
+            f"camera_viz: --layer-shape {args.layer_shape} is native-only "
+            "(XrCompositionLayer*KHR) and requires XR mode; use --mode xr "
+            "or drop the flag in window mode."
         )
-        layer_cfg.format = viz.PixelFormat.kRGBA8
-        if entry.stereo:
-            layer_cfg.stereo = True
-            layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
-        # Native OpenXR quad path (kXr only; a no-op fallback in window mode).
-        # Requires a placement, which the placement strategy applies below.
-        layer_cfg.use_openxr_quad_layer = args.native_quad
-        layers.append(session.add_quad_layer(layer_cfg))
-        strategies.append(entry.placement)
 
-    print(
-        f"camera_viz: source={source_mode}, mode={effective_mode}, "
-        f"xr={is_xr}, {len(sources)} layer(s)",
-        flush=True,
+    # In XR mode, launch the in-process CloudXR runtime (+ WSS proxy for
+    # headset clients) before creating the session — VizSession's OpenXR
+    # instance needs XR_RUNTIME_JSON + a running service, both of which the
+    # launcher provides. --no-launch-cloudxr-runtime skips this when a
+    # runtime is already up (e.g. after sourcing ~/.cloudxr/run/cloudxr.env).
+    # Window mode never launches a runtime.
+    launch_ctx = (
+        CloudXRLauncher.launch_context(args)
+        if effective_mode == "xr"
+        else contextlib.nullcontext(None)
     )
+    with launch_ctx:
+        session = _make_session(cfg, mode_override=args.mode)
+        is_xr = session.is_xr_mode()
 
-    runner = VizRunner(session, sources, layers, strategies)
-
-    def _on_signal(signum, frame):
-        print(f"camera_viz: stopping (signal {signum})...", flush=True)
-        runner.stop()
-
-    signal.signal(signal.SIGINT, _on_signal)
-    signal.signal(signal.SIGTERM, _on_signal)
-
-    runner.start()
-    try:
-        runner.wait()
-    finally:
-        # Skip session.destroy() when a worker thread is still alive —
-        # it may be inside session.render() and destroying under it
-        # would UAF on the Vulkan / CUDA handles. Non-daemon thread
-        # keeps the process alive; OS reaps at exit.
-        clean = runner.stop()
-        if clean:
-            session.destroy()
+        if source_mode == "local":
+            entries = _build_local_entries(cfg, is_xr)
         else:
-            print(
-                "camera_viz: worker thread did not exit; leaving VizSession "
-                "alive to avoid use-after-free. Process will keep running "
-                "until the stuck thread completes.",
-                file=sys.stderr,
-                flush=True,
-            )
+            entries = _build_rtp_entries(cfg, is_xr)
+
+        # Build sources, layers, and placement strategies in parallel arrays.
+        sources, layers, strategies = [], [], []
+        for entry in entries:
+            sources.append(entry.source)
+            layers.append(_add_layer(session, entry, args))
+            # Placement lock-mode strategies drive QuadLayer.set_placement;
+            # cylinder/equirect placements are fixed at add time.
+            strategies.append(entry.placement if args.layer_shape == "quad" else None)
+
+        print(
+            f"camera_viz: source={source_mode}, mode={effective_mode}, "
+            f"xr={is_xr}, shape={args.layer_shape}, {len(sources)} layer(s)",
+            flush=True,
+        )
+
+        runner = VizRunner(session, sources, layers, strategies)
+
+        def _on_signal(signum, frame):
+            print(f"camera_viz: stopping (signal {signum})...", flush=True)
+            runner.stop()
+
+        signal.signal(signal.SIGINT, _on_signal)
+        signal.signal(signal.SIGTERM, _on_signal)
+
+        runner.start()
+        try:
+            runner.wait()
+        finally:
+            # Skip session.destroy() when a worker thread is still alive —
+            # it may be inside session.render() and destroying under it
+            # would UAF on the Vulkan / CUDA handles. Non-daemon thread
+            # keeps the process alive; OS reaps at exit.
+            clean = runner.stop()
+            if clean:
+                session.destroy()
+            else:
+                print(
+                    "camera_viz: worker thread did not exit; leaving VizSession "
+                    "alive to avoid use-after-free. Process will keep running "
+                    "until the stuck thread completes.",
+                    file=sys.stderr,
+                    flush=True,
+                )
     return 0
 
 

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -267,9 +267,10 @@ def _add_layer(session: viz.VizSession, entry: SourceEntry, args: argparse.Names
     if entry.stereo:
         layer_cfg.stereo = True
         layer_cfg.stereo_baseline_mm = entry.stereo_baseline_mm
-    # Native OpenXR quad path (kXr only; a no-op fallback in window mode).
-    # Requires a placement, which the placement strategy applies below.
-    layer_cfg.use_openxr_quad_layer = args.native_quad
+    # Native OpenXR quad path is the default (kXr only; window mode always
+    # composites). Requires a placement, which the placement strategy
+    # applies below.
+    layer_cfg.native_composition = args.native_quad
     return session.add_quad_layer(layer_cfg)
 
 
@@ -285,12 +286,15 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     parser.add_argument(
         "--native-quad",
-        action="store_true",
+        action=argparse.BooleanOptionalAction,
+        default=True,
         help="Submit each camera as a native OpenXR quad layer "
-        "(XrCompositionLayerQuad) instead of the built-in compositor. "
-        "kXr only; ignored in window mode. When every layer is a native "
-        "quad the projection layer is dropped, letting the runtime engage "
-        "its quad fast path / client-reconstructed streaming.",
+        "(XrCompositionLayerQuad) — the default in XR mode; window mode "
+        "always composites. When every layer is native the projection "
+        "layer is dropped, letting the runtime engage its quad fast path / "
+        "client-reconstructed streaming. Pass --no-native-quad to fall "
+        "back to the built-in compositor (e.g. for runtimes that "
+        "mishandle native quad layers).",
     )
     parser.add_argument(
         "--layer-shape",
@@ -351,12 +355,20 @@ def main(argv: Optional[list[str]] = None) -> int:
     # launcher provides. --no-launch-cloudxr-runtime skips this when a
     # runtime is already up (e.g. after sourcing ~/.cloudxr/run/cloudxr.env).
     # Window mode never launches a runtime.
+    # Entered manually (not ``with``) so the unclean-stop path below can
+    # SKIP the teardown: stopping the runtime while a worker thread is
+    # still inside session.render() would rip the OpenXR service out from
+    # under a live xrWaitFrame — the same hazard the skip-destroy
+    # mitigation exists for. The launcher registers an atexit stop, which
+    # fires once the stuck (non-daemon) thread finally exits.
     launch_ctx = (
         CloudXRLauncher.launch_context(args)
         if effective_mode == "xr"
         else contextlib.nullcontext(None)
     )
-    with launch_ctx:
+    launch_ctx.__enter__()
+    stop_launcher = True
+    try:
         session = _make_session(cfg, mode_override=args.mode)
         is_xr = session.is_xr_mode()
 
@@ -396,18 +408,23 @@ def main(argv: Optional[list[str]] = None) -> int:
             # Skip session.destroy() when a worker thread is still alive —
             # it may be inside session.render() and destroying under it
             # would UAF on the Vulkan / CUDA handles. Non-daemon thread
-            # keeps the process alive; OS reaps at exit.
+            # keeps the process alive; OS reaps at exit. Leave the CloudXR
+            # runtime up too (see launch_ctx comment above).
             clean = runner.stop()
             if clean:
                 session.destroy()
             else:
+                stop_launcher = False
                 print(
                     "camera_viz: worker thread did not exit; leaving VizSession "
-                    "alive to avoid use-after-free. Process will keep running "
-                    "until the stuck thread completes.",
+                    "and the CloudXR runtime alive to avoid use-after-free. "
+                    "Process will keep running until the stuck thread completes.",
                     file=sys.stderr,
                     flush=True,
                 )
+    finally:
+        if stop_launcher:
+            launch_ctx.__exit__(None, None, None)
     return 0
 
 

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -41,17 +41,6 @@ from sources import (
     set_verbose,
 )
 
-# camera_viz tracks the in-repo isaacteleop; a PyPI wheel that predates
-# this example lacks the CloudXR launcher helpers and the shaped-layer /
-# compositor-choice APIs. Detect once and either degrade (launcher) or
-# fail with the remedy (layer APIs) instead of stack-tracing.
-_HAS_LAUNCHER_HELPERS = hasattr(CloudXRLauncher, "add_launcher_arguments")
-_UPGRADE_HINT = (
-    "your installed isaacteleop is too old for this camera_viz — install the "
-    "matching wheel (./camera_viz.sh setup --wheel <path-to-built-wheel>) or "
-    "point PYTHONPATH at an IsaacTeleop build's python_package/."
-)
-
 
 @dataclass
 class SourceEntry:
@@ -376,17 +365,7 @@ def _add_layer(session: viz.VizSession, entry: SourceEntry):
     # OpenXR-runtime composition is the default (kXr only; window mode is
     # always composited by Televiz). Requires a placement, which the
     # placement strategy applies below.
-    want_openxr = entry.compositor == "openxr"
-    if hasattr(layer_cfg, "openxr_composition"):
-        layer_cfg.openxr_composition = want_openxr
-    elif want_openxr:
-        # Old isaacteleop wheel: quads are Televiz-composited only.
-        print(
-            f"camera_viz: warning: {_UPGRADE_HINT} Falling back to "
-            "compositor: televiz for quads.",
-            file=sys.stderr,
-            flush=True,
-        )
+    layer_cfg.openxr_composition = entry.compositor == "openxr"
     return session.add_quad_layer(layer_cfg)
 
 
@@ -400,8 +379,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="Override display.mode from the config "
         "(default: the config's value, or xr when the config omits it).",
     )
-    if _HAS_LAUNCHER_HELPERS:
-        CloudXRLauncher.add_launcher_arguments(parser)
+    CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv)
 
     with open(args.config) as f:
@@ -435,11 +413,6 @@ def main(argv: Optional[list[str]] = None) -> int:
                 "composited by the OpenXR runtime and requires XR mode; "
                 "use --mode xr or shape: quad in window mode."
             )
-        if not hasattr(viz, "CylinderLayerConfig"):
-            raise SystemExit(
-                f"camera_viz: placements.{cam['name']}.shape: {shape} needs "
-                f"cylinder/equirect layer support — {_UPGRADE_HINT}"
-            )
 
     # In XR mode, launch the in-process CloudXR runtime (+ WSS proxy for
     # headset clients) before creating the session — VizSession's OpenXR
@@ -453,17 +426,9 @@ def main(argv: Optional[list[str]] = None) -> int:
     # under a live xrWaitFrame — the same hazard the skip-destroy
     # mitigation exists for. The launcher registers an atexit stop, which
     # fires once the stuck (non-daemon) thread finally exits.
-    if effective_mode == "xr" and not _HAS_LAUNCHER_HELPERS:
-        print(
-            f"camera_viz: warning: {_UPGRADE_HINT} Continuing WITHOUT "
-            "launching the CloudXR runtime — start it yourself if one "
-            "isn't already running.",
-            file=sys.stderr,
-            flush=True,
-        )
     launch_ctx = (
         CloudXRLauncher.launch_context(args)
-        if effective_mode == "xr" and _HAS_LAUNCHER_HELPERS
+        if effective_mode == "xr"
         else contextlib.nullcontext(None)
     )
     launch_ctx.__enter__()

--- a/examples/camera_viz/configs/oakd.yaml
+++ b/examples/camera_viz/configs/oakd.yaml
@@ -46,4 +46,9 @@ display:
   placements:
     oakd:                       # size defaults to 1.0 m wide × aspect-derived height
       lock_mode: lazy
-      distance: 1.5
+      distance: 1.0
+      shape: cylinder           # quad (default) | cylinder | equirect
+      native: true          # quads only: native XrCompositionLayerQuad
+                            # (default) vs the built-in compositor
+      cylinder_radius_m: 1.0    # cylinder only
+      cylinder_angle_deg: 45    # cylinder only

--- a/examples/camera_viz/configs/oakd.yaml
+++ b/examples/camera_viz/configs/oakd.yaml
@@ -48,7 +48,8 @@ display:
       lock_mode: lazy
       distance: 1.0
       # shape: cylinder           # quad (default) | cylinder | equirect
-      # native: true          # quads only: native XrCompositionLayerQuad
-      #                       # (default) vs the built-in compositor
+      # compositor: openxr    # openxr (default: the OpenXR runtime
+      #                       # composites the layer) | televiz (built-in
+      #                       # compositor; quad shape only)
       # cylinder_radius_m: 1.0    # cylinder only
       # cylinder_angle_deg: 45    # cylinder only

--- a/examples/camera_viz/configs/oakd.yaml
+++ b/examples/camera_viz/configs/oakd.yaml
@@ -47,8 +47,8 @@ display:
     oakd:                       # size defaults to 1.0 m wide × aspect-derived height
       lock_mode: lazy
       distance: 1.0
-      shape: cylinder           # quad (default) | cylinder | equirect
-      native: true          # quads only: native XrCompositionLayerQuad
-                            # (default) vs the built-in compositor
-      cylinder_radius_m: 1.0    # cylinder only
-      cylinder_angle_deg: 45    # cylinder only
+      # shape: cylinder           # quad (default) | cylinder | equirect
+      # native: true          # quads only: native XrCompositionLayerQuad
+      #                       # (default) vs the built-in compositor
+      # cylinder_radius_m: 1.0    # cylinder only
+      # cylinder_angle_deg: 45    # cylinder only

--- a/examples/camera_viz/configs/realsense.yaml
+++ b/examples/camera_viz/configs/realsense.yaml
@@ -48,4 +48,4 @@ display:
   placements:
     cam:                        # size defaults to 1.0 m wide × aspect-derived height
       lock_mode: lazy
-      distance: 1.5
+      distance: 1.0

--- a/examples/camera_viz/configs/replay.yaml
+++ b/examples/camera_viz/configs/replay.yaml
@@ -46,8 +46,14 @@ display:
   xr:
     near_z: 0.05
     far_z: 100.0
-  clear_color: [0.05, 0.05, 0.08, 1.0]
+  clear_color: [0.0, 0.0, 0.0, 0.0]
   placements:
     replay:                     # size defaults to 1.0 m wide × aspect-derived height
       lock_mode: lazy
       distance: 1.5
+      # Surface the feed is mapped onto (all shapes are per-camera):
+      #   shape: quad           # quad (default) | cylinder | equirect
+      #   native: true          # quads only: native XrCompositionLayerQuad
+      #                         # (default) vs the built-in compositor
+      #   cylinder_radius_m: 2.0    # cylinder only
+      #   cylinder_angle_deg: 90    # cylinder only

--- a/examples/camera_viz/configs/replay.yaml
+++ b/examples/camera_viz/configs/replay.yaml
@@ -53,7 +53,8 @@ display:
       distance: 1.5
       # Surface the feed is mapped onto (all shapes are per-camera):
       #   shape: quad           # quad (default) | cylinder | equirect
-      #   native: true          # quads only: native XrCompositionLayerQuad
-      #                         # (default) vs the built-in compositor
+      #   compositor: openxr    # openxr (default: the OpenXR runtime
+      #                         # composites the layer) | televiz (built-in
+      #                         # compositor; quad shape only)
       #   cylinder_radius_m: 2.0    # cylinder only
       #   cylinder_angle_deg: 90    # cylinder only

--- a/examples/camera_viz/configs/synthetic.yaml
+++ b/examples/camera_viz/configs/synthetic.yaml
@@ -36,4 +36,4 @@ display:
   placements:
     synth:                      # size defaults to 1.0 m wide × aspect-derived height
       lock_mode: lazy
-      distance: 1.5
+      distance: 1.0

--- a/examples/camera_viz/configs/synthetic_stereo.yaml
+++ b/examples/camera_viz/configs/synthetic_stereo.yaml
@@ -39,7 +39,7 @@ display:
   placements:
     synth:
       lock_mode: lazy
-      distance: 1.5
+      distance: 1.0
       stereo_baseline_mm: 0.0     # 0 → both eyes see the same world quad
                                   # (parallax purely from the captured frames).
                                   # Try 65.0 (typical IPD) to virtually push the

--- a/examples/camera_viz/configs/v4l2.yaml
+++ b/examples/camera_viz/configs/v4l2.yaml
@@ -43,4 +43,4 @@ display:
   placements:
     cam:                        # size defaults to 1.0 m wide × aspect-derived height
       lock_mode: lazy
-      distance: 1.5
+      distance: 1.0

--- a/examples/camera_viz/configs/zed.yaml
+++ b/examples/camera_viz/configs/zed.yaml
@@ -48,8 +48,8 @@ display:
       distance: 1.0
       stereo_baseline_mm: 50.0
       # Surface the feed is mapped onto (all shapes are per-camera):
-      shape: cylinder           # quad (default) | cylinder | equirect
-      native: true          # quads only: native XrCompositionLayerQuad
-                            # (default) vs the built-in compositor
-      cylinder_radius_m: 2.0    # cylinder only
-      cylinder_angle_deg: 45    # cylinder only
+      # shape: cylinder           # quad (default) | cylinder | equirect
+      # native: true          # quads only: native XrCompositionLayerQuad
+      #                       # (default) vs the built-in compositor
+      # cylinder_radius_m: 2.0    # cylinder only
+      # cylinder_angle_deg: 45    # cylinder only

--- a/examples/camera_viz/configs/zed.yaml
+++ b/examples/camera_viz/configs/zed.yaml
@@ -49,7 +49,8 @@ display:
       stereo_baseline_mm: 50.0
       # Surface the feed is mapped onto (all shapes are per-camera):
       # shape: cylinder           # quad (default) | cylinder | equirect
-      # native: true          # quads only: native XrCompositionLayerQuad
-      #                       # (default) vs the built-in compositor
+      # compositor: openxr    # openxr (default: the OpenXR runtime
+      #                       # composites the layer) | televiz (built-in
+      #                       # compositor; quad shape only)
       # cylinder_radius_m: 2.0    # cylinder only
       # cylinder_angle_deg: 45    # cylinder only

--- a/examples/camera_viz/configs/zed.yaml
+++ b/examples/camera_viz/configs/zed.yaml
@@ -47,3 +47,9 @@ display:
       lock_mode: lazy
       distance: 1.0
       stereo_baseline_mm: 50.0
+      # Surface the feed is mapped onto (all shapes are per-camera):
+      shape: cylinder           # quad (default) | cylinder | equirect
+      native: true          # quads only: native XrCompositionLayerQuad
+                            # (default) vs the built-in compositor
+      cylinder_radius_m: 2.0    # cylinder only
+      cylinder_angle_deg: 45    # cylinder only

--- a/examples/camera_viz/configs/zed.yaml
+++ b/examples/camera_viz/configs/zed.yaml
@@ -23,7 +23,7 @@ cameras:
     # full list.
     width: 1280
     height: 720
-    fps: 30
+    fps: 60
     bus_type: usb               # usb | gmsl
     serial_number: 0            # 0 → first available
     stereo: true
@@ -49,7 +49,7 @@ display:
       stereo_baseline_mm: 50.0
       # Surface the feed is mapped onto (all shapes are per-camera):
       # shape: cylinder           # quad (default) | cylinder | equirect
-      # compositor: openxr    # openxr (default: the OpenXR runtime
+      compositor: televiz   # openxr (default: the OpenXR runtime
       #                       # composites the layer) | televiz (built-in
       #                       # compositor; quad shape only)
       # cylinder_radius_m: 2.0    # cylinder only

--- a/examples/camera_viz/configs/zed.yaml
+++ b/examples/camera_viz/configs/zed.yaml
@@ -49,7 +49,7 @@ display:
       stereo_baseline_mm: 50.0
       # Surface the feed is mapped onto (all shapes are per-camera):
       # shape: cylinder           # quad (default) | cylinder | equirect
-      compositor: televiz   # openxr (default: the OpenXR runtime
+      # compositor: openxr    # openxr (default: the OpenXR runtime
       #                       # composites the layer) | televiz (built-in
       #                       # compositor; quad shape only)
       # cylinder_radius_m: 2.0    # cylinder only

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -16,7 +16,9 @@ VizRunner owns two threads:
 from __future__ import annotations
 
 import logging
+import sys
 import threading
+import time
 from typing import Optional, Sequence
 
 import isaacteleop.viz as viz
@@ -28,6 +30,14 @@ logger = logging.getLogger(__name__)
 
 # Submit thread poll interval when no source has new data.
 SUBMIT_POLL_S = 0.001
+
+# Pipeline-stats print interval. One line per period on stderr showing
+# per-source submit rate and the session's render rate — the first thing
+# to look at when "the fps is low": a submit rate below the camera's
+# capture rate points at the source/pairing/submit path, a render rate
+# below the display rate points at the XR runtime pacing (missed
+# deadlines / GPU time).
+STATS_PERIOD_S = 5.0
 
 # Window-mode stop-check granularity. stop() calls cond.notify_all()
 # so this is normally a safety net, not a hot path — value isn't a
@@ -87,6 +97,10 @@ class VizRunner:
         # falling through to ``return 0``.
         self._error: Optional[BaseException] = None
         self._error_lock = threading.Lock()
+        # Per-source submit counters (submit thread writes, stats print
+        # reads — plain ints under the GIL, approximate reads are fine).
+        self._submit_counts = [0] * len(self._layers)
+        self._stats_t0 = 0.0
 
     def start(self) -> None:
         if self._submit_thread is not None or self._render_thread is not None:
@@ -202,9 +216,10 @@ class VizRunner:
     def _submit_loop_inner(self) -> None:
         # Pin to the source's GPU on the first frame.
         device_pinned = False
+        self._stats_t0 = time.monotonic()
         while not self._stop.is_set():
             published_any = False
-            for layer, source in zip(self._layers, self._sources):
+            for i, (layer, source) in enumerate(zip(self._layers, self._sources)):
                 frame = source.latest()
                 if frame is None:
                     continue
@@ -215,6 +230,7 @@ class VizRunner:
                     layer.submit(frame.image, frame.image_right, stream=frame.stream)
                 else:
                     layer.submit(frame.image, stream=frame.stream)
+                self._submit_counts[i] += 1
                 published_any = True
             if published_any:
                 with self._data_cond:
@@ -222,6 +238,35 @@ class VizRunner:
                     self._data_cond.notify()
             else:
                 self._stop.wait(timeout=SUBMIT_POLL_S)
+            now = time.monotonic()
+            if now - self._stats_t0 >= STATS_PERIOD_S:
+                self._print_stats(now - self._stats_t0)
+                self._stats_t0 = now
+
+    def _print_stats(self, elapsed: float) -> None:
+        """One stderr line per STATS_PERIOD_S: per-source submit rate +
+        the session's render-side numbers."""
+        parts = []
+        for i, source in enumerate(self._sources):
+            rate = self._submit_counts[i] / elapsed if elapsed > 0 else 0.0
+            self._submit_counts[i] = 0
+            parts.append(f"{source.spec.name} {rate:.1f} submit/s")
+        try:
+            t = self._session.get_frame_timing_stats()
+            render = (
+                f"render {t.render_fps:.1f} fps"
+                + (f" (target {t.target_fps:.0f})" if t.target_fps else "")
+                + f", missed {t.missed_frames}"
+                + (f", gpu {t.gpu_time_ms:.1f} ms" if t.gpu_time_ms else "")
+                + (f", stale {t.stale_layers}" if t.stale_layers else "")
+            )
+        except Exception:
+            render = "render n/a"
+        print(
+            "camera_viz: stats: " + render + " | " + " | ".join(parts),
+            file=sys.stderr,
+            flush=True,
+        )
 
     def _pin_to_device(self, frame) -> None:
         try:

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -25,6 +25,7 @@ from .interface import FrameSource
 
 logger = logging.getLogger(__name__)
 
+
 # Submit thread poll interval when no source has new data.
 SUBMIT_POLL_S = 0.001
 
@@ -288,9 +289,19 @@ class VizRunner:
             if strategy is None:
                 continue
             placement = strategy.update(head.position, head.orientation)
-            layer.set_placement(
-                viz.QuadLayerPlacement(
-                    viz.Pose3D(placement.position, placement.orientation),
-                    placement.size_meters,
+            if isinstance(layer, viz.CylinderLayer):
+                # The cylinder's pose is the strategy's head anchor (its arc
+                # bows out along the anchor's -z at radius); radius / angle /
+                # aspect stay as configured.
+                cyl = layer.placement()
+                cyl.pose = viz.Pose3D(
+                    placement.anchor_position, placement.anchor_orientation
                 )
-            )
+                layer.set_placement(cyl)
+            else:
+                layer.set_placement(
+                    viz.QuadLayerPlacement(
+                        viz.Pose3D(placement.position, placement.orientation),
+                        placement.size_meters,
+                    )
+                )

--- a/examples/camera_viz/placements/lock_modes.py
+++ b/examples/camera_viz/placements/lock_modes.py
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""World / head / lazy locked placement strategies."""
+"""World / head / lazy / gimbal locked placement strategies."""
 
 from __future__ import annotations
 
@@ -162,6 +162,41 @@ class HeadLocked(PlacementStrategy):
         )
 
 
+class GimbalLocked(PlacementStrategy):
+    """Translation head-locked, rotation world-locked: the surface follows
+    your position every frame but keeps the yaw captured at first sight —
+    walk and it comes with you, turn your head and you look around it.
+    The "virtual gimbal" mode for wide cylinder feeds."""
+
+    def __init__(self, config: PlacementConfig) -> None:
+        self._config = config
+        self._forward_xz: Optional[Vec3] = None
+        self._yaw = 0.0
+
+    def update(self, head_pos: Vec3, head_orientation: Quat) -> Placement:
+        if self._forward_xz is None:
+            # Capture the world-locked heading once: face where the user
+            # is looking at first update.
+            self._forward_xz = project_forward_xz(head_orientation)
+            probe = _target_position(head_pos, self._forward_xz, self._config)
+            self._yaw = _yaw_to_face(head_pos, probe)
+        position = _target_position(head_pos, self._forward_xz, self._config)
+        orientation = yaw_quat(self._yaw)
+        # Anchor = the head itself (plus offsets, already baked into
+        # ``position``): pull back along the fixed heading.
+        anchor = tuple(
+            position[i] - self._forward_xz[i] * self._config.distance for i in range(3)
+        )
+        return Placement(
+            position,
+            orientation,
+            self._config.size_meters,
+            self._config.distance,
+            anchor,
+            orientation,
+        )
+
+
 class LazyLocked(PlacementStrategy):
     """World-locked, but smoothly re-snaps in front of the user when they
     look away (or drift) past a threshold for ``reposition_delay_s``.
@@ -266,11 +301,14 @@ class LazyLocked(PlacementStrategy):
 def build(lock_mode: str, config: PlacementConfig) -> PlacementStrategy:
     """Factory used by the YAML loader.
 
-    ``"world"`` → WorldLocked, ``"head"`` → HeadLocked, anything else
-    (including ``"lazy"``) → LazyLocked.
+    ``"world"`` → WorldLocked, ``"head"`` → HeadLocked, ``"gimbal"`` →
+    GimbalLocked (translation follows the head, rotation stays
+    world-locked), anything else (including ``"lazy"``) → LazyLocked.
     """
     if lock_mode == "world":
         return WorldLocked(config)
     if lock_mode == "head":
         return HeadLocked(config)
+    if lock_mode == "gimbal":
+        return GimbalLocked(config)
     return LazyLocked(config)

--- a/examples/camera_viz/placements/lock_modes.py
+++ b/examples/camera_viz/placements/lock_modes.py
@@ -43,11 +43,24 @@ class PlacementConfig:
 
 @dataclass
 class Placement:
-    """Output of a strategy: feeds straight into ``viz.QuadLayerPlacement``."""
+    """Output of a strategy.
+
+    ``position`` / ``orientation`` / ``size_meters`` feed straight into
+    ``viz.QuadLayerPlacement``. ``anchor_position`` / ``anchor_orientation``
+    are the head-anchored pose ``distance`` behind the plane, oriented so
+    local −z points at the plane — the pose a curved surface centered on
+    the viewer (``viz.CylinderLayerPlacement``) should use. Each strategy
+    computes the anchor itself because the facing conventions differ
+    (world/lazy build yaw-only quats whose +z faces the head; head-locked
+    uses the full head orientation flipped 180°).
+    """
 
     position: Vec3
     orientation: Quat  # (w, x, y, z)
     size_meters: Tuple[float, float]
+    distance: float = 1.5
+    anchor_position: Vec3 = (0.0, 0.0, 0.0)
+    anchor_orientation: Quat = (1.0, 0.0, 0.0, 0.0)
 
 
 class PlacementStrategy(ABC):
@@ -89,7 +102,21 @@ class WorldLocked(PlacementStrategy):
             forward_xz = project_forward_xz(head_orientation)
             position = _target_position(head_pos, forward_xz, self._config)
             yaw = _yaw_to_face(head_pos, position)
-            self._cached = Placement(position, yaw_quat(yaw), self._config.size_meters)
+            orientation = yaw_quat(yaw)
+            # Anchor = the head point the plane was placed around: push the
+            # plane back along its local +z (which faces the head).
+            back = rotate_vec(orientation, (0.0, 0.0, 1.0))
+            anchor = tuple(
+                position[i] + back[i] * self._config.distance for i in range(3)
+            )
+            self._cached = Placement(
+                position,
+                orientation,
+                self._config.size_meters,
+                self._config.distance,
+                anchor,
+                orientation,
+            )
         return self._cached
 
 
@@ -116,7 +143,23 @@ class HeadLocked(PlacementStrategy):
             head_pos[2] + forward[2] * d + right[2] * ox + up[2] * oy,
         )
         orientation = quat_mul(head_orientation, _ROT_Y_180)
-        return Placement(position, orientation, self._config.size_meters)
+        # Anchor = the head itself (plus the configured offsets, already
+        # baked into ``position``): pull the plane back by ``distance``.
+        # Orientation is the UNflipped head pose so the anchor's local −z
+        # (where a cylinder arc bows out) tracks the gaze direction.
+        anchor = (
+            position[0] - forward[0] * d,
+            position[1] - forward[1] * d,
+            position[2] - forward[2] * d,
+        )
+        return Placement(
+            position,
+            orientation,
+            self._config.size_meters,
+            self._config.distance,
+            anchor,
+            head_orientation,
+        )
 
 
 class LazyLocked(PlacementStrategy):
@@ -150,9 +193,7 @@ class LazyLocked(PlacementStrategy):
             self._yaw = _yaw_to_face(head_pos, self._position)
             self._target_yaw = self._yaw
             self._initialized = True
-            return Placement(
-                self._position, yaw_quat(self._yaw), self._config.size_meters
-            )
+            return self._placement()
 
         # Look-away check: angle between head forward and head→plane vector.
         head_to_plane = (
@@ -201,7 +242,25 @@ class LazyLocked(PlacementStrategy):
                 self._is_transitioning = False
                 self._is_looking_away = False
 
-        return Placement(self._position, yaw_quat(self._yaw), self._config.size_meters)
+        return self._placement()
+
+    def _placement(self) -> Placement:
+        """Current (possibly mid-transition) pose as a Placement. The anchor
+        glides with the smoothed plane pose so a cylinder re-snaps along the
+        same eased path a quad does."""
+        orientation = yaw_quat(self._yaw)
+        back = rotate_vec(orientation, (0.0, 0.0, 1.0))
+        anchor = tuple(
+            self._position[i] + back[i] * self._config.distance for i in range(3)
+        )
+        return Placement(
+            self._position,
+            orientation,
+            self._config.size_meters,
+            self._config.distance,
+            anchor,
+            orientation,
+        )
 
 
 def build(lock_mode: str, config: PlacementConfig) -> PlacementStrategy:

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -297,11 +297,12 @@ EOF
     fi
 fi
 
-# isaacteleop comes from PyPI by default (the published wheel includes the
-# viz module). --wheel <path> installs a locally built wheel instead — only
-# needed when developing against an unreleased build (see the build-from-source
-# docs). Sender-only deploys don't install isaacteleop at all.
-ISAACTELEOP_PKG="isaacteleop"
+# isaacteleop comes from PyPI by default. camera_viz needs >= 1.4 (shaped
+# composition layers, compositor choice, CloudXR launcher helpers).
+# --wheel <path> installs a locally built wheel instead — only needed when
+# developing against an unreleased build (see the build-from-source docs).
+# Sender-only deploys don't install isaacteleop at all.
+ISAACTELEOP_PKG="isaacteleop>=1.4"
 if [[ "$MODE" == full && -n "$WHEEL" ]]; then
     [[ -f "$WHEEL" ]] || {
         echo "_install_deps.sh: --wheel '$WHEEL' not found." >&2

--- a/examples/camera_viz/sources/zed.py
+++ b/examples/camera_viz/sources/zed.py
@@ -28,11 +28,15 @@ from typing import List, Optional
 
 from pipeline import Frame, FrameSource, SourceSpec
 
-from ._helpers import notify
+from ._helpers import notify, notify_verbose
 
 
 def _notify(msg: str) -> None:
     notify("zed", msg)
+
+
+# Periodic capture-rate breadcrumb interval (verbose mode).
+_STATS_PERIOD_S = 5.0
 
 
 # Open() blocks inside pyzed's C extension; print a USB-3 hint after this
@@ -293,6 +297,17 @@ class _ZedCamera:
             camera.close()
             return False
 
+        # The SDK silently grants a lower rate than requested when the
+        # resolution/fps combination or the link can't sustain it (USB 2,
+        # shared bandwidth). Surface it — a 60 fps config quietly running
+        # at 30 is otherwise invisible until someone measures.
+        granted_fps = int(getattr(info.camera_configuration, "fps", 0) or 0)
+        if granted_fps and granted_fps != self._fps:
+            _notify(
+                f"SDK granted {granted_fps} fps (requested {self._fps}) — "
+                "unsupported resolution/fps combination or USB bandwidth cap"
+            )
+
         # Pyzed Mats are pitched GPU buffers — one per eye, reused every
         # grab() / retrieve_image() pair.
         for eye, slot in self._slots.items():
@@ -339,6 +354,8 @@ class _ZedCamera:
         }
 
         first_frame_seen = False
+        grab_count = 0
+        stats_t0 = time.monotonic()
         while not self._stop.is_set():
             if not self._connected:
                 now = time.monotonic()
@@ -401,6 +418,25 @@ class _ZedCamera:
                     if not first_frame_seen:
                         first_frame_seen = True
                         _notify("streaming")
+                    # Measured capture rate + the SDK's own estimate.
+                    # get_current_fps() exposes auto-exposure throttling
+                    # (low light halves the sensor rate even when the
+                    # grant was 60) that a wall-clock count alone hides.
+                    grab_count += 1
+                    now = time.monotonic()
+                    if now - stats_t0 >= _STATS_PERIOD_S:
+                        measured = grab_count / (now - stats_t0)
+                        try:
+                            sdk_fps = float(self._camera.get_current_fps())
+                        except Exception:
+                            sdk_fps = 0.0
+                        notify_verbose(
+                            "zed",
+                            f"capture {measured:.1f} fps"
+                            + (f" (SDK current {sdk_fps:.1f})" if sdk_fps else ""),
+                        )
+                        grab_count = 0
+                        stats_t0 = now
             except Exception as e:
                 _notify(f"frame error ({e}); reconnecting")
                 self._close_camera()

--- a/src/viz/layers/cpp/CMakeLists.txt
+++ b/src/viz/layers/cpp/CMakeLists.txt
@@ -11,9 +11,13 @@ cmake_minimum_required(VERSION 3.20)
 add_library(viz_layers STATIC
     image_layer_base.cpp
     quad_layer.cpp
+    cylinder_layer.cpp
+    equirect_layer.cpp
     projection_layer.cpp
     inc/viz/layers/image_layer_base.hpp
     inc/viz/layers/quad_layer.hpp
+    inc/viz/layers/cylinder_layer.hpp
+    inc/viz/layers/equirect_layer.hpp
     inc/viz/layers/projection_layer.hpp
 )
 

--- a/src/viz/layers/cpp/CMakeLists.txt
+++ b/src/viz/layers/cpp/CMakeLists.txt
@@ -9,8 +9,10 @@ cmake_minimum_required(VERSION 3.20)
 # helper layers (ClearRectLayer, ThrowingLayer) live in
 # viz/layers_tests/.
 add_library(viz_layers STATIC
+    image_layer_base.cpp
     quad_layer.cpp
     projection_layer.cpp
+    inc/viz/layers/image_layer_base.hpp
     inc/viz/layers/quad_layer.hpp
     inc/viz/layers/projection_layer.hpp
 )

--- a/src/viz/layers/cpp/cylinder_layer.cpp
+++ b/src/viz/layers/cpp/cylinder_layer.cpp
@@ -1,0 +1,127 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "inc/viz/layers/cylinder_layer.hpp"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace viz
+{
+
+namespace
+{
+
+// Placement validation shared by the ctor and set_placement. Angle upper
+// bound is 2π (full wrap) per XR_KHR_composition_layer_cylinder.
+void validate_placement(const CylinderLayer::Config::Placement& p)
+{
+    if (!std::isfinite(p.radius) || p.radius <= 0.0f)
+    {
+        throw std::invalid_argument("CylinderLayer: Placement::radius must be finite and > 0");
+    }
+    if (!std::isfinite(p.central_angle) || p.central_angle <= 0.0f || p.central_angle > glm::two_pi<float>())
+    {
+        throw std::invalid_argument("CylinderLayer: Placement::central_angle must be in (0, 2*pi]");
+    }
+    if (!std::isfinite(p.aspect_ratio) || p.aspect_ratio < 0.0f)
+    {
+        throw std::invalid_argument("CylinderLayer: Placement::aspect_ratio must be >= 0 (0 = derive from resolution)");
+    }
+}
+
+// Runs quietly inside the base-initializer expression so all validation
+// precedes the base's image allocation.
+const CylinderLayer::Config& validate_config(const CylinderLayer::Config& config)
+{
+    validate_placement(config.placement);
+    return config;
+}
+
+} // namespace
+
+CylinderLayer::CylinderLayer(const VkContext& ctx, Config config)
+    : ImageLayerBase(ctx,
+                     "CylinderLayer",
+                     validate_config(config).name,
+                     config.resolution,
+                     config.format,
+                     config.stereo,
+                     /*mip_levels=*/1),
+      config_(std::move(config))
+{
+    placement_ = config_.placement;
+}
+
+CylinderLayer::~CylinderLayer()
+{
+    destroy();
+}
+
+void CylinderLayer::destroy()
+{
+    destroy_images();
+}
+
+void CylinderLayer::record(VkCommandBuffer /*cmd*/,
+                           const std::vector<ViewInfo>& /*views*/,
+                           const RenderTarget& /*target*/,
+                           uint32_t /*in_flight_slot*/)
+{
+    // add_layer rejects this layer on any backend that can't composite it
+    // natively, so the compositor never routes it here. Reaching this is a
+    // wiring bug, not a runtime condition to paper over.
+    throw std::logic_error(
+        "CylinderLayer::record: layer is native-only (XrCompositionLayerCylinderKHR); "
+        "it cannot draw into the shared render target");
+}
+
+std::optional<NativeLayerView> CylinderLayer::acquire_native_layer(uint32_t in_flight_slot)
+{
+    require_alive("acquire_native_layer");
+
+    const uint8_t cur = promote_slot(in_flight_slot);
+    if (cur == kSlotNone)
+    {
+        // Nothing published yet — no layer this frame.
+        return std::nullopt;
+    }
+
+    // Snapshot placement under lock so set_placement() can run concurrently.
+    Config::Placement placement;
+    {
+        std::lock_guard<std::mutex> lk(placement_mutex_);
+        placement = placement_;
+    }
+
+    NativeLayerView v{};
+    v.shape = NativeLayerShape::kCylinder;
+    v.color_left = slots_[cur]->vk_image();
+    v.color_right = config_.stereo ? slots_right_[cur]->vk_image() : VK_NULL_HANDLE;
+    v.extent = resolution();
+    v.pose = placement.pose;
+    v.radius = placement.radius;
+    v.central_angle = placement.central_angle;
+    // aspect_ratio 0 → square texels: visible arc is width/height of the
+    // source image.
+    v.aspect_ratio = (placement.aspect_ratio > 0.0f) ?
+                         placement.aspect_ratio :
+                         static_cast<float>(resolution().width) / static_cast<float>(resolution().height);
+    v.source_id = this;
+    return v;
+}
+
+void CylinderLayer::set_placement(const Config::Placement& placement)
+{
+    validate_placement(placement);
+    std::lock_guard<std::mutex> lk(placement_mutex_);
+    placement_ = placement;
+}
+
+CylinderLayer::Config::Placement CylinderLayer::placement() const noexcept
+{
+    std::lock_guard<std::mutex> lk(placement_mutex_);
+    return placement_;
+}
+
+} // namespace viz

--- a/src/viz/layers/cpp/cylinder_layer.cpp
+++ b/src/viz/layers/cpp/cylinder_layer.cpp
@@ -12,8 +12,7 @@ namespace viz
 namespace
 {
 
-// Placement validation shared by the ctor and set_placement. Angle upper
-// bound is 2π (full wrap) per XR_KHR_composition_layer_cylinder.
+// Placement validation shared by the ctor and set_placement.
 void validate_placement(const CylinderLayer::Config::Placement& p)
 {
     // NaN and negatives are invalid; 0 and +inf are the documented
@@ -23,9 +22,11 @@ void validate_placement(const CylinderLayer::Config::Placement& p)
     {
         throw std::invalid_argument("CylinderLayer: Placement::radius_m must be >= 0 (0 or +inf = infinite cylinder)");
     }
-    if (!std::isfinite(p.central_angle_rad) || p.central_angle_rad <= 0.0f || p.central_angle_rad > glm::two_pi<float>())
+    // Unlike equirect2's horizontal angle, the cylinder spec excludes the
+    // full wrap: centralAngle is defined on [0, 2*pi).
+    if (!std::isfinite(p.central_angle_rad) || p.central_angle_rad <= 0.0f || p.central_angle_rad >= glm::two_pi<float>())
     {
-        throw std::invalid_argument("CylinderLayer: Placement::central_angle_rad must be in (0, 2*pi]");
+        throw std::invalid_argument("CylinderLayer: Placement::central_angle_rad must be in (0, 2*pi)");
     }
     if (!std::isfinite(p.aspect_ratio) || p.aspect_ratio < 0.0f)
     {

--- a/src/viz/layers/cpp/cylinder_layer.cpp
+++ b/src/viz/layers/cpp/cylinder_layer.cpp
@@ -109,6 +109,7 @@ std::optional<NativeLayerView> CylinderLayer::acquire_native_layer(uint32_t in_f
     v.extent = resolution();
     v.pose = placement.pose;
     v.stereo_baseline_mm = config_.stereo ? config_.stereo_baseline_mm : 0.0f;
+    v.alpha_blend = config_.alpha_blend;
     v.radius = placement.radius_m;
     v.central_angle = placement.central_angle_rad;
     // aspect_ratio 0 → square texels: visible arc is width/height of the

--- a/src/viz/layers/cpp/cylinder_layer.cpp
+++ b/src/viz/layers/cpp/cylinder_layer.cpp
@@ -16,13 +16,16 @@ namespace
 // bound is 2π (full wrap) per XR_KHR_composition_layer_cylinder.
 void validate_placement(const CylinderLayer::Config::Placement& p)
 {
-    if (!std::isfinite(p.radius) || p.radius <= 0.0f)
+    // NaN and negatives are invalid; 0 and +inf are the documented
+    // "infinite cylinder" spellings (per XR_KHR_composition_layer_cylinder;
+    // Monado/CloudXR implement it).
+    if (std::isnan(p.radius_m) || p.radius_m < 0.0f)
     {
-        throw std::invalid_argument("CylinderLayer: Placement::radius must be finite and > 0");
+        throw std::invalid_argument("CylinderLayer: Placement::radius_m must be >= 0 (0 or +inf = infinite cylinder)");
     }
-    if (!std::isfinite(p.central_angle) || p.central_angle <= 0.0f || p.central_angle > glm::two_pi<float>())
+    if (!std::isfinite(p.central_angle_rad) || p.central_angle_rad <= 0.0f || p.central_angle_rad > glm::two_pi<float>())
     {
-        throw std::invalid_argument("CylinderLayer: Placement::central_angle must be in (0, 2*pi]");
+        throw std::invalid_argument("CylinderLayer: Placement::central_angle_rad must be in (0, 2*pi]");
     }
     if (!std::isfinite(p.aspect_ratio) || p.aspect_ratio < 0.0f)
     {
@@ -34,6 +37,10 @@ void validate_placement(const CylinderLayer::Config::Placement& p)
 // precedes the base's image allocation.
 const CylinderLayer::Config& validate_config(const CylinderLayer::Config& config)
 {
+    if (!std::isfinite(config.stereo_baseline_mm))
+    {
+        throw std::invalid_argument("CylinderLayer: stereo_baseline_mm must be finite");
+    }
     validate_placement(config.placement);
     return config;
 }
@@ -100,8 +107,9 @@ std::optional<NativeLayerView> CylinderLayer::acquire_native_layer(uint32_t in_f
     v.color_right = config_.stereo ? slots_right_[cur]->vk_image() : VK_NULL_HANDLE;
     v.extent = resolution();
     v.pose = placement.pose;
-    v.radius = placement.radius;
-    v.central_angle = placement.central_angle;
+    v.stereo_baseline_mm = config_.stereo ? config_.stereo_baseline_mm : 0.0f;
+    v.radius = placement.radius_m;
+    v.central_angle = placement.central_angle_rad;
     // aspect_ratio 0 → square texels: visible arc is width/height of the
     // source image.
     v.aspect_ratio = (placement.aspect_ratio > 0.0f) ?

--- a/src/viz/layers/cpp/equirect_layer.cpp
+++ b/src/viz/layers/cpp/equirect_layer.cpp
@@ -19,24 +19,25 @@ void validate_placement(const EquirectLayer::Config::Placement& p)
 {
     // NaN and negatives are invalid; +inf is the documented "infinite
     // sphere" spelling alongside 0.
-    if (std::isnan(p.radius) || p.radius < 0.0f)
+    if (std::isnan(p.radius_m) || p.radius_m < 0.0f)
     {
-        throw std::invalid_argument("EquirectLayer: Placement::radius must be >= 0 (0 or +inf = infinite sphere)");
+        throw std::invalid_argument("EquirectLayer: Placement::radius_m must be >= 0 (0 or +inf = infinite sphere)");
     }
-    if (!std::isfinite(p.central_horizontal_angle) || p.central_horizontal_angle <= 0.0f ||
-        p.central_horizontal_angle > glm::two_pi<float>())
+    if (!std::isfinite(p.central_horizontal_angle_rad) || p.central_horizontal_angle_rad <= 0.0f ||
+        p.central_horizontal_angle_rad > glm::two_pi<float>())
     {
-        throw std::invalid_argument("EquirectLayer: Placement::central_horizontal_angle must be in (0, 2*pi]");
+        throw std::invalid_argument("EquirectLayer: Placement::central_horizontal_angle_rad must be in (0, 2*pi]");
     }
     const float half_pi = glm::half_pi<float>();
-    if (!std::isfinite(p.upper_vertical_angle) || p.upper_vertical_angle < -half_pi || p.upper_vertical_angle > half_pi ||
-        !std::isfinite(p.lower_vertical_angle) || p.lower_vertical_angle < -half_pi || p.lower_vertical_angle > half_pi)
+    if (!std::isfinite(p.upper_vertical_angle_rad) || p.upper_vertical_angle_rad < -half_pi ||
+        p.upper_vertical_angle_rad > half_pi || !std::isfinite(p.lower_vertical_angle_rad) ||
+        p.lower_vertical_angle_rad < -half_pi || p.lower_vertical_angle_rad > half_pi)
     {
         throw std::invalid_argument("EquirectLayer: vertical angles must be in [-pi/2, pi/2]");
     }
-    if (p.upper_vertical_angle <= p.lower_vertical_angle)
+    if (p.upper_vertical_angle_rad <= p.lower_vertical_angle_rad)
     {
-        throw std::invalid_argument("EquirectLayer: upper_vertical_angle must be > lower_vertical_angle");
+        throw std::invalid_argument("EquirectLayer: upper_vertical_angle_rad must be > lower_vertical_angle_rad");
     }
 }
 
@@ -44,6 +45,10 @@ void validate_placement(const EquirectLayer::Config::Placement& p)
 // precedes the base's image allocation.
 const EquirectLayer::Config& validate_config(const EquirectLayer::Config& config)
 {
+    if (!std::isfinite(config.stereo_baseline_mm))
+    {
+        throw std::invalid_argument("EquirectLayer: stereo_baseline_mm must be finite");
+    }
     validate_placement(config.placement);
     return config;
 }
@@ -110,10 +115,11 @@ std::optional<NativeLayerView> EquirectLayer::acquire_native_layer(uint32_t in_f
     v.color_right = config_.stereo ? slots_right_[cur]->vk_image() : VK_NULL_HANDLE;
     v.extent = resolution();
     v.pose = placement.pose;
-    v.radius = placement.radius;
-    v.central_horizontal_angle = placement.central_horizontal_angle;
-    v.upper_vertical_angle = placement.upper_vertical_angle;
-    v.lower_vertical_angle = placement.lower_vertical_angle;
+    v.stereo_baseline_mm = config_.stereo ? config_.stereo_baseline_mm : 0.0f;
+    v.radius = placement.radius_m;
+    v.central_horizontal_angle = placement.central_horizontal_angle_rad;
+    v.upper_vertical_angle = placement.upper_vertical_angle_rad;
+    v.lower_vertical_angle = placement.lower_vertical_angle_rad;
     v.source_id = this;
     return v;
 }

--- a/src/viz/layers/cpp/equirect_layer.cpp
+++ b/src/viz/layers/cpp/equirect_layer.cpp
@@ -116,6 +116,7 @@ std::optional<NativeLayerView> EquirectLayer::acquire_native_layer(uint32_t in_f
     v.extent = resolution();
     v.pose = placement.pose;
     v.stereo_baseline_mm = config_.stereo ? config_.stereo_baseline_mm : 0.0f;
+    v.alpha_blend = config_.alpha_blend;
     v.radius = placement.radius_m;
     v.central_horizontal_angle = placement.central_horizontal_angle_rad;
     v.upper_vertical_angle = placement.upper_vertical_angle_rad;

--- a/src/viz/layers/cpp/equirect_layer.cpp
+++ b/src/viz/layers/cpp/equirect_layer.cpp
@@ -1,0 +1,134 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "inc/viz/layers/equirect_layer.hpp"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace viz
+{
+
+namespace
+{
+
+// Placement validation shared by the ctor and set_placement. Bounds
+// follow XR_KHR_composition_layer_equirect2: radius 0 / +inf = infinite
+// sphere, angles are radians around the pose.
+void validate_placement(const EquirectLayer::Config::Placement& p)
+{
+    // NaN and negatives are invalid; +inf is the documented "infinite
+    // sphere" spelling alongside 0.
+    if (std::isnan(p.radius) || p.radius < 0.0f)
+    {
+        throw std::invalid_argument("EquirectLayer: Placement::radius must be >= 0 (0 or +inf = infinite sphere)");
+    }
+    if (!std::isfinite(p.central_horizontal_angle) || p.central_horizontal_angle <= 0.0f ||
+        p.central_horizontal_angle > glm::two_pi<float>())
+    {
+        throw std::invalid_argument("EquirectLayer: Placement::central_horizontal_angle must be in (0, 2*pi]");
+    }
+    const float half_pi = glm::half_pi<float>();
+    if (!std::isfinite(p.upper_vertical_angle) || p.upper_vertical_angle < -half_pi || p.upper_vertical_angle > half_pi ||
+        !std::isfinite(p.lower_vertical_angle) || p.lower_vertical_angle < -half_pi || p.lower_vertical_angle > half_pi)
+    {
+        throw std::invalid_argument("EquirectLayer: vertical angles must be in [-pi/2, pi/2]");
+    }
+    if (p.upper_vertical_angle <= p.lower_vertical_angle)
+    {
+        throw std::invalid_argument("EquirectLayer: upper_vertical_angle must be > lower_vertical_angle");
+    }
+}
+
+// Runs quietly inside the base-initializer expression so all validation
+// precedes the base's image allocation.
+const EquirectLayer::Config& validate_config(const EquirectLayer::Config& config)
+{
+    validate_placement(config.placement);
+    return config;
+}
+
+} // namespace
+
+EquirectLayer::EquirectLayer(const VkContext& ctx, Config config)
+    : ImageLayerBase(ctx,
+                     "EquirectLayer",
+                     validate_config(config).name,
+                     config.resolution,
+                     config.format,
+                     config.stereo,
+                     /*mip_levels=*/1),
+      config_(std::move(config))
+{
+    placement_ = config_.placement;
+}
+
+EquirectLayer::~EquirectLayer()
+{
+    destroy();
+}
+
+void EquirectLayer::destroy()
+{
+    destroy_images();
+}
+
+void EquirectLayer::record(VkCommandBuffer /*cmd*/,
+                           const std::vector<ViewInfo>& /*views*/,
+                           const RenderTarget& /*target*/,
+                           uint32_t /*in_flight_slot*/)
+{
+    // add_layer rejects this layer on any backend that can't composite it
+    // natively, so the compositor never routes it here. Reaching this is a
+    // wiring bug, not a runtime condition to paper over.
+    throw std::logic_error(
+        "EquirectLayer::record: layer is native-only (XrCompositionLayerEquirect2KHR); "
+        "it cannot draw into the shared render target");
+}
+
+std::optional<NativeLayerView> EquirectLayer::acquire_native_layer(uint32_t in_flight_slot)
+{
+    require_alive("acquire_native_layer");
+
+    const uint8_t cur = promote_slot(in_flight_slot);
+    if (cur == kSlotNone)
+    {
+        // Nothing published yet — no layer this frame.
+        return std::nullopt;
+    }
+
+    // Snapshot placement under lock so set_placement() can run concurrently.
+    Config::Placement placement;
+    {
+        std::lock_guard<std::mutex> lk(placement_mutex_);
+        placement = placement_;
+    }
+
+    NativeLayerView v{};
+    v.shape = NativeLayerShape::kEquirect2;
+    v.color_left = slots_[cur]->vk_image();
+    v.color_right = config_.stereo ? slots_right_[cur]->vk_image() : VK_NULL_HANDLE;
+    v.extent = resolution();
+    v.pose = placement.pose;
+    v.radius = placement.radius;
+    v.central_horizontal_angle = placement.central_horizontal_angle;
+    v.upper_vertical_angle = placement.upper_vertical_angle;
+    v.lower_vertical_angle = placement.lower_vertical_angle;
+    v.source_id = this;
+    return v;
+}
+
+void EquirectLayer::set_placement(const Config::Placement& placement)
+{
+    validate_placement(placement);
+    std::lock_guard<std::mutex> lk(placement_mutex_);
+    placement_ = placement;
+}
+
+EquirectLayer::Config::Placement EquirectLayer::placement() const noexcept
+{
+    std::lock_guard<std::mutex> lk(placement_mutex_);
+    return placement_;
+}
+
+} // namespace viz

--- a/src/viz/layers/cpp/image_layer_base.cpp
+++ b/src/viz/layers/cpp/image_layer_base.cpp
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "inc/viz/layers/image_layer_base.hpp"
+
+#include <viz/core/vk_context.hpp>
+
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include <string>
+
+namespace viz
+{
+
+namespace
+{
+
+void check_cuda(cudaError_t result, const char* layer_type, const char* what)
+{
+    if (result != cudaSuccess)
+    {
+        throw std::runtime_error(std::string(layer_type) + ": " + what + " failed: " + cudaGetErrorString(result));
+    }
+}
+
+// Queue an async D2D copy of ``buf`` → ``image.cuda_array()`` on
+// ``stream``. Shared between the mono and stereo submit paths.
+void enqueue_copy(const VizBuffer& buf, DeviceImage& image, cudaStream_t stream, const std::string& layer_type)
+{
+    const size_t row_bytes = static_cast<size_t>(buf.width) * bytes_per_pixel(buf.format);
+    const size_t src_pitch = (buf.pitch == 0) ? row_bytes : buf.pitch;
+    const cudaError_t err = cudaMemcpy2DToArrayAsync(
+        image.cuda_array(), 0, 0, buf.data, src_pitch, row_bytes, buf.height, cudaMemcpyDeviceToDevice, stream);
+    if (err != cudaSuccess)
+    {
+        throw std::runtime_error(layer_type + "::submit: cudaMemcpy2DToArrayAsync failed: " + cudaGetErrorString(err));
+    }
+}
+
+} // namespace
+
+ImageLayerBase::ImageLayerBase(const VkContext& ctx,
+                               std::string layer_type,
+                               std::string name,
+                               Resolution resolution,
+                               PixelFormat format,
+                               bool stereo,
+                               uint32_t mip_levels)
+    : LayerBase(std::move(name)),
+      ctx_(&ctx),
+      layer_type_(std::move(layer_type)),
+      resolution_(resolution),
+      format_(format),
+      stereo_(stereo)
+{
+    // Composition (draw sampler / swapchain copy) assumes a color image;
+    // depth views aren't color-samplable or copy-compatible with the
+    // color swapchains.
+    if (format_ != PixelFormat::kRGBA8)
+    {
+        throw std::invalid_argument(layer_type_ + ": only PixelFormat::kRGBA8 is supported");
+    }
+    if (resolution_.width == 0 || resolution_.height == 0)
+    {
+        throw std::invalid_argument(layer_type_ + ": resolution must be non-zero");
+    }
+    if (!ctx.is_initialized())
+    {
+        throw std::invalid_argument(layer_type_ + ": VkContext is not initialized");
+    }
+
+    // Atomic<uint8_t>'s default state is unspecified per the standard;
+    // explicitly seed every entry to kSlotNone so submit / promote /
+    // get_wait_semaphores see a defined initial state.
+    for (auto& e : in_use_)
+    {
+        e.store(kSlotNone, std::memory_order_relaxed);
+    }
+    last_in_use_slot_.store(kSlotNone, std::memory_order_relaxed);
+
+    // DeviceImages are RAII — a mid-loop throw releases the already-
+    // created slots via the members' destructors.
+    for (auto& slot : slots_)
+    {
+        slot = DeviceImage::create(*ctx_, resolution_, format_, mip_levels);
+    }
+    if (stereo_)
+    {
+        for (auto& slot : slots_right_)
+        {
+            slot = DeviceImage::create(*ctx_, resolution_, format_, mip_levels);
+        }
+    }
+}
+
+ImageLayerBase::~ImageLayerBase()
+{
+    destroy_images();
+}
+
+void ImageLayerBase::destroy_images()
+{
+    for (auto& slot : slots_)
+    {
+        slot.reset();
+    }
+    for (auto& slot : slots_right_)
+    {
+        slot.reset();
+    }
+    latest_.store(kSlotNone, std::memory_order_release);
+    for (auto& e : in_use_)
+    {
+        e.store(kSlotNone, std::memory_order_release);
+    }
+    last_in_use_slot_.store(kSlotNone, std::memory_order_release);
+}
+
+void ImageLayerBase::require_alive(const char* what) const
+{
+    if (!slots_[0])
+    {
+        throw std::logic_error(layer_type_ + "::" + what + " called after destroy()");
+    }
+}
+
+const DeviceImage* ImageLayerBase::device_image(uint32_t slot) const noexcept
+{
+    if (slot >= kSlotCount)
+    {
+        return nullptr;
+    }
+    return slots_[slot].get();
+}
+
+const DeviceImage* ImageLayerBase::device_image_right(uint32_t slot) const noexcept
+{
+    if (slot >= kSlotCount)
+    {
+        return nullptr;
+    }
+    return slots_right_[slot].get();
+}
+
+uint8_t ImageLayerBase::pick_free_slot(uint8_t latest) const noexcept
+{
+    // Forbidden = {latest} ∪ in_use_. kSlotCount = kMaxFramesInFlight + 2
+    // guarantees one free slot under the invariant; we still return
+    // kSlotNone defensively if the invariant ever breaks, so submit()
+    // drops the publish rather than overwriting a slot the GPU is sampling.
+    static_assert(kSlotCount > kMaxFramesInFlight + 1,
+                  "kSlotCount must exceed kMaxFramesInFlight + 1 so at least one slot is free");
+    for (uint8_t i = 0; i < kSlotCount; ++i)
+    {
+        if (i == latest)
+            continue;
+        bool conflicts = false;
+        for (uint32_t k = 0; k < kMaxFramesInFlight; ++k)
+        {
+            if (i == in_use_[k].load(std::memory_order_acquire))
+            {
+                conflicts = true;
+                break;
+            }
+        }
+        if (!conflicts)
+        {
+            return i;
+        }
+    }
+    return kSlotNone;
+}
+
+void ImageLayerBase::validate_submit_buffer(const VizBuffer& buf, const char* label) const
+{
+    if (buf.space != MemorySpace::kDevice)
+    {
+        throw std::invalid_argument(layer_type_ + "::submit: " + label + " must be MemorySpace::kDevice");
+    }
+    if (buf.width != resolution_.width || buf.height != resolution_.height)
+    {
+        throw std::invalid_argument(layer_type_ + "::submit: " + label + " dimensions do not match layer resolution");
+    }
+    if (buf.format != format_)
+    {
+        throw std::invalid_argument(layer_type_ + "::submit: " + label + " format does not match layer format");
+    }
+    if (buf.data == nullptr)
+    {
+        throw std::invalid_argument(layer_type_ + "::submit: " + label + ".data is null");
+    }
+}
+
+void ImageLayerBase::submit(const VizBuffer& src, cudaStream_t stream)
+{
+    require_alive("submit");
+    if (stereo_)
+    {
+        throw std::logic_error(layer_type_ +
+                               "::submit: this layer is stereo — use the two-arg submit(left, right) overload");
+    }
+    validate_submit_buffer(src, "src");
+
+    const uint8_t latest = latest_.load(std::memory_order_acquire);
+    const uint8_t slot = pick_free_slot(latest);
+    if (slot == kSlotNone)
+    {
+        // Mailbox drop: producer outran the renderer beyond the sizing
+        // invariant. Keep latest_ where it is; consumer keeps using it.
+        return;
+    }
+    DeviceImage& image = *slots_[slot];
+
+    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), layer_type_.c_str(), "cudaSetDevice");
+    enqueue_copy(src, image, stream, layer_type_);
+    image.cuda_signal_write_done(stream);
+
+    // Wait for the D2D copy to complete before returning. Sources publish
+    // buffers by reference and treat ``latest()`` returning them as proof
+    // of consumption; without a sync here a fast producer could wrap the
+    // mailbox and overwrite src.data while our async memcpy is still
+    // reading from it. Cost is ~0.5 ms per 1080p submit on the caller's
+    // thread; the render path is unaffected.
+    check_cuda(cudaStreamSynchronize(stream), layer_type_.c_str(), "cudaStreamSynchronize(submit)");
+
+    // memory_order_release pairs with the renderer's acquire load.
+    latest_.store(slot, std::memory_order_release);
+}
+
+void ImageLayerBase::submit(const VizBuffer& left, const VizBuffer& right, cudaStream_t stream)
+{
+    require_alive("submit");
+    if (!stereo_)
+    {
+        throw std::logic_error(layer_type_ + "::submit: this layer is mono — call submit(src) with a single buffer");
+    }
+    validate_submit_buffer(left, "left");
+    validate_submit_buffer(right, "right");
+
+    const uint8_t latest = latest_.load(std::memory_order_acquire);
+    const uint8_t slot = pick_free_slot(latest);
+    if (slot == kSlotNone)
+    {
+        return;
+    }
+    DeviceImage& image_l = *slots_[slot];
+    DeviceImage& image_r = *slots_right_[slot];
+
+    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), layer_type_.c_str(), "cudaSetDevice");
+    // Both copies on the same stream + a single signal on the left's
+    // semaphore. Stream ordering guarantees the right copy completes
+    // before the signal fires, so the renderer waiting on the left's
+    // semaphore implies the right is ready too. No second semaphore
+    // needed — by construction the renderer cannot see a half-pair.
+    //
+    // Stream precondition (see header): ``left.data`` and ``right.data``
+    // must both be reachable from ``stream`` by the time control reaches
+    // here. If a producer wrote either buffer on a different stream, the
+    // caller is responsible for syncing it before submit; otherwise the
+    // memcpy below may read pre-write state on that eye.
+    enqueue_copy(left, image_l, stream, layer_type_);
+    enqueue_copy(right, image_r, stream, layer_type_);
+    image_l.cuda_signal_write_done(stream);
+
+    check_cuda(cudaStreamSynchronize(stream), layer_type_.c_str(), "cudaStreamSynchronize(submit-stereo)");
+
+    latest_.store(slot, std::memory_order_release);
+}
+
+uint8_t ImageLayerBase::promote_slot(uint32_t in_flight_slot)
+{
+    // Backends are contracted to image_count <= kMaxFramesInFlight; if
+    // that ever breaks, two in-flight frames would alias on the same
+    // in_use_ entry and we'd lose the slot-tracking invariant.
+    if (in_flight_slot >= kMaxFramesInFlight)
+    {
+        throw std::logic_error(layer_type_ + ": in_flight_slot " + std::to_string(in_flight_slot) +
+                               " >= kMaxFramesInFlight (" + std::to_string(kMaxFramesInFlight) +
+                               "); bump kMaxFramesInFlight to match the backend's image_count");
+    }
+
+    // Promote latest_ -> in_use_[in_flight_slot]. The compositor's
+    // per-slot fence wait at the top of render() guarantees the GPU
+    // has finished sampling the previous in_use_ value. The consuming
+    // call (draw record or native-layer copy) reads the same entry —
+    // the promoting call and the consuming call MUST agree on
+    // in_flight_slot.
+    const uint8_t latest = latest_.load(std::memory_order_acquire);
+    const uint32_t idx = in_flight_slot;
+    if (latest != kSlotNone)
+    {
+        in_use_[idx].store(latest, std::memory_order_release);
+    }
+    const uint8_t cur = in_use_[idx].load(std::memory_order_acquire);
+    if (cur != kSlotNone)
+    {
+        // Record which slot this frame is sampling so get_wait_semaphores
+        // (called by the compositor before submit) reads the matching
+        // cuda_done_writing semaphore.
+        last_in_use_slot_.store(cur, std::memory_order_release);
+    }
+    return cur;
+}
+
+uint8_t ImageLayerBase::promoted_slot(uint32_t in_flight_slot) const noexcept
+{
+    if (in_flight_slot >= kMaxFramesInFlight)
+    {
+        return kSlotNone;
+    }
+    return in_use_[in_flight_slot].load(std::memory_order_acquire);
+}
+
+std::vector<LayerBase::WaitSemaphore> ImageLayerBase::get_wait_semaphores() const
+{
+    // The compositor promotes first (record_pre_render_pass or the
+    // native-layer acquire, both of which set last_in_use_slot_). We
+    // return THAT slot's cuda_done_writing semaphore so the submit waits
+    // for the producer's memcpy, gated at the subclass's first read.
+    const uint8_t cur = last_in_use_slot_.load(std::memory_order_acquire);
+    if (cur == kSlotNone || !slots_[cur])
+    {
+        return {};
+    }
+    const DeviceImage& image = *slots_[cur];
+    const uint64_t value = image.cuda_done_writing_value();
+    if (value == 0)
+    {
+        return {};
+    }
+    return {
+        WaitSemaphore{
+            image.cuda_done_writing(),
+            value,
+            first_read_stage(),
+        },
+    };
+}
+
+} // namespace viz

--- a/src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp
@@ -26,11 +26,11 @@ class VkContext;
 // std::invalid_argument otherwise, and record() (unreachable through a
 // validated session) throws std::logic_error.
 //
-// Stereo: per-eye textures on the SAME cylinder (one
-// XrCompositionLayerCylinderKHR per eye via eyeVisibility). The depth
-// cue comes from the image pair, matching how stereo panoramas are
-// authored — there is no per-eye pose shift (unlike QuadLayer's
-// stereo_baseline_mm).
+// Stereo: per-eye textures (one XrCompositionLayerCylinderKHR per eye
+// via eyeVisibility), by default on the SAME cylinder — the depth cue
+// comes from the image pair, matching how stereo panoramas are
+// authored. Config::stereo_baseline_mm optionally shifts each eye's
+// cylinder laterally, same convention as QuadLayer.
 //
 // Like all native composition layers it carries no depth, so it
 // composites in submission order rather than z-testing against
@@ -48,6 +48,15 @@ public:
         // with both buffers (see ImageLayerBase::submit). Memory doubles.
         bool stereo = false;
 
+        // Horizontal disparity between the left-eye and right-eye layer
+        // (millimeters, along the placement's local +x axis): each eye's
+        // cylinder center shifts by ±stereo_baseline_mm/2 (left −, right
+        // +), same convention as QuadLayer. 0 means both eyes see the
+        // same world cylinder — all stereo cues come from the captured
+        // image pair (the VR-video convention). Ignored when stereo is
+        // false.
+        float stereo_baseline_mm = 0.0f;
+
         // Placement in the session's reference space. Defaults describe a
         // 90° arc of a 1 m cylinder directly usable for smoke tests;
         // real apps set pose + shape explicitly (or via set_placement).
@@ -57,10 +66,12 @@ public:
             // pose's -z axis (bows away from the viewer at identity);
             // the cylinder axis is the pose's +y.
             Pose3D pose{};
-            // Cylinder radius in meters. Must be finite and > 0.
-            float radius = 1.0f;
+            // Cylinder radius in meters. 0 or +infinity = infinite
+            // cylinder (per XR_KHR_composition_layer_cylinder); finite
+            // values must be > 0.
+            float radius_m = 1.0f;
             // Visible arc in radians, (0, 2π].
-            float central_angle = glm::half_pi<float>();
+            float central_angle_rad = glm::half_pi<float>();
             // Width/height ratio of the visible arc (width = radius ×
             // central_angle). 0 (default) derives it from ``resolution``
             // so texture pixels stay square.

--- a/src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp
@@ -70,7 +70,7 @@ public:
             // cylinder (per XR_KHR_composition_layer_cylinder); finite
             // values must be > 0.
             float radius_m = 1.0f;
-            // Visible arc in radians, (0, 2π].
+            // Visible arc in radians, (0, 2π) — the spec excludes a full wrap.
             float central_angle_rad = glm::half_pi<float>();
             // Width/height ratio of the visible arc (width = radius ×
             // central_angle). 0 (default) derives it from ``resolution``

--- a/src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp
@@ -57,6 +57,13 @@ public:
         // false.
         float stereo_baseline_mm = 0.0f;
 
+        // Composite honoring the texture's alpha channel
+        // (XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT). Off by
+        // default: camera feeds are opaque, and alpha-free layers keep
+        // the frame eligible for the runtime's client-reconstructed
+        // streaming (which excludes source-alpha layers).
+        bool alpha_blend = false;
+
         // Placement in the session's reference space. Defaults describe a
         // 90° arc of a 1 m cylinder directly usable for smoke tests;
         // real apps set pose + shape explicitly (or via set_placement).

--- a/src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/cylinder_layer.hpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "image_layer_base.hpp"
+
+#include <glm/gtc/constants.hpp>
+#include <viz/core/viz_types.hpp>
+#include <vulkan/vulkan.h>
+
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace viz
+{
+
+class VkContext;
+
+// CylinderLayer: a CUDA-fed RGBA8 texture curved onto the inside of a
+// cylinder arc, submitted to the OpenXR runtime as a native
+// XrCompositionLayerCylinderKHR. NATIVE-ONLY: there is no compositor
+// draw path — the layer requires DisplayMode::kXr and a runtime that
+// advertises XR_KHR_composition_layer_cylinder; add_layer throws
+// std::invalid_argument otherwise, and record() (unreachable through a
+// validated session) throws std::logic_error.
+//
+// Stereo: per-eye textures on the SAME cylinder (one
+// XrCompositionLayerCylinderKHR per eye via eyeVisibility). The depth
+// cue comes from the image pair, matching how stereo panoramas are
+// authored — there is no per-eye pose shift (unlike QuadLayer's
+// stereo_baseline_mm).
+//
+// Like all native composition layers it carries no depth, so it
+// composites in submission order rather than z-testing against
+// projection-layer content.
+class CylinderLayer : public ImageLayerBase
+{
+public:
+    struct Config
+    {
+        std::string name = "CylinderLayer";
+        Resolution resolution{};
+        PixelFormat format = PixelFormat::kRGBA8;
+
+        // Stereo mode: paired left+right mailbox; submit MUST be called
+        // with both buffers (see ImageLayerBase::submit). Memory doubles.
+        bool stereo = false;
+
+        // Placement in the session's reference space. Defaults describe a
+        // 90° arc of a 1 m cylinder directly usable for smoke tests;
+        // real apps set pose + shape explicitly (or via set_placement).
+        struct Placement
+        {
+            // Center point of the cylinder. The arc is centered on the
+            // pose's -z axis (bows away from the viewer at identity);
+            // the cylinder axis is the pose's +y.
+            Pose3D pose{};
+            // Cylinder radius in meters. Must be finite and > 0.
+            float radius = 1.0f;
+            // Visible arc in radians, (0, 2π].
+            float central_angle = glm::half_pi<float>();
+            // Width/height ratio of the visible arc (width = radius ×
+            // central_angle). 0 (default) derives it from ``resolution``
+            // so texture pixels stay square.
+            float aspect_ratio = 0.0f;
+        };
+        Placement placement{};
+    };
+
+    // Builds the mailbox DeviceImages up front. Throws
+    // std::invalid_argument on bad config; std::runtime_error on
+    // Vulkan / CUDA failure.
+    CylinderLayer(const VkContext& ctx, Config config);
+    ~CylinderLayer() override;
+    void destroy();
+
+    // Native-only: reachable only if the layer bypassed add_layer's
+    // backend validation. Throws std::logic_error.
+    void record(VkCommandBuffer cmd,
+                const std::vector<ViewInfo>& views,
+                const RenderTarget& target,
+                uint32_t in_flight_slot) override;
+
+    bool is_native_layer() const noexcept override
+    {
+        return true;
+    }
+    std::optional<NativeLayerShape> required_native_shape() const noexcept override
+    {
+        return NativeLayerShape::kCylinder;
+    }
+    std::optional<NativeLayerView> acquire_native_layer(uint32_t in_flight_slot) override;
+
+    // Atomic placement swap, thread-safe vs the frame loop. Validates the
+    // same invariants as construction (throws std::invalid_argument).
+    void set_placement(const Config::Placement& placement);
+    Config::Placement placement() const noexcept;
+
+private:
+    Config config_;
+
+    mutable std::mutex placement_mutex_;
+    Config::Placement placement_{};
+};
+
+} // namespace viz

--- a/src/viz/layers/cpp/inc/viz/layers/equirect_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/equirect_layer.hpp
@@ -65,6 +65,13 @@ public:
         // Ignored when stereo is false.
         float stereo_baseline_mm = 0.0f;
 
+        // Composite honoring the texture's alpha channel
+        // (XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT). Off by
+        // default: opaque panoramas keep the frame eligible for the
+        // runtime's client-reconstructed streaming (which excludes
+        // source-alpha layers).
+        bool alpha_blend = false;
+
         // Placement in the session's reference space. Defaults = full
         // sphere (360° × 180°) at infinite radius, centered on the
         // reference-space origin.

--- a/src/viz/layers/cpp/inc/viz/layers/equirect_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/equirect_layer.hpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "image_layer_base.hpp"
+
+#include <glm/gtc/constants.hpp>
+#include <viz/core/viz_types.hpp>
+#include <vulkan/vulkan.h>
+
+#include <mutex>
+#include <optional>
+#include <string>
+
+namespace viz
+{
+
+class VkContext;
+
+// EquirectLayer: a CUDA-fed RGBA8 equirectangular texture mapped onto
+// the inside of a sphere, submitted to the OpenXR runtime as a native
+// XrCompositionLayerEquirect2KHR (the angle-parameterized revision of
+// the equirect extension). NATIVE-ONLY: there is no compositor draw
+// path — the layer requires DisplayMode::kXr and a runtime that
+// advertises XR_KHR_composition_layer_equirect2; add_layer throws
+// std::invalid_argument otherwise, and record() (unreachable through a
+// validated session) throws std::logic_error.
+//
+// Defaults describe a full 360°×180° sphere of infinite radius — the
+// standard mono panorama / skybox case works with a default Placement.
+//
+// Stereo: per-eye textures on the SAME sphere (one
+// XrCompositionLayerEquirect2KHR per eye via eyeVisibility) — the VR180
+// / VR360 stereo-video convention. No per-eye pose shift.
+//
+// Like all native composition layers it carries no depth, so it
+// composites in submission order rather than z-testing against
+// projection-layer content. Submit it FIRST (add it before other
+// layers) when it acts as a background.
+class EquirectLayer : public ImageLayerBase
+{
+public:
+    struct Config
+    {
+        std::string name = "EquirectLayer";
+        Resolution resolution{};
+        PixelFormat format = PixelFormat::kRGBA8;
+
+        // Stereo mode: paired left+right mailbox; submit MUST be called
+        // with both buffers (see ImageLayerBase::submit). Memory doubles.
+        bool stereo = false;
+
+        // Placement in the session's reference space. Defaults = full
+        // sphere (360° × 180°) at infinite radius, centered on the
+        // reference-space origin.
+        struct Placement
+        {
+            // Center of the sphere; orientation turns the texture seam.
+            // The horizontal center of the texture maps to the pose's -z.
+            Pose3D pose{};
+            // Sphere radius in meters. 0 or +infinity = infinite sphere
+            // (per XR_KHR_composition_layer_equirect2); finite values
+            // must be > 0.
+            float radius = 0.0f;
+            // Visible horizontal span in radians, (0, 2π]. 2π = full 360°.
+            float central_horizontal_angle = glm::two_pi<float>();
+            // Vertical span as angles from the horizon, radians in
+            // [−π/2, π/2] with upper > lower. Defaults cover zenith to
+            // nadir (full 180°).
+            float upper_vertical_angle = glm::half_pi<float>();
+            float lower_vertical_angle = -glm::half_pi<float>();
+        };
+        Placement placement{};
+    };
+
+    // Builds the mailbox DeviceImages up front. Throws
+    // std::invalid_argument on bad config; std::runtime_error on
+    // Vulkan / CUDA failure.
+    EquirectLayer(const VkContext& ctx, Config config);
+    ~EquirectLayer() override;
+    void destroy();
+
+    // Native-only: reachable only if the layer bypassed add_layer's
+    // backend validation. Throws std::logic_error.
+    void record(VkCommandBuffer cmd,
+                const std::vector<ViewInfo>& views,
+                const RenderTarget& target,
+                uint32_t in_flight_slot) override;
+
+    bool is_native_layer() const noexcept override
+    {
+        return true;
+    }
+    std::optional<NativeLayerShape> required_native_shape() const noexcept override
+    {
+        return NativeLayerShape::kEquirect2;
+    }
+    std::optional<NativeLayerView> acquire_native_layer(uint32_t in_flight_slot) override;
+
+    // Atomic placement swap, thread-safe vs the frame loop. Validates the
+    // same invariants as construction (throws std::invalid_argument).
+    void set_placement(const Config::Placement& placement);
+    Config::Placement placement() const noexcept;
+
+private:
+    Config config_;
+
+    mutable std::mutex placement_mutex_;
+    Config::Placement placement_{};
+};
+
+} // namespace viz

--- a/src/viz/layers/cpp/inc/viz/layers/equirect_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/equirect_layer.hpp
@@ -30,9 +30,14 @@ class VkContext;
 // Defaults describe a full 360°×180° sphere of infinite radius — the
 // standard mono panorama / skybox case works with a default Placement.
 //
-// Stereo: per-eye textures on the SAME sphere (one
-// XrCompositionLayerEquirect2KHR per eye via eyeVisibility) — the VR180
-// / VR360 stereo-video convention. No per-eye pose shift.
+// Stereo: per-eye textures (one XrCompositionLayerEquirect2KHR per eye
+// via eyeVisibility), by default on the SAME sphere — the VR180 / VR360
+// stereo-video convention, where all depth comes from the image pair.
+// Config::stereo_baseline_mm optionally shifts each eye's sphere
+// laterally (same convention as QuadLayer); note this only has a
+// visible effect at FINITE radius — viewing direction to a sphere of
+// radius R changes by ~shift/R, which is exactly zero for the
+// infinite-radius (0 / +inf) sphere.
 //
 // Like all native composition layers it carries no depth, so it
 // composites in submission order rather than z-testing against
@@ -51,6 +56,15 @@ public:
         // with both buffers (see ImageLayerBase::submit). Memory doubles.
         bool stereo = false;
 
+        // Horizontal disparity between the left-eye and right-eye layer
+        // (millimeters, along the placement's local +x axis): each eye's
+        // sphere center shifts by ±stereo_baseline_mm/2 (left −, right
+        // +), same convention as QuadLayer. Only visible at FINITE
+        // radius (see the class comment); the default 0 keeps the
+        // VR180/VR360 convention where both eyes share one sphere.
+        // Ignored when stereo is false.
+        float stereo_baseline_mm = 0.0f;
+
         // Placement in the session's reference space. Defaults = full
         // sphere (360° × 180°) at infinite radius, centered on the
         // reference-space origin.
@@ -62,14 +76,14 @@ public:
             // Sphere radius in meters. 0 or +infinity = infinite sphere
             // (per XR_KHR_composition_layer_equirect2); finite values
             // must be > 0.
-            float radius = 0.0f;
+            float radius_m = 0.0f;
             // Visible horizontal span in radians, (0, 2π]. 2π = full 360°.
-            float central_horizontal_angle = glm::two_pi<float>();
+            float central_horizontal_angle_rad = glm::two_pi<float>();
             // Vertical span as angles from the horizon, radians in
             // [−π/2, π/2] with upper > lower. Defaults cover zenith to
             // nadir (full 180°).
-            float upper_vertical_angle = glm::half_pi<float>();
-            float lower_vertical_angle = -glm::half_pi<float>();
+            float upper_vertical_angle_rad = glm::half_pi<float>();
+            float lower_vertical_angle_rad = -glm::half_pi<float>();
         };
         Placement placement{};
     };

--- a/src/viz/layers/cpp/inc/viz/layers/image_layer_base.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/image_layer_base.hpp
@@ -1,0 +1,221 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <viz/core/device_image.hpp>
+#include <viz/core/viz_buffer.hpp>
+#include <viz/core/viz_types.hpp>
+#include <viz/session/layer_base.hpp>
+#include <vulkan/vulkan.h>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <memory>
+#include <string>
+
+namespace viz
+{
+
+class VkContext;
+
+// Shared base for layers whose content is a CUDA-fed RGBA8 texture
+// (QuadLayer, CylinderLayer, EquirectLayer): owns the DeviceImage
+// mailbox and the producer/consumer protocol; subclasses decide how the
+// texture is composited (draw call into the shared RT, or a native
+// OpenXR composition layer).
+//
+// Mailbox: kSlotCount DeviceImages. submit() picks a slot that's
+// neither the latest publish nor in use by any in-flight frame, copies
+// pixels in, signals cuda_done_writing, and atomic-stores latest.
+// The consumer (promote_slot) atomic-stores latest into
+// in_use_[in_flight_slot] and samples/copies it. Producer never
+// collides with the slot any in-flight renderer is reading; renderer
+// always sees the most recent completed publish.
+//
+// Sizing invariant: kSlotCount = kMaxFramesInFlight + 2. Worst-case
+// forbidden set is {latest} ∪ in_use_ → 1 + kMaxFramesInFlight distinct
+// values, the +2 leaves at least one free slot. If a backend's
+// image_count ever exceeds kMaxFramesInFlight, promote_slot throws —
+// bump kMaxFramesInFlight and kSlotCount together.
+//
+// Memory: kSlotCount × width × height × bpp (× mip overhead when the
+// subclass requests a mip chain, ×2 when stereo).
+//   mono   1080p RGBA8: ~56 MB / layer
+//   mono   4K    RGBA8: ~232 MB / layer
+//   stereo 1080p RGBA8: ~112 MB / layer (×2 from paired slots)
+//   stereo 4K    RGBA8: ~464 MB / layer
+//
+// Stereo: when ``stereo`` is true, each slot owns a PAIR of
+// DeviceImages (left + right). The two-arg submit() does both
+// memcpy2Ds + the cuda_done_writing signal on a single CUDA stream,
+// so stream ordering guarantees the renderer never sees a half-
+// updated pair.
+class ImageLayerBase : public LayerBase
+{
+public:
+    // Sized to cover swapchains up to 5 images. The window swapchain
+    // requests <= 3 (see Swapchain::init), but drivers may grant more
+    // than requested; this headroom keeps promote_slot from throwing on
+    // those platforms. Memory cost: kSlotCount × W × H × bpp per layer
+    // (~56 MB at 1080p RGBA8).
+    static constexpr uint32_t kMaxFramesInFlight = 5;
+    static constexpr uint32_t kSlotCount = kMaxFramesInFlight + 2;
+
+    // submit() = producer side, promote_slot() = consumer side; may run
+    // on separate threads. NOT safe with multiple concurrent producers
+    // (one layer per producer).
+    //
+    // src.space must be kDevice; dims/format must match the layer.
+    // The copy + cuda_done_writing signal run on ``stream``. submit()
+    // BLOCKS on cudaStreamSynchronize(stream) before returning so the
+    // producer can safely reuse src.data — without that wait, a fast
+    // producer wrapping its mailbox could overwrite src.data while our
+    // async memcpy was still reading. Cost: ~0.5 ms per 1080p call on
+    // the calling thread; the render path is unaffected.
+    //
+    // Mono layer (stereo == false): use the one-arg overload.
+    // The two-arg overload throws std::logic_error.
+    //
+    // Stereo layer (stereo == true): use the two-arg overload.
+    // Both buffers are copied + the single cuda_done_writing signal is
+    // emitted on the SAME ``stream``, so stream ordering guarantees
+    // the renderer never reads a half-matched pair. The one-arg
+    // overload throws std::logic_error.
+    //
+    // STREAM PRECONDITION (stereo): the two-arg overload runs the copies
+    // for BOTH eyes on the single ``stream`` argument. CUDA's stream
+    // ordering only sequences work submitted to the SAME stream, so
+    // when ``left.data`` or ``right.data`` was produced on a different
+    // stream than ``stream``, the caller MUST synchronize that producer
+    // stream before calling submit (cudaStreamSynchronize, or a recorded
+    // event waited on ``stream`` via cudaStreamWaitEvent). Otherwise the
+    // memcpy here can read stale / torn pixels for that eye. The
+    // in-tree ZED + OAK-D producers handle this by calling
+    // ``cu_stream.synchronize()`` per eye-slot before publishing, which
+    // makes calling ``submit(left, right, stream=0)`` safe; external
+    // producers wiring separate per-eye streams must follow the same
+    // pattern.
+    void submit(const VizBuffer& src, cudaStream_t stream = 0);
+    void submit(const VizBuffer& left, const VizBuffer& right, cudaStream_t stream = 0);
+
+    // Timeline wait on the in-use slot's cuda_done_writing, at the
+    // subclass's first_read_stage().
+    std::vector<LayerBase::WaitSemaphore> get_wait_semaphores() const override;
+
+    const VkContext* vk_context() const noexcept override
+    {
+        return ctx_;
+    }
+
+    Resolution resolution() const noexcept
+    {
+        return resolution_;
+    }
+    PixelFormat format() const noexcept
+    {
+        return format_;
+    }
+    bool stereo() const noexcept
+    {
+        return stereo_;
+    }
+
+    // Diagnostic accessor; nullptr for slots beyond kSlotCount, and
+    // device_image_right is null on mono layers.
+    const DeviceImage* device_image(uint32_t slot) const noexcept;
+    const DeviceImage* device_image_right(uint32_t slot) const noexcept;
+
+protected:
+    // Validates + allocates the mailbox images up front. ``layer_type``
+    // prefixes error messages (e.g. "QuadLayer"). Throws
+    // std::invalid_argument on bad parameters; std::runtime_error on
+    // Vulkan / CUDA failure (nothing leaks — DeviceImages are RAII).
+    ImageLayerBase(const VkContext& ctx,
+                   std::string layer_type,
+                   std::string name,
+                   Resolution resolution,
+                   PixelFormat format,
+                   bool stereo,
+                   uint32_t mip_levels);
+
+    // Subclass dtors/destroy() call destroy_images(); the base dtor
+    // covers subclasses without an explicit destroy.
+    ~ImageLayerBase() override;
+
+    // Mailbox slot allocation. submit() picks one of these states
+    // and atomically takes ownership; promote_slot atomically promotes
+    // a freshly-published slot to `in_use_`.
+    static constexpr uint8_t kSlotNone = 0xFF;
+
+    // Releases every DeviceImage and resets the mailbox to its initial
+    // state. Idempotent; safe after partial subclass init.
+    void destroy_images();
+
+    // Once destroy has run, slots_[0] is the canonical "alive" signal.
+    // Throwing logic_error converts use-after-destroy from a silent
+    // null-deref into a clean failure callers can catch in tests.
+    void require_alive(const char* what) const;
+
+    // Promote latest_ -> in_use_[in_flight_slot] and update
+    // last_in_use_slot_ (shared by the render-pass consumer and the
+    // native-layer consumer). Returns the promoted slot, or kSlotNone if
+    // nothing has been published yet. Throws if in_flight_slot is out of
+    // range. Renderer thread only.
+    uint8_t promote_slot(uint32_t in_flight_slot);
+
+    // Slot already promoted for ``in_flight_slot`` this frame (kSlotNone
+    // before any publish, or for an out-of-range slot). Read-only view of
+    // the mailbox for subclass consumers that promote in one hook and
+    // consume in another (QuadLayer's pre-pass / record split).
+    uint8_t promoted_slot(uint32_t in_flight_slot) const noexcept;
+
+    // First pipeline stage that reads the promoted image in the frame's
+    // command buffer — threads into the queue submit's cuda_done_writing
+    // wait. Default TRANSFER (native composition copies the image);
+    // QuadLayer's draw path overrides with FRAGMENT_SHADER when the
+    // sampler is the first reader.
+    virtual VkPipelineStageFlags first_read_stage() const noexcept
+    {
+        return VK_PIPELINE_STAGE_TRANSFER_BIT;
+    }
+
+    const VkContext* ctx_ = nullptr;
+
+    // One DeviceImage per mailbox slot. ``slots_`` is the left/mono
+    // image; ``slots_right_`` only allocated when stereo.
+    std::array<std::unique_ptr<DeviceImage>, kSlotCount> slots_;
+    std::array<std::unique_ptr<DeviceImage>, kSlotCount> slots_right_;
+
+private:
+    // Picks a slot that is neither latest_ nor in any in_use_ entry.
+    // Returns kSlotNone if every slot is forbidden (producer outran the
+    // renderer beyond the sizing invariant) — caller drops the publish.
+    uint8_t pick_free_slot(uint8_t latest) const noexcept;
+
+    void validate_submit_buffer(const VizBuffer& buf, const char* label) const;
+
+    std::string layer_type_;
+    Resolution resolution_{};
+    PixelFormat format_ = PixelFormat::kRGBA8;
+    bool stereo_ = false;
+
+    // Mailbox: latest_ = most recent publish. in_use_[i] = slot the
+    // i-th in-flight frame is sampling. Atomic so producer and
+    // renderer share without locks. All kSlotNone until first
+    // submit() / first consumer promote.
+    std::atomic<uint8_t> latest_{ kSlotNone };
+    std::array<std::atomic<uint8_t>, kMaxFramesInFlight> in_use_{};
+    // Tracks which in_use_ entry was MOST RECENTLY promoted.
+    // get_wait_semaphores() reads this entry's slot — it's the one whose
+    // cuda_done_writing semaphore gates the GPU's read work that was
+    // just queued. Atomic but doesn't need mutual exclusion with
+    // in_use_ stores (the renderer thread does both writes; we use
+    // atomics for cross-thread visibility with submit's reads in
+    // pick_free_slot).
+    std::atomic<uint8_t> last_in_use_slot_{ kSlotNone };
+};
+
+} // namespace viz

--- a/src/viz/layers/cpp/inc/viz/layers/projection_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/projection_layer.hpp
@@ -33,7 +33,8 @@ class VkContext;
 // that means the renderer's depth lands in the XR depth swapchain with no
 // gl_FragDepth round-trip, so CloudXR positional reprojection gets exact
 // depth. Consequently a VizSession holds EITHER one ProjectionLayer OR
-// any number of texture layers, never both (enforced by VizSession). Because
+// any number of texture layers (native XR composition or compositor-drawn),
+// never both (enforced by VizSession). Because
 // the copy is 1:1, ``view_resolution`` MUST equal the swapchain per-view
 // size (use VizSession::get_recommended_resolution()).
 //

--- a/src/viz/layers/cpp/inc/viz/layers/projection_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/projection_layer.hpp
@@ -33,7 +33,7 @@ class VkContext;
 // that means the renderer's depth lands in the XR depth swapchain with no
 // gl_FragDepth round-trip, so CloudXR positional reprojection gets exact
 // depth. Consequently a VizSession holds EITHER one ProjectionLayer OR
-// any number of QuadLayers, never both (enforced by VizSession). Because
+// any number of texture layers, never both (enforced by VizSession). Because
 // the copy is 1:1, ``view_resolution`` MUST equal the swapchain per-view
 // size (use VizSession::get_recommended_resolution()).
 //

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -87,22 +87,25 @@ public:
         // world IPDs and camera baselines are 50–80 mm.
         float stereo_baseline_mm = 0.0f;
 
-        // Submit this quad as a native OpenXR quad layer
-        // (XrCompositionLayerQuad) instead of compositing it into the
-        // shared render target. kXr only: the runtime places + samples the
-        // quad directly, which enables its quad fast path (and, for
-        // quad-only frames, client-reconstructed streaming — the shared
-        // projection layer is dropped when every visible layer is native).
-        // Ignored outside kXr (window/offscreen fall back to the compositor
-        // draw path). Stereo emits one quad per eye via eyeVisibility.
+        // In kXr, submit this quad as a native OpenXR quad layer
+        // (XrCompositionLayerQuad) — the DEFAULT: the runtime places +
+        // samples the quad directly, which enables its quad fast path
+        // (and, for frames where every visible layer is native,
+        // client-reconstructed streaming — the shared projection layer is
+        // dropped). Stereo emits one quad per eye via eyeVisibility.
+        // Ignored outside kXr (window/offscreen always use the compositor
+        // draw path).
         //
-        // Trade-off vs the compositor path: a native quad carries NO depth
-        // (OpenXR quad layers have none), so it can't z-compose with 3D
-        // ProjectionLayer content — it's a flat billboard ordered by
-        // submission. ``generate_mipmaps`` is unused in native mode (the
-        // runtime samples the quad). Requires ``placement`` at record time,
-        // same as any kXr quad. Off by default.
-        bool use_openxr_quad_layer = false;
+        // Set to false to fall back to compositing into the shared render
+        // target instead. The compositor path is the right choice when the
+        // quad must z-compose with 3D ProjectionLayer content — a native
+        // quad carries NO depth (OpenXR quad layers have none), so it's a
+        // flat billboard ordered by submission — or when a runtime
+        // mishandles native quad layers. ``generate_mipmaps`` only applies
+        // on the compositor path (the runtime samples native quads).
+        // Requires ``placement`` at record time either way, same as any
+        // kXr quad.
+        bool native_composition = true;
     };
 
     // Hard cap on the mip chain when generate_mipmaps is enabled.
@@ -133,12 +136,13 @@ public:
                 const RenderTarget& target,
                 uint32_t in_flight_slot) override;
 
-    // Native OpenXR quad path. is_native_layer() is true only when the flag
-    // is set AND this layer is in a kXr session (so window/offscreen keep
-    // using record()). acquire_native_layer() promotes the mailbox slot (like
-    // record()'s consumer side) and returns the per-eye source images +
-    // placement for the backend to blit into its quad swapchain. See
-    // Config::use_openxr_quad_layer.
+    // Native OpenXR quad path. is_native_layer() is true only when
+    // native_composition is on (the default) AND this layer is in a kXr
+    // session (so window/offscreen keep using record()).
+    // acquire_native_layer() promotes the mailbox slot (like record()'s
+    // consumer side) and returns the per-eye source images + placement for
+    // the backend to blit into its quad swapchain. See
+    // Config::native_composition.
     bool is_native_layer() const noexcept override;
     std::optional<NativeLayerView> acquire_native_layer(uint32_t in_flight_slot) override;
 

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -133,14 +133,14 @@ public:
                 const RenderTarget& target,
                 uint32_t in_flight_slot) override;
 
-    // Native OpenXR quad path. is_native_quad() is true only when the flag
+    // Native OpenXR quad path. is_native_layer() is true only when the flag
     // is set AND this layer is in a kXr session (so window/offscreen keep
-    // using record()). acquire_native_quad() promotes the mailbox slot (like
+    // using record()). acquire_native_layer() promotes the mailbox slot (like
     // record()'s consumer side) and returns the per-eye source images +
     // placement for the backend to blit into its quad swapchain. See
     // Config::use_openxr_quad_layer.
-    bool is_native_quad() const noexcept override;
-    std::optional<NativeQuadView> acquire_native_quad(uint32_t in_flight_slot) override;
+    bool is_native_layer() const noexcept override;
+    std::optional<NativeLayerView> acquire_native_layer(uint32_t in_flight_slot) override;
 
     // Drives aspect-fit letterbox in window mode; ignored in kXr.
     std::optional<float> aspect_ratio() const noexcept override;

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -106,6 +106,16 @@ public:
         // Requires ``placement`` at record time either way, same as any
         // kXr quad.
         bool native_composition = true;
+
+        // Composite honoring the texture's alpha channel. Native path:
+        // sets XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT on the
+        // submitted XrCompositionLayerQuad. Off by default: camera feeds
+        // are opaque, and alpha-free layers keep the frame eligible for
+        // the runtime's client-reconstructed streaming (which excludes
+        // source-alpha layers). Turn on for translucent content (HUDs).
+        // Compositor path: currently ignored (the draw pipeline blends
+        // per the shared render target setup).
+        bool alpha_blend = false;
     };
 
     // Hard cap on the mip chain when generate_mipmaps is enabled.

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -3,16 +3,15 @@
 
 #pragma once
 
+#include "image_layer_base.hpp"
+
 #include <viz/core/device_image.hpp>
 #include <viz/core/viz_buffer.hpp>
 #include <viz/core/viz_types.hpp>
-#include <viz/session/layer_base.hpp>
 #include <vulkan/vulkan.h>
 
 #include <array>
-#include <atomic>
 #include <cstdint>
-#include <cuda_runtime.h>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -27,48 +26,16 @@ class VkContext;
 // (window/offscreen — quad fills the layer's tile) or as a world-space
 // rectangle (kXr — Config::placement required).
 //
-// Mailbox: kSlotCount DeviceImages. submit() picks a slot that's
-// neither the latest publish nor in use by any in-flight frame, copies
-// pixels in, signals cuda_done_writing, and atomic-stores latest.
-// record(slot_index) atomic-stores latest into in_use_[slot_index]
-// and draws. Producer never collides with the slot any in-flight
-// renderer is sampling; renderer always sees the most recent
-// completed publish.
+// The image mailbox (submit / slot promotion / CUDA semaphores) lives in
+// ImageLayerBase; this class adds the draw path into the shared render
+// target plus the optional native XrCompositionLayerQuad path.
 //
-// Sizing invariant: kSlotCount = kMaxFramesInFlight + 2. Worst-case
-// forbidden set is {latest} ∪ in_use_ → 1 + kMaxFramesInFlight distinct
-// values, the +2 leaves at least one free slot. If a backend's
-// image_count ever exceeds kMaxFramesInFlight, record() asserts —
-// bump kMaxFramesInFlight and kSlotCount together.
-//
-// Memory: kSlotCount × width × height × bpp.
-//   mono   1080p RGBA8: ~56 MB / layer
-//   mono   4K    RGBA8: ~232 MB / layer
-//   stereo 1080p RGBA8: ~112 MB / layer (×2 from paired slots)
-//   stereo 4K    RGBA8: ~464 MB / layer
-// With ``generate_mipmaps`` on (default), add ~33% for the mip chain.
-// A single 4K stereo layer with mips is ~620 MB — sizing concern for
-// the host's VRAM budget and worth surfacing to whoever picks the
-// resolution / layer count.
-//
-// Stereo: when Config::stereo is true, each slot owns a PAIR of
-// DeviceImages (left + right). The two-arg submit() does both
-// memcpy2Ds + the cuda_done_writing signal on a single CUDA stream,
-// so stream ordering guarantees the renderer never sees a half-
-// updated pair. In kXr, record() binds the left descriptor for
-// view 0 and the right for view 1; window/offscreen (single view)
-// draws the left buffer only.
-class QuadLayer : public LayerBase
+// Stereo: in kXr, record() binds the left descriptor for view 0 and the
+// right for view 1; window/offscreen (single view) draws the left buffer
+// only. See ImageLayerBase for the paired-mailbox submit contract.
+class QuadLayer : public ImageLayerBase
 {
 public:
-    // Sized to cover swapchains up to 5 images. The window swapchain
-    // requests <= 3 (see Swapchain::init), but drivers may grant more
-    // than requested; this headroom keeps record() from throwing on
-    // those platforms. Memory cost: kSlotCount × W × H × bpp per layer
-    // (~56 MB at 1080p RGBA8).
-    static constexpr uint32_t kMaxFramesInFlight = 5;
-    static constexpr uint32_t kSlotCount = kMaxFramesInFlight + 2;
-
     struct Config
     {
         std::string name = "QuadLayer";
@@ -143,50 +110,13 @@ public:
     // at 4 that's 1/8 (240x135 from 1080p, 480x270 from 4K).
     static constexpr uint32_t kMaxMipLevels = 4;
 
-    // Builds the 3 DeviceImages + pipeline up front. Throws
+    // Builds the mailbox DeviceImages + pipeline up front. Throws
     // std::invalid_argument on bad config; std::runtime_error on
     // Vulkan / CUDA failure.
     QuadLayer(const VkContext& ctx, VkRenderPass render_pass, Config config);
 
     ~QuadLayer() override;
     void destroy();
-
-    // submit() = producer side, record() = consumer side; may run on
-    // separate threads. NOT safe with multiple concurrent producers
-    // (one QuadLayer per producer).
-    //
-    // src.space must be kDevice; dims/format must match the layer.
-    // The copy + cuda_done_writing signal run on ``stream``. submit()
-    // BLOCKS on cudaStreamSynchronize(stream) before returning so the
-    // producer can safely reuse src.data — without that wait, a fast
-    // producer wrapping its mailbox could overwrite src.data while our
-    // async memcpy was still reading. Cost: ~0.5 ms per 1080p call on
-    // the calling thread; the render path is unaffected.
-    //
-    // Mono layer (Config::stereo == false): use the one-arg overload.
-    // The two-arg overload throws std::logic_error.
-    //
-    // Stereo layer (Config::stereo == true): use the two-arg overload.
-    // Both buffers are copied + the single cuda_done_writing signal is
-    // emitted on the SAME ``stream``, so stream ordering guarantees
-    // the renderer never reads a half-matched pair. The one-arg
-    // overload throws std::logic_error.
-    //
-    // STREAM PRECONDITION (stereo): the two-arg overload runs the copies
-    // for BOTH eyes on the single ``stream`` argument. CUDA's stream
-    // ordering only sequences work submitted to the SAME stream, so
-    // when ``left.data`` or ``right.data`` was produced on a different
-    // stream than ``stream``, the caller MUST synchronize that producer
-    // stream before calling submit (cudaStreamSynchronize, or a recorded
-    // event waited on ``stream`` via cudaStreamWaitEvent). Otherwise the
-    // memcpy here can read stale / torn pixels for that eye. The
-    // in-tree ZED + OAK-D producers handle this by calling
-    // ``cu_stream.synchronize()`` per eye-slot before publishing, which
-    // makes calling ``submit(left, right, stream=0)`` safe; external
-    // producers wiring separate per-eye streams must follow the same
-    // pattern.
-    void submit(const VizBuffer& src, cudaStream_t stream = 0);
-    void submit(const VizBuffer& left, const VizBuffer& right, cudaStream_t stream = 0);
 
     // Pre-pass slot: promote latest_ -> in_use_[in_flight_slot] AND
     // (when generate_mipmaps is on) emit the mip-chain blits on the
@@ -203,9 +133,6 @@ public:
                 const RenderTarget& target,
                 uint32_t in_flight_slot) override;
 
-    // Timeline wait on the in-use slot's cuda_done_writing.
-    std::vector<LayerBase::WaitSemaphore> get_wait_semaphores() const override;
-
     // Native OpenXR quad path. is_native_quad() is true only when the flag
     // is set AND this layer is in a kXr session (so window/offscreen keep
     // using record()). acquire_native_quad() promotes the mailbox slot (like
@@ -218,23 +145,17 @@ public:
     // Drives aspect-fit letterbox in window mode; ignored in kXr.
     std::optional<float> aspect_ratio() const noexcept override;
 
-    const VkContext* vk_context() const noexcept override
-    {
-        return ctx_;
-    }
-
-    Resolution resolution() const noexcept;
-    PixelFormat format() const noexcept;
-
     // Atomic placement swap, thread-safe vs record(). nullopt switches
     // to fullscreen mode (kXr will throw on next record).
     void set_placement(std::optional<Config::Placement> placement) noexcept;
     std::optional<Config::Placement> placement() const noexcept;
 
-    // Diagnostic accessor; nullptr for slots beyond kSlotCount, and
-    // device_image_right is null on mono layers.
-    const DeviceImage* device_image(uint32_t slot) const noexcept;
-    const DeviceImage* device_image_right(uint32_t slot) const noexcept;
+protected:
+    // Native quad: first GPU read is the backend's copy into the quad
+    // swapchain (TRANSFER). Composited-with-mips: the mip-gen blit chain
+    // reads level 0 at TRANSFER first. Plain composited: the fragment
+    // sampler is the first read.
+    VkPipelineStageFlags first_read_stage() const noexcept override;
 
 private:
     void init();
@@ -247,28 +168,10 @@ private:
     void allocate_descriptor_sets();
     void update_descriptor_sets();
 
-    // Mailbox slot allocation. submit() picks one of these states
-    // and atomically takes ownership; record() atomically promotes
-    // a freshly-published slot to `in_use_`.
-    static constexpr uint8_t kSlotNone = 0xFF;
-
-    // Promote latest_ -> in_use_[in_flight_slot] and update
-    // last_in_use_slot_ (shared by the render-pass consumer and the
-    // native-quad consumer). Returns the promoted slot, or kSlotNone if
-    // nothing has been published yet. Throws if in_flight_slot is out of
-    // range. Renderer thread only.
-    uint8_t promote_slot(uint32_t in_flight_slot);
-
     // True when this layer should composite as a native OpenXR quad:
     // the flag is set AND the attached session is kXr. Non-XR sessions
     // (and a detached layer) fall back to the record() draw path.
     bool native_active() const noexcept;
-
-    // Picks a slot that is neither latest_ nor in any in_use_ entry.
-    // Returns kSlotNone if every slot is forbidden (producer outran the
-    // renderer beyond the sizing invariant) — caller drops the publish.
-    uint8_t pick_free_slot(uint8_t latest,
-                           const std::array<std::atomic<uint8_t>, kMaxFramesInFlight>& in_use) const noexcept;
 
     // Emit a full mip-chain regeneration for ``image`` via
     // vkCmdBlitImage. Assumes the image is currently in
@@ -276,16 +179,10 @@ private:
     // same layout. Only called when Config::generate_mipmaps is true.
     void record_mip_generation(VkCommandBuffer cmd, DeviceImage& image);
 
-    const VkContext* ctx_ = nullptr;
     VkRenderPass render_pass_ = VK_NULL_HANDLE; // borrowed from compositor
     Config config_;
     // Number of mip levels per DeviceImage slot. 1 when mips disabled.
     uint32_t mip_levels_ = 1;
-
-    // One DeviceImage per mailbox slot. ``slots_`` is the left/mono
-    // image; ``slots_right_`` only allocated when Config::stereo.
-    std::array<std::unique_ptr<DeviceImage>, kSlotCount> slots_;
-    std::array<std::unique_ptr<DeviceImage>, kSlotCount> slots_right_;
 
     VkSampler sampler_ = VK_NULL_HANDLE;
     VkDescriptorSetLayout descriptor_set_layout_ = VK_NULL_HANDLE;
@@ -297,25 +194,6 @@ private:
     // ``descriptor_sets_right_`` is only populated when Config::stereo.
     std::array<VkDescriptorSet, kSlotCount> descriptor_sets_{};
     std::array<VkDescriptorSet, kSlotCount> descriptor_sets_right_{};
-
-    // Mailbox: latest_ = most recent publish. in_use_[i] = slot the
-    // i-th in-flight frame is sampling. Atomic so producer and
-    // renderer share without locks. All kSlotNone until first
-    // submit() / first sampling record(). Both record() and
-    // get_wait_semaphores() use the LAST seen in_use_ slot (any
-    // entry — record updates one, get_wait_semaphores reads from
-    // whichever entry corresponds to the in-flight frame that just
-    // recorded).
-    std::atomic<uint8_t> latest_{ kSlotNone };
-    std::array<std::atomic<uint8_t>, kMaxFramesInFlight> in_use_{};
-    // Tracks which in_use_ entry was MOST RECENTLY promoted by
-    // record(). get_wait_semaphores() reads this entry's slot — it's
-    // the one whose cuda_done_writing semaphore gates the GPU's
-    // sampling work that was just queued. Atomic but doesn't need
-    // mutual exclusion with in_use_ stores (the renderer thread does
-    // both writes; we use atomics for cross-thread visibility with
-    // submit's reads in pick_free_slot).
-    std::atomic<uint8_t> last_in_use_slot_{ kSlotNone };
 
     // Live placement; lock for set_placement / record() snapshot.
     mutable std::mutex placement_mutex_;

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -146,8 +146,10 @@ public:
     std::optional<float> aspect_ratio() const noexcept override;
 
     // Atomic placement swap, thread-safe vs record(). nullopt switches
-    // to fullscreen mode (kXr will throw on next record).
-    void set_placement(std::optional<Config::Placement> placement) noexcept;
+    // to fullscreen mode (kXr will throw on next record). Validates the
+    // same invariants as construction (size_meters > 0); throws
+    // std::invalid_argument.
+    void set_placement(std::optional<Config::Placement> placement);
     std::optional<Config::Placement> placement() const noexcept;
 
 protected:

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -97,14 +97,13 @@ public:
         // draw path).
         //
         // Set to false to fall back to compositing into the shared render
-        // target instead. The compositor path is the right choice when the
-        // quad must z-compose with 3D ProjectionLayer content — a native
-        // quad carries NO depth (OpenXR quad layers have none), so it's a
-        // flat billboard ordered by submission — or when a runtime
-        // mishandles native quad layers. ``generate_mipmaps`` only applies
-        // on the compositor path (the runtime samples native quads).
-        // Requires ``placement`` at record time either way, same as any
-        // kXr quad.
+        // target instead, where 3D-placed quads depth-test against each
+        // other — a native quad carries NO depth (OpenXR quad layers have
+        // none), so it's a flat billboard ordered by submission. Also the
+        // escape hatch for runtimes that mishandle native quad layers.
+        // ``generate_mipmaps`` only applies on the compositor path (the
+        // runtime samples native quads). Requires ``placement`` at record
+        // time either way, same as any kXr quad.
         bool native_composition = true;
 
         // Composite honoring the texture's alpha channel. Native path:

--- a/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
+++ b/src/viz/layers/cpp/inc/viz/layers/quad_layer.hpp
@@ -87,24 +87,26 @@ public:
         // world IPDs and camera baselines are 50–80 mm.
         float stereo_baseline_mm = 0.0f;
 
-        // In kXr, submit this quad as a native OpenXR quad layer
-        // (XrCompositionLayerQuad) — the DEFAULT: the runtime places +
-        // samples the quad directly, which enables its quad fast path
-        // (and, for frames where every visible layer is native,
-        // client-reconstructed streaming — the shared projection layer is
-        // dropped). Stereo emits one quad per eye via eyeVisibility.
-        // Ignored outside kXr (window/offscreen always use the compositor
-        // draw path).
+        // WHO composites this quad in kXr. true (the DEFAULT): the OpenXR
+        // runtime — the quad is submitted as an XrCompositionLayerQuad and
+        // the runtime places + samples it directly, enabling its layer
+        // fast path (and, for frames where every visible layer is
+        // runtime-composited, client-reconstructed streaming — the shared
+        // projection layer is dropped). Stereo emits one quad per eye via
+        // eyeVisibility. Ignored outside kXr (window/offscreen are always
+        // composited by Televiz).
         //
-        // Set to false to fall back to compositing into the shared render
-        // target instead, where 3D-placed quads depth-test against each
-        // other — a native quad carries NO depth (OpenXR quad layers have
-        // none), so it's a flat billboard ordered by submission. Also the
-        // escape hatch for runtimes that mishandle native quad layers.
+        // false: Televiz's built-in compositor draws the quad into the
+        // shared render target, where 3D-placed quads depth-test against
+        // each other — a runtime-composited quad carries NO depth (OpenXR
+        // quad layers have none), so it's a flat billboard ordered by
+        // submission. Also the escape hatch for runtimes that mishandle
+        // quad layers. QuadLayer is the only shape with this choice:
+        // CylinderLayer / EquirectLayer are runtime-composited always.
         // ``generate_mipmaps`` only applies on the compositor path (the
         // runtime samples native quads). Requires ``placement`` at record
         // time either way, same as any kXr quad.
-        bool native_composition = true;
+        bool openxr_composition = true;
 
         // Composite honoring the texture's alpha channel. Native path:
         // sets XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT on the
@@ -146,12 +148,12 @@ public:
                 uint32_t in_flight_slot) override;
 
     // Native OpenXR quad path. is_native_layer() is true only when
-    // native_composition is on (the default) AND this layer is in a kXr
+    // openxr_composition is on (the default) AND this layer is in a kXr
     // session (so window/offscreen keep using record()).
     // acquire_native_layer() promotes the mailbox slot (like record()'s
     // consumer side) and returns the per-eye source images + placement for
     // the backend to blit into its quad swapchain. See
-    // Config::native_composition.
+    // Config::openxr_composition.
     bool is_native_layer() const noexcept override;
     std::optional<NativeLayerView> acquire_native_layer(uint32_t in_flight_slot) override;
 

--- a/src/viz/layers/cpp/quad_layer.cpp
+++ b/src/viz/layers/cpp/quad_layer.cpp
@@ -302,10 +302,11 @@ void QuadLayer::record_mip_generation(VkCommandBuffer cmd, DeviceImage& image)
 
 bool QuadLayer::native_active() const noexcept
 {
-    // Flag only takes effect in a kXr session; window/offscreen fall back
-    // to the record() draw path. A detached layer (no session) is not
-    // native either, so standalone construction/tests keep the draw path.
-    return config_.use_openxr_quad_layer && session() != nullptr && session()->is_xr_mode();
+    // Native composition (the default) only takes effect in a kXr session;
+    // window/offscreen always use the record() draw path. A detached layer
+    // (no session) is not native either, so standalone construction/tests
+    // keep the draw path.
+    return config_.native_composition && session() != nullptr && session()->is_xr_mode();
 }
 
 bool QuadLayer::is_native_layer() const noexcept

--- a/src/viz/layers/cpp/quad_layer.cpp
+++ b/src/viz/layers/cpp/quad_layer.cpp
@@ -351,6 +351,7 @@ std::optional<NativeLayerView> QuadLayer::acquire_native_layer(uint32_t in_fligh
     v.pose = placement->pose;
     v.size_meters = placement->size_meters;
     v.stereo_baseline_mm = config_.stereo ? config_.stereo_baseline_mm : 0.0f;
+    v.alpha_blend = config_.alpha_blend;
     v.source_id = this;
     return v;
 }

--- a/src/viz/layers/cpp/quad_layer.cpp
+++ b/src/viz/layers/cpp/quad_layer.cpp
@@ -64,6 +64,19 @@ glm::mat4 placement_mvp(const QuadLayer::Config::Placement& p, const ViewInfo& v
     return view.projection_matrix * view.view_matrix * model;
 }
 
+// Placement validation shared by the ctor and set_placement.
+void validate_placement(const std::optional<QuadLayer::Config::Placement>& placement)
+{
+    if (placement.has_value())
+    {
+        const auto& ext = placement->size_meters;
+        if (ext.x <= 0.0f || ext.y <= 0.0f)
+        {
+            throw std::invalid_argument("QuadLayer: Placement::size_meters must be > 0 in both components");
+        }
+    }
+}
+
 // Quad-specific config validation (the base validates format /
 // resolution / context). Returns its argument so it can run inside the
 // base-initializer expression — i.e. BEFORE the base allocates images.
@@ -73,14 +86,7 @@ const QuadLayer::Config& validate_config(const QuadLayer::Config& config, VkRend
     {
         throw std::invalid_argument("QuadLayer: render_pass must be non-null");
     }
-    if (config.placement.has_value())
-    {
-        const auto& ext = config.placement->size_meters;
-        if (ext.x <= 0.0f || ext.y <= 0.0f)
-        {
-            throw std::invalid_argument("QuadLayer: Placement::size_meters must be > 0 in both components");
-        }
-    }
+    validate_placement(config.placement);
     if (!std::isfinite(config.stereo_baseline_mm))
     {
         throw std::invalid_argument("QuadLayer: stereo_baseline_mm must be finite");
@@ -461,8 +467,9 @@ void QuadLayer::record(VkCommandBuffer cmd,
     }
 }
 
-void QuadLayer::set_placement(std::optional<Config::Placement> placement) noexcept
+void QuadLayer::set_placement(std::optional<Config::Placement> placement)
 {
+    validate_placement(placement);
     std::lock_guard<std::mutex> lk(placement_mutex_);
     placement_ = std::move(placement);
 }

--- a/src/viz/layers/cpp/quad_layer.cpp
+++ b/src/viz/layers/cpp/quad_layer.cpp
@@ -302,14 +302,14 @@ bool QuadLayer::native_active() const noexcept
     return config_.use_openxr_quad_layer && session() != nullptr && session()->is_xr_mode();
 }
 
-bool QuadLayer::is_native_quad() const noexcept
+bool QuadLayer::is_native_layer() const noexcept
 {
     return native_active();
 }
 
-std::optional<NativeQuadView> QuadLayer::acquire_native_quad(uint32_t in_flight_slot)
+std::optional<NativeLayerView> QuadLayer::acquire_native_layer(uint32_t in_flight_slot)
 {
-    require_alive("acquire_native_quad");
+    require_alive("acquire_native_layer");
 
     // Promote first, matching record()'s consumer ordering: before the first
     // publish there is nothing to composite, so return early WITHOUT requiring
@@ -336,7 +336,8 @@ std::optional<NativeQuadView> QuadLayer::acquire_native_quad(uint32_t in_flight_
         throw std::logic_error("QuadLayer: native OpenXR quad requires Config::placement to be set");
     }
 
-    NativeQuadView v{};
+    NativeLayerView v{};
+    v.shape = NativeLayerShape::kQuad;
     v.color_left = slots_[cur]->vk_image();
     v.color_right = config_.stereo ? slots_right_[cur]->vk_image() : VK_NULL_HANDLE;
     v.extent = config_.resolution;

--- a/src/viz/layers/cpp/quad_layer.cpp
+++ b/src/viz/layers/cpp/quad_layer.cpp
@@ -15,7 +15,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
-#include <cuda_runtime.h>
 #include <stdexcept>
 #include <string>
 
@@ -33,14 +32,6 @@ void check_vk(VkResult result, const char* what)
     }
 }
 
-void check_cuda(cudaError_t result, const char* what)
-{
-    if (result != cudaSuccess)
-    {
-        throw std::runtime_error(std::string("QuadLayer: ") + what + " failed: " + cudaGetErrorString(result));
-    }
-}
-
 VkShaderModule create_shader_module(VkDevice device, const unsigned char* spv, size_t size)
 {
     VkShaderModuleCreateInfo info{};
@@ -50,18 +41,6 @@ VkShaderModule create_shader_module(VkDevice device, const unsigned char* spv, s
     VkShaderModule mod = VK_NULL_HANDLE;
     check_vk(vkCreateShaderModule(device, &info, nullptr, &mod), "vkCreateShaderModule");
     return mod;
-}
-
-// Once destroy() has run, slots_[0] is the canonical "alive" signal
-// (it's the first thing init() builds and the last thing destroy()
-// resets). Throwing logic_error converts use-after-destroy from a
-// silent null-deref into a clean failure callers can catch in tests.
-void require_alive(const std::unique_ptr<DeviceImage>& slot0, const char* what)
-{
-    if (!slot0)
-    {
-        throw std::logic_error(std::string("QuadLayer::") + what + " called after destroy()");
-    }
 }
 
 // Mirrors textured_quad.vert's push_constant block.
@@ -85,61 +64,63 @@ glm::mat4 placement_mvp(const QuadLayer::Config::Placement& p, const ViewInfo& v
     return view.projection_matrix * view.view_matrix * model;
 }
 
-} // namespace
-
-QuadLayer::QuadLayer(const VkContext& ctx, VkRenderPass render_pass, Config config)
-    : LayerBase(config.name), ctx_(&ctx), render_pass_(render_pass), config_(std::move(config))
+// Quad-specific config validation (the base validates format /
+// resolution / context). Returns its argument so it can run inside the
+// base-initializer expression — i.e. BEFORE the base allocates images.
+const QuadLayer::Config& validate_config(const QuadLayer::Config& config, VkRenderPass render_pass)
 {
-    // textured_quad's frag samples a color image; depth views aren't
-    // color-samplable.
-    if (config_.format != PixelFormat::kRGBA8)
-    {
-        throw std::invalid_argument("QuadLayer: only PixelFormat::kRGBA8 is supported");
-    }
-    if (config_.resolution.width == 0 || config_.resolution.height == 0)
-    {
-        throw std::invalid_argument("QuadLayer: resolution must be non-zero");
-    }
     if (render_pass == VK_NULL_HANDLE)
     {
         throw std::invalid_argument("QuadLayer: render_pass must be non-null");
     }
-    if (!ctx.is_initialized())
+    if (config.placement.has_value())
     {
-        throw std::invalid_argument("QuadLayer: VkContext is not initialized");
-    }
-    if (config_.placement.has_value())
-    {
-        const auto& ext = config_.placement->size_meters;
+        const auto& ext = config.placement->size_meters;
         if (ext.x <= 0.0f || ext.y <= 0.0f)
         {
             throw std::invalid_argument("QuadLayer: Placement::size_meters must be > 0 in both components");
         }
     }
-    if (!std::isfinite(config_.stereo_baseline_mm))
+    if (!std::isfinite(config.stereo_baseline_mm))
     {
         throw std::invalid_argument("QuadLayer: stereo_baseline_mm must be finite");
     }
+    return config;
+}
 
-    // Resolve mip count: capped chain when enabled, single level
-    // otherwise. The cap (kMaxMipLevels) keeps the per-frame blit
-    // cost and the extra image storage in check; full log2 chain
-    // adds levels that the sampler rarely picks anyway.
-    if (config_.generate_mipmaps)
+// Resolve mip count: capped chain when enabled, single level
+// otherwise. The cap (kMaxMipLevels) keeps the per-frame blit
+// cost and the extra image storage in check; full log2 chain
+// adds levels that the sampler rarely picks anyway.
+uint32_t resolve_mip_levels(const QuadLayer::Config& config)
+{
+    if (!config.generate_mipmaps)
     {
-        const uint32_t max_dim = std::max(config_.resolution.width, config_.resolution.height);
-        uint32_t full_chain = 1;
-        for (uint32_t d = max_dim; d > 1; d >>= 1)
-        {
-            ++full_chain;
-        }
-        mip_levels_ = std::min(full_chain, kMaxMipLevels);
+        return 1;
     }
-    else
+    const uint32_t max_dim = std::max(config.resolution.width, config.resolution.height);
+    uint32_t full_chain = 1;
+    for (uint32_t d = max_dim; d > 1; d >>= 1)
     {
-        mip_levels_ = 1;
+        ++full_chain;
     }
+    return std::min(full_chain, QuadLayer::kMaxMipLevels);
+}
 
+} // namespace
+
+QuadLayer::QuadLayer(const VkContext& ctx, VkRenderPass render_pass, Config config)
+    : ImageLayerBase(ctx,
+                     "QuadLayer",
+                     validate_config(config, render_pass).name,
+                     config.resolution,
+                     config.format,
+                     config.stereo,
+                     resolve_mip_levels(config)),
+      render_pass_(render_pass),
+      config_(std::move(config)),
+      mip_levels_(resolve_mip_levels(config_))
+{
     placement_ = config_.placement;
     init();
 }
@@ -153,25 +134,6 @@ void QuadLayer::init()
 {
     try
     {
-        // Atomic<uint8_t>'s default state is unspecified per the
-        // standard; explicitly seed every entry to kSlotNone so submit
-        // / record / get_wait_semaphores see a defined initial state.
-        for (auto& e : in_use_)
-        {
-            e.store(kSlotNone, std::memory_order_relaxed);
-        }
-        last_in_use_slot_.store(kSlotNone, std::memory_order_relaxed);
-        for (auto& slot : slots_)
-        {
-            slot = DeviceImage::create(*ctx_, config_.resolution, config_.format, mip_levels_);
-        }
-        if (config_.stereo)
-        {
-            for (auto& slot : slots_right_)
-            {
-                slot = DeviceImage::create(*ctx_, config_.resolution, config_.format, mip_levels_);
-            }
-        }
         create_sampler();
         create_descriptor_set_layout();
         create_pipeline_layout();
@@ -189,76 +151,40 @@ void QuadLayer::init()
 
 void QuadLayer::destroy()
 {
-    if (ctx_ == nullptr)
+    const VkDevice device = (ctx_ != nullptr) ? ctx_->device() : VK_NULL_HANDLE;
+    if (device != VK_NULL_HANDLE)
     {
-        return;
-    }
-    const VkDevice device = ctx_->device();
-    if (device == VK_NULL_HANDLE)
-    {
-        for (auto& slot : slots_)
+        if (descriptor_pool_ != VK_NULL_HANDLE)
         {
-            slot.reset();
+            // descriptor_sets_ + descriptor_sets_right_ are freed implicitly
+            // with the pool.
+            vkDestroyDescriptorPool(device, descriptor_pool_, nullptr);
+            descriptor_pool_ = VK_NULL_HANDLE;
+            descriptor_sets_.fill(VK_NULL_HANDLE);
+            descriptor_sets_right_.fill(VK_NULL_HANDLE);
         }
-        for (auto& slot : slots_right_)
+        if (pipeline_ != VK_NULL_HANDLE)
         {
-            slot.reset();
+            vkDestroyPipeline(device, pipeline_, nullptr);
+            pipeline_ = VK_NULL_HANDLE;
         }
-        return;
+        if (pipeline_layout_ != VK_NULL_HANDLE)
+        {
+            vkDestroyPipelineLayout(device, pipeline_layout_, nullptr);
+            pipeline_layout_ = VK_NULL_HANDLE;
+        }
+        if (descriptor_set_layout_ != VK_NULL_HANDLE)
+        {
+            vkDestroyDescriptorSetLayout(device, descriptor_set_layout_, nullptr);
+            descriptor_set_layout_ = VK_NULL_HANDLE;
+        }
+        if (sampler_ != VK_NULL_HANDLE)
+        {
+            vkDestroySampler(device, sampler_, nullptr);
+            sampler_ = VK_NULL_HANDLE;
+        }
     }
-    if (descriptor_pool_ != VK_NULL_HANDLE)
-    {
-        // descriptor_sets_ + descriptor_sets_right_ are freed implicitly
-        // with the pool.
-        vkDestroyDescriptorPool(device, descriptor_pool_, nullptr);
-        descriptor_pool_ = VK_NULL_HANDLE;
-        descriptor_sets_.fill(VK_NULL_HANDLE);
-        descriptor_sets_right_.fill(VK_NULL_HANDLE);
-    }
-    if (pipeline_ != VK_NULL_HANDLE)
-    {
-        vkDestroyPipeline(device, pipeline_, nullptr);
-        pipeline_ = VK_NULL_HANDLE;
-    }
-    if (pipeline_layout_ != VK_NULL_HANDLE)
-    {
-        vkDestroyPipelineLayout(device, pipeline_layout_, nullptr);
-        pipeline_layout_ = VK_NULL_HANDLE;
-    }
-    if (descriptor_set_layout_ != VK_NULL_HANDLE)
-    {
-        vkDestroyDescriptorSetLayout(device, descriptor_set_layout_, nullptr);
-        descriptor_set_layout_ = VK_NULL_HANDLE;
-    }
-    if (sampler_ != VK_NULL_HANDLE)
-    {
-        vkDestroySampler(device, sampler_, nullptr);
-        sampler_ = VK_NULL_HANDLE;
-    }
-    for (auto& slot : slots_)
-    {
-        slot.reset();
-    }
-    for (auto& slot : slots_right_)
-    {
-        slot.reset();
-    }
-    latest_.store(kSlotNone, std::memory_order_release);
-    for (auto& e : in_use_)
-    {
-        e.store(kSlotNone, std::memory_order_release);
-    }
-    last_in_use_slot_.store(kSlotNone, std::memory_order_release);
-}
-
-Resolution QuadLayer::resolution() const noexcept
-{
-    return config_.resolution;
-}
-
-PixelFormat QuadLayer::format() const noexcept
-{
-    return config_.format;
+    destroy_images();
 }
 
 std::optional<float> QuadLayer::aspect_ratio() const noexcept
@@ -270,171 +196,6 @@ std::optional<float> QuadLayer::aspect_ratio() const noexcept
     return static_cast<float>(config_.resolution.width) / static_cast<float>(config_.resolution.height);
 }
 
-const DeviceImage* QuadLayer::device_image(uint32_t slot) const noexcept
-{
-    if (slot >= kSlotCount)
-    {
-        return nullptr;
-    }
-    return slots_[slot].get();
-}
-
-const DeviceImage* QuadLayer::device_image_right(uint32_t slot) const noexcept
-{
-    if (slot >= kSlotCount)
-    {
-        return nullptr;
-    }
-    return slots_right_[slot].get();
-}
-
-uint8_t QuadLayer::pick_free_slot(uint8_t latest,
-                                  const std::array<std::atomic<uint8_t>, kMaxFramesInFlight>& in_use) const noexcept
-{
-    // Forbidden = {latest} ∪ in_use_. kSlotCount = kMaxFramesInFlight + 2
-    // guarantees one free slot under the invariant; we still return
-    // kSlotNone defensively if the invariant ever breaks, so submit()
-    // drops the publish rather than overwriting a slot the GPU is sampling.
-    static_assert(kSlotCount > kMaxFramesInFlight + 1,
-                  "kSlotCount must exceed kMaxFramesInFlight + 1 so at least one slot is free");
-    for (uint8_t i = 0; i < kSlotCount; ++i)
-    {
-        if (i == latest)
-            continue;
-        bool conflicts = false;
-        for (uint32_t k = 0; k < kMaxFramesInFlight; ++k)
-        {
-            if (i == in_use[k].load(std::memory_order_acquire))
-            {
-                conflicts = true;
-                break;
-            }
-        }
-        if (!conflicts)
-        {
-            return i;
-        }
-    }
-    return kSlotNone;
-}
-
-namespace
-{
-// Shared per-buffer validation for the submit overloads. ``label`` is
-// the caller's tag (e.g. "src", "left", "right") so the error message
-// names which buffer failed in the stereo case.
-void validate_submit_buffer(const VizBuffer& buf, const QuadLayer::Config& cfg, const char* label)
-{
-    if (buf.space != MemorySpace::kDevice)
-    {
-        throw std::invalid_argument(std::string("QuadLayer::submit: ") + label + " must be MemorySpace::kDevice");
-    }
-    if (buf.width != cfg.resolution.width || buf.height != cfg.resolution.height)
-    {
-        throw std::invalid_argument(std::string("QuadLayer::submit: ") + label +
-                                    " dimensions do not match layer resolution");
-    }
-    if (buf.format != cfg.format)
-    {
-        throw std::invalid_argument(std::string("QuadLayer::submit: ") + label + " format does not match layer format");
-    }
-    if (buf.data == nullptr)
-    {
-        throw std::invalid_argument(std::string("QuadLayer::submit: ") + label + ".data is null");
-    }
-}
-
-// Queue an async D2D copy of ``buf`` → ``image.cuda_array()`` on
-// ``stream``. Shared between the mono and stereo submit paths.
-void enqueue_copy(const VizBuffer& buf, DeviceImage& image, cudaStream_t stream)
-{
-    const size_t row_bytes = static_cast<size_t>(buf.width) * bytes_per_pixel(buf.format);
-    const size_t src_pitch = (buf.pitch == 0) ? row_bytes : buf.pitch;
-    const cudaError_t err = cudaMemcpy2DToArrayAsync(
-        image.cuda_array(), 0, 0, buf.data, src_pitch, row_bytes, buf.height, cudaMemcpyDeviceToDevice, stream);
-    if (err != cudaSuccess)
-    {
-        throw std::runtime_error(std::string("QuadLayer::submit: cudaMemcpy2DToArrayAsync failed: ") +
-                                 cudaGetErrorString(err));
-    }
-}
-} // namespace
-
-void QuadLayer::submit(const VizBuffer& src, cudaStream_t stream)
-{
-    require_alive(slots_[0], "submit");
-    if (config_.stereo)
-    {
-        throw std::logic_error("QuadLayer::submit: this layer is stereo — use the two-arg submit(left, right) overload");
-    }
-    validate_submit_buffer(src, config_, "src");
-
-    const uint8_t latest = latest_.load(std::memory_order_acquire);
-    const uint8_t slot = pick_free_slot(latest, in_use_);
-    if (slot == kSlotNone)
-    {
-        // Mailbox drop: producer outran the renderer beyond the sizing
-        // invariant. Keep latest_ where it is; consumer keeps using it.
-        return;
-    }
-    DeviceImage& image = *slots_[slot];
-
-    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), "cudaSetDevice");
-    enqueue_copy(src, image, stream);
-    image.cuda_signal_write_done(stream);
-
-    // Wait for the D2D copy to complete before returning. Sources publish
-    // buffers by reference and treat ``latest()`` returning them as proof
-    // of consumption; without a sync here a fast producer could wrap the
-    // mailbox and overwrite src.data while our async memcpy is still
-    // reading from it. Cost is ~0.5 ms per 1080p submit on the caller's
-    // thread; the render path is unaffected.
-    check_cuda(cudaStreamSynchronize(stream), "cudaStreamSynchronize(submit)");
-
-    // memory_order_release pairs with the renderer's acquire load.
-    latest_.store(slot, std::memory_order_release);
-}
-
-void QuadLayer::submit(const VizBuffer& left, const VizBuffer& right, cudaStream_t stream)
-{
-    require_alive(slots_[0], "submit");
-    if (!config_.stereo)
-    {
-        throw std::logic_error("QuadLayer::submit: this layer is mono — call submit(src) with a single buffer");
-    }
-    validate_submit_buffer(left, config_, "left");
-    validate_submit_buffer(right, config_, "right");
-
-    const uint8_t latest = latest_.load(std::memory_order_acquire);
-    const uint8_t slot = pick_free_slot(latest, in_use_);
-    if (slot == kSlotNone)
-    {
-        return;
-    }
-    DeviceImage& image_l = *slots_[slot];
-    DeviceImage& image_r = *slots_right_[slot];
-
-    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), "cudaSetDevice");
-    // Both copies on the same stream + a single signal on the left's
-    // semaphore. Stream ordering guarantees the right copy completes
-    // before the signal fires, so the renderer waiting on the left's
-    // semaphore implies the right is ready too. No second semaphore
-    // needed — by construction the renderer cannot see a half-pair.
-    //
-    // Stream precondition (see header): ``left.data`` and ``right.data``
-    // must both be reachable from ``stream`` by the time control reaches
-    // here. If a producer wrote either buffer on a different stream, the
-    // caller is responsible for syncing it before submit; otherwise the
-    // memcpy below may read pre-write state on that eye.
-    enqueue_copy(left, image_l, stream);
-    enqueue_copy(right, image_r, stream);
-    image_l.cuda_signal_write_done(stream);
-
-    check_cuda(cudaStreamSynchronize(stream), "cudaStreamSynchronize(submit-stereo)");
-
-    latest_.store(slot, std::memory_order_release);
-}
-
 void QuadLayer::record_mip_generation(VkCommandBuffer cmd, DeviceImage& image)
 {
     // Mip-chain regeneration via vkCmdBlitImage. The image lives in
@@ -443,7 +204,7 @@ void QuadLayer::record_mip_generation(VkCommandBuffer cmd, DeviceImage& image)
     // the post-pass sample sees the same invariant. CUDA wrote level 0
     // out-of-band; the queue submit's TRANSFER-stage wait on
     // cuda_done_writing gates this against the producer (see
-    // get_wait_semaphores).
+    // first_read_stage).
     const VkImage vk_image = image.vk_image();
     const uint32_t levels = image.mip_levels();
     const int32_t base_w = static_cast<int32_t>(image.resolution().width);
@@ -533,40 +294,6 @@ void QuadLayer::record_mip_generation(VkCommandBuffer cmd, DeviceImage& image)
                       VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT);
 }
 
-uint8_t QuadLayer::promote_slot(uint32_t in_flight_slot)
-{
-    // Backends are contracted to image_count <= kMaxFramesInFlight; if
-    // that ever breaks, two in-flight frames would alias on the same
-    // in_use_ entry and we'd lose the slot-tracking invariant.
-    if (in_flight_slot >= kMaxFramesInFlight)
-    {
-        throw std::logic_error("QuadLayer: in_flight_slot " + std::to_string(in_flight_slot) +
-                               " >= kMaxFramesInFlight (" + std::to_string(kMaxFramesInFlight) +
-                               "); bump kMaxFramesInFlight to match the backend's image_count");
-    }
-
-    // Promote latest_ -> in_use_[in_flight_slot]. The compositor's
-    // per-slot fence wait at the top of render() guarantees the GPU
-    // has finished sampling the previous in_use_ value. record() (or the
-    // native-quad copy) reads the same entry — the promoting call and the
-    // consuming call MUST agree on in_flight_slot.
-    const uint8_t latest = latest_.load(std::memory_order_acquire);
-    const uint32_t idx = in_flight_slot;
-    if (latest != kSlotNone)
-    {
-        in_use_[idx].store(latest, std::memory_order_release);
-    }
-    const uint8_t cur = in_use_[idx].load(std::memory_order_acquire);
-    if (cur != kSlotNone)
-    {
-        // Record which slot this frame is sampling so get_wait_semaphores
-        // (called by the compositor before submit) reads the matching
-        // cuda_done_writing semaphore.
-        last_in_use_slot_.store(cur, std::memory_order_release);
-    }
-    return cur;
-}
-
 bool QuadLayer::native_active() const noexcept
 {
     // Flag only takes effect in a kXr session; window/offscreen fall back
@@ -582,7 +309,7 @@ bool QuadLayer::is_native_quad() const noexcept
 
 std::optional<NativeQuadView> QuadLayer::acquire_native_quad(uint32_t in_flight_slot)
 {
-    require_alive(slots_[0], "acquire_native_quad");
+    require_alive("acquire_native_quad");
 
     // Promote first, matching record()'s consumer ordering: before the first
     // publish there is nothing to composite, so return early WITHOUT requiring
@@ -622,7 +349,7 @@ std::optional<NativeQuadView> QuadLayer::acquire_native_quad(uint32_t in_flight_
 
 void QuadLayer::record_pre_render_pass(VkCommandBuffer cmd, uint32_t in_flight_slot)
 {
-    require_alive(slots_[0], "record_pre_render_pass");
+    require_alive("record_pre_render_pass");
 
     const uint8_t cur = promote_slot(in_flight_slot);
     if (cur == kSlotNone)
@@ -651,13 +378,12 @@ void QuadLayer::record(VkCommandBuffer cmd,
                        const RenderTarget& /*target*/,
                        uint32_t in_flight_slot)
 {
-    require_alive(slots_[0], "record");
+    require_alive("record");
 
     // Slot promotion ran in record_pre_render_pass with the same
     // in_flight_slot. Read the result; skip the draw if there's been
     // no publish yet (RT keeps its clear value).
-    const uint32_t idx = in_flight_slot;
-    const uint8_t cur = in_use_[idx].load(std::memory_order_acquire);
+    const uint8_t cur = promoted_slot(in_flight_slot);
     if (cur == kSlotNone)
     {
         return;
@@ -746,41 +472,13 @@ std::optional<QuadLayer::Config::Placement> QuadLayer::placement() const noexcep
     return placement_;
 }
 
-std::vector<LayerBase::WaitSemaphore> QuadLayer::get_wait_semaphores() const
+VkPipelineStageFlags QuadLayer::first_read_stage() const noexcept
 {
-    // Compositor calls record_pre_render_pass first (which sets
-    // last_in_use_slot_). We return THAT slot's cuda_done_writing
-    // semaphore so the submit waits for the producer's memcpy.
-    // Wait stage:
-    //   * No mips: first GPU read is the fragment sampler.
-    //   * Mips on: the mip-gen blit chain in pre-pass reads level 0
-    //     first (TRANSFER stage); fragment sampling comes later but
-    //     is already ordered via the chain's barriers, so the submit
-    //     wait can gate at TRANSFER.
-    const uint8_t cur = last_in_use_slot_.load(std::memory_order_acquire);
-    if (cur == kSlotNone || !slots_[cur])
-    {
-        return {};
-    }
-    const DeviceImage& image = *slots_[cur];
-    const uint64_t value = image.cuda_done_writing_value();
-    if (value == 0)
-    {
-        return {};
-    }
     // Native quad: first GPU read is the backend's copy into the quad
     // swapchain (TRANSFER). Composited-with-mips: the mip-gen blit chain
     // reads level 0 at TRANSFER first. Plain composited: the fragment
     // sampler is the first read.
-    const VkPipelineStageFlags wait_stage =
-        (native_active() || mip_levels_ > 1) ? VK_PIPELINE_STAGE_TRANSFER_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
-    return {
-        WaitSemaphore{
-            image.cuda_done_writing(),
-            value,
-            wait_stage,
-        },
-    };
+    return (native_active() || mip_levels_ > 1) ? VK_PIPELINE_STAGE_TRANSFER_BIT : VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
 }
 
 void QuadLayer::create_sampler()
@@ -910,7 +608,6 @@ void QuadLayer::create_pipeline()
     multisample.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
     multisample.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-    // Depth disabled — fullscreen blits don't need it.
     // Depth on so XR backends can submit XrCompositionLayerDepthInfoKHR
     // alongside the projection layer (CloudXR uses depth for server-
     // side reprojection). LESS_OR_EQUAL keeps last-wins semantics for

--- a/src/viz/layers/cpp/quad_layer.cpp
+++ b/src/viz/layers/cpp/quad_layer.cpp
@@ -306,7 +306,7 @@ bool QuadLayer::native_active() const noexcept
     // window/offscreen always use the record() draw path. A detached layer
     // (no session) is not native either, so standalone construction/tests
     // keep the draw path.
-    return config_.native_composition && session() != nullptr && session()->is_xr_mode();
+    return config_.openxr_composition && session() != nullptr && session()->is_xr_mode();
 }
 
 bool QuadLayer::is_native_layer() const noexcept

--- a/src/viz/layers_tests/cpp/CMakeLists.txt
+++ b/src/viz/layers_tests/cpp/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable(viz_layers_tests
     test_clear_rect_layer.cpp
     test_projection_layer.cpp
     test_quad_layer.cpp
+    test_shaped_layers.cpp
     test_throwing_layer.cpp
 )
 

--- a/src/viz/layers_tests/cpp/test_quad_layer.cpp
+++ b/src/viz/layers_tests/cpp/test_quad_layer.cpp
@@ -63,12 +63,12 @@ TEST_CASE("QuadLayer ctor rejects null render pass", "[unit][quad_layer]")
     CHECK_THROWS_AS(QuadLayer(ctx, VK_NULL_HANDLE, cfg), std::invalid_argument);
 }
 
-TEST_CASE("QuadLayer::Config native_composition defaults ON with a compositor opt-out", "[unit][quad_layer][native]")
+TEST_CASE("QuadLayer::Config openxr_composition defaults ON with a compositor opt-out", "[unit][quad_layer][native]")
 {
     QuadLayer::Config cfg;
-    CHECK(cfg.native_composition);
-    cfg.native_composition = false;
-    CHECK_FALSE(cfg.native_composition);
+    CHECK(cfg.openxr_composition);
+    cfg.openxr_composition = false;
+    CHECK_FALSE(cfg.openxr_composition);
 }
 
 // A native-quad layer only goes native inside a kXr session; a detached
@@ -87,7 +87,7 @@ TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_laye
 
     QuadLayer::Config cfg;
     cfg.resolution = { 64, 64 };
-    cfg.native_composition = true;
+    cfg.openxr_composition = true;
     QuadLayer::Config::Placement pl;
     pl.pose = viz::Pose3D{};
     pl.size_meters = glm::vec2(1.0f, 1.0f);
@@ -117,7 +117,7 @@ TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_laye
     // once a frame is published without a placement, it's a misconfiguration.
     QuadLayer::Config no_placement;
     no_placement.resolution = { 64, 64 };
-    no_placement.native_composition = true;
+    no_placement.openxr_composition = true;
     QuadLayer layer_np(ctx, target->render_pass(), no_placement);
     CHECK_FALSE(layer_np.acquire_native_layer(0).has_value()); // lenient pre-publish
 

--- a/src/viz/layers_tests/cpp/test_quad_layer.cpp
+++ b/src/viz/layers_tests/cpp/test_quad_layer.cpp
@@ -95,14 +95,14 @@ TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_laye
     QuadLayer layer(ctx, target->render_pass(), cfg);
 
     // No session attached → not native (so the compositor uses record()).
-    CHECK_FALSE(layer.is_native_quad());
+    CHECK_FALSE(layer.is_native_layer());
 
     // Nothing published yet → nullopt (no quad this frame), even before any
     // placement matters.
-    CHECK_FALSE(layer.acquire_native_quad(0).has_value());
+    CHECK_FALSE(layer.acquire_native_layer(0).has_value());
 
     // Out-of-range in_flight_slot is rejected (same guard as record()).
-    CHECK_THROWS_AS(layer.acquire_native_quad(QuadLayer::kMaxFramesInFlight), std::logic_error);
+    CHECK_THROWS_AS(layer.acquire_native_layer(QuadLayer::kMaxFramesInFlight), std::logic_error);
 
     // A native-quad layer with no placement is lenient before the first
     // publish (returns nullopt) — this keeps a native session from throwing
@@ -112,7 +112,7 @@ TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_laye
     no_placement.resolution = { 64, 64 };
     no_placement.use_openxr_quad_layer = true;
     QuadLayer layer_np(ctx, target->render_pass(), no_placement);
-    CHECK_FALSE(layer_np.acquire_native_quad(0).has_value()); // lenient pre-publish
+    CHECK_FALSE(layer_np.acquire_native_layer(0).has_value()); // lenient pre-publish
 
     void* dev_ptr = nullptr;
     REQUIRE(cudaMalloc(&dev_ptr, static_cast<size_t>(64) * 64 * 4) == cudaSuccess);
@@ -132,7 +132,7 @@ TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_laye
     src.pitch = static_cast<size_t>(64) * 4;
     src.space = viz::MemorySpace::kDevice;
     layer_np.submit(src);
-    CHECK_THROWS_AS(layer_np.acquire_native_quad(0), std::logic_error); // content, no placement
+    CHECK_THROWS_AS(layer_np.acquire_native_layer(0), std::logic_error); // content, no placement
 }
 
 TEST_CASE("QuadLayer creates valid Vulkan + CUDA handles for every mailbox slot", "[gpu][quad_layer]")

--- a/src/viz/layers_tests/cpp/test_quad_layer.cpp
+++ b/src/viz/layers_tests/cpp/test_quad_layer.cpp
@@ -63,12 +63,12 @@ TEST_CASE("QuadLayer ctor rejects null render pass", "[unit][quad_layer]")
     CHECK_THROWS_AS(QuadLayer(ctx, VK_NULL_HANDLE, cfg), std::invalid_argument);
 }
 
-TEST_CASE("QuadLayer::Config use_openxr_quad_layer defaults off and is settable", "[unit][quad_layer][native]")
+TEST_CASE("QuadLayer::Config native_composition defaults ON with a compositor opt-out", "[unit][quad_layer][native]")
 {
     QuadLayer::Config cfg;
-    CHECK_FALSE(cfg.use_openxr_quad_layer);
-    cfg.use_openxr_quad_layer = true;
-    CHECK(cfg.use_openxr_quad_layer);
+    CHECK(cfg.native_composition);
+    cfg.native_composition = false;
+    CHECK_FALSE(cfg.native_composition);
 }
 
 // A native-quad layer only goes native inside a kXr session; a detached
@@ -87,7 +87,7 @@ TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_laye
 
     QuadLayer::Config cfg;
     cfg.resolution = { 64, 64 };
-    cfg.use_openxr_quad_layer = true;
+    cfg.native_composition = true;
     QuadLayer::Config::Placement pl;
     pl.pose = viz::Pose3D{};
     pl.size_meters = glm::vec2(1.0f, 1.0f);
@@ -117,7 +117,7 @@ TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_laye
     // once a frame is published without a placement, it's a misconfiguration.
     QuadLayer::Config no_placement;
     no_placement.resolution = { 64, 64 };
-    no_placement.use_openxr_quad_layer = true;
+    no_placement.native_composition = true;
     QuadLayer layer_np(ctx, target->render_pass(), no_placement);
     CHECK_FALSE(layer_np.acquire_native_layer(0).has_value()); // lenient pre-publish
 

--- a/src/viz/layers_tests/cpp/test_quad_layer.cpp
+++ b/src/viz/layers_tests/cpp/test_quad_layer.cpp
@@ -97,6 +97,13 @@ TEST_CASE("QuadLayer native-quad gate + acquire preconditions", "[gpu][quad_laye
     // No session attached → not native (so the compositor uses record()).
     CHECK_FALSE(layer.is_native_layer());
 
+    // set_placement enforces the same invariants as construction; nullopt
+    // (fullscreen, window mode) stays legal.
+    QuadLayer::Config::Placement zero_size;
+    zero_size.size_meters = glm::vec2(0.0f, 1.0f);
+    CHECK_THROWS_AS(layer.set_placement(zero_size), std::invalid_argument);
+    layer.set_placement(std::nullopt);
+
     // Nothing published yet → nullopt (no quad this frame), even before any
     // placement matters.
     CHECK_FALSE(layer.acquire_native_layer(0).has_value());

--- a/src/viz/layers_tests/cpp/test_shaped_layers.cpp
+++ b/src/viz/layers_tests/cpp/test_shaped_layers.cpp
@@ -156,6 +156,7 @@ TEST_CASE("CylinderLayer acquire promotes the mailbox and carries shape params",
 
     CylinderLayer::Config cfg;
     cfg.resolution = { 64, 32 };
+    cfg.alpha_blend = true;
     cfg.placement.pose.position = glm::vec3(0.0f, 1.0f, -2.0f);
     cfg.placement.radius_m = 1.5f;
     cfg.placement.central_angle_rad = glm::half_pi<float>();
@@ -188,6 +189,7 @@ TEST_CASE("CylinderLayer acquire promotes the mailbox and carries shape params",
     CHECK(view->radius == 1.5f);
     CHECK(view->central_angle == glm::half_pi<float>());
     CHECK(view->aspect_ratio == 2.0f); // derived: 64 / 32
+    CHECK(view->alpha_blend); // per-layer alpha choice reaches the backend
     CHECK(view->source_id == &layer);
 
     // The promoted slot must feed the queue-submit wait at TRANSFER (the
@@ -256,4 +258,7 @@ TEST_CASE("EquirectLayer stereo acquire pairs both eyes on one sphere", "[gpu][e
     // The per-eye pose shift threads through for shaped layers too (a
     // no-op at infinite radius, but the plumbing must carry it).
     CHECK(view->stereo_baseline_mm == 63.0f);
+    // Default = opaque: no source-alpha flag, so the frame stays eligible
+    // for the runtime's client-reconstructed streaming.
+    CHECK_FALSE(view->alpha_blend);
 }

--- a/src/viz/layers_tests/cpp/test_shaped_layers.cpp
+++ b/src/viz/layers_tests/cpp/test_shaped_layers.cpp
@@ -80,22 +80,32 @@ TEST_CASE("CylinderLayer ctor rejects invalid placement", "[unit][cylinder_layer
     CylinderLayer::Config cfg;
     cfg.resolution = { 64, 64 };
 
-    cfg.placement.radius = 0.0f;
+    // NaN / negative radii are invalid; 0 and +inf are the spec's
+    // "infinite cylinder" spellings and must pass placement validation
+    // (they then throw on the uninitialized context, proving the radius
+    // check accepted them).
+    cfg.placement.radius_m = -1.0f;
     CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("radius"));
-    cfg.placement.radius = -1.0f;
+    cfg.placement.radius_m = std::numeric_limits<float>::quiet_NaN();
     CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("radius"));
-    cfg.placement.radius = std::numeric_limits<float>::infinity();
-    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("radius"));
+    cfg.placement.radius_m = 0.0f;
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("VkContext"));
+    cfg.placement.radius_m = std::numeric_limits<float>::infinity();
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("VkContext"));
 
-    cfg.placement.radius = 1.0f;
-    cfg.placement.central_angle = 0.0f;
+    cfg.placement.radius_m = 1.0f;
+    cfg.placement.central_angle_rad = 0.0f;
     CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("central_angle"));
-    cfg.placement.central_angle = glm::two_pi<float>() + 0.1f;
+    cfg.placement.central_angle_rad = glm::two_pi<float>() + 0.1f;
     CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("central_angle"));
 
-    cfg.placement.central_angle = glm::half_pi<float>();
+    cfg.placement.central_angle_rad = glm::half_pi<float>();
     cfg.placement.aspect_ratio = -1.0f;
     CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("aspect_ratio"));
+
+    cfg.placement.aspect_ratio = 0.0f;
+    cfg.stereo_baseline_mm = std::numeric_limits<float>::infinity();
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("stereo_baseline_mm"));
 }
 
 TEST_CASE("EquirectLayer ctor rejects invalid placement", "[unit][equirect_layer][native]")
@@ -104,32 +114,32 @@ TEST_CASE("EquirectLayer ctor rejects invalid placement", "[unit][equirect_layer
     EquirectLayer::Config cfg;
     cfg.resolution = { 64, 64 };
 
-    cfg.placement.radius = -1.0f;
+    cfg.placement.radius_m = -1.0f;
     CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("radius"));
 
-    cfg.placement.radius = 0.0f;
-    cfg.placement.central_horizontal_angle = 0.0f;
+    cfg.placement.radius_m = 0.0f;
+    cfg.placement.central_horizontal_angle_rad = 0.0f;
     CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("central_horizontal_angle"));
-    cfg.placement.central_horizontal_angle = glm::two_pi<float>() + 0.1f;
+    cfg.placement.central_horizontal_angle_rad = glm::two_pi<float>() + 0.1f;
     CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("central_horizontal_angle"));
 
-    cfg.placement.central_horizontal_angle = glm::two_pi<float>();
-    cfg.placement.upper_vertical_angle = glm::pi<float>(); // > pi/2
+    cfg.placement.central_horizontal_angle_rad = glm::two_pi<float>();
+    cfg.placement.upper_vertical_angle_rad = glm::pi<float>(); // > pi/2
     CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("vertical"));
 
     // Inverted span: upper must be strictly above lower.
-    cfg.placement.upper_vertical_angle = -0.5f;
-    cfg.placement.lower_vertical_angle = 0.5f;
+    cfg.placement.upper_vertical_angle_rad = -0.5f;
+    cfg.placement.lower_vertical_angle_rad = 0.5f;
     CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("upper_vertical_angle"));
 }
 
 TEST_CASE("EquirectLayer default placement is a valid full sphere", "[unit][equirect_layer][native]")
 {
     EquirectLayer::Config::Placement p;
-    CHECK(p.radius == 0.0f);
-    CHECK(p.central_horizontal_angle == glm::two_pi<float>());
-    CHECK(p.upper_vertical_angle == glm::half_pi<float>());
-    CHECK(p.lower_vertical_angle == -glm::half_pi<float>());
+    CHECK(p.radius_m == 0.0f);
+    CHECK(p.central_horizontal_angle_rad == glm::two_pi<float>());
+    CHECK(p.upper_vertical_angle_rad == glm::half_pi<float>());
+    CHECK(p.lower_vertical_angle_rad == -glm::half_pi<float>());
 }
 
 TEST_CASE("CylinderLayer acquire promotes the mailbox and carries shape params", "[gpu][cylinder_layer][native]")
@@ -143,8 +153,8 @@ TEST_CASE("CylinderLayer acquire promotes the mailbox and carries shape params",
     CylinderLayer::Config cfg;
     cfg.resolution = { 64, 32 };
     cfg.placement.pose.position = glm::vec3(0.0f, 1.0f, -2.0f);
-    cfg.placement.radius = 1.5f;
-    cfg.placement.central_angle = glm::half_pi<float>();
+    cfg.placement.radius_m = 1.5f;
+    cfg.placement.central_angle_rad = glm::half_pi<float>();
     // aspect_ratio left 0 → derived from resolution (64/32 = 2).
     CylinderLayer layer(ctx, cfg);
 
@@ -187,10 +197,13 @@ TEST_CASE("CylinderLayer acquire promotes the mailbox and carries shape params",
     auto target = viz::RenderTarget::create(ctx, viz::RenderTarget::Config{ Resolution{ 64, 64 } });
     CHECK_THROWS_AS(layer.record(VK_NULL_HANDLE, {}, *target, 0), std::logic_error);
 
-    // set_placement revalidates.
+    // set_placement revalidates; the spec's infinite-cylinder radius is legal.
     CylinderLayer::Config::Placement bad = layer.placement();
-    bad.radius = -1.0f;
+    bad.radius_m = -1.0f;
     CHECK_THROWS_AS(layer.set_placement(bad), std::invalid_argument);
+    CylinderLayer::Config::Placement infinite = layer.placement();
+    infinite.radius_m = 0.0f;
+    layer.set_placement(infinite);
 
     // Idempotent destroy + use-after-destroy is a clean logic_error.
     layer.destroy();
@@ -209,6 +222,7 @@ TEST_CASE("EquirectLayer stereo acquire pairs both eyes on one sphere", "[gpu][e
     EquirectLayer::Config cfg;
     cfg.resolution = { 64, 32 };
     cfg.stereo = true;
+    cfg.stereo_baseline_mm = 63.0f;
     EquirectLayer layer(ctx, cfg);
 
     CHECK(layer.is_native_layer());
@@ -235,6 +249,7 @@ TEST_CASE("EquirectLayer stereo acquire pairs both eyes on one sphere", "[gpu][e
     CHECK(view->central_horizontal_angle == glm::two_pi<float>());
     CHECK(view->upper_vertical_angle == glm::half_pi<float>());
     CHECK(view->lower_vertical_angle == -glm::half_pi<float>());
-    // No quad params leak through.
-    CHECK(view->stereo_baseline_mm == 0.0f);
+    // The per-eye pose shift threads through for shaped layers too (a
+    // no-op at infinite radius, but the plumbing must carry it).
+    CHECK(view->stereo_baseline_mm == 63.0f);
 }

--- a/src/viz/layers_tests/cpp/test_shaped_layers.cpp
+++ b/src/viz/layers_tests/cpp/test_shaped_layers.cpp
@@ -96,6 +96,10 @@ TEST_CASE("CylinderLayer ctor rejects invalid placement", "[unit][cylinder_layer
     cfg.placement.radius_m = 1.0f;
     cfg.placement.central_angle_rad = 0.0f;
     CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("central_angle"));
+    // The cylinder spec defines centralAngle on [0, 2*pi) — exactly 2*pi
+    // (a full wrap) is invalid, unlike equirect2's horizontal angle.
+    cfg.placement.central_angle_rad = glm::two_pi<float>();
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("central_angle"));
     cfg.placement.central_angle_rad = glm::two_pi<float>() + 0.1f;
     CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("central_angle"));
 

--- a/src/viz/layers_tests/cpp/test_shaped_layers.cpp
+++ b/src/viz/layers_tests/cpp/test_shaped_layers.cpp
@@ -1,0 +1,240 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Tests for the native-only shaped layers (CylinderLayer, EquirectLayer):
+// placement validation (unit-level) and mailbox / acquire semantics
+// (gpu-level). The add_layer rejection outside kXr lives in
+// viz_session_tests; live XrCompositionLayer* submission is validated
+// manually against CloudXR (needs a runtime).
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <glm/gtc/constants.hpp>
+#include <viz/core/render_target.hpp>
+#include <viz/core/viz_buffer.hpp>
+#include <viz/core/vk_context.hpp>
+#include <viz/layers/cylinder_layer.hpp>
+#include <viz/layers/equirect_layer.hpp>
+#include <viz/test_support/test_helpers.hpp>
+
+#include <cstdint>
+#include <cuda_runtime.h>
+#include <limits>
+#include <optional>
+#include <stdexcept>
+
+using Catch::Matchers::ContainsSubstring;
+using viz::CylinderLayer;
+using viz::EquirectLayer;
+using viz::NativeLayerShape;
+using viz::PixelFormat;
+using viz::Resolution;
+using viz::VizBuffer;
+using viz::VkContext;
+
+using viz::testing::is_gpu_available;
+using viz::testing::shared_vk_context;
+
+namespace
+{
+
+// Fill a device buffer usable as submit() source. Caller owns the ptr.
+void* alloc_device_pixels(uint32_t w, uint32_t h)
+{
+    void* p = nullptr;
+    REQUIRE(cudaMalloc(&p, static_cast<size_t>(w) * h * 4) == cudaSuccess);
+    return p;
+}
+
+VizBuffer device_buffer(void* data, uint32_t w, uint32_t h)
+{
+    VizBuffer b{};
+    b.data = data;
+    b.width = w;
+    b.height = h;
+    b.format = PixelFormat::kRGBA8;
+    b.pitch = static_cast<size_t>(w) * 4;
+    b.space = viz::MemorySpace::kDevice;
+    return b;
+}
+
+struct CudaFree
+{
+    void* p;
+    ~CudaFree()
+    {
+        cudaFree(p);
+    }
+};
+
+} // namespace
+
+// Placement validation runs before the base allocates images, so these
+// unit tests exercise each rejection with a default-constructed
+// VkContext (message-matched to pin the placement check, not the
+// context check).
+
+TEST_CASE("CylinderLayer ctor rejects invalid placement", "[unit][cylinder_layer][native]")
+{
+    VkContext ctx;
+    CylinderLayer::Config cfg;
+    cfg.resolution = { 64, 64 };
+
+    cfg.placement.radius = 0.0f;
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("radius"));
+    cfg.placement.radius = -1.0f;
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("radius"));
+    cfg.placement.radius = std::numeric_limits<float>::infinity();
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("radius"));
+
+    cfg.placement.radius = 1.0f;
+    cfg.placement.central_angle = 0.0f;
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("central_angle"));
+    cfg.placement.central_angle = glm::two_pi<float>() + 0.1f;
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("central_angle"));
+
+    cfg.placement.central_angle = glm::half_pi<float>();
+    cfg.placement.aspect_ratio = -1.0f;
+    CHECK_THROWS_WITH(CylinderLayer(ctx, cfg), ContainsSubstring("aspect_ratio"));
+}
+
+TEST_CASE("EquirectLayer ctor rejects invalid placement", "[unit][equirect_layer][native]")
+{
+    VkContext ctx;
+    EquirectLayer::Config cfg;
+    cfg.resolution = { 64, 64 };
+
+    cfg.placement.radius = -1.0f;
+    CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("radius"));
+
+    cfg.placement.radius = 0.0f;
+    cfg.placement.central_horizontal_angle = 0.0f;
+    CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("central_horizontal_angle"));
+    cfg.placement.central_horizontal_angle = glm::two_pi<float>() + 0.1f;
+    CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("central_horizontal_angle"));
+
+    cfg.placement.central_horizontal_angle = glm::two_pi<float>();
+    cfg.placement.upper_vertical_angle = glm::pi<float>(); // > pi/2
+    CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("vertical"));
+
+    // Inverted span: upper must be strictly above lower.
+    cfg.placement.upper_vertical_angle = -0.5f;
+    cfg.placement.lower_vertical_angle = 0.5f;
+    CHECK_THROWS_WITH(EquirectLayer(ctx, cfg), ContainsSubstring("upper_vertical_angle"));
+}
+
+TEST_CASE("EquirectLayer default placement is a valid full sphere", "[unit][equirect_layer][native]")
+{
+    EquirectLayer::Config::Placement p;
+    CHECK(p.radius == 0.0f);
+    CHECK(p.central_horizontal_angle == glm::two_pi<float>());
+    CHECK(p.upper_vertical_angle == glm::half_pi<float>());
+    CHECK(p.lower_vertical_angle == -glm::half_pi<float>());
+}
+
+TEST_CASE("CylinderLayer acquire promotes the mailbox and carries shape params", "[gpu][cylinder_layer][native]")
+{
+    if (!is_gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+    auto& ctx = shared_vk_context();
+
+    CylinderLayer::Config cfg;
+    cfg.resolution = { 64, 32 };
+    cfg.placement.pose.position = glm::vec3(0.0f, 1.0f, -2.0f);
+    cfg.placement.radius = 1.5f;
+    cfg.placement.central_angle = glm::half_pi<float>();
+    // aspect_ratio left 0 → derived from resolution (64/32 = 2).
+    CylinderLayer layer(ctx, cfg);
+
+    // Native-only identity, independent of session attachment.
+    CHECK(layer.is_native_layer());
+    REQUIRE(layer.required_native_shape().has_value());
+    CHECK(*layer.required_native_shape() == NativeLayerShape::kCylinder);
+
+    // Nothing published yet → no layer this frame.
+    CHECK_FALSE(layer.acquire_native_layer(0).has_value());
+
+    // Out-of-range in_flight_slot is rejected (same guard as QuadLayer).
+    CHECK_THROWS_AS(layer.acquire_native_layer(CylinderLayer::kMaxFramesInFlight), std::logic_error);
+
+    void* px = alloc_device_pixels(64, 32);
+    CudaFree guard{ px };
+    layer.submit(device_buffer(px, 64, 32));
+
+    const auto view = layer.acquire_native_layer(0);
+    REQUIRE(view.has_value());
+    CHECK(view->shape == NativeLayerShape::kCylinder);
+    CHECK(view->color_left != VK_NULL_HANDLE);
+    CHECK(view->color_right == VK_NULL_HANDLE); // mono
+    CHECK(view->extent.width == 64);
+    CHECK(view->extent.height == 32);
+    CHECK(view->pose.position == glm::vec3(0.0f, 1.0f, -2.0f));
+    CHECK(view->radius == 1.5f);
+    CHECK(view->central_angle == glm::half_pi<float>());
+    CHECK(view->aspect_ratio == 2.0f); // derived: 64 / 32
+    CHECK(view->source_id == &layer);
+
+    // The promoted slot must feed the queue-submit wait at TRANSFER (the
+    // backend copy is the only consumer).
+    const auto waits = layer.get_wait_semaphores();
+    REQUIRE(waits.size() == 1);
+    CHECK(waits[0].wait_stage == VK_PIPELINE_STAGE_TRANSFER_BIT);
+
+    // record() is unreachable through a validated session; direct calls
+    // fail loudly rather than drawing nothing.
+    auto target = viz::RenderTarget::create(ctx, viz::RenderTarget::Config{ Resolution{ 64, 64 } });
+    CHECK_THROWS_AS(layer.record(VK_NULL_HANDLE, {}, *target, 0), std::logic_error);
+
+    // set_placement revalidates.
+    CylinderLayer::Config::Placement bad = layer.placement();
+    bad.radius = -1.0f;
+    CHECK_THROWS_AS(layer.set_placement(bad), std::invalid_argument);
+
+    // Idempotent destroy + use-after-destroy is a clean logic_error.
+    layer.destroy();
+    layer.destroy();
+    CHECK_THROWS_AS(layer.acquire_native_layer(0), std::logic_error);
+}
+
+TEST_CASE("EquirectLayer stereo acquire pairs both eyes on one sphere", "[gpu][equirect_layer][native]")
+{
+    if (!is_gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+    auto& ctx = shared_vk_context();
+
+    EquirectLayer::Config cfg;
+    cfg.resolution = { 64, 32 };
+    cfg.stereo = true;
+    EquirectLayer layer(ctx, cfg);
+
+    CHECK(layer.is_native_layer());
+    REQUIRE(layer.required_native_shape().has_value());
+    CHECK(*layer.required_native_shape() == NativeLayerShape::kEquirect2);
+    CHECK_FALSE(layer.acquire_native_layer(0).has_value());
+
+    void* left = alloc_device_pixels(64, 32);
+    CudaFree guard_l{ left };
+    void* right = alloc_device_pixels(64, 32);
+    CudaFree guard_r{ right };
+
+    // Stereo submit contract comes from ImageLayerBase: one-arg throws.
+    CHECK_THROWS_AS(layer.submit(device_buffer(left, 64, 32)), std::logic_error);
+    layer.submit(device_buffer(left, 64, 32), device_buffer(right, 64, 32));
+
+    const auto view = layer.acquire_native_layer(0);
+    REQUIRE(view.has_value());
+    CHECK(view->shape == NativeLayerShape::kEquirect2);
+    CHECK(view->color_left != VK_NULL_HANDLE);
+    CHECK(view->color_right != VK_NULL_HANDLE);
+    // Defaults: full 360°×180° sphere at infinite radius.
+    CHECK(view->radius == 0.0f);
+    CHECK(view->central_horizontal_angle == glm::two_pi<float>());
+    CHECK(view->upper_vertical_angle == glm::half_pi<float>());
+    CHECK(view->lower_vertical_angle == -glm::half_pi<float>());
+    // No quad params leak through.
+    CHECK(view->stereo_baseline_mm == 0.0f);
+}

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -13,6 +13,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <viz/core/viz_buffer.hpp>
+#include <viz/layers/cylinder_layer.hpp>
+#include <viz/layers/equirect_layer.hpp>
 #include <viz/layers/projection_layer.hpp>
 #include <viz/layers/quad_layer.hpp>
 
@@ -26,6 +28,55 @@ namespace viz_py
 
 namespace py = pybind11;
 using namespace pybind11::literals;
+
+namespace
+{
+
+// Shared method set for ImageLayerBase-derived layers (submit + the
+// common accessors). Bound per concrete type because LayerBase /
+// ImageLayerBase aren't registered pybind bases.
+template <typename LayerT, typename ClassT>
+void bind_image_layer_common(ClassT& cls, const char* label)
+{
+    cls.def(
+           "submit",
+           [label](LayerT& self, py::object left, py::object right, uintptr_t stream)
+           {
+               auto to_buf = [&self, label](py::object obj) -> viz::VizBuffer
+               {
+                   if (py::isinstance<viz::VizBuffer>(obj))
+                   {
+                       return obj.cast<viz::VizBuffer>();
+                   }
+                   return cuda_array_to_viz_buffer(obj, self.format(), self.resolution(), label);
+               };
+
+               if (right.is_none())
+               {
+                   viz::VizBuffer left_buf = to_buf(left);
+                   py::gil_scoped_release release;
+                   self.submit(left_buf, reinterpret_cast<cudaStream_t>(stream));
+               }
+               else
+               {
+                   viz::VizBuffer left_buf = to_buf(left);
+                   viz::VizBuffer right_buf = to_buf(right);
+                   py::gil_scoped_release release;
+                   self.submit(left_buf, right_buf, reinterpret_cast<cudaStream_t>(stream));
+               }
+           },
+           "left"_a, "right"_a = py::none(), "stream"_a = 0,
+           "Submit a frame. Each arg is a VizBuffer or any __cuda_array_interface__ "
+           "object. Mono layer: pass only ``left``. Stereo layer: pass both.")
+        .def_property_readonly("resolution", &LayerT::resolution)
+        .def_property_readonly("format", &LayerT::format)
+        .def(
+            "set_visible", [](LayerT& self, bool visible) { self.set_visible(visible); }, "visible"_a)
+        .def("is_visible", [](const LayerT& self) { return self.is_visible(); })
+        .def_property_readonly("name", [](const LayerT& l) { return l.name(); });
+}
+
+} // namespace
 
 void bind_layers(py::module_& m)
 {
@@ -150,6 +201,93 @@ numpy on a CUDA device pointer); the binding converts it on the fly.
             "set_visible", [](viz::QuadLayer& self, bool visible) { self.set_visible(visible); }, "visible"_a)
         .def("is_visible", [](const viz::QuadLayer& self) { return self.is_visible(); })
         .def_property_readonly("name", [](const viz::QuadLayer& l) { return l.name(); });
+
+    // ── CylinderLayer (native-only: XrCompositionLayerCylinderKHR) ────
+
+    py::class_<viz::CylinderLayer::Config::Placement>(m, "CylinderLayerPlacement",
+                                                      "Cylinder placement: pose = center of the cylinder (arc "
+                                                      "centered on the pose's -z, axis = +y), radius in meters, "
+                                                      "central_angle = visible arc in radians (0, 2*pi], "
+                                                      "aspect_ratio = arc-width/height (0 = derive from resolution).")
+        .def(py::init<>())
+        .def_readwrite("pose", &viz::CylinderLayer::Config::Placement::pose)
+        .def_readwrite("radius", &viz::CylinderLayer::Config::Placement::radius)
+        .def_readwrite("central_angle", &viz::CylinderLayer::Config::Placement::central_angle)
+        .def_readwrite("aspect_ratio", &viz::CylinderLayer::Config::Placement::aspect_ratio);
+
+    py::class_<viz::CylinderLayer::Config>(m, "CylinderLayerConfig")
+        .def(py::init<>())
+        .def_readwrite("name", &viz::CylinderLayer::Config::name)
+        .def_readwrite("resolution", &viz::CylinderLayer::Config::resolution)
+        .def_readwrite("format", &viz::CylinderLayer::Config::format)
+        .def_readwrite("stereo", &viz::CylinderLayer::Config::stereo,
+                       "Per-eye stereo: submit MUST be called with both buffers. Both eyes "
+                       "share the same cylinder pose (no baseline shift) — the depth cue "
+                       "comes from the image pair. Memory doubles. Off by default.")
+        .def_readwrite("placement", &viz::CylinderLayer::Config::placement);
+
+    auto cylinder_cls =
+        py::class_<viz::CylinderLayer, std::unique_ptr<viz::CylinderLayer, py::nodelete>>(m, "CylinderLayer",
+                                                                                          R"doc(
+CUDA-fed texture curved onto the inside of a cylinder arc, submitted to
+the OpenXR runtime as a native XrCompositionLayerCylinderKHR. Owned by
+VizSession; the Python handle is non-owning.
+
+NATIVE-ONLY: requires DisplayMode.kXr and a runtime advertising
+XR_KHR_composition_layer_cylinder — add_cylinder_layer raises
+ValueError otherwise. Carries no depth (composited in submission
+order). Same submit contract as QuadLayer.
+)doc");
+    cylinder_cls
+        .def("set_placement", &viz::CylinderLayer::set_placement, "placement"_a,
+             "Update placement at runtime (validated; raises ValueError on bad shape params).")
+        .def("placement", &viz::CylinderLayer::placement);
+    bind_image_layer_common<viz::CylinderLayer>(cylinder_cls, "CylinderLayer.submit");
+
+    // ── EquirectLayer (native-only: XrCompositionLayerEquirect2KHR) ───
+
+    py::class_<viz::EquirectLayer::Config::Placement>(m, "EquirectLayerPlacement",
+                                                      "Equirect placement: pose = sphere center (texture horizontal "
+                                                      "center maps to the pose's -z), radius in meters (0 or +inf = "
+                                                      "infinite sphere), central_horizontal_angle in radians "
+                                                      "(2*pi = full 360), vertical angles from the horizon in "
+                                                      "[-pi/2, pi/2] with upper > lower. Defaults = full sphere.")
+        .def(py::init<>())
+        .def_readwrite("pose", &viz::EquirectLayer::Config::Placement::pose)
+        .def_readwrite("radius", &viz::EquirectLayer::Config::Placement::radius)
+        .def_readwrite("central_horizontal_angle", &viz::EquirectLayer::Config::Placement::central_horizontal_angle)
+        .def_readwrite("upper_vertical_angle", &viz::EquirectLayer::Config::Placement::upper_vertical_angle)
+        .def_readwrite("lower_vertical_angle", &viz::EquirectLayer::Config::Placement::lower_vertical_angle);
+
+    py::class_<viz::EquirectLayer::Config>(m, "EquirectLayerConfig")
+        .def(py::init<>())
+        .def_readwrite("name", &viz::EquirectLayer::Config::name)
+        .def_readwrite("resolution", &viz::EquirectLayer::Config::resolution)
+        .def_readwrite("format", &viz::EquirectLayer::Config::format)
+        .def_readwrite("stereo", &viz::EquirectLayer::Config::stereo,
+                       "Per-eye stereo (VR180/VR360 convention): submit MUST be called with "
+                       "both buffers; both eyes share the same sphere. Memory doubles. "
+                       "Off by default.")
+        .def_readwrite("placement", &viz::EquirectLayer::Config::placement);
+
+    auto equirect_cls =
+        py::class_<viz::EquirectLayer, std::unique_ptr<viz::EquirectLayer, py::nodelete>>(m, "EquirectLayer",
+                                                                                          R"doc(
+CUDA-fed equirectangular texture on the inside of a sphere, submitted
+to the OpenXR runtime as a native XrCompositionLayerEquirect2KHR.
+Owned by VizSession; the Python handle is non-owning.
+
+NATIVE-ONLY: requires DisplayMode.kXr and a runtime advertising
+XR_KHR_composition_layer_equirect2 — add_equirect_layer raises
+ValueError otherwise. Defaults to a full 360x180 sphere at infinite
+radius. Carries no depth (composited in submission order) — add it
+FIRST when it acts as a background. Same submit contract as QuadLayer.
+)doc");
+    equirect_cls
+        .def("set_placement", &viz::EquirectLayer::set_placement, "placement"_a,
+             "Update placement at runtime (validated; raises ValueError on bad shape params).")
+        .def("placement", &viz::EquirectLayer::placement);
+    bind_image_layer_common<viz::EquirectLayer>(equirect_cls, "EquirectLayer.submit");
 
     // ── ProjectionLayer ────────────────────────────────────────────────
 

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -124,7 +124,7 @@ void bind_layers(py::module_& m)
                        "applied along the placement's local +x axis. 0 → both eyes see the "
                        "same world quad. Ignored unless stereo + kXr. mm-scale chosen because "
                        "typical IPDs / stereo camera baselines are 50–80 mm.")
-        .def_readwrite("native_composition", &viz::QuadLayer::Config::native_composition,
+        .def_readwrite("openxr_composition", &viz::QuadLayer::Config::openxr_composition,
                        "In kXr, submit as a native OpenXR quad layer (XrCompositionLayerQuad) — "
                        "the DEFAULT: the runtime places + samples the quad directly, enabling "
                        "its quad fast path; a frame whose visible layers are all native drops "

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -132,7 +132,10 @@ void bind_layers(py::module_& m)
                        "render target instead — needed when the quad must z-compose with "
                        "ProjectionLayer 3D content (native quads carry no depth: flat "
                        "billboard, submission-order composited). Ignored outside kXr "
-                       "(window/offscreen always composite). Stereo emits one quad per eye.");
+                       "(window/offscreen always composite). Stereo emits one quad per eye.")
+        .def_readwrite(
+            "alpha_blend", &viz::QuadLayer::Config::alpha_blend,
+            "Composite honoring the texture's alpha channel (XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT). Off by default: opaque content composites fully within the layer bounds (passthrough still shows outside them) and alpha-free layers keep the frame eligible for CloudXR's client-reconstructed streaming, which excludes source-alpha layers. Turn on for translucent content (HUDs, overlays).");
 
     // ── QuadLayer (non-owning; session owns the lifetime) ─────────────
 
@@ -243,6 +246,9 @@ numpy on a CUDA device pointer); the binding converts it on the fly.
                        "along the placement's local +x axis — same convention as QuadLayer. "
                        "0 (default) → both eyes see the same world cylinder and depth comes "
                        "from the image pair. Ignored unless stereo.")
+        .def_readwrite(
+            "alpha_blend", &viz::CylinderLayer::Config::alpha_blend,
+            "Composite honoring the texture's alpha channel (XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT). Off by default: opaque content composites fully within the layer bounds (passthrough still shows outside them) and alpha-free layers keep the frame eligible for CloudXR's client-reconstructed streaming, which excludes source-alpha layers. Turn on for translucent content (HUDs, overlays).")
         .def_readwrite("placement", &viz::CylinderLayer::Config::placement);
 
     auto cylinder_cls =
@@ -309,6 +315,9 @@ order). Same submit contract as QuadLayer.
                        "R changes by ~shift/R, which is zero for the infinite (0/+inf) sphere. "
                        "0 (default) keeps the VR180/VR360 shared-sphere convention. Ignored "
                        "unless stereo.")
+        .def_readwrite(
+            "alpha_blend", &viz::EquirectLayer::Config::alpha_blend,
+            "Composite honoring the texture's alpha channel (XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT). Off by default: opaque content composites fully within the layer bounds (passthrough still shows outside them) and alpha-free layers keep the frame eligible for CloudXR's client-reconstructed streaming, which excludes source-alpha layers. Turn on for translucent content (HUDs, overlays).")
         .def_readwrite("placement", &viz::EquirectLayer::Config::placement);
 
     auto equirect_cls =

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -135,7 +135,7 @@ void bind_layers(py::module_& m)
                        "(window/offscreen always composite). Stereo emits one quad per eye.")
         .def_readwrite(
             "alpha_blend", &viz::QuadLayer::Config::alpha_blend,
-            "Composite honoring the texture's alpha channel (XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT). Off by default: opaque content composites fully within the layer bounds (passthrough still shows outside them) and alpha-free layers keep the frame eligible for CloudXR's client-reconstructed streaming, which excludes source-alpha layers. Turn on for translucent content (HUDs, overlays).");
+            "Composite honoring the texture's alpha channel (XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT). Off by default: opaque content composites fully within the layer bounds (passthrough still shows outside them) and alpha-free layers keep the frame eligible for CloudXR's client-reconstructed streaming, which excludes source-alpha layers. Turn on for translucent content (HUDs, overlays). Native path only; ignored on the compositor path.");
 
     // ── QuadLayer (non-owning; session owns the lifetime) ─────────────
 

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -124,14 +124,15 @@ void bind_layers(py::module_& m)
                        "applied along the placement's local +x axis. 0 → both eyes see the "
                        "same world quad. Ignored unless stereo + kXr. mm-scale chosen because "
                        "typical IPDs / stereo camera baselines are 50–80 mm.")
-        .def_readwrite("use_openxr_quad_layer", &viz::QuadLayer::Config::use_openxr_quad_layer,
-                       "Submit as a native OpenXR quad layer (XrCompositionLayerQuad) instead "
-                       "of compositing into the shared render target. kXr only (ignored in "
-                       "window/offscreen). Lets the runtime place + sample the quad directly, "
-                       "enabling its quad fast path; a frame whose visible layers are all native "
-                       "quads drops the projection layer entirely. Native quads carry no depth "
-                       "(flat billboard, submission-order composited) and require placement. "
-                       "Stereo emits one quad per eye. Off by default.");
+        .def_readwrite("native_composition", &viz::QuadLayer::Config::native_composition,
+                       "In kXr, submit as a native OpenXR quad layer (XrCompositionLayerQuad) — "
+                       "the DEFAULT: the runtime places + samples the quad directly, enabling "
+                       "its quad fast path; a frame whose visible layers are all native drops "
+                       "the projection layer entirely. Set False to composite into the shared "
+                       "render target instead — needed when the quad must z-compose with "
+                       "ProjectionLayer 3D content (native quads carry no depth: flat "
+                       "billboard, submission-order composited). Ignored outside kXr "
+                       "(window/offscreen always composite). Stereo emits one quad per eye.");
 
     // ── QuadLayer (non-owning; session owns the lifetime) ─────────────
 
@@ -209,7 +210,7 @@ numpy on a CUDA device pointer); the binding converts it on the fly.
                                                       "Cylinder placement: pose = center of the cylinder (arc "
                                                       "centered on the pose's -z, axis = +y), radius_m in meters "
                                                       "(0 or +inf = infinite cylinder), central_angle_rad = visible "
-                                                      "arc in radians (0, 2*pi], aspect_ratio = arc-width/height "
+                                                      "arc in radians (0, 2*pi), aspect_ratio = arc-width/height "
                                                       "(0 = derive from resolution).")
         .def(py::init<>())
         .def(py::init(

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -191,7 +191,8 @@ numpy on a CUDA device pointer); the binding converts it on the fly.
         .def_property_readonly("format", &viz::QuadLayer::format)
         .def_property_readonly("aspect_ratio", &viz::QuadLayer::aspect_ratio)
         .def("set_placement", &viz::QuadLayer::set_placement, "placement"_a,
-             "Update placement at runtime. None switches to fullscreen (window mode only).")
+             "Update placement at runtime (validated; raises ValueError on non-positive "
+             "size_meters). None switches to fullscreen (window mode only).")
         .def("placement", &viz::QuadLayer::placement)
         // Bind via concrete-type lambdas: is_visible/set_visible live on
         // LayerBase, which isn't a registered pybind base of QuadLayer, so a
@@ -206,13 +207,26 @@ numpy on a CUDA device pointer); the binding converts it on the fly.
 
     py::class_<viz::CylinderLayer::Config::Placement>(m, "CylinderLayerPlacement",
                                                       "Cylinder placement: pose = center of the cylinder (arc "
-                                                      "centered on the pose's -z, axis = +y), radius in meters, "
-                                                      "central_angle = visible arc in radians (0, 2*pi], "
-                                                      "aspect_ratio = arc-width/height (0 = derive from resolution).")
+                                                      "centered on the pose's -z, axis = +y), radius_m in meters "
+                                                      "(0 or +inf = infinite cylinder), central_angle_rad = visible "
+                                                      "arc in radians (0, 2*pi], aspect_ratio = arc-width/height "
+                                                      "(0 = derive from resolution).")
         .def(py::init<>())
+        .def(py::init(
+                 [](viz::Pose3D pose, float radius_m, float central_angle_rad, float aspect_ratio)
+                 {
+                     viz::CylinderLayer::Config::Placement p;
+                     p.pose = pose;
+                     p.radius_m = radius_m;
+                     p.central_angle_rad = central_angle_rad;
+                     p.aspect_ratio = aspect_ratio;
+                     return p;
+                 }),
+             "pose"_a = viz::Pose3D{}, "radius_m"_a = 1.0f, "central_angle_rad"_a = glm::half_pi<float>(),
+             "aspect_ratio"_a = 0.0f)
         .def_readwrite("pose", &viz::CylinderLayer::Config::Placement::pose)
-        .def_readwrite("radius", &viz::CylinderLayer::Config::Placement::radius)
-        .def_readwrite("central_angle", &viz::CylinderLayer::Config::Placement::central_angle)
+        .def_readwrite("radius_m", &viz::CylinderLayer::Config::Placement::radius_m)
+        .def_readwrite("central_angle_rad", &viz::CylinderLayer::Config::Placement::central_angle_rad)
         .def_readwrite("aspect_ratio", &viz::CylinderLayer::Config::Placement::aspect_ratio);
 
     py::class_<viz::CylinderLayer::Config>(m, "CylinderLayerConfig")
@@ -221,9 +235,13 @@ numpy on a CUDA device pointer); the binding converts it on the fly.
         .def_readwrite("resolution", &viz::CylinderLayer::Config::resolution)
         .def_readwrite("format", &viz::CylinderLayer::Config::format)
         .def_readwrite("stereo", &viz::CylinderLayer::Config::stereo,
-                       "Per-eye stereo: submit MUST be called with both buffers. Both eyes "
-                       "share the same cylinder pose (no baseline shift) — the depth cue "
-                       "comes from the image pair. Memory doubles. Off by default.")
+                       "Per-eye stereo: submit MUST be called with both buffers; one cylinder "
+                       "layer per eye via eyeVisibility. Memory doubles. Off by default.")
+        .def_readwrite("stereo_baseline_mm", &viz::CylinderLayer::Config::stereo_baseline_mm,
+                       "Horizontal disparity between the eyes' cylinders (millimeters), applied "
+                       "along the placement's local +x axis — same convention as QuadLayer. "
+                       "0 (default) → both eyes see the same world cylinder and depth comes "
+                       "from the image pair. Ignored unless stereo.")
         .def_readwrite("placement", &viz::CylinderLayer::Config::placement);
 
     auto cylinder_cls =
@@ -248,16 +266,31 @@ order). Same submit contract as QuadLayer.
 
     py::class_<viz::EquirectLayer::Config::Placement>(m, "EquirectLayerPlacement",
                                                       "Equirect placement: pose = sphere center (texture horizontal "
-                                                      "center maps to the pose's -z), radius in meters (0 or +inf = "
-                                                      "infinite sphere), central_horizontal_angle in radians "
+                                                      "center maps to the pose's -z), radius_m in meters (0 or +inf "
+                                                      "= infinite sphere), central_horizontal_angle_rad in radians "
                                                       "(2*pi = full 360), vertical angles from the horizon in "
                                                       "[-pi/2, pi/2] with upper > lower. Defaults = full sphere.")
         .def(py::init<>())
+        .def(py::init(
+                 [](viz::Pose3D pose, float radius_m, float central_horizontal_angle_rad,
+                    float upper_vertical_angle_rad, float lower_vertical_angle_rad)
+                 {
+                     viz::EquirectLayer::Config::Placement p;
+                     p.pose = pose;
+                     p.radius_m = radius_m;
+                     p.central_horizontal_angle_rad = central_horizontal_angle_rad;
+                     p.upper_vertical_angle_rad = upper_vertical_angle_rad;
+                     p.lower_vertical_angle_rad = lower_vertical_angle_rad;
+                     return p;
+                 }),
+             "pose"_a = viz::Pose3D{}, "radius_m"_a = 0.0f, "central_horizontal_angle_rad"_a = glm::two_pi<float>(),
+             "upper_vertical_angle_rad"_a = glm::half_pi<float>(), "lower_vertical_angle_rad"_a = -glm::half_pi<float>())
         .def_readwrite("pose", &viz::EquirectLayer::Config::Placement::pose)
-        .def_readwrite("radius", &viz::EquirectLayer::Config::Placement::radius)
-        .def_readwrite("central_horizontal_angle", &viz::EquirectLayer::Config::Placement::central_horizontal_angle)
-        .def_readwrite("upper_vertical_angle", &viz::EquirectLayer::Config::Placement::upper_vertical_angle)
-        .def_readwrite("lower_vertical_angle", &viz::EquirectLayer::Config::Placement::lower_vertical_angle);
+        .def_readwrite("radius_m", &viz::EquirectLayer::Config::Placement::radius_m)
+        .def_readwrite(
+            "central_horizontal_angle_rad", &viz::EquirectLayer::Config::Placement::central_horizontal_angle_rad)
+        .def_readwrite("upper_vertical_angle_rad", &viz::EquirectLayer::Config::Placement::upper_vertical_angle_rad)
+        .def_readwrite("lower_vertical_angle_rad", &viz::EquirectLayer::Config::Placement::lower_vertical_angle_rad);
 
     py::class_<viz::EquirectLayer::Config>(m, "EquirectLayerConfig")
         .def(py::init<>())
@@ -266,8 +299,15 @@ order). Same submit contract as QuadLayer.
         .def_readwrite("format", &viz::EquirectLayer::Config::format)
         .def_readwrite("stereo", &viz::EquirectLayer::Config::stereo,
                        "Per-eye stereo (VR180/VR360 convention): submit MUST be called with "
-                       "both buffers; both eyes share the same sphere. Memory doubles. "
-                       "Off by default.")
+                       "both buffers; one equirect layer per eye via eyeVisibility. Memory "
+                       "doubles. Off by default.")
+        .def_readwrite("stereo_baseline_mm", &viz::EquirectLayer::Config::stereo_baseline_mm,
+                       "Horizontal disparity between the eyes' spheres (millimeters), applied "
+                       "along the placement's local +x axis — same convention as QuadLayer. "
+                       "Only visible at FINITE radius: viewing direction to a sphere of radius "
+                       "R changes by ~shift/R, which is zero for the infinite (0/+inf) sphere. "
+                       "0 (default) keeps the VR180/VR360 shared-sphere convention. Ignored "
+                       "unless stereo.")
         .def_readwrite("placement", &viz::EquirectLayer::Config::placement);
 
     auto equirect_cls =

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -129,9 +129,9 @@ void bind_layers(py::module_& m)
                        "the DEFAULT: the runtime places + samples the quad directly, enabling "
                        "its quad fast path; a frame whose visible layers are all native drops "
                        "the projection layer entirely. Set False to composite into the shared "
-                       "render target instead — needed when the quad must z-compose with "
-                       "ProjectionLayer 3D content (native quads carry no depth: flat "
-                       "billboard, submission-order composited). Ignored outside kXr "
+                       "render target instead, where 3D-placed quads depth-test against each "
+                       "other (native quads carry no depth: flat billboard, submission-order "
+                       "composited). Ignored outside kXr "
                        "(window/offscreen always composite). Stereo emits one quad per eye.")
         .def_readwrite(
             "alpha_blend", &viz::QuadLayer::Config::alpha_blend,

--- a/src/viz/python/session_bindings.cpp
+++ b/src/viz/python/session_bindings.cpp
@@ -12,6 +12,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <viz/core/vk_context.hpp>
+#include <viz/layers/cylinder_layer.hpp>
+#include <viz/layers/equirect_layer.hpp>
 #include <viz/layers/projection_layer.hpp>
 #include <viz/layers/quad_layer.hpp>
 #include <viz/session/frame_info.hpp>
@@ -111,6 +113,36 @@ Construct via ``VizSession.create(config)``. Add layers with
             "config"_a, py::return_value_policy::reference_internal,
             "Construct + register a QuadLayer. Returns a non-owning handle.")
         .def(
+            "add_cylinder_layer",
+            [](viz::VizSession& self, viz::CylinderLayer::Config config) -> viz::CylinderLayer*
+            {
+                const auto* ctx = self.get_vk_context();
+                if (ctx == nullptr)
+                {
+                    throw std::runtime_error("VizSession: cannot add layer before session is initialized");
+                }
+                // Native-only — no render pass; the runtime composites it.
+                return self.add_layer<viz::CylinderLayer>(*ctx, std::move(config));
+            },
+            "config"_a, py::return_value_policy::reference_internal,
+            "Construct + register a CylinderLayer (native XrCompositionLayerCylinderKHR; kXr only). "
+            "Returns a non-owning handle.")
+        .def(
+            "add_equirect_layer",
+            [](viz::VizSession& self, viz::EquirectLayer::Config config) -> viz::EquirectLayer*
+            {
+                const auto* ctx = self.get_vk_context();
+                if (ctx == nullptr)
+                {
+                    throw std::runtime_error("VizSession: cannot add layer before session is initialized");
+                }
+                // Native-only — no render pass; the runtime composites it.
+                return self.add_layer<viz::EquirectLayer>(*ctx, std::move(config));
+            },
+            "config"_a, py::return_value_policy::reference_internal,
+            "Construct + register an EquirectLayer (native XrCompositionLayerEquirect2KHR; kXr only). "
+            "Returns a non-owning handle.")
+        .def(
             "add_projection_layer",
             [](viz::VizSession& self, viz::ProjectionLayer::Config config) -> viz::ProjectionLayer*
             {
@@ -130,6 +162,10 @@ Construct via ``VizSession.create(config)``. Add layers with
             "layer"_a, "Remove + destroy a previously added layer (drains the GPU first; no-op if unregistered).")
         .def(
             "remove_layer", [](viz::VizSession& self, viz::QuadLayer* layer) { self.remove_layer(layer); }, "layer"_a)
+        .def(
+            "remove_layer", [](viz::VizSession& self, viz::CylinderLayer* layer) { self.remove_layer(layer); }, "layer"_a)
+        .def(
+            "remove_layer", [](viz::VizSession& self, viz::EquirectLayer* layer) { self.remove_layer(layer); }, "layer"_a)
         .def("render", &viz::VizSession::render, py::call_guard<py::gil_scoped_release>(),
              "Wait + composite + present in one call. Returns FrameInfo.")
         .def("begin_frame", &viz::VizSession::begin_frame, py::call_guard<py::gil_scoped_release>())

--- a/src/viz/python/session_bindings.cpp
+++ b/src/viz/python/session_bindings.cpp
@@ -92,7 +92,8 @@ Top-level Televiz session. Owns the Vulkan context, compositor, and
 layer registry.
 
 Construct via ``VizSession.create(config)``. Add layers with
-``add_quad_layer(config)``. Drive the frame loop with ``render()``
+``add_quad_layer(config)`` (or ``add_cylinder_layer`` / ``add_equirect_layer``
+/ ``add_projection_layer``). Drive the frame loop with ``render()``
 (one-shot) or ``begin_frame()`` / ``end_frame()`` (paired).
 )doc")
         .def_static("create", &viz::VizSession::create, "config"_a,

--- a/src/viz/python/viz_init.py
+++ b/src/viz/python/viz_init.py
@@ -31,6 +31,12 @@ Quick start::
 """
 
 from ._viz import (
+    CylinderLayer,
+    CylinderLayerConfig,
+    CylinderLayerPlacement,
+    EquirectLayer,
+    EquirectLayerConfig,
+    EquirectLayerPlacement,
     DisplayMode,
     Fov,
     FrameInfo,
@@ -56,6 +62,12 @@ from ._viz import (
 )
 
 __all__ = [
+    "CylinderLayer",
+    "CylinderLayerConfig",
+    "CylinderLayerPlacement",
+    "EquirectLayer",
+    "EquirectLayerConfig",
+    "EquirectLayerPlacement",
     "DisplayMode",
     "Fov",
     "FrameInfo",

--- a/src/viz/session/cpp/inc/viz/session/display_backend.hpp
+++ b/src/viz/session/cpp/inc/viz/session/display_backend.hpp
@@ -148,25 +148,35 @@ public:
         return current_extent();
     }
 
-    // True when the backend can composite native OpenXR quad layers
-    // (XrCompositionLayerQuad). Only the kXr backend does. The compositor
-    // pairs this with a layer's is_native_quad() to route it natively.
-    virtual bool supports_native_quad() const noexcept
+    // True when the backend can composite native OpenXR composition layers
+    // (quad / cylinder / equirect). Only the kXr backend does. The
+    // compositor pairs this with a layer's is_native_layer() to route it
+    // natively.
+    virtual bool supports_native_layers() const noexcept
     {
         return false;
     }
 
-    // Native-quad path: for each NativeQuadView, copy the source image(s)
-    // into a backend-owned per-quad swapchain and remember it for
-    // submission at end_frame (as one XrCompositionLayerQuad per eye).
+    // Fine-grained per-shape capability: quads are core OpenXR, cylinder /
+    // equirect need their XR_KHR_composition_layer_* extension on the
+    // runtime. VizSession::add_layer checks a layer's
+    // required_native_shape() against this. Default: nothing supported.
+    virtual bool supports_native_layer_shape(NativeLayerShape /*shape*/) const noexcept
+    {
+        return false;
+    }
+
+    // Native path: for each NativeLayerView, copy the source image(s)
+    // into a backend-owned per-layer swapchain and remember it for
+    // submission at end_frame (as one XrCompositionLayer* per eye).
     // Recorded into the compositor's command buffer (so the layer's
     // CUDA-done wait semaphores, threaded at TRANSFER stage, gate the copy)
     // OUTSIDE any render pass. Empty ``views`` → nothing to composite.
     // end_frame submits the shared projection layer only if the render pass
     // or direct path also ran this frame. Default: unsupported (no-op).
-    virtual void record_native_quads(VkCommandBuffer /*cmd*/,
-                                     const Frame& /*frame*/,
-                                     const std::vector<NativeQuadView>& /*views*/)
+    virtual void record_native_layers(VkCommandBuffer /*cmd*/,
+                                      const Frame& /*frame*/,
+                                      const std::vector<NativeLayerView>& /*views*/)
     {
     }
 

--- a/src/viz/session/cpp/inc/viz/session/layer_base.hpp
+++ b/src/viz/session/cpp/inc/viz/session/layer_base.hpp
@@ -88,13 +88,16 @@ struct NativeLayerView
     // away from -z). Equirect: center of the sphere.
     Pose3D pose{};
 
+    // Per-eye horizontal disparity along the placement's local +x axis
+    // (millimeters); the left eye's layer pose shifts −half, the right
+    // +half. Ignored mono. Any shape (a translated infinite-radius
+    // equirect sphere is unchanged by construction, so it's a no-op there).
+    float stereo_baseline_mm = 0.0f;
+
     NativeLayerShape shape = NativeLayerShape::kQuad;
 
     // ── kQuad ────────────────────────────────────────────────────────
     glm::vec2 size_meters{ 0.0f, 0.0f }; // physical width × height
-    // Per-eye horizontal disparity along the placement's local +x axis
-    // (millimeters); left eye shifts −half, right eye +half. Ignored mono.
-    float stereo_baseline_mm = 0.0f;
 
     // ── kCylinder ────────────────────────────────────────────────────
     float radius = 0.0f; // meters (kEquirect2 shares it: 0 / +inf = infinite sphere)

--- a/src/viz/session/cpp/inc/viz/session/layer_base.hpp
+++ b/src/viz/session/cpp/inc/viz/session/layer_base.hpp
@@ -47,34 +47,66 @@ struct DirectPresentView
     Resolution extent{}; // must equal the swapchain per-view size
 };
 
+// Geometry a native OpenXR composition layer is sampled onto by the
+// runtime. Each shape maps 1:1 to an XrCompositionLayer* struct; the
+// backend gates non-quad shapes on the matching XR_KHR extension.
+enum class NativeLayerShape
+{
+    kQuad, // XrCompositionLayerQuad (core)
+    kCylinder, // XrCompositionLayerCylinderKHR (XR_KHR_composition_layer_cylinder)
+    kEquirect2, // XrCompositionLayerEquirect2KHR (XR_KHR_composition_layer_equirect2)
+};
+
 // Per-frame descriptor for a layer that composites as a native OpenXR
-// quad (XrCompositionLayerQuad) instead of drawing into the shared render
-// target. The XR backend owns a color swapchain per quad, copies
-// ``color_left`` (and ``color_right`` for stereo) straight in, and submits
-// one XrCompositionLayerQuad per eye — no shared RT, no projection draw.
-// Only meaningful in kXr; non-XR backends never ask for one.
+// composition layer (quad / cylinder / equirect) instead of drawing into
+// the shared render target. The XR backend owns a color swapchain per
+// layer, copies ``color_left`` (and ``color_right`` for stereo) straight
+// in, and submits one XrCompositionLayer* per eye — no shared RT, no
+// projection draw. Only meaningful in kXr; non-XR backends never ask for
+// one.
 //
-// A native quad carries no depth: XrCompositionLayerQuad has no depth
-// field, so the runtime composites it in submission order (flat billboard),
+// A native layer carries no depth: the XrCompositionLayer* structs have
+// no depth field, so the runtime composites them in submission order,
 // not z-tested against projection-layer 3D content. This is inherent to
-// OpenXR quad layers and is also what lets the runtime's quad fast path /
-// client-reconstructed streaming treat it cheaply.
-struct NativeQuadView
+// OpenXR composition layers and is also what lets the runtime's layer
+// fast path / client-reconstructed streaming treat them cheaply.
+//
+// ``shape`` selects which of the per-shape parameter groups below is
+// meaningful; the others are ignored. A tagged flat struct (not a
+// variant) to keep this header light and the backend's consumption
+// simple.
+struct NativeLayerView
 {
     // Source images (resting layout SHADER_READ_ONLY_OPTIMAL). Backend
-    // copies these into its own quad swapchain(s).
+    // copies these into its own layer swapchain(s).
     VkImage color_left = VK_NULL_HANDLE;
     VkImage color_right = VK_NULL_HANDLE; // VK_NULL_HANDLE => mono (eyeVisibility BOTH)
-    Resolution extent{}; // per-eye source size; the quad swapchain matches it
+    Resolution extent{}; // per-eye source size; the layer swapchain matches it
 
-    // Placement in the session's reference space + physical size (meters).
+    // Placement origin in the session's reference space. Quad: center of
+    // the rectangle. Cylinder: center point of the cylinder (arc bows
+    // away from -z). Equirect: center of the sphere.
     Pose3D pose{};
-    glm::vec2 size_meters{ 0.0f, 0.0f };
+
+    NativeLayerShape shape = NativeLayerShape::kQuad;
+
+    // ── kQuad ────────────────────────────────────────────────────────
+    glm::vec2 size_meters{ 0.0f, 0.0f }; // physical width × height
     // Per-eye horizontal disparity along the placement's local +x axis
     // (millimeters); left eye shifts −half, right eye +half. Ignored mono.
     float stereo_baseline_mm = 0.0f;
 
-    // Stable identity the backend keys its persistent quad swapchain(s) on
+    // ── kCylinder ────────────────────────────────────────────────────
+    float radius = 0.0f; // meters (kEquirect2 shares it: 0 / +inf = infinite sphere)
+    float central_angle = 0.0f; // visible arc, radians
+    float aspect_ratio = 0.0f; // arc-width / height of the visible portion
+
+    // ── kEquirect2 ───────────────────────────────────────────────────
+    float central_horizontal_angle = 0.0f; // radians, 2π = full 360°
+    float upper_vertical_angle = 0.0f; // radians from horizon, +π/2 = zenith
+    float lower_vertical_angle = 0.0f; // radians from horizon, −π/2 = nadir
+
+    // Stable identity the backend keys its persistent swapchain(s) on
     // across frames (the layer's ``this``). Never dereferenced by the backend.
     const void* source_id = nullptr;
 };
@@ -178,24 +210,38 @@ public:
         return {};
     }
 
-    // Native OpenXR quad support (see NativeQuadView). When true, the
-    // compositor — on a backend that supports_native_quad() — routes this
-    // layer through acquire_native_quad()/record_native_quads() instead of
-    // record(), and DROPS the shared projection layer for frames where every
-    // visible layer is a native quad (unlocking the runtime's quad fast
-    // path). Must return false unless the layer is in a kXr session, so the
-    // window/offscreen fallback still uses record(). Default: not native.
-    virtual bool is_native_quad() const noexcept
+    // Native OpenXR composition-layer support (see NativeLayerView). When
+    // true, the compositor — on a backend that supports_native_layers() —
+    // routes this layer through acquire_native_layer()/record_native_layers()
+    // instead of record(), and DROPS the shared projection layer for frames
+    // where every visible layer is native (unlocking the runtime's layer fast
+    // path). A layer WITH a composite fallback (QuadLayer) must return false
+    // unless it is in a kXr session, so the window/offscreen fallback still
+    // uses record(); native-only layers return true unconditionally and are
+    // rejected at add_layer on unsupported backends (required_native_shape).
+    // Default: not native.
+    virtual bool is_native_layer() const noexcept
     {
         return false;
     }
 
     // Promote this frame's content into ``in_flight_slot`` (same slot the
     // compositor passes to get_wait_semaphores()) and return the native
-    // quad descriptor. nullopt = nothing fresh to composite this frame (no
-    // publish yet) — the backend submits no quad for this layer. Called
-    // instead of record_pre_render_pass()/record() on the native-quad path.
-    virtual std::optional<NativeQuadView> acquire_native_quad(uint32_t /*in_flight_slot*/)
+    // layer descriptor. nullopt = nothing fresh to composite this frame (no
+    // publish yet) — the backend submits no layer for this frame. Called
+    // instead of record_pre_render_pass()/record() on the native path.
+    virtual std::optional<NativeLayerView> acquire_native_layer(uint32_t /*in_flight_slot*/)
+    {
+        return std::nullopt;
+    }
+
+    // Shape this layer REQUIRES the backend to composite natively, or
+    // nullopt when the layer has a composite fallback (QuadLayer) / isn't
+    // native at all. add_layer rejects the layer up front when the backend
+    // can't composite the shape (non-XR session, or the runtime lacks the
+    // XR_KHR_composition_layer_* extension) — better than failing on the
+    // first frame.
+    virtual std::optional<NativeLayerShape> required_native_shape() const noexcept
     {
         return std::nullopt;
     }

--- a/src/viz/session/cpp/inc/viz/session/layer_base.hpp
+++ b/src/viz/session/cpp/inc/viz/session/layer_base.hpp
@@ -94,6 +94,13 @@ struct NativeLayerView
     // equirect sphere is unchanged by construction, so it's a no-op there).
     float stereo_baseline_mm = 0.0f;
 
+    // Composite this layer honoring its texture's alpha channel
+    // (XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT). False =
+    // opaque within the layer's bounds — the right setting for camera
+    // feeds, and the one that keeps the layer eligible for the runtime's
+    // client-reconstructed streaming (which excludes source-alpha layers).
+    bool alpha_blend = false;
+
     NativeLayerShape shape = NativeLayerShape::kQuad;
 
     // ── kQuad ────────────────────────────────────────────────────────

--- a/src/viz/session/cpp/inc/viz/session/viz_session.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_session.hpp
@@ -110,10 +110,12 @@ public:
     //
     // Layer-mode invariant (for now): a session holds EITHER one
     // ProjectionLayer OR any number of texture layers (QuadLayer /
-    // CylinderLayer / EquirectLayer), never both. The
-    // ProjectionLayer is direct-present (copied straight to the swapchain),
-    // while QuadLayers composite into the shared render target — the two
-    // paths don't coexist yet. Violations throw std::invalid_argument.
+    // CylinderLayer / EquirectLayer), never both. The ProjectionLayer is
+    // direct-present (copied straight to the swapchain), while texture
+    // layers submit as native XR composition layers by default (kXr,
+    // native_composition = true) or draw into the shared render target
+    // (fallback / window / offscreen) — neither coexists with the direct
+    // path yet. Violations throw std::invalid_argument.
     template <typename L, typename... Args>
     L* add_layer(Args&&... args)
     {

--- a/src/viz/session/cpp/inc/viz/session/viz_session.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_session.hpp
@@ -109,7 +109,8 @@ public:
     // as the frame loop; only LayerBase::set_visible() is atomic.
     //
     // Layer-mode invariant (for now): a session holds EITHER one
-    // ProjectionLayer OR any number of QuadLayers, never both. The
+    // ProjectionLayer OR any number of texture layers (QuadLayer /
+    // CylinderLayer / EquirectLayer), never both. The
     // ProjectionLayer is direct-present (copied straight to the swapchain),
     // while QuadLayers composite into the shared render target — the two
     // paths don't coexist yet. Violations throw std::invalid_argument.

--- a/src/viz/session/cpp/inc/viz/session/viz_session.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_session.hpp
@@ -113,7 +113,7 @@ public:
     // CylinderLayer / EquirectLayer), never both. The ProjectionLayer is
     // direct-present (copied straight to the swapchain), while texture
     // layers submit as native XR composition layers by default (kXr,
-    // native_composition = true) or draw into the shared render target
+    // openxr_composition = true) or draw into the shared render target
     // (fallback / window / offscreen) — neither coexists with the direct
     // path yet. Violations throw std::invalid_argument.
     template <typename L, typename... Args>

--- a/src/viz/session/cpp/inc/viz/session/xr_backend.hpp
+++ b/src/viz/session/cpp/inc/viz/session/xr_backend.hpp
@@ -231,9 +231,9 @@ private:
     bool frame_renderable_ = false; // false on shouldRender=0 / locate failure
     // Set when the shared render pass (record_post_render_pass) or the
     // direct path (record_direct) produced content for the projection
-    // layer this frame. When false at end_frame (every visible layer was a
-    // native quad), the projection layer is dropped so the runtime sees a
-    // quad-only frame and can engage its client-reconstructed path.
+    // layer this frame. When false at end_frame (every visible layer was
+    // native), the projection layer is dropped so the runtime sees a
+    // native-only frame and can engage its client-reconstructed path.
     bool projection_active_ = false;
     // Monotonic counter that drives Frame::backend_token; the contract
     // (display_backend.hpp) requires 0..image_count()-1, which the

--- a/src/viz/session/cpp/inc/viz/session/xr_backend.hpp
+++ b/src/viz/session/cpp/inc/viz/session/xr_backend.hpp
@@ -202,6 +202,7 @@ private:
         uint32_t height = 0;
         XrPosef pose{};
         XrEyeVisibility eye_visibility = XR_EYE_VISIBILITY_BOTH;
+        bool alpha_blend = false; // honor the texture's alpha when compositing
         NativeLayerShape shape = NativeLayerShape::kQuad;
         XrExtent2Df size{}; // kQuad
         float radius = 0.0f; // kCylinder + kEquirect2

--- a/src/viz/session/cpp/inc/viz/session/xr_backend.hpp
+++ b/src/viz/session/cpp/inc/viz/session/xr_backend.hpp
@@ -79,15 +79,18 @@ public:
     void record_direct(VkCommandBuffer cmd, const Frame& frame, const std::vector<DirectPresentView>& views) override;
     Resolution recommended_view_resolution() const override;
 
-    // Native OpenXR quad layers (XrCompositionLayerQuad). Copies each
-    // NativeQuadView's source image(s) into a per-quad color swapchain and
-    // records the submission for end_frame; quad-only frames drop the shared
-    // projection layer (see projection_active_).
-    bool supports_native_quad() const noexcept override
+    // Native OpenXR composition layers (quad / cylinder / equirect).
+    // Copies each NativeLayerView's source image(s) into a per-layer color
+    // swapchain and records the submission for end_frame; native-only
+    // frames drop the shared projection layer (see projection_active_).
+    bool supports_native_layers() const noexcept override
     {
         return true;
     }
-    void record_native_quads(VkCommandBuffer cmd, const Frame& frame, const std::vector<NativeQuadView>& views) override;
+    // Quads are core; cylinder / equirect are gated on the runtime
+    // advertising the matching XR_KHR_composition_layer_* extension.
+    bool supports_native_layer_shape(NativeLayerShape shape) const noexcept override;
+    void record_native_layers(VkCommandBuffer cmd, const Frame& frame, const std::vector<NativeLayerView>& views) override;
 
     void poll_events() override;
     bool should_close() const override;
@@ -138,17 +141,17 @@ private:
     void destroy_swapchains();
     void create_intermediate();
 
-    // Native-quad color swapchain(s) for one QuadLayer: 1 (mono) or 2
+    // Native-layer color swapchain(s) for one source layer: 1 (mono) or 2
     // (stereo, [left, right]). Created lazily on first submission, keyed by
     // the layer's stable source_id, reused each frame.
-    struct NativeQuadSwapchain
+    struct NativeLayerSwapchain
     {
         std::vector<ViewSwapchain> eyes; // 1 mono, 2 stereo
     };
-    // Ensure (lazily create) the quad swapchain(s) for ``key`` sized to
+    // Ensure (lazily create) the layer swapchain(s) for ``key`` sized to
     // ``extent`` with ``eye_count`` eyes; returns the cached entry.
-    NativeQuadSwapchain& ensure_native_quad_swapchain(const void* key, Resolution extent, uint32_t eye_count);
-    void destroy_native_quad_swapchains();
+    NativeLayerSwapchain& ensure_native_layer_swapchain(const void* key, Resolution extent, uint32_t eye_count);
+    void destroy_native_layer_swapchains();
 
     // Per-eye staging buffers that bridge a direct ProjectionLayer's depth
     // (stored as R32_SFLOAT — CUDA can't interop a depth-format image) into
@@ -180,26 +183,35 @@ private:
     std::vector<ViewSwapchain> depth_swapchains_;
     bool depth_layer_enabled_ = false;
 
-    // Persistent per-QuadLayer native-quad swapchains, keyed by the layer's
-    // source_id. Created lazily in record_native_quads, destroyed with the
-    // backend. (Removing a native quad layer mid-session leaves its
-    // swapchain allocated until destroy — layer removal is rare.)
-    std::map<const void*, NativeQuadSwapchain> native_quad_swapchains_;
+    // Persistent per-layer native swapchains, keyed by the layer's
+    // source_id. Created lazily in record_native_layers, destroyed with the
+    // backend. (Removing a native layer mid-session leaves its swapchain
+    // allocated until destroy — layer removal is rare.)
+    std::map<const void*, NativeLayerSwapchain> native_layer_swapchains_;
 
-    // One XrCompositionLayerQuad to submit this frame. Storage for the
-    // built XrCompositionLayerQuad lives in end_frame; this holds the
-    // inputs record_native_quads gathered. eye_visibility selects the eye
-    // (BOTH for mono).
-    struct NativeQuadSubmit
+    // One XrCompositionLayer* to submit this frame. Storage for the built
+    // struct lives in end_frame; this holds the inputs
+    // record_native_layers gathered. eye_visibility selects the eye (BOTH
+    // for mono). shape picks which XrCompositionLayer* struct end_frame
+    // builds and which of the per-shape params are read (see
+    // NativeLayerView for their meaning).
+    struct NativeLayerSubmit
     {
         XrSwapchain swapchain = XR_NULL_HANDLE;
         uint32_t width = 0;
         uint32_t height = 0;
         XrPosef pose{};
-        XrExtent2Df size{};
         XrEyeVisibility eye_visibility = XR_EYE_VISIBILITY_BOTH;
+        NativeLayerShape shape = NativeLayerShape::kQuad;
+        XrExtent2Df size{}; // kQuad
+        float radius = 0.0f; // kCylinder + kEquirect2
+        float central_angle = 0.0f; // kCylinder
+        float aspect_ratio = 0.0f; // kCylinder
+        float central_horizontal_angle = 0.0f; // kEquirect2
+        float upper_vertical_angle = 0.0f; // kEquirect2
+        float lower_vertical_angle = 0.0f; // kEquirect2
     };
-    std::vector<NativeQuadSubmit> active_native_quads_;
+    std::vector<NativeLayerSubmit> active_native_layers_;
 
     // Per-eye R32_SFLOAT->D32_SFLOAT bridge buffers (see create_depth_staging).
     struct DepthStaging

--- a/src/viz/session/cpp/viz_compositor.cpp
+++ b/src/viz/session/cpp/viz_compositor.cpp
@@ -301,17 +301,17 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
     // window/offscreen letterboxing only.
     const bool xr_mode = backend_->is_xr();
 
-    // Partition visible layers into native OpenXR quads (composited by the
-    // runtime as XrCompositionLayerQuad) and the rest (composited into the
-    // shared render target). is_native_quad() is true only in a kXr session,
+    // Partition visible layers into native OpenXR composition layers (handled by the
+    // runtime as XrCompositionLayer* structs) and the rest (composited into the
+    // shared render target). is_native_layer() is only true in a kXr session,
     // so window/offscreen keep every layer on the composite path.
     std::vector<LayerBase*> composite_layers;
     std::vector<LayerBase*> native_layers;
     composite_layers.reserve(visible_layers.size());
-    const bool backend_native = backend_->supports_native_quad();
+    const bool backend_native = backend_->supports_native_layers();
     for (LayerBase* layer : visible_layers)
     {
-        if (backend_native && layer->is_native_quad())
+        if (backend_native && layer->is_native_layer())
         {
             native_layers.push_back(layer);
         }
@@ -322,10 +322,10 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
     }
 
     // Run the shared render pass (and thus submit the projection layer) when
-    // there is composite content, OR when there are no native quads at all
+    // there is composite content, OR when there are no native layers at all
     // (preserve the "no visible layers → cleared frame" behavior). A
-    // native-quad-only frame skips the render pass entirely, so the backend
-    // drops the projection layer and the runtime sees a quad-only frame.
+    // native-only frame skips the render pass entirely, so the backend
+    // drops the projection layer and the runtime sees a native-only frame.
     const bool run_composite = !composite_layers.empty() || native_layers.empty();
 
     // Direct-present: a single ProjectionLayer copied straight to the
@@ -362,15 +362,15 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
         vkCmdWriteTimestamp(command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, gpu_timestamp_pool_, query_base + 0);
     }
 
-    // Native quads: promote each layer's mailbox slot and gather its per-eye
+    // Native layers: promote each layer's mailbox slot and gather its per-eye
     // source images. Must precede the wait-semaphore gather below so
     // get_wait_semaphores() reflects the promoted slot (like acquire_direct_views).
-    // acquire_native_quad returns nullopt when the layer hasn't published yet.
-    std::vector<NativeQuadView> native_views;
+    // acquire_native_layer returns nullopt when the layer hasn't published yet.
+    std::vector<NativeLayerView> native_views;
     native_views.reserve(native_layers.size());
     for (LayerBase* layer : native_layers)
     {
-        if (auto v = layer->acquire_native_quad(slot))
+        if (auto v = layer->acquire_native_layer(slot))
         {
             native_views.push_back(*v);
         }
@@ -481,10 +481,10 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
         }
     }
 
-    // Copy each native quad's source image(s) into the backend's runtime quad
+    // Copy each native layer's source image(s) into the backend's runtime layer
     // swapchain(s). No-op (and no projection-layer effect) when empty. Outside
     // any render pass; the layer's CUDA-done waits gate it at TRANSFER stage.
-    backend_->record_native_quads(command_buffer, frame, native_views);
+    backend_->record_native_layers(command_buffer, frame, native_views);
 
     // ts3: cmd-buffer-end (total = ts3-ts0).
     if (gpu_timestamp_pool_ != VK_NULL_HANDLE)

--- a/src/viz/session/cpp/viz_compositor.cpp
+++ b/src/viz/session/cpp/viz_compositor.cpp
@@ -470,7 +470,7 @@ void VizCompositor::render(const DisplayBackend::Frame& frame, const std::vector
     }
     else
     {
-        // Native-quad-only frame: no shared render pass, no projection layer.
+        // Native-only frame: no shared render pass, no projection layer.
         // Mark ts1/ts2 for gpu-timing symmetry (no render/post-pass work).
         if (gpu_timestamp_pool_ != VK_NULL_HANDLE)
         {

--- a/src/viz/session/cpp/viz_session.cpp
+++ b/src/viz/session/cpp/viz_session.cpp
@@ -353,10 +353,10 @@ void VizSession::validate_layer_against_backend_(LayerBase* layer) const
         }
         if (!backend_->supports_native_layer_shape(*shape))
         {
-            throw std::invalid_argument("VizSession: layer '" + layer->name() +
-                                        "' requires an OpenXR composition-layer extension "
-                                        "(XR_KHR_composition_layer_cylinder / _equirect2) the runtime "
-                                        "does not advertise");
+            const char* ext = (*shape == NativeLayerShape::kCylinder) ? "XR_KHR_composition_layer_cylinder" :
+                                                                        "XR_KHR_composition_layer_equirect2";
+            throw std::invalid_argument("VizSession: layer '" + layer->name() + "' requires the " + ext +
+                                        " extension, which the OpenXR runtime does not advertise");
         }
     }
     const uint32_t backend_view_count = backend_->is_xr() ? 2u : 1u;

--- a/src/viz/session/cpp/viz_session.cpp
+++ b/src/viz/session/cpp/viz_session.cpp
@@ -340,6 +340,25 @@ void VizSession::validate_layer_against_backend_(LayerBase* layer) const
             "VizSession: layer was created from a different VkContext than the session's; "
             "build layers with VizSession::get_vk_context().");
     }
+    // Native-only layers (cylinder / equirect) can't fall back to the
+    // composite draw path — reject them up front when the backend can't
+    // composite the shape, instead of failing on the first frame.
+    if (const auto shape = layer->required_native_shape(); shape.has_value())
+    {
+        if (!backend_->supports_native_layers())
+        {
+            throw std::invalid_argument("VizSession: layer '" + layer->name() +
+                                        "' requires native OpenXR composition (DisplayMode::kXr); "
+                                        "window/offscreen sessions cannot composite it");
+        }
+        if (!backend_->supports_native_layer_shape(*shape))
+        {
+            throw std::invalid_argument("VizSession: layer '" + layer->name() +
+                                        "' requires an OpenXR composition-layer extension "
+                                        "(XR_KHR_composition_layer_cylinder / _equirect2) the runtime "
+                                        "does not advertise");
+        }
+    }
     const uint32_t backend_view_count = backend_->is_xr() ? 2u : 1u;
     layer->validate_backend_compatibility(
         backend_->recommended_view_resolution(), backend_view_count, backend_->image_count());

--- a/src/viz/session/cpp/xr_backend.cpp
+++ b/src/viz/session/cpp/xr_backend.cpp
@@ -147,7 +147,7 @@ void XrBackend::destroy()
     // images, so xrDestroySwapchain is enough (no vkDestroyImage).
     render_target_.reset();
     destroy_depth_staging();
-    destroy_native_quad_swapchains();
+    destroy_native_layer_swapchains();
     destroy_swapchains();
     session_.reset();
     ctx_ = nullptr;
@@ -173,7 +173,7 @@ void XrBackend::release_acquired_swapchains() noexcept
     {
         release_one(sw);
     }
-    for (auto& [key, qs] : native_quad_swapchains_)
+    for (auto& [key, qs] : native_layer_swapchains_)
     {
         (void)key;
         for (auto& sw : qs.eyes)
@@ -196,7 +196,7 @@ void XrBackend::abort_in_flight_frame() noexcept
     frame_began_ = false;
     frame_renderable_ = false;
     projection_active_ = false;
-    active_native_quads_.clear();
+    active_native_layers_.clear();
     try
     {
         session_->end_frame(last_frame_state_.predictedDisplayTime, {});
@@ -230,9 +230,9 @@ void XrBackend::destroy_swapchains()
     depth_swapchains_.clear();
 }
 
-void XrBackend::destroy_native_quad_swapchains()
+void XrBackend::destroy_native_layer_swapchains()
 {
-    for (auto& [key, qs] : native_quad_swapchains_)
+    for (auto& [key, qs] : native_layer_swapchains_)
     {
         (void)key;
         for (auto& sw : qs.eyes)
@@ -245,7 +245,7 @@ void XrBackend::destroy_native_quad_swapchains()
             sw.images.clear();
         }
     }
-    native_quad_swapchains_.clear();
+    native_layer_swapchains_.clear();
 }
 
 int64_t XrBackend::pick_swapchain_format() const
@@ -501,9 +501,9 @@ std::optional<DisplayBackend::Frame> XrBackend::begin_frame(int64_t /*ignored*/)
     frame_renderable_ = false;
     // Reset per-frame composition state. projection_active_ is raised by
     // record_post_render_pass / record_direct; native quads accumulate in
-    // record_native_quads. end_frame consumes both.
+    // record_native_layers. end_frame consumes both.
     projection_active_ = false;
-    active_native_quads_.clear();
+    active_native_layers_.clear();
 
     // From here on, an exception MUST balance xrBeginFrame with an
     // empty xrEndFrame and release any swapchains we acquired. The
@@ -894,18 +894,18 @@ void XrBackend::record_direct(VkCommandBuffer cmd, const Frame& /*frame*/, const
     }
 }
 
-XrBackend::NativeQuadSwapchain& XrBackend::ensure_native_quad_swapchain(const void* key,
-                                                                        Resolution extent,
-                                                                        uint32_t eye_count)
+XrBackend::NativeLayerSwapchain& XrBackend::ensure_native_layer_swapchain(const void* key,
+                                                                          Resolution extent,
+                                                                          uint32_t eye_count)
 {
-    // Called from record_native_quads, i.e. between xrBeginFrame/xrEndFrame.
+    // Called from record_native_layers, i.e. between xrBeginFrame/xrEndFrame.
     // xrCreateSwapchain is not part of the frame loop and is legal to call at
     // any time after session creation (Monado/CloudXR allow it), so creating
     // on a quad's first appearance is fine; every later frame hits the cache
     // below. If some runtime ever rejects mid-frame creation, pre-create here
     // from a layer-add hook instead.
-    auto it = native_quad_swapchains_.find(key);
-    if (it != native_quad_swapchains_.end() && it->second.eyes.size() == eye_count && !it->second.eyes.empty() &&
+    auto it = native_layer_swapchains_.find(key);
+    if (it != native_layer_swapchains_.end() && it->second.eyes.size() == eye_count && !it->second.eyes.empty() &&
         it->second.eyes[0].width == extent.width && it->second.eyes[0].height == extent.height)
     {
         return it->second;
@@ -913,7 +913,7 @@ XrBackend::NativeQuadSwapchain& XrBackend::ensure_native_quad_swapchain(const vo
     // Fresh (or shape changed): (re)create. A shape change on an existing
     // key is not expected — a QuadLayer's resolution/stereo are fixed at
     // construction — but destroy the stale one defensively if it happens.
-    if (it != native_quad_swapchains_.end())
+    if (it != native_layer_swapchains_.end())
     {
         for (auto& sw : it->second.eyes)
         {
@@ -922,16 +922,16 @@ XrBackend::NativeQuadSwapchain& XrBackend::ensure_native_quad_swapchain(const vo
                 (void)xrDestroySwapchain(sw.handle);
             }
         }
-        native_quad_swapchains_.erase(it);
+        native_layer_swapchains_.erase(it);
     }
 
     // Destroy any already-created eye swapchains if creation of a later eye
     // throws below (e.g. eye 1 of a stereo pair) — otherwise the eye-0 handle
     // in this local would leak until session destroy.
-    NativeQuadSwapchain qs;
+    NativeLayerSwapchain qs;
     struct PartialGuard
     {
-        NativeQuadSwapchain& qs;
+        NativeLayerSwapchain& qs;
         bool dismissed = false;
         ~PartialGuard()
         {
@@ -965,18 +965,18 @@ XrBackend::NativeQuadSwapchain& XrBackend::ensure_native_quad_swapchain(const vo
         info.faceCount = 1;
         info.arraySize = 1;
         info.mipCount = 1;
-        check_xr(xrCreateSwapchain(session_->session(), &info, &qs.eyes[e].handle), "xrCreateSwapchain(native quad)");
+        check_xr(xrCreateSwapchain(session_->session(), &info, &qs.eyes[e].handle), "xrCreateSwapchain(native layer)");
         qs.eyes[e].width = info.width;
         qs.eyes[e].height = info.height;
 
         uint32_t img_count = 0;
         check_xr(xrEnumerateSwapchainImages(qs.eyes[e].handle, 0, &img_count, nullptr),
-                 "xrEnumerateSwapchainImages(native quad count)");
+                 "xrEnumerateSwapchainImages(native layer count)");
         std::vector<XrSwapchainImageVulkan2KHR> vk_images(
             img_count, XrSwapchainImageVulkan2KHR{ XR_TYPE_SWAPCHAIN_IMAGE_VULKAN2_KHR });
         check_xr(xrEnumerateSwapchainImages(qs.eyes[e].handle, img_count, &img_count,
                                             reinterpret_cast<XrSwapchainImageBaseHeader*>(vk_images.data())),
-                 "xrEnumerateSwapchainImages(native quad data)");
+                 "xrEnumerateSwapchainImages(native layer data)");
         qs.eyes[e].images.reserve(img_count);
         for (const auto& vi : vk_images)
         {
@@ -985,13 +985,31 @@ XrBackend::NativeQuadSwapchain& XrBackend::ensure_native_quad_swapchain(const vo
     }
     // Once emplace succeeds the map owns the handles (qs is moved-from, its
     // eyes vector empty, so the guard's sweep is a no-op either way).
-    auto [ins, ok] = native_quad_swapchains_.emplace(key, std::move(qs));
+    auto [ins, ok] = native_layer_swapchains_.emplace(key, std::move(qs));
     partial_guard.dismissed = true;
     (void)ok;
     return ins->second;
 }
 
-void XrBackend::record_native_quads(VkCommandBuffer cmd, const Frame& /*frame*/, const std::vector<NativeQuadView>& views)
+bool XrBackend::supports_native_layer_shape(NativeLayerShape shape) const noexcept
+{
+    if (session_ == nullptr)
+    {
+        return false;
+    }
+    switch (shape)
+    {
+    case NativeLayerShape::kQuad:
+        return true; // XrCompositionLayerQuad is core OpenXR
+    case NativeLayerShape::kCylinder:
+        return session_->has_cylinder_composition_layer();
+    case NativeLayerShape::kEquirect2:
+        return session_->has_equirect2_composition_layer();
+    }
+    return false;
+}
+
+void XrBackend::record_native_layers(VkCommandBuffer cmd, const Frame& /*frame*/, const std::vector<NativeLayerView>& views)
 {
     if (!frame_renderable_ || views.empty())
     {
@@ -1002,12 +1020,15 @@ void XrBackend::record_native_quads(VkCommandBuffer cmd, const Frame& /*frame*/,
     {
         const bool stereo = view.color_right != VK_NULL_HANDLE;
         const uint32_t eye_count = stereo ? 2u : 1u;
-        NativeQuadSwapchain& qs = ensure_native_quad_swapchain(view.source_id, view.extent, eye_count);
+        NativeLayerSwapchain& qs = ensure_native_layer_swapchain(view.source_id, view.extent, eye_count);
 
         // Per-eye baseline offset along the placement's local +x axis
         // (world space), mirroring QuadLayer::record()'s stereo shift.
+        // Quads only: cylinder / equirect stereo keeps a single shared
+        // pose — the depth cue comes from the per-eye textures, matching
+        // how 180°/360° stereo video is authored.
         glm::vec3 baseline_axis_ws{ 0.0f };
-        const bool apply_baseline = stereo && view.stereo_baseline_mm != 0.0f;
+        const bool apply_baseline = view.shape == NativeLayerShape::kQuad && stereo && view.stereo_baseline_mm != 0.0f;
         if (apply_baseline)
         {
             baseline_axis_ws = glm::mat3_cast(view.pose.orientation) * glm::vec3(1.0f, 0.0f, 0.0f);
@@ -1020,11 +1041,11 @@ void XrBackend::record_native_quads(VkCommandBuffer cmd, const Frame& /*frame*/,
             // Acquire + wait this quad swapchain image (released in end_frame).
             XrSwapchainImageAcquireInfo acquire_info{ XR_TYPE_SWAPCHAIN_IMAGE_ACQUIRE_INFO };
             check_xr(xrAcquireSwapchainImage(sw.handle, &acquire_info, &sw.current_image_index),
-                     "xrAcquireSwapchainImage(native quad)");
+                     "xrAcquireSwapchainImage(native layer)");
             sw.acquired = true;
             XrSwapchainImageWaitInfo wait_info{ XR_TYPE_SWAPCHAIN_IMAGE_WAIT_INFO };
             wait_info.timeout = XR_INFINITE_DURATION;
-            check_xr(xrWaitSwapchainImage(sw.handle, &wait_info), "xrWaitSwapchainImage(native quad)");
+            check_xr(xrWaitSwapchainImage(sw.handle, &wait_info), "xrWaitSwapchainImage(native layer)");
 
             const VkImage dst = sw.images[sw.current_image_index];
             const VkImage src = (e == 0) ? view.color_left : view.color_right;
@@ -1066,15 +1087,22 @@ void XrBackend::record_native_quads(VkCommandBuffer cmd, const Frame& /*frame*/,
                 eye_pose.position += sign * (view.stereo_baseline_mm * 0.0005f) * baseline_axis_ws;
             }
 
-            NativeQuadSubmit submit{};
+            NativeLayerSubmit submit{};
             submit.swapchain = sw.handle;
             submit.width = sw.width;
             submit.height = sw.height;
             submit.pose = pose3d_to_xr_pose(eye_pose);
-            submit.size = XrExtent2Df{ view.size_meters.x, view.size_meters.y };
             submit.eye_visibility =
                 stereo ? (e == 0 ? XR_EYE_VISIBILITY_LEFT : XR_EYE_VISIBILITY_RIGHT) : XR_EYE_VISIBILITY_BOTH;
-            active_native_quads_.push_back(submit);
+            submit.shape = view.shape;
+            submit.size = XrExtent2Df{ view.size_meters.x, view.size_meters.y };
+            submit.radius = view.radius;
+            submit.central_angle = view.central_angle;
+            submit.aspect_ratio = view.aspect_ratio;
+            submit.central_horizontal_angle = view.central_horizontal_angle;
+            submit.upper_vertical_angle = view.upper_vertical_angle;
+            submit.lower_vertical_angle = view.lower_vertical_angle;
+            active_native_layers_.push_back(submit);
         }
     }
 }
@@ -1128,10 +1156,10 @@ void XrBackend::end_frame(const Frame& /*frame*/)
         check_xr(xrReleaseSwapchainImage(sw.handle, &release_info), "xrReleaseSwapchainImage(depth)");
         sw.acquired = false;
     }
-    // Release native-quad swapchains acquired in record_native_quads. Their
+    // Release native-quad swapchains acquired in record_native_layers. Their
     // XrCompositionLayerQuad references the handle (not the image), so
     // releasing before xrEndFrame is correct — matching the projection path.
-    for (auto& [key, qs] : native_quad_swapchains_)
+    for (auto& [key, qs] : native_layer_swapchains_)
     {
         (void)key;
         for (auto& sw : qs.eyes)
@@ -1141,7 +1169,7 @@ void XrBackend::end_frame(const Frame& /*frame*/)
                 continue;
             }
             XrSwapchainImageReleaseInfo release_info{ XR_TYPE_SWAPCHAIN_IMAGE_RELEASE_INFO };
-            check_xr(xrReleaseSwapchainImage(sw.handle, &release_info), "xrReleaseSwapchainImage(native quad)");
+            check_xr(xrReleaseSwapchainImage(sw.handle, &release_info), "xrReleaseSwapchainImage(native layer)");
             sw.acquired = false;
         }
     }
@@ -1211,26 +1239,73 @@ void XrBackend::end_frame(const Frame& /*frame*/)
         layers.push_back(reinterpret_cast<const XrCompositionLayerBaseHeader*>(&projection_layer));
     }
 
-    // Native quad layers gathered in record_native_quads (one per eye).
+    // Native composition layers gathered in record_native_layers (one per
+    // eye), each built as its shape's XrCompositionLayer* struct. The three
+    // per-shape vectors are reserved to the full entry count up front so
+    // the pointers pushed into ``layers`` stay stable (no reallocation) —
+    // which also lets one pass preserve the original submission order
+    // across shapes.
     std::vector<XrCompositionLayerQuad> quad_layers;
-    quad_layers.reserve(active_native_quads_.size());
-    for (const auto& q : active_native_quads_)
+    std::vector<XrCompositionLayerCylinderKHR> cylinder_layers;
+    std::vector<XrCompositionLayerEquirect2KHR> equirect_layers;
+    quad_layers.reserve(active_native_layers_.size());
+    cylinder_layers.reserve(active_native_layers_.size());
+    equirect_layers.reserve(active_native_layers_.size());
+    for (const auto& q : active_native_layers_)
     {
-        XrCompositionLayerQuad ql{ XR_TYPE_COMPOSITION_LAYER_QUAD };
-        ql.layerFlags = blend_flags;
-        ql.space = session_->reference_space();
-        ql.eyeVisibility = q.eye_visibility;
-        ql.subImage.swapchain = q.swapchain;
-        ql.subImage.imageRect.offset = { 0, 0 };
-        ql.subImage.imageRect.extent = { static_cast<int32_t>(q.width), static_cast<int32_t>(q.height) };
-        ql.subImage.imageArrayIndex = 0;
-        ql.pose = q.pose;
-        ql.size = q.size;
-        quad_layers.push_back(ql);
-    }
-    for (const auto& ql : quad_layers)
-    {
-        layers.push_back(reinterpret_cast<const XrCompositionLayerBaseHeader*>(&ql));
+        XrSwapchainSubImage sub_image{};
+        sub_image.swapchain = q.swapchain;
+        sub_image.imageRect.offset = { 0, 0 };
+        sub_image.imageRect.extent = { static_cast<int32_t>(q.width), static_cast<int32_t>(q.height) };
+        sub_image.imageArrayIndex = 0;
+
+        switch (q.shape)
+        {
+        case NativeLayerShape::kQuad:
+        {
+            XrCompositionLayerQuad ql{ XR_TYPE_COMPOSITION_LAYER_QUAD };
+            ql.layerFlags = blend_flags;
+            ql.space = session_->reference_space();
+            ql.eyeVisibility = q.eye_visibility;
+            ql.subImage = sub_image;
+            ql.pose = q.pose;
+            ql.size = q.size;
+            quad_layers.push_back(ql);
+            layers.push_back(reinterpret_cast<const XrCompositionLayerBaseHeader*>(&quad_layers.back()));
+            break;
+        }
+        case NativeLayerShape::kCylinder:
+        {
+            XrCompositionLayerCylinderKHR cl{ XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR };
+            cl.layerFlags = blend_flags;
+            cl.space = session_->reference_space();
+            cl.eyeVisibility = q.eye_visibility;
+            cl.subImage = sub_image;
+            cl.pose = q.pose;
+            cl.radius = q.radius;
+            cl.centralAngle = q.central_angle;
+            cl.aspectRatio = q.aspect_ratio;
+            cylinder_layers.push_back(cl);
+            layers.push_back(reinterpret_cast<const XrCompositionLayerBaseHeader*>(&cylinder_layers.back()));
+            break;
+        }
+        case NativeLayerShape::kEquirect2:
+        {
+            XrCompositionLayerEquirect2KHR eq{ XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR };
+            eq.layerFlags = blend_flags;
+            eq.space = session_->reference_space();
+            eq.eyeVisibility = q.eye_visibility;
+            eq.subImage = sub_image;
+            eq.pose = q.pose;
+            eq.radius = q.radius;
+            eq.centralHorizontalAngle = q.central_horizontal_angle;
+            eq.upperVerticalAngle = q.upper_vertical_angle;
+            eq.lowerVerticalAngle = q.lower_vertical_angle;
+            equirect_layers.push_back(eq);
+            layers.push_back(reinterpret_cast<const XrCompositionLayerBaseHeader*>(&equirect_layers.back()));
+            break;
+        }
+        }
     }
 
     // Clear flags BEFORE end_frame so a throw doesn't trigger a second
@@ -1238,7 +1313,7 @@ void XrBackend::end_frame(const Frame& /*frame*/)
     frame_began_ = false;
     frame_renderable_ = false;
     projection_active_ = false;
-    active_native_quads_.clear();
+    active_native_layers_.clear();
     session_->end_frame(last_frame_state_.predictedDisplayTime, layers);
 }
 

--- a/src/viz/session/cpp/xr_backend.cpp
+++ b/src/viz/session/cpp/xr_backend.cpp
@@ -1095,6 +1095,7 @@ void XrBackend::record_native_layers(VkCommandBuffer cmd, const Frame& /*frame*/
             submit.pose = pose3d_to_xr_pose(eye_pose);
             submit.eye_visibility =
                 stereo ? (e == 0 ? XR_EYE_VISIBILITY_LEFT : XR_EYE_VISIBILITY_RIGHT) : XR_EYE_VISIBILITY_BOTH;
+            submit.alpha_blend = view.alpha_blend;
             submit.shape = view.shape;
             submit.size = XrExtent2Df{ view.size_meters.x, view.size_meters.y };
             submit.radius = view.radius;
@@ -1198,11 +1199,13 @@ void XrBackend::end_frame(const Frame& /*frame*/)
     }
 
     // Non-opaque env modes need the alpha-blend layer flag for the runtime
-    // to honor our alpha channel. Straight alpha (not premultiplied). Shared
-    // by the projection layer and native quads. Note: with this flag set,
-    // the runtime's client-reconstructed optimization stays off (it excludes
-    // source-alpha layers) — so passthrough quads composite correctly but
-    // don't get the color-only fast path; opaque VR quads do.
+    // to honor our alpha channel. Straight alpha (not premultiplied).
+    // PROJECTION layer only: its unrendered pixels carry alpha 0 so the
+    // camera passthrough shows through. Native layers instead use their
+    // per-layer alpha_blend flag (below) — an opaque camera quad needs no
+    // source alpha even in a passthrough session, and staying alpha-free
+    // keeps the frame eligible for the runtime's client-reconstructed
+    // streaming (which excludes source-alpha layers).
     const bool is_passthrough = session_->environment_blend_mode() != XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
     const XrCompositionLayerFlags blend_flags = is_passthrough ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
 
@@ -1265,7 +1268,7 @@ void XrBackend::end_frame(const Frame& /*frame*/)
         case NativeLayerShape::kQuad:
         {
             XrCompositionLayerQuad ql{ XR_TYPE_COMPOSITION_LAYER_QUAD };
-            ql.layerFlags = blend_flags;
+            ql.layerFlags = q.alpha_blend ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
             ql.space = session_->reference_space();
             ql.eyeVisibility = q.eye_visibility;
             ql.subImage = sub_image;
@@ -1278,7 +1281,7 @@ void XrBackend::end_frame(const Frame& /*frame*/)
         case NativeLayerShape::kCylinder:
         {
             XrCompositionLayerCylinderKHR cl{ XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR };
-            cl.layerFlags = blend_flags;
+            cl.layerFlags = q.alpha_blend ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
             cl.space = session_->reference_space();
             cl.eyeVisibility = q.eye_visibility;
             cl.subImage = sub_image;
@@ -1293,7 +1296,7 @@ void XrBackend::end_frame(const Frame& /*frame*/)
         case NativeLayerShape::kEquirect2:
         {
             XrCompositionLayerEquirect2KHR eq{ XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR };
-            eq.layerFlags = blend_flags;
+            eq.layerFlags = q.alpha_blend ? XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT : 0;
             eq.space = session_->reference_space();
             eq.eyeVisibility = q.eye_visibility;
             eq.subImage = sub_image;

--- a/src/viz/session/cpp/xr_backend.cpp
+++ b/src/viz/session/cpp/xr_backend.cpp
@@ -500,7 +500,7 @@ std::optional<DisplayBackend::Frame> XrBackend::begin_frame(int64_t /*ignored*/)
     frame_began_ = true;
     frame_renderable_ = false;
     // Reset per-frame composition state. projection_active_ is raised by
-    // record_post_render_pass / record_direct; native quads accumulate in
+    // record_post_render_pass / record_direct; native layers accumulate in
     // record_native_layers. end_frame consumes both.
     projection_active_ = false;
     active_native_layers_.clear();
@@ -1158,9 +1158,10 @@ void XrBackend::end_frame(const Frame& /*frame*/)
         check_xr(xrReleaseSwapchainImage(sw.handle, &release_info), "xrReleaseSwapchainImage(depth)");
         sw.acquired = false;
     }
-    // Release native-quad swapchains acquired in record_native_layers. Their
-    // XrCompositionLayerQuad references the handle (not the image), so
-    // releasing before xrEndFrame is correct — matching the projection path.
+    // Release native-layer swapchains acquired in record_native_layers.
+    // The built XrCompositionLayer* references the handle (not the image),
+    // so releasing before xrEndFrame is correct — matching the projection
+    // path.
     for (auto& [key, qs] : native_layer_swapchains_)
     {
         (void)key;
@@ -1214,8 +1215,9 @@ void XrBackend::end_frame(const Frame& /*frame*/)
     std::vector<const XrCompositionLayerBaseHeader*> layers;
 
     // Projection layer — only when the shared RT / direct path produced
-    // content this frame. Dropped for quad-only frames so the runtime sees a
-    // quad-only submission (enabling client-reconstructed streaming).
+    // content this frame. Dropped for native-only frames so the runtime
+    // sees a native-only submission (enabling client-reconstructed
+    // streaming).
     std::vector<XrCompositionLayerProjectionView> proj_views;
     XrCompositionLayerProjection projection_layer{ XR_TYPE_COMPOSITION_LAYER_PROJECTION };
     if (projection_active_)

--- a/src/viz/session/cpp/xr_backend.cpp
+++ b/src/viz/session/cpp/xr_backend.cpp
@@ -1024,11 +1024,12 @@ void XrBackend::record_native_layers(VkCommandBuffer cmd, const Frame& /*frame*/
 
         // Per-eye baseline offset along the placement's local +x axis
         // (world space), mirroring QuadLayer::record()'s stereo shift.
-        // Quads only: cylinder / equirect stereo keeps a single shared
-        // pose — the depth cue comes from the per-eye textures, matching
-        // how 180°/360° stereo video is authored.
+        // Shape-agnostic: the whole layer pose translates per eye. For an
+        // infinite-radius equirect sphere the translation is invisible by
+        // construction — the depth cue there comes from the per-eye
+        // textures alone, matching how 360° stereo video is authored.
         glm::vec3 baseline_axis_ws{ 0.0f };
-        const bool apply_baseline = view.shape == NativeLayerShape::kQuad && stereo && view.stereo_baseline_mm != 0.0f;
+        const bool apply_baseline = stereo && view.stereo_baseline_mm != 0.0f;
         if (apply_baseline)
         {
             baseline_axis_ws = glm::mat3_cast(view.pose.orientation) * glm::vec3(1.0f, 0.0f, 0.0f);

--- a/src/viz/session_tests/cpp/test_quad_milestone.cpp
+++ b/src/viz/session_tests/cpp/test_quad_milestone.cpp
@@ -491,7 +491,7 @@ TEST_CASE("QuadLayer use_openxr_quad_layer falls back to the compositor outside 
 {
     // The native OpenXR quad path only engages in a kXr session (needs a
     // live runtime, validated manually against CloudXR). In offscreen the
-    // flag must be a no-op: is_native_quad() stays false and the layer still
+    // flag must be a no-op: is_native_layer() stays false and the layer still
     // composites through record() exactly as a plain QuadLayer would.
     if (!is_gpu_available())
     {
@@ -524,7 +524,7 @@ TEST_CASE("QuadLayer use_openxr_quad_layer falls back to the compositor outside 
 
     // Offscreen backend doesn't support native quads → the layer stays on
     // the draw path, so the compositor renders it into the shared RT.
-    CHECK_FALSE(layer->is_native_quad());
+    CHECK_FALSE(layer->is_native_layer());
 
     const auto host_pattern = build_host_pattern(kSide);
     void* device_ptr = nullptr;

--- a/src/viz/session_tests/cpp/test_quad_milestone.cpp
+++ b/src/viz/session_tests/cpp/test_quad_milestone.cpp
@@ -14,6 +14,8 @@
 #include <viz/core/host_image.hpp>
 #include <viz/core/viz_buffer.hpp>
 #include <viz/core/vk_context.hpp>
+#include <viz/layers/cylinder_layer.hpp>
+#include <viz/layers/equirect_layer.hpp>
 #include <viz/layers/quad_layer.hpp>
 #include <viz/session/viz_session.hpp>
 #include <viz/test_support/test_helpers.hpp>
@@ -549,4 +551,37 @@ TEST_CASE("QuadLayer use_openxr_quad_layer falls back to the compositor outside 
     REQUIRE(image.resolution().width == kSide);
     REQUIRE(image.resolution().height == kSide);
     check_quadrant_pattern(image, kSide);
+}
+
+TEST_CASE("Native-only shaped layers are rejected outside kXr", "[gpu][native][shaped]")
+{
+    // CylinderLayer / EquirectLayer have no compositor draw path, so
+    // add_layer must reject them on a non-XR backend up front (instead of
+    // the layer throwing on its first frame).
+    if (!is_gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    VizSession::Config cfg{};
+    cfg.mode = DisplayMode::kOffscreen;
+    cfg.external_context = &shared_vk_context();
+    cfg.window_width = 64;
+    cfg.window_height = 64;
+
+    auto session = VizSession::create(cfg);
+    REQUIRE(session != nullptr);
+    const auto* ctx = session->get_vk_context();
+    REQUIRE(ctx != nullptr);
+
+    viz::CylinderLayer::Config cyl_cfg;
+    cyl_cfg.resolution = { 64, 64 };
+    CHECK_THROWS_AS(session->add_layer<viz::CylinderLayer>(*ctx, cyl_cfg), std::invalid_argument);
+
+    viz::EquirectLayer::Config eq_cfg;
+    eq_cfg.resolution = { 64, 64 };
+    CHECK_THROWS_AS(session->add_layer<viz::EquirectLayer>(*ctx, eq_cfg), std::invalid_argument);
+
+    // A rejected add leaves no state behind: the session still renders.
+    session->render();
 }

--- a/src/viz/session_tests/cpp/test_quad_milestone.cpp
+++ b/src/viz/session_tests/cpp/test_quad_milestone.cpp
@@ -489,7 +489,7 @@ TEST_CASE("QuadLayer fast producer: render samples only the latest publish", "[g
     CHECK(sample.a == expected.a);
 }
 
-TEST_CASE("QuadLayer native_composition falls back to the compositor outside kXr", "[gpu][quad_layer][native]")
+TEST_CASE("QuadLayer openxr_composition falls back to the compositor outside kXr", "[gpu][quad_layer][native]")
 {
     // The native OpenXR quad path only engages in a kXr session (needs a
     // live runtime, validated manually against CloudXR). In offscreen the
@@ -515,7 +515,7 @@ TEST_CASE("QuadLayer native_composition falls back to the compositor outside kXr
     QuadLayer::Config layer_cfg;
     layer_cfg.name = "native_fallback";
     layer_cfg.resolution = { kSide, kSide };
-    layer_cfg.native_composition = true; // ignored outside kXr
+    layer_cfg.openxr_composition = true; // ignored outside kXr
     // Placement is provided (a kXr native quad requires it); offscreen
     // ignores it and draws fullscreen.
     QuadLayer::Config::Placement pl;

--- a/src/viz/session_tests/cpp/test_quad_milestone.cpp
+++ b/src/viz/session_tests/cpp/test_quad_milestone.cpp
@@ -489,7 +489,7 @@ TEST_CASE("QuadLayer fast producer: render samples only the latest publish", "[g
     CHECK(sample.a == expected.a);
 }
 
-TEST_CASE("QuadLayer use_openxr_quad_layer falls back to the compositor outside kXr", "[gpu][quad_layer][native]")
+TEST_CASE("QuadLayer native_composition falls back to the compositor outside kXr", "[gpu][quad_layer][native]")
 {
     // The native OpenXR quad path only engages in a kXr session (needs a
     // live runtime, validated manually against CloudXR). In offscreen the
@@ -515,7 +515,7 @@ TEST_CASE("QuadLayer use_openxr_quad_layer falls back to the compositor outside 
     QuadLayer::Config layer_cfg;
     layer_cfg.name = "native_fallback";
     layer_cfg.resolution = { kSide, kSide };
-    layer_cfg.use_openxr_quad_layer = true; // ignored outside kXr
+    layer_cfg.native_composition = true; // ignored outside kXr
     // Placement is provided (a kXr native quad requires it); offscreen
     // ignores it and draws fullscreen.
     QuadLayer::Config::Placement pl;

--- a/src/viz/xr/cpp/inc/viz/xr/openxr_session.hpp
+++ b/src/viz/xr/cpp/inc/viz/xr/openxr_session.hpp
@@ -90,6 +90,17 @@ public:
         return has_depth_composition_layer_;
     }
 
+    // True iff the shaped composition-layer extension is enabled. Drives
+    // whether XrBackend accepts CylinderLayer / EquirectLayer.
+    bool has_cylinder_composition_layer() const noexcept
+    {
+        return has_cylinder_composition_layer_;
+    }
+    bool has_equirect2_composition_layer() const noexcept
+    {
+        return has_equirect2_composition_layer_;
+    }
+
     // True iff XR_KHR_convert_timespec_time is enabled. When false the
     // conversion methods throw. CLOCK_MONOTONIC == steady_clock on Linux.
     bool has_time_conversion() const noexcept
@@ -199,6 +210,8 @@ private:
     InstanceHandle instance_{ nullptr, nullptr };
     XrSystemId system_id_ = XR_NULL_SYSTEM_ID;
     bool has_depth_composition_layer_ = false;
+    bool has_cylinder_composition_layer_ = false;
+    bool has_equirect2_composition_layer_ = false;
     bool has_time_conversion_ = false;
     // Type-erased so this header doesn't need XR_USE_TIMESPEC; .cpp casts back.
     PFN_xrVoidFunction xr_convert_timespec_time_to_time_ = nullptr;

--- a/src/viz/xr/cpp/openxr_session.cpp
+++ b/src/viz/xr/cpp/openxr_session.cpp
@@ -76,6 +76,8 @@ void OpenXrSession::create_instance(const std::string& app_name, const std::vect
     }
     const bool runtime_has_depth_layer = available_exts.count(XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME) > 0;
     const bool runtime_has_time_conversion = available_exts.count(XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME) > 0;
+    const bool runtime_has_cylinder_layer = available_exts.count(XR_KHR_COMPOSITION_LAYER_CYLINDER_EXTENSION_NAME) > 0;
+    const bool runtime_has_equirect2_layer = available_exts.count(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME) > 0;
 
     // Build the request list deduped: required → opt-in → caller extras.
     // Caller extras are validated; passing an unsupported one is fatal.
@@ -96,6 +98,17 @@ void OpenXrSession::create_instance(const std::string& app_name, const std::vect
     if (runtime_has_time_conversion)
     {
         add_unique(XR_KHR_CONVERT_TIMESPEC_TIME_EXTENSION_NAME);
+    }
+    // Shaped composition layers (CylinderLayer / EquirectLayer). Opt-in
+    // when advertised; layers requiring them are rejected at add_layer
+    // when the runtime lacks the extension.
+    if (runtime_has_cylinder_layer)
+    {
+        add_unique(XR_KHR_COMPOSITION_LAYER_CYLINDER_EXTENSION_NAME);
+    }
+    if (runtime_has_equirect2_layer)
+    {
+        add_unique(XR_KHR_COMPOSITION_LAYER_EQUIRECT2_EXTENSION_NAME);
     }
     for (const auto& e : extra_extensions)
     {
@@ -118,6 +131,8 @@ void OpenXrSession::create_instance(const std::string& app_name, const std::vect
     check_xr(xrCreateInstance(&info, &raw_instance), "xrCreateInstance");
     instance_ = InstanceHandle(raw_instance, &xrDestroyInstance);
     has_depth_composition_layer_ = runtime_has_depth_layer;
+    has_cylinder_composition_layer_ = runtime_has_cylinder_layer;
+    has_equirect2_composition_layer_ = runtime_has_equirect2_layer;
 
     // Resolve PFNs only if both succeed — leave the feature off rather
     // than half-working.


### PR DESCRIPTION
Generalizes Televiz's native OpenXR quad path into shaped composition layers, makes native
  composition the default, and unblocks CloudXR's client-reconstructed streaming.

  - **`CylinderLayer` / `EquirectLayer`** — CUDA-fed textures submitted natively as
    `XrCompositionLayerCylinderKHR` / `XrCompositionLayerEquirect2KHR` (native-only; rejected at
    `add_layer` outside kXr or without the runtime extension). Validation follows each spec;
    equirect defaults to a full 360°×180° infinite sphere.
  - **`ImageLayerBase`** — QuadLayer's CUDA mailbox extracted and shared by all texture layers.
  - **BREAKING: `use_openxr_quad_layer` → `native_composition`, default `true`** — XR quads are
    native by default; `false` opts back into the compositor (needed for ProjectionLayer
    z-compositing). Window/offscreen always composite.
  - **Per-layer `alpha_blend` (default off)** replaces the session-global passthrough source-alpha
    flag. Opaque layers now stay eligible for CloudXR's client-reconstructed streaming (which
    excludes source-alpha layers) even in ALPHA_BLEND sessions; translucent content opts in.
  - **`stereo_baseline_mm` on all three shapes** — shape-agnostic per-eye pose shift (no-op at
    infinite equirect radius).
  - **camera_viz** — launches the in-process CloudXR runtime by default; surface options live in
    the YAML per camera (`display.placements.<name>.shape/native/cylinder_radius_m/…`), so one
    config can mix shapes; all placement lock modes drive cylinders (`head` = gaze-tracking curved
    visor). Docs: new Televiz "Native OpenXR composition layers" section + camera-streaming updates.

  ## Testing

  Full viz suites (Release + ASAN+UBSAN) and Python binding tests pass; new unit/GPU tests cover
  placement validation, acquire semantics, alpha/baseline plumbing, and non-XR rejection. Verified
  on headset against CloudXR 6.3 launched in-process: quad/cylinder/equirect, mixed frames, all
  lock modes, compositor opt-out. `pre-commit` clean; commits DCO-signed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cylindrical and equirectangular display layers for XR experiences, including stereo support and configurable geometry.
  * Added native OpenXR composition for quad, cylinder, and equirectangular layers when supported by the runtime.
  * Added Python APIs and camera example configuration for selecting layer shapes, placement, and native composition.
  * XR mode now launches the bundled CloudXR runtime and WSS proxy by default.

* **Documentation**
  * Expanded Televiz and camera-streaming guides with layer options, runtime behavior, configuration examples, and troubleshooting details.

* **Bug Fixes**
  * Improved XR placement handling, validation, layer compatibility checks, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->