### PR TITLE
feat(client): show host workstation notices in the teleop UI

### DIFF
--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -70,6 +70,7 @@ import { RecorderComponent } from './RecorderComponent';
 import { RecorderProvider, useRecorder } from './RecorderContext';
 import { SuppressWebGLRendererWhenHeadless } from './SuppressWebGLRendererWhenHeadless';
 import { TraceVisualization } from './TraceVisualization';
+import { SystemNotice, formatSystemNotice, isSystemNoticeMessage } from './types/serverMessages';
 
 // Performance metrics signals - raw numeric data backing the in-XR HUD.
 // Signals update their value without triggering React re-renders.
@@ -123,6 +124,25 @@ function resolveStreamTestSeconds(configured: number | undefined): number {
   const seconds = configured ?? DEFAULT_STREAM_TEST_SECONDS;
   return Math.min(MAX_STREAM_TEST_SECONDS, Math.max(MIN_STREAM_TEST_SECONDS, seconds));
 }
+
+// Advisory pushed by the host when its workstation is below the recommended
+// teleop spec. Held in a signal so the in-XR banner updates without a React
+// re-render, matching the metrics signals above.
+const systemNotice = signal<SystemNotice | null>(null);
+const systemNoticeTitleText = computed(() => systemNotice.value?.title ?? '');
+const systemNoticeBodyText = computed(() =>
+  systemNotice.value
+    ? [
+        systemNotice.value.summary,
+        ...systemNotice.value.items.map(
+          item => `- ${item.name}: ${item.actual} (need ${item.required})`
+        ),
+      ].join('\n')
+    : ''
+);
+
+/** How long the in-XR notice stays up before dismissing itself [ms]. */
+const SYSTEM_NOTICE_AUTO_DISMISS_MS = 20000;
 
 const CONTROL_PANEL_LAYOUT = {
   distance: 1.8,
@@ -655,6 +675,66 @@ function AppContent() {
   };
 
   /**
+   * Dispatch a message received from the server on the teleop channel.
+   *
+   * Unknown `type` values are logged and ignored rather than treated as errors:
+   * the host and this client version independently, so a newer host may send
+   * message kinds this build does not know about.
+   */
+  const systemNoticeTimerRef = useRef<number | null>(null);
+  // Signal writes deliberately bypass React, so the banner's *text* updates
+  // without a re-render -- but its presence must be React state, or mounting and
+  // unmounting it would never happen.
+  const [systemNoticeVisible, setSystemNoticeVisible] = useState(false);
+
+  /** Take the notice down and cancel any pending auto-dismiss. */
+  const dismissSystemNotice = () => {
+    systemNotice.value = null;
+    setSystemNoticeVisible(false);
+    if (systemNoticeTimerRef.current !== null) {
+      clearTimeout(systemNoticeTimerRef.current);
+      systemNoticeTimerRef.current = null;
+    }
+  };
+
+  const handleServerMessage = (message: unknown) => {
+    if (isSystemNoticeMessage(message)) {
+      const notice = message.message;
+      // Nothing to show if the host reported no unmet requirements.
+      if (notice.items.length === 0) return;
+
+      systemNotice.value = notice;
+      setSystemNoticeVisible(true);
+      // Restart the countdown so a second notice gets its full dwell time.
+      if (systemNoticeTimerRef.current !== null) {
+        clearTimeout(systemNoticeTimerRef.current);
+      }
+      systemNoticeTimerRef.current = window.setTimeout(() => {
+        systemNotice.value = null;
+        setSystemNoticeVisible(false);
+        systemNoticeTimerRef.current = null;
+      }, SYSTEM_NOTICE_AUTO_DISMISS_MS);
+
+      // Mirror to the 2D banner so the notice is visible when testing from a
+      // desktop browser, where the in-XR panel never renders.
+      cloudXR2DUI?.showStatus(
+        formatSystemNotice(notice),
+        notice.level === 'warning' ? 'error' : 'info'
+      );
+      return;
+    }
+
+    const type = (message as { type?: unknown })?.type;
+    console.info(`Ignoring server message of unhandled type: ${String(type)}`);
+  };
+
+  // The receive loop below is created once per session and lives for its whole
+  // duration, so it must not capture this handler directly -- that would pin the
+  // first render's `cloudXR2DUI`. Route through a ref that each render refreshes.
+  const handleServerMessageRef = useRef(handleServerMessage);
+  handleServerMessageRef.current = handleServerMessage;
+
+  /**
    * Helper to send a message using MessageChannel API (new) or legacy API (fallback).
    * Looks for the teleop_command channel by UUID, then falls back to legacy API.
    */
@@ -806,6 +886,9 @@ function AppContent() {
     setIsCountingDown(false);
     setCountdownRemaining(0);
     setIsTeleopRunning(false);
+    // The notice describes the host we are leaving; it must not persist into a
+    // later connection to a different one.
+    dismissSystemNotice();
 
     // Close message channels before ending XR session to avoid
     // "Cannot send control message" errors during SDK cleanup.
@@ -974,7 +1057,7 @@ function AppContent() {
               try {
                 const message = JSON.parse(messageText);
                 console.info('Parsed message:', message);
-                // Handle message here if needed
+                handleServerMessageRef.current(message);
               } catch {
                 console.info('Non-JSON message:', messageText);
               }
@@ -1101,6 +1184,10 @@ function AppContent() {
                   streamTestText={streamTestText}
                   streamTestColor={streamTestColor}
                   showRecordingControls={config.showRecordingControls}
+                  systemNoticeTitleText={systemNoticeTitleText}
+                  systemNoticeBodyText={systemNoticeBodyText}
+                  systemNoticeVisible={systemNoticeVisible}
+                  onDismissSystemNotice={dismissSystemNotice}
                 />
               )}
             </>

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -70,7 +70,12 @@ import { RecorderComponent } from './RecorderComponent';
 import { RecorderProvider, useRecorder } from './RecorderContext';
 import { SuppressWebGLRendererWhenHeadless } from './SuppressWebGLRendererWhenHeadless';
 import { TraceVisualization } from './TraceVisualization';
-import { SystemNotice, formatSystemNotice, isSystemNoticeMessage } from './types/serverMessages';
+import {
+  SystemNotice,
+  formatSystemNotice,
+  formatSystemNoticeBody,
+  isSystemNoticeMessage,
+} from './types/serverMessages';
 
 // Performance metrics signals - raw numeric data backing the in-XR HUD.
 // Signals update their value without triggering React re-renders.
@@ -130,15 +135,11 @@ function resolveStreamTestSeconds(configured: number | undefined): number {
 // re-render, matching the metrics signals above.
 const systemNotice = signal<SystemNotice | null>(null);
 const systemNoticeTitleText = computed(() => systemNotice.value?.title ?? '');
+// Shares formatSystemNoticeBody with the 2D banner rather than formatting here,
+// so the in-headset text cannot drift from what a desktop tester sees -- notably
+// the per-item remediation hint, which is the most actionable part of a notice.
 const systemNoticeBodyText = computed(() =>
-  systemNotice.value
-    ? [
-        systemNotice.value.summary,
-        ...systemNotice.value.items.map(
-          item => `- ${item.name}: ${item.actual} (need ${item.required})`
-        ),
-      ].join('\n')
-    : ''
+  systemNotice.value ? formatSystemNoticeBody(systemNotice.value) : ''
 );
 
 /** How long the in-XR notice stays up before dismissing itself [ms]. */

--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -675,37 +675,61 @@ function AppContent() {
     setCloudXRSession(session);
   };
 
-  /**
-   * Dispatch a message received from the server on the teleop channel.
-   *
-   * Unknown `type` values are logged and ignored rather than treated as errors:
-   * the host and this client version independently, so a newer host may send
-   * message kinds this build does not know about.
-   */
   const systemNoticeTimerRef = useRef<number | null>(null);
   // Signal writes deliberately bypass React, so the banner's *text* updates
   // without a re-render -- but its presence must be React state, or mounting and
   // unmounting it would never happen.
   const [systemNoticeVisible, setSystemNoticeVisible] = useState(false);
+  // Level drives the XR banner palette. Kept as React state next to the
+  // visibility flag rather than read off the signal, because the banner picks
+  // static colors at render time rather than subscribing.
+  const [systemNoticeLevel, setSystemNoticeLevel] = useState<'warning' | 'info'>('warning');
 
-  /** Take the notice down and cancel any pending auto-dismiss. */
+  /** Take the notice down, in both surfaces, and cancel any pending auto-dismiss. */
   const dismissSystemNotice = () => {
     systemNotice.value = null;
     setSystemNoticeVisible(false);
+    // showStatus() sets .show and never clears itself, so without this the 2D
+    // status box keeps the notice after dismissal, after the timeout, and
+    // across a disconnect into the next connection.
+    cloudXR2DUI?.hideError();
     if (systemNoticeTimerRef.current !== null) {
       clearTimeout(systemNoticeTimerRef.current);
       systemNoticeTimerRef.current = null;
     }
   };
 
+  // [4] Cancel a pending auto-dismiss if the app tears down first; otherwise the
+  // timeout fires setSystemNoticeVisible on an unmounted component.
+  useEffect(
+    () => () => {
+      if (systemNoticeTimerRef.current !== null) {
+        clearTimeout(systemNoticeTimerRef.current);
+      }
+    },
+    []
+  );
+
+  /**
+   * Dispatch a message received from the server on the teleop channel.
+   *
+   * Unknown `type` values are logged and ignored rather than treated as errors:
+   * the host and this client are versioned independently, so a newer host may
+   * send message kinds this build does not know about.
+   */
   const handleServerMessage = (message: unknown) => {
     if (isSystemNoticeMessage(message)) {
       const notice = message.message;
-      // Nothing to show if the host reported no unmet requirements.
-      if (notice.items.length === 0) return;
+      // No unmet requirements: treat it as an all-clear so a host can retract a
+      // notice it raised earlier, rather than leaving a stale banner up.
+      if (notice.items.length === 0) {
+        dismissSystemNotice();
+        return;
+      }
 
       systemNotice.value = notice;
       setSystemNoticeVisible(true);
+      setSystemNoticeLevel(notice.level);
       // Restart the countdown so a second notice gets its full dwell time.
       if (systemNoticeTimerRef.current !== null) {
         clearTimeout(systemNoticeTimerRef.current);
@@ -1188,6 +1212,7 @@ function AppContent() {
                   systemNoticeTitleText={systemNoticeTitleText}
                   systemNoticeBodyText={systemNoticeBodyText}
                   systemNoticeVisible={systemNoticeVisible}
+                  systemNoticeLevel={systemNoticeLevel}
                   onDismissSystemNotice={dismissSystemNotice}
                 />
               )}

--- a/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
@@ -285,6 +285,10 @@ export default function CloudXR3DUI({
   const isMinimizedLayout = isCompact || panelHidden;
   const handleWidth = panelHidden ? 0.12 : isCompact ? 0.28 : 1.0;
   const handleY = panelHidden ? -0.065 : isCompact ? -0.15 : -0.42;
+  // Sit the workstation notice just above the panel's top edge. The panel is
+  // centred on the group, so its top is sizeY/2 and the clearance has to track
+  // whichever of the three sizes is showing.
+  const noticeY = panelHidden ? 0.42 : isCompact ? 0.6 : 1.5;
 
   // Face-camera rotation: smoothly rotate UI to face the user (Y-axis only)
   useFrame((state, dt) => {
@@ -625,15 +629,6 @@ export default function CloudXR3DUI({
                   Controls
                 </Text>
 
-                {/* Workstation spec advisory pushed by the host */}
-                {systemNoticeVisible && (
-                  <SystemNoticeBanner
-                    titleText={systemNoticeTitleText}
-                    bodyText={systemNoticeBodyText}
-                    onDismiss={onDismissSystemNotice}
-                  />
-                )}
-
                 {/* Server Info */}
                 <Container
                   flexDirection="column"
@@ -813,6 +808,36 @@ export default function CloudXR3DUI({
             </Container>
           )}
         </Container>
+
+        {/* Workstation advisory from the host.
+            Deliberately a sibling of the control panel rather than content
+            inside it: the panel collapses to compact when "minimize on play"
+            fires, and to a bare Show button when hidden, either of which would
+            swallow the warning at exactly the moment the operator is working.
+            As its own window it stays visible in all three panel states, while
+            still riding the panel's drag position and face-camera rotation so
+            it appears where the operator already put their UI. */}
+        {systemNoticeVisible && (
+          <group position={[0, noticeY, 0]}>
+            <Container
+              pixelSize={0.001}
+              width={1400}
+              height={340}
+              alignItems="center"
+              justifyContent="center"
+              pointerEvents="auto"
+              sizeX={2.33}
+              sizeY={0.57}
+              flexDirection="column"
+            >
+              <SystemNoticeBanner
+                titleText={systemNoticeTitleText}
+                bodyText={systemNoticeBodyText}
+                onDismiss={onDismissSystemNotice}
+              />
+            </Container>
+          </group>
+        )}
       </group>
     </HandleTarget>
   );

--- a/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
@@ -100,6 +100,8 @@ interface CloudXRUIProps {
   systemNoticeBodyText?: ReadonlySignal<string>;
   /** Whether a workstation notice is currently active. */
   systemNoticeVisible?: boolean;
+  /** Severity of the active notice; selects the banner palette. */
+  systemNoticeLevel?: 'warning' | 'info';
   /** Dismiss the workstation notice. */
   onDismissSystemNotice?: () => void;
 }
@@ -112,15 +114,32 @@ interface CloudXRUIProps {
  * times out on its own. Text comes in as signals so updates bypass React,
  * matching how the performance metrics are rendered.
  */
+/** Palette per notice level, so an informational notice does not read as a warning. */
+const SYSTEM_NOTICE_PALETTE = {
+  warning: {
+    border: 'rgba(255, 193, 7, 0.9)',
+    background: 'rgba(80, 60, 0, 0.85)',
+    title: 'rgba(255, 213, 79, 1)',
+  },
+  info: {
+    border: 'rgba(66, 165, 245, 0.9)',
+    background: 'rgba(10, 45, 80, 0.85)',
+    title: 'rgba(144, 202, 249, 1)',
+  },
+} as const;
+
 function SystemNoticeBanner({
   titleText,
   bodyText,
+  level = 'warning',
   onDismiss,
 }: {
   titleText?: ReadonlySignal<string>;
   bodyText?: ReadonlySignal<string>;
+  level?: 'warning' | 'info';
   onDismiss?: () => void;
 }) {
+  const palette = SYSTEM_NOTICE_PALETTE[level];
   const xrButton = useXRButton();
   return (
     <Container
@@ -132,11 +151,11 @@ function SystemNoticeBanner({
       marginBottom={8}
       borderRadius={12}
       borderWidth={2}
-      borderColor="rgba(255, 193, 7, 0.9)"
-      backgroundColor="rgba(80, 60, 0, 0.85)"
+      borderColor={palette.border}
+      backgroundColor={palette.background}
     >
       <Container flexDirection="column" gap={6} flexGrow={1}>
-        <Text fontSize={34} fontWeight="bold" color="rgba(255, 213, 79, 1)">
+        <Text fontSize={34} fontWeight="bold" color={palette.title}>
           {titleText}
         </Text>
         {/* whiteSpace="pre-line" is required, not cosmetic: uikit's default
@@ -243,6 +262,7 @@ export default function CloudXR3DUI({
   systemNoticeTitleText,
   systemNoticeBodyText,
   systemNoticeVisible = false,
+  systemNoticeLevel = 'warning',
   onDismissSystemNotice,
 }: CloudXRUIProps) {
   const recorder = useRecorder();
@@ -642,6 +662,7 @@ export default function CloudXR3DUI({
                   <SystemNoticeBanner
                     titleText={systemNoticeTitleText}
                     bodyText={systemNoticeBodyText}
+                    level={systemNoticeLevel}
                     onDismiss={onDismissSystemNotice}
                   />
                 )}
@@ -853,6 +874,7 @@ export default function CloudXR3DUI({
               <SystemNoticeBanner
                 titleText={systemNoticeTitleText}
                 bodyText={systemNoticeBodyText}
+                level={systemNoticeLevel}
                 onDismiss={onDismissSystemNotice}
               />
             </Container>

--- a/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
@@ -94,6 +94,70 @@ interface CloudXRUIProps {
   isXRMode?: boolean;
   /** Show input recording controls in the XR panel. */
   showRecordingControls?: boolean;
+  /** Computed signal for the workstation notice title; empty when no notice is active. */
+  systemNoticeTitleText?: ReadonlySignal<string>;
+  /** Computed signal for the workstation notice body (one unmet requirement per line). */
+  systemNoticeBodyText?: ReadonlySignal<string>;
+  /** Whether a workstation notice is currently active. */
+  systemNoticeVisible?: boolean;
+  /** Dismiss the workstation notice. */
+  onDismissSystemNotice?: () => void;
+}
+
+/**
+ * Warning banner shown in-headset when the host reports that its workstation is
+ * below the recommended teleop spec.
+ *
+ * Advisory only: it never blocks the session, so it is dismissible and also
+ * times out on its own. Text comes in as signals so updates bypass React,
+ * matching how the performance metrics are rendered.
+ */
+function SystemNoticeBanner({
+  titleText,
+  bodyText,
+  onDismiss,
+}: {
+  titleText?: ReadonlySignal<string>;
+  bodyText?: ReadonlySignal<string>;
+  onDismiss?: () => void;
+}) {
+  const xrButton = useXRButton();
+  return (
+    <Container
+      flexDirection="row"
+      gap={16}
+      alignItems="center"
+      justifyContent="space-between"
+      padding={16}
+      marginBottom={8}
+      borderRadius={12}
+      borderWidth={2}
+      borderColor="rgba(255, 193, 7, 0.9)"
+      backgroundColor="rgba(80, 60, 0, 0.85)"
+    >
+      <Container flexDirection="column" gap={6} flexGrow={1}>
+        <Text fontSize={34} fontWeight="bold" color="rgba(255, 213, 79, 1)">
+          {titleText}
+        </Text>
+        <Text fontSize={28} color="rgba(240, 240, 240, 1)">
+          {bodyText}
+        </Text>
+      </Container>
+      <Button
+        {...xrButton('system-notice-dismiss', onDismiss ?? (() => {}))}
+        variant="default"
+        width={80}
+        height={64}
+        borderRadius={16}
+        backgroundColor="rgba(220, 220, 220, 0.9)"
+        hover={{ backgroundColor: 'rgba(100, 150, 255, 1)', borderColor: 'white', borderWidth: 2 }}
+      >
+        <Text fontSize={32} color="black" fontWeight="bold">
+          X
+        </Text>
+      </Button>
+    </Container>
+  );
 }
 
 // Reusable objects for face-camera rotation (avoid allocations in render loop)
@@ -172,6 +236,10 @@ export default function CloudXR3DUI({
   panelHiddenAtStart = false,
   isXRMode = false,
   showRecordingControls = false,
+  systemNoticeTitleText,
+  systemNoticeBodyText,
+  systemNoticeVisible = false,
+  onDismissSystemNotice,
 }: CloudXRUIProps) {
   const recorder = useRecorder();
   const MINIMIZE_ON_PLAY_KEY = 'cxr.isaac.minimizeOnPlay';
@@ -556,6 +624,15 @@ export default function CloudXR3DUI({
                 <Text fontSize={72} fontWeight="bold" color="white" textAlign="center">
                   Controls
                 </Text>
+
+                {/* Workstation spec advisory pushed by the host */}
+                {systemNoticeVisible && (
+                  <SystemNoticeBanner
+                    titleText={systemNoticeTitleText}
+                    bodyText={systemNoticeBodyText}
+                    onDismiss={onDismissSystemNotice}
+                  />
+                )}
 
                 {/* Server Info */}
                 <Container

--- a/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
@@ -139,7 +139,11 @@ function SystemNoticeBanner({
         <Text fontSize={34} fontWeight="bold" color="rgba(255, 213, 79, 1)">
           {titleText}
         </Text>
-        <Text fontSize={28} color="rgba(240, 240, 240, 1)">
+        {/* whiteSpace="pre-line" is required, not cosmetic: uikit's default
+            normalization collapses every run of whitespace -- newlines
+            included -- into a single space, which would run the summary, each
+            unmet requirement, and its fix together on one unreadable line. */}
+        <Text fontSize={28} color="rgba(240, 240, 240, 1)" whiteSpace="pre-line">
           {bodyText}
         </Text>
       </Container>

--- a/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXRUI.tsx
@@ -289,10 +289,13 @@ export default function CloudXR3DUI({
   const isMinimizedLayout = isCompact || panelHidden;
   const handleWidth = panelHidden ? 0.12 : isCompact ? 0.28 : 1.0;
   const handleY = panelHidden ? -0.065 : isCompact ? -0.15 : -0.42;
-  // Sit the workstation notice just above the panel's top edge. The panel is
-  // centred on the group, so its top is sizeY/2 and the clearance has to track
-  // whichever of the three sizes is showing.
-  const noticeY = panelHidden ? 0.42 : isCompact ? 0.6 : 1.5;
+  // The notice only floats when the panel is collapsed; the full panel renders
+  // it inline. Clearing the top edge of a 2.33-unit-tall panel would put the
+  // notice about a metre above the operator's head, out of view entirely --
+  // floating is what keeps it visible when the panel is small, not a layout
+  // that makes sense at full size.
+  const noticeFloats = panelHidden || isCompact;
+  const noticeY = panelHidden ? 0.42 : 0.6;
 
   // Face-camera rotation: smoothly rotate UI to face the user (Y-axis only)
   useFrame((state, dt) => {
@@ -633,6 +636,16 @@ export default function CloudXR3DUI({
                   Controls
                 </Text>
 
+                {/* Workstation advisory, inline while the panel is full size.
+                    See the floating copy below for the collapsed states. */}
+                {systemNoticeVisible && !noticeFloats && (
+                  <SystemNoticeBanner
+                    titleText={systemNoticeTitleText}
+                    bodyText={systemNoticeBodyText}
+                    onDismiss={onDismissSystemNotice}
+                  />
+                )}
+
                 {/* Server Info */}
                 <Container
                   flexDirection="column"
@@ -813,15 +826,18 @@ export default function CloudXR3DUI({
           )}
         </Container>
 
-        {/* Workstation advisory from the host.
-            Deliberately a sibling of the control panel rather than content
-            inside it: the panel collapses to compact when "minimize on play"
-            fires, and to a bare Show button when hidden, either of which would
-            swallow the warning at exactly the moment the operator is working.
-            As its own window it stays visible in all three panel states, while
-            still riding the panel's drag position and face-camera rotation so
-            it appears where the operator already put their UI. */}
-        {systemNoticeVisible && (
+        {/* Workstation advisory from the host, in its floating form.
+            The panel collapses to compact when "minimize on play" fires, and to
+            a bare Show button when hidden -- either would swallow the warning at
+            exactly the moment the operator is working. Rendering it as a sibling
+            of the panel keeps it visible in those states, while it still rides
+            the panel's drag position and face-camera rotation so it appears
+            where the operator already put their UI.
+
+            The full panel renders the notice inline instead: it is 2.33 units
+            tall, so a floating notice clearing its top edge would sit about a
+            metre above the operator's head. */}
+        {systemNoticeVisible && noticeFloats && (
           <group position={[0, noticeY, 0]}>
             <Container
               pixelSize={0.001}

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -641,6 +641,10 @@ limitations under the License.
         font-size: 0.9rem;
         font-weight: 500;
         line-height: 1.4;
+        /* Messages are set via textContent and separate entries with newlines
+           (browser capability failures, host workstation notices), so newlines
+           must render while long lines still wrap. */
+        white-space: pre-line;
       }
 
       .error-message-box.show {

--- a/deps/cloudxr/webxr_client/src/types/serverMessages.test.ts
+++ b/deps/cloudxr/webxr_client/src/types/serverMessages.test.ts
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { formatSystemNotice, isSystemNoticeMessage, SystemNotice } from './serverMessages';
+
+/** A well-formed notice, matching what the Isaac Lab host sends. */
+const validNotice = (): SystemNotice => ({
+  level: 'warning',
+  title: 'Workstation below recommended spec',
+  summary: 'Teleoperation may run below the 45 FPS target.',
+  items: [
+    {
+      name: 'CPU governor',
+      actual: 'powersave',
+      required: 'performance',
+      detail: 'sudo cpupower frequency-set -g performance',
+    },
+  ],
+  doc_url: 'https://example.invalid/docs',
+});
+
+const validMessage = () => ({ type: 'system_notice', message: validNotice() });
+
+describe('isSystemNoticeMessage', () => {
+  it('accepts a well-formed notice', () => {
+    expect(isSystemNoticeMessage(validMessage())).toBe(true);
+  });
+
+  it('accepts a notice with no items and no optional fields', () => {
+    expect(
+      isSystemNoticeMessage({
+        type: 'system_notice',
+        message: { level: 'info', title: 't', summary: 's', items: [] },
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    ['a non-object', 42],
+    ['null', null],
+    ['undefined', undefined],
+    ['an array', []],
+  ])('rejects %s', (_label, value) => {
+    expect(isSystemNoticeMessage(value)).toBe(false);
+  });
+
+  it.each([
+    ['another message type', { type: 'teleop_command', message: validNotice() }],
+    ['a missing type', { message: validNotice() }],
+    ['a missing message body', { type: 'system_notice' }],
+    ['a null message body', { type: 'system_notice', message: null }],
+    ['a non-object message body', { type: 'system_notice', message: 'nope' }],
+  ])('rejects %s', (_label, value) => {
+    expect(isSystemNoticeMessage(value)).toBe(false);
+  });
+
+  it.each([
+    ['an unknown level', { level: 'catastrophe' }],
+    ['a missing level', { level: undefined }],
+    ['a non-string title', { title: 7 }],
+    ['a missing title', { title: undefined }],
+    ['a non-string summary', { summary: {} }],
+    ['a non-array items', { items: 'none' }],
+    ['a missing items', { items: undefined }],
+    ['a non-string doc_url', { doc_url: 3 }],
+  ])('rejects %s', (_label, override) => {
+    expect(isSystemNoticeMessage({ type: 'system_notice', message: { ...validNotice(), ...override } })).toBe(
+      false
+    );
+  });
+
+  // The XR panel dereferences every item field while rendering, so a bad item
+  // must be rejected here rather than thrown from inside the render loop.
+  it.each([
+    ['a null item', [null]],
+    ['an undefined item', [undefined]],
+    ['a non-object item', ['CPU governor']],
+    ['an item missing name', [{ actual: 'a', required: 'r' }]],
+    ['an item missing actual', [{ name: 'n', required: 'r' }]],
+    ['an item missing required', [{ name: 'n', actual: 'a' }]],
+    ['an item with a non-string name', [{ name: 1, actual: 'a', required: 'r' }]],
+    ['an item with a non-string detail', [{ name: 'n', actual: 'a', required: 'r', detail: 5 }]],
+    ['one bad item among good ones', [{ name: 'n', actual: 'a', required: 'r' }, null]],
+  ])('rejects %s', (_label, items) => {
+    expect(isSystemNoticeMessage({ type: 'system_notice', message: { ...validNotice(), items } })).toBe(false);
+  });
+
+  it('accepts an item without the optional detail', () => {
+    const items = [{ name: 'n', actual: 'a', required: 'r' }];
+    expect(isSystemNoticeMessage({ type: 'system_notice', message: { ...validNotice(), items } })).toBe(true);
+  });
+});
+
+describe('formatSystemNotice', () => {
+  it('renders every accepted notice without throwing', () => {
+    const text = formatSystemNotice(validNotice());
+    expect(text).toContain('Workstation below recommended spec');
+    expect(text).toContain('CPU governor: powersave (need performance)');
+    expect(text).toContain('sudo cpupower frequency-set -g performance');
+    expect(text).toContain('https://example.invalid/docs');
+  });
+
+  it('separates entries with newlines for the pre-line status box', () => {
+    expect(formatSystemNotice(validNotice()).split('\n').length).toBeGreaterThan(1);
+  });
+
+  it('omits optional fields that are absent', () => {
+    const notice: SystemNotice = {
+      level: 'info',
+      title: 't',
+      summary: 's',
+      items: [{ name: 'n', actual: 'a', required: 'r' }],
+    };
+    expect(formatSystemNotice(notice)).toBe('t\ns\n• n: a (need r)');
+  });
+});

--- a/deps/cloudxr/webxr_client/src/types/serverMessages.test.ts
+++ b/deps/cloudxr/webxr_client/src/types/serverMessages.test.ts
@@ -15,7 +15,12 @@
  * limitations under the License.
  */
 
-import { formatSystemNotice, isSystemNoticeMessage, SystemNotice } from './serverMessages';
+import {
+  formatSystemNotice,
+  formatSystemNoticeBody,
+  isSystemNoticeMessage,
+  SystemNotice,
+} from './serverMessages';
 
 /** A well-formed notice, matching what the Isaac Lab host sends. */
 const validNotice = (): SystemNotice => ({
@@ -105,11 +110,49 @@ describe('isSystemNoticeMessage', () => {
   });
 });
 
+describe('formatSystemNoticeBody', () => {
+  // The XR panel styles the title separately and renders only this body, so
+  // anything missing here is invisible to the operator wearing the headset --
+  // the primary display surface for this feature.
+  it('includes the remediation hint for each item', () => {
+    expect(formatSystemNoticeBody(validNotice())).toContain(
+      'sudo cpupower frequency-set -g performance'
+    );
+  });
+
+  it('includes the documentation link', () => {
+    expect(formatSystemNoticeBody(validNotice())).toContain('https://example.invalid/docs');
+  });
+
+  it('omits the title, which the XR panel renders separately', () => {
+    expect(formatSystemNoticeBody(validNotice())).not.toContain(
+      'Workstation below recommended spec'
+    );
+  });
+
+  it('matches the body the 2D banner shows', () => {
+    // Guards against the two surfaces drifting apart again.
+    const notice = validNotice();
+    expect(formatSystemNotice(notice)).toBe(`${notice.title}\n${formatSystemNoticeBody(notice)}`);
+  });
+
+  it('uses ASCII bullets so the MSDF font atlas can render them', () => {
+    expect(formatSystemNoticeBody(validNotice())).not.toMatch(/[\u2022\u00b7\u25aa]/);
+  });
+
+  it('separates every line with a newline for pre-line rendering', () => {
+    // uikit collapses whitespace unless whiteSpace="pre-line"; the body relies
+    // on those newlines surviving to stay readable in the headset.
+    const lines = formatSystemNoticeBody(validNotice()).split('\n');
+    expect(lines.length).toBeGreaterThanOrEqual(4); // summary + item + detail + doc_url
+  });
+});
+
 describe('formatSystemNotice', () => {
   it('renders every accepted notice without throwing', () => {
     const text = formatSystemNotice(validNotice());
     expect(text).toContain('Workstation below recommended spec');
-    expect(text).toContain('CPU governor: powersave (need performance)');
+    expect(text).toContain('- CPU governor: powersave (need performance)');
     expect(text).toContain('sudo cpupower frequency-set -g performance');
     expect(text).toContain('https://example.invalid/docs');
   });
@@ -125,6 +168,6 @@ describe('formatSystemNotice', () => {
       summary: 's',
       items: [{ name: 'n', actual: 'a', required: 'r' }],
     };
-    expect(formatSystemNotice(notice)).toBe('t\ns\n• n: a (need r)');
+    expect(formatSystemNotice(notice)).toBe('t\ns\n- n: a (need r)');
   });
 });

--- a/deps/cloudxr/webxr_client/src/types/serverMessages.ts
+++ b/deps/cloudxr/webxr_client/src/types/serverMessages.ts
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * serverMessages.ts - Types for messages the server sends to this client.
+ *
+ * These travel over the `teleop_command` CloudXR MessageChannel, the same
+ * channel this client uses to send teleop commands the other way. Every message
+ * is UTF-8 JSON carrying a `type` discriminator.
+ *
+ * Unknown `type` values must be ignored rather than treated as errors: the
+ * server and client version independently, so a newer host may send message
+ * kinds this client does not know about.
+ */
+
+/** One unmet workstation requirement reported by the host. */
+export interface SystemNoticeItem {
+  /** Requirement name, e.g. `"CPU governor"`. */
+  name: string;
+  /** The measured value on the host, e.g. `"powersave"`. */
+  actual: string;
+  /** The threshold that was not met, e.g. `"performance"`. */
+  required: string;
+  /** Optional actionable hint, e.g. a command that resolves the item. */
+  detail?: string;
+}
+
+/**
+ * Advisory from the host that its workstation is below the recommended spec
+ * for teleoperation. Informational only -- the session still runs.
+ */
+export interface SystemNotice {
+  level: 'warning' | 'info';
+  title: string;
+  summary: string;
+  items: SystemNoticeItem[];
+  /** Link to the documented requirements. */
+  doc_url?: string;
+}
+
+/** A `system_notice` message as it appears on the wire. */
+export interface SystemNoticeMessage {
+  type: 'system_notice';
+  message: SystemNotice;
+}
+
+/** Any message the server may send. Widen this union as kinds are added. */
+export type ServerMessage = SystemNoticeMessage | { type: string; message?: unknown };
+
+/** Narrow an arbitrary parsed payload to a {@link SystemNoticeMessage}. */
+export function isSystemNoticeMessage(value: unknown): value is SystemNoticeMessage {
+  if (typeof value !== 'object' || value === null) return false;
+  const candidate = value as { type?: unknown; message?: unknown };
+  if (candidate.type !== 'system_notice') return false;
+  const body = candidate.message as { items?: unknown } | undefined;
+  return typeof body === 'object' && body !== null && Array.isArray(body.items);
+}
+
+/**
+ * Render a notice as plain text for the 2D status banner.
+ *
+ * The banner sets `textContent`, so this uses newlines rather than markup; the
+ * `.error-message-box` style declares `white-space: pre-line` to preserve them.
+ */
+export function formatSystemNotice(notice: SystemNotice): string {
+  const lines = [notice.title, notice.summary];
+  for (const item of notice.items) {
+    lines.push(`• ${item.name}: ${item.actual} (need ${item.required})`);
+    if (item.detail) lines.push(`   ${item.detail}`);
+  }
+  if (notice.doc_url) lines.push(notice.doc_url);
+  return lines.join('\n');
+}

--- a/deps/cloudxr/webxr_client/src/types/serverMessages.ts
+++ b/deps/cloudxr/webxr_client/src/types/serverMessages.ts
@@ -23,7 +23,7 @@
  * is UTF-8 JSON carrying a `type` discriminator.
  *
  * Unknown `type` values must be ignored rather than treated as errors: the
- * server and client version independently, so a newer host may send message
+ * server and client are versioned independently, so a newer host may send message
  * kinds this client does not know about.
  */
 
@@ -57,9 +57,6 @@ export interface SystemNoticeMessage {
   type: 'system_notice';
   message: SystemNotice;
 }
-
-/** Any message the server may send. Widen this union as kinds are added. */
-export type ServerMessage = SystemNoticeMessage | { type: string; message?: unknown };
 
 /** Narrow an unknown value to a {@link SystemNoticeItem}. */
 function isSystemNoticeItem(value: unknown): value is SystemNoticeItem {

--- a/deps/cloudxr/webxr_client/src/types/serverMessages.ts
+++ b/deps/cloudxr/webxr_client/src/types/serverMessages.ts
@@ -103,17 +103,34 @@ export function isSystemNoticeMessage(value: unknown): value is SystemNoticeMess
 }
 
 /**
+ * Render everything below the title: the summary, one line per unmet
+ * requirement, each item's remediation hint, and the documentation link.
+ *
+ * Shared by both display surfaces. The XR panel styles the title separately
+ * from the body, so it needs the body on its own; the 2D banner appends this
+ * to the title via {@link formatSystemNotice}. Keeping one formatter is what
+ * stops the two surfaces from drifting -- the in-headset banner is the primary
+ * display, so it must not be the one missing the actionable hint.
+ *
+ * Bullets are plain ASCII on purpose: the XR text is rendered from an MSDF
+ * font atlas with no guaranteed glyph coverage for characters like `•`.
+ */
+export function formatSystemNoticeBody(notice: SystemNotice): string {
+  const lines = [notice.summary];
+  for (const item of notice.items) {
+    lines.push(`- ${item.name}: ${item.actual} (need ${item.required})`);
+    if (item.detail) lines.push(`   ${item.detail}`);
+  }
+  if (notice.doc_url) lines.push(notice.doc_url);
+  return lines.join('\n');
+}
+
+/**
  * Render a notice as plain text for the 2D status banner.
  *
  * The banner sets `textContent`, so this uses newlines rather than markup; the
  * `.error-message-box` style declares `white-space: pre-line` to preserve them.
  */
 export function formatSystemNotice(notice: SystemNotice): string {
-  const lines = [notice.title, notice.summary];
-  for (const item of notice.items) {
-    lines.push(`• ${item.name}: ${item.actual} (need ${item.required})`);
-    if (item.detail) lines.push(`   ${item.detail}`);
-  }
-  if (notice.doc_url) lines.push(notice.doc_url);
-  return lines.join('\n');
+  return `${notice.title}\n${formatSystemNoticeBody(notice)}`;
 }

--- a/deps/cloudxr/webxr_client/src/types/serverMessages.ts
+++ b/deps/cloudxr/webxr_client/src/types/serverMessages.ts
@@ -61,13 +61,45 @@ export interface SystemNoticeMessage {
 /** Any message the server may send. Widen this union as kinds are added. */
 export type ServerMessage = SystemNoticeMessage | { type: string; message?: unknown };
 
-/** Narrow an arbitrary parsed payload to a {@link SystemNoticeMessage}. */
+/** Narrow an unknown value to a {@link SystemNoticeItem}. */
+function isSystemNoticeItem(value: unknown): value is SystemNoticeItem {
+  if (typeof value !== 'object' || value === null) return false;
+  const item = value as Record<string, unknown>;
+  return (
+    typeof item.name === 'string' &&
+    typeof item.actual === 'string' &&
+    typeof item.required === 'string' &&
+    (item.detail === undefined || typeof item.detail === 'string')
+  );
+}
+
+/**
+ * Narrow an arbitrary parsed payload to a {@link SystemNoticeMessage}.
+ *
+ * Every field is validated, not just the shape of the envelope. This runs on
+ * data straight off the wire, and an accepted notice is dereferenced field by
+ * field while rendering the XR panel -- so a payload with, say, `items: [null]`
+ * or a non-string title would throw inside the render loop rather than being
+ * rejected here. Anything that does not match is ignored like an unknown
+ * message type: the session keeps running without the notice.
+ */
 export function isSystemNoticeMessage(value: unknown): value is SystemNoticeMessage {
   if (typeof value !== 'object' || value === null) return false;
   const candidate = value as { type?: unknown; message?: unknown };
   if (candidate.type !== 'system_notice') return false;
-  const body = candidate.message as { items?: unknown } | undefined;
-  return typeof body === 'object' && body !== null && Array.isArray(body.items);
+
+  const body = candidate.message;
+  if (typeof body !== 'object' || body === null) return false;
+  const notice = body as Record<string, unknown>;
+
+  return (
+    (notice.level === 'warning' || notice.level === 'info') &&
+    typeof notice.title === 'string' &&
+    typeof notice.summary === 'string' &&
+    Array.isArray(notice.items) &&
+    notice.items.every(isSystemNoticeItem) &&
+    (notice.doc_url === undefined || typeof notice.doc_url === 'string')
+  );
 }
 
 /**


### PR DESCRIPTION
## Description
The client already ran a receive loop on the teleop_command message channel, but the handler was an empty stub, so nothing the host sent was ever surfaced. Dispatch received messages by type and render a system_notice as a dismissible warning banner.

Isaac Lab uses this to report that its workstation is below the recommended spec for teleoperation (CPU single-thread throughput, frequency governor, GPU, memory). Without it the operator sees only a low frame rate and no explanation, and the terminal warning is not visible while wearing a headset.

The banner renders in XR via uikit and is mirrored to the 2D status box so it is also visible when testing from a desktop browser. Text is carried in signals so updates bypass React re-renders, matching the existing performance metrics. Unknown message types are logged and ignored, keeping this client compatible with hosts that send message kinds it does not know about.

Also set white-space: pre-line on the 2D status box. It is populated with textContent and existing callers already separate entries with newlines, which were being collapsed onto one line.

<img width="594" height="282" alt="Screenshot from 2026-07-29 17-19-55" src="https://github.com/user-attachments/assets/5ad99312-2c88-4226-a1da-349d763ba819" />


Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added system notices delivered from the server.
  * Displays notice titles, details, requirements, and documentation links in the 2D and in-headset interfaces.
  * Added a dismiss button and automatic dismissal after 20 seconds.
  * Clears active notices when disconnecting from XR.

* **Bug Fixes**
  * Invalid or unsupported server notices are safely ignored.
  * Notices no longer persist across XR connections.

* **Tests**
  * Added coverage for notice validation and formatted display content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->