### PR TITLE
Drop Python 3.10 support

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
         build_type: ["Debug", "Release"]
-        python_version: ['3.10', '3.11', '3.12', '3.13']
+        python_version: ['3.11', '3.12', '3.13']
         arch: ['x64', 'arm64']
 
     steps:
@@ -45,7 +45,7 @@ jobs:
       with:
         fetch-depth: 0 # Full history for accurate git describe
 
-    # CMakePresets.json defines one preset per supported Python (py3.10 … py3.13),
+    # CMakePresets.json defines one preset per supported Python (py3.11 … py3.13),
     # each configuring an isolated build/cmake-cpython-3XX directory. Derive the
     # preset name and its build directory once here; later steps (ctest, coverage,
     # test packaging, install) need the directory the preset chose.
@@ -590,7 +590,7 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
-        python_version: ['3.10', '3.11', '3.12', '3.13']
+        python_version: ['3.11', '3.12', '3.13']
         arch: ['x64', 'arm64']
 
     steps:

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -633,7 +633,7 @@ jobs:
     strategy:
       fail-fast: ${{ github.event_name == 'pull_request' }}
       matrix:
-        python_version: ['3.10', '3.12']
+        python_version: ['3.12']
         arch: ['x64', 'arm64']
 
     steps:
@@ -665,13 +665,17 @@ jobs:
       with:
         github-token: ${{ secrets.V2D_RETARGETER_TOKEN }}
 
+    # Each ROS distro is tied to its own system Python, so the distro follows
+    # from the matrix entry: Jazzy is 3.12. Humble would be 3.10, which is below
+    # the supported floor.
     - name: Set ROS Distro
       id: ros-distro
       run: |
-        if [ "${{ matrix.python_version }}" = "3.10" ]; then
-          echo "ROS_DISTRO=humble" >> $GITHUB_ENV
-        elif [ "${{ matrix.python_version }}" = "3.12" ]; then
+        if [ "${{ matrix.python_version }}" = "3.12" ]; then
           echo "ROS_DISTRO=jazzy" >> $GITHUB_ENV
+        else
+          echo "::error::No ROS distro mapped to Python ${{ matrix.python_version }}"
+          exit 1
         fi
 
     - name: Setup CloudXR SDK

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 # All Python-related configurations should reference this variable.
 # To change the Python version, only modify this line:
 set(ISAAC_TELEOP_PYTHON_VERSION "3.11" CACHE STRING "Python version for Isaac Teleop")
-set(ISAAC_TELEOP_PYTHON_VERSION_MIN "3.10")
+set(ISAAC_TELEOP_PYTHON_VERSION_MIN "3.11")
 set(ISAAC_TELEOP_PYTHON_VERSION_MAX_EXCLUSIVE "3.14")
 message(STATUS "Configuring for Python ${ISAAC_TELEOP_PYTHON_VERSION}")
 # ==============================================================================

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -3,12 +3,6 @@
   "cmakeMinimumRequired": { "major": 3, "minor": 21, "patch": 0 },
   "configurePresets": [
     {
-      "name": "py3.10",
-      "displayName": "Python 3.10 (build/cmake-cpython-310)",
-      "binaryDir": "${sourceDir}/build/cmake-cpython-310",
-      "cacheVariables": { "ISAAC_TELEOP_PYTHON_VERSION": "3.10" }
-    },
-    {
       "name": "py3.11",
       "displayName": "Python 3.11 (build/cmake-cpython-311)",
       "binaryDir": "${sourceDir}/build/cmake-cpython-311",
@@ -28,7 +22,6 @@
     }
   ],
   "buildPresets": [
-    { "name": "py3.10", "configurePreset": "py3.10" },
     { "name": "py3.11", "configurePreset": "py3.11" },
     { "name": "py3.12", "configurePreset": "py3.12" },
     { "name": "py3.13", "configurePreset": "py3.13" }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ SPDX-License-Identifier: Apache-2.0
 
 **The unified framework for high-fidelity ego-centric and robotics data collection.**
 
-[![Python](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
 [![Isaac Lab](https://img.shields.io/badge/Isaac%20Lab-3.0.0-orange.svg)](https://isaac-sim.github.io/IsaacLab/develop)
 [![numpy](https://img.shields.io/badge/numpy-1.23%2B-lightgrey.svg)](https://numpy.org/)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -21,7 +21,7 @@ Prerequisites
 
 - **CMake** 3.20 or higher
 - **C++20** compatible compiler
-- **Python** 3.10, 3.11, 3.12, or 3.13 (default 3.11; see ``ISAAC_TELEOP_PYTHON_VERSION`` in root ``CMakeLists.txt``)
+- **Python** 3.11, 3.12, or 3.13 (default 3.11; see ``ISAAC_TELEOP_PYTHON_VERSION`` in root ``CMakeLists.txt``)
 - **uv** for Python dependency management and managed Python
 - **Internet connection** for downloading dependencies via CMake FetchContent
 
@@ -108,7 +108,7 @@ See :ref:`dedicated-cloudxr-runtime`.
 -----------------------------
 
 From the project root, configure with a **preset** — there is one per supported
-Python version (``py3.10`` … ``py3.13``; see :code-file:`CMakePresets.json`). A
+Python version (``py3.11`` … ``py3.13``; see :code-file:`CMakePresets.json`). A
 preset selects the Python version and an isolated per-version build directory, so
 different versions never share (and clobber) one configured CMake cache:
 
@@ -197,7 +197,7 @@ The CMake options (defined in root :code-file:`CMakeLists.txt` and :code-file:`c
      - ``ON``
    * - **Python version**
      - ``ISAAC_TELEOP_PYTHON_VERSION``
-     - ``3.11`` (3.10, 3.11, 3.12, or 3.13)
+     - ``3.11`` (3.11, 3.12, or 3.13)
    * - **Testing**
      - ``BUILD_TESTING``
      - ``ON``; enables CTest and Catch2
@@ -228,13 +228,13 @@ The CMake options (defined in root :code-file:`CMakeLists.txt` and :code-file:`c
 Examples
 ~~~~~~~~
 
-Build for a different Python version — use the matching preset (``py3.10``,
-``py3.11``, ``py3.12``, ``py3.13``):
+Build for a different Python version — use the matching preset (``py3.11``,
+``py3.12``, ``py3.13``):
 
 .. code-block:: bash
 
-   cmake --preset py3.10
-   cmake --build --preset py3.10 --parallel
+   cmake --preset py3.12
+   cmake --build --preset py3.12 --parallel
 
 Debug build:
 

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -31,7 +31,7 @@ Televiz ships inside the ``isaacteleop`` wheel — install it from PyPI:
 
    pip install isaacteleop
 
-The published wheels (Linux x86_64 / aarch64, CPython 3.10–3.13) bundle the compiled
+The published wheels (Linux x86_64 / aarch64, CPython 3.11–3.13) bundle the compiled
 ``isaacteleop.viz`` module, so **no source build is required**. Verify with:
 
 .. code-block:: python

--- a/docs/source/references/build.rst
+++ b/docs/source/references/build.rst
@@ -98,7 +98,7 @@ e.g. ``cpython-312``) so the per-version tag is consistent between them:
   ``build/wheel-cpython-312/``), set by ``build-dir`` in
   :code-file:`pyproject.toml` and chosen automatically per interpreter.
 - **classic CMake** → ``build/cmake-<cache-tag>/``, via the presets in
-  :code-file:`CMakePresets.json` (``py3.10`` … ``py3.13``). Each preset sets
+  :code-file:`CMakePresets.json` (``py3.11`` … ``py3.13``). Each preset sets
   ``ISAAC_TELEOP_PYTHON_VERSION`` and its own ``binaryDir``:
 
   .. code-block:: bash
@@ -162,8 +162,8 @@ uv or Python version
 ~~~~~~~~~~~~~~~~~~~~
 
 ``cmake/SetupPython.cmake`` requires **uv** and uses ``ISAAC_TELEOP_PYTHON_VERSION``. Install uv as
-in :ref:`One time setup <one-time-setup>` and pass ``-DISAAC_TELEOP_PYTHON_VERSION=3.10`` (or 3.11,
-3.12, 3.13) if you need a specific version.
+in :ref:`One time setup <one-time-setup>` and pass ``-DISAAC_TELEOP_PYTHON_VERSION=3.12`` (or 3.11,
+3.13) if you need a specific version.
 
 Reference
 ---------

--- a/docs/source/references/requirements.rst
+++ b/docs/source/references/requirements.rst
@@ -27,7 +27,7 @@ network.  The minimum requirements for the laptop/workstation are:
     * - OS
       - Ubuntu 22.04 or 24.04
     * - Python
-      - 3.10 / 3.11 / 3.12 / 3.13
+      - 3.11 / 3.12 / 3.13
     * - CUDA
       - 12.8 or newer
     * - NVIDIA Driver
@@ -93,7 +93,7 @@ to device peripherals. The minimum requirements for the laptop/workstation are:
     * - OS
       - Ubuntu 22.04 or 24.04
     * - Python
-      - 3.10 / 3.11 / 3.12 / 3.13
+      - 3.11 / 3.12 / 3.13
     * - CUDA
       - 12.8 or newer
     * - NVIDIA Driver

--- a/examples/camera_viz/pyproject.toml
+++ b/examples/camera_viz/pyproject.toml
@@ -11,7 +11,7 @@
 name = "camera-viz"
 version = "0.0.0"
 description = "Televiz camera-feed visualizer"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "pyyaml>=6.0",
     "cupy-cuda12x",

--- a/examples/camera_viz/tests/pyproject.toml
+++ b/examples/camera_viz/tests/pyproject.toml
@@ -10,7 +10,7 @@
 [project]
 name = "camera-viz-tests"
 version = "0.0.0"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 [project.optional-dependencies]
 dev = [

--- a/examples/cloudxr_mujoco_teleop/pyproject.toml
+++ b/examples/cloudxr_mujoco_teleop/pyproject.toml
@@ -5,7 +5,7 @@
 name = "cloudxr-mujoco-teleop-example"
 version = "0.1.0"
 description = "Visualize OpenXR / CloudXR headset + controller poses in MuJoCo."
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop",
     "mujoco>=3.0",

--- a/examples/deviceio_live_view/python/pyproject.toml
+++ b/examples/deviceio_live_view/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "deviceio-live-view-example"
 version = "0.0.0"  # Internal example - not versioned
 description = "Isaac Teleop live DeviceIO viewer with viser visualization"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop[cloudxr]==1.3.9rc1",
     "numpy>=1.23.0",

--- a/examples/haptic_feedback/python/pyproject.toml
+++ b/examples/haptic_feedback/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "isaacteleop-haptic-feedback-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "Isaac Teleop haptic feedback CLI examples (OpenXR controller)."
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop",
     "numpy>=1.23.0",

--- a/examples/mcap_record_replay/python/pyproject.toml
+++ b/examples/mcap_record_replay/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "mcap-record-replay-example"
 version = "0.0.0"  # Internal example - not versioned
 description = "Isaac Teleop MCAP record / replay example with viser visualization"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop[cloudxr]==1.3.9rc1",
     "mcap>=1.2.0",

--- a/examples/oxr/python/pyproject.toml
+++ b/examples/oxr/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "oxr-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "OpenXR Tracking Python Examples"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop",
     "numpy>=1.23.0",

--- a/examples/retargeting/python/pyproject.toml
+++ b/examples/retargeting/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "retargeting-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "Retargeting Engine Python Examples"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop[ui,retargeters-lite]",
     "numpy>=1.23.0",

--- a/examples/teleop/python/pyproject.toml
+++ b/examples/teleop/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleop-examples"
 version = "0.1.0"
 description = "Isaac Teleop Retargeting Examples"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop[retargeters]",
 ]

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -2,9 +2,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# Build for Jazzy: --build-arg ROS_DISTRO=jazzy --build-arg PYTHON_VERSION=3.12
-ARG ROS_DISTRO=humble
-ARG PYTHON_VERSION=3.10
+# Defaults target ROS 2 Jazzy, whose system Python matches the wheel's floor.
+# ROS_DISTRO and PYTHON_VERSION must be overridden together: rclpy is built
+# against the distro's own interpreter.
+ARG ROS_DISTRO=jazzy
+ARG PYTHON_VERSION=3.12
 
 # -----------------------------------------------------------------------------
 # Base: common runtime deps + uv + Python (shared by builder and runtime)

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -80,17 +80,20 @@ Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
 
 From the repo root.
 
-**Humble (default):**
+**Jazzy (default):**
 ```bash
 docker build -f examples/teleop_ros2/Dockerfile -t teleop_ros2_ref .
 ```
 
-**Jazzy:**
+ROS 2 Humble is no longer supported: it ships Python 3.10, which is below the
+`isaacteleop` wheel's minimum of 3.11. Another distro needs `ROS_DISTRO` and
+`PYTHON_VERSION` overridden together, and its interpreter must be 3.11 or newer:
+
 ```bash
-docker build -f examples/teleop_ros2/Dockerfile --build-arg ROS_DISTRO=jazzy --build-arg PYTHON_VERSION=3.12 -t teleop_ros2_ref:jazzy .
+docker build -f examples/teleop_ros2/Dockerfile --build-arg ROS_DISTRO=<distro> --build-arg PYTHON_VERSION=<py> -t teleop_ros2_ref:<distro> .
 ```
 
-You can tag by distro (e.g. `teleop_ros2_ref:humble`, `teleop_ros2_ref:jazzy`) to build and run both side by side.
+You can tag by distro (e.g. `teleop_ros2_ref:jazzy`) to build and run several side by side.
 
 Incremental rebuilds use Docker BuildKit cache. Ensure BuildKit is enabled (default in Docker 23+), or run with `DOCKER_BUILDKIT=1 docker build ...`.
 

--- a/examples/teleop_ros2/python/constants.py
+++ b/examples/teleop_ros2/python/constants.py
@@ -4,20 +4,12 @@
 
 """Constants and enum values shared by the Teleop ROS 2 node."""
 
-from enum import Enum
+from enum import StrEnum
 
 from isaacteleop.retargeting_engine.tensor_types.indices import (
     BodyJointIndex,
     HandJointIndex,
 )
-
-try:
-    from enum import StrEnum
-except ImportError:  # pragma: no cover - Python 3.10 compatibility for ROS Humble.
-
-    class StrEnum(str, Enum):
-        def __str__(self) -> str:
-            return self.value
 
 
 class HandRetargeter(StrEnum):

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleop-ros2-ref"
 version = "0.1.0"
 description = "Isaac Teleop ROS 2 reference publisher"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop[cloudxr,grounding,retargeters]",
     "msgpack",

--- a/examples/teleop_session_manager/python/pyproject.toml
+++ b/examples/teleop_session_manager/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleop-utils-examples"
 version = "0.0.0"  # Internal examples - not versioned
 description = "TeleopUtils Python Examples"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 dependencies = [
     "isaacteleop[ui]",
     "numpy>=1.23.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ name = "isaacteleop"
 dynamic = ["version"]
 description = "Isaac Teleop"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [
     { name = "NVIDIA" },

--- a/scripts/run_tests_with_cloudxr.sh
+++ b/scripts/run_tests_with_cloudxr.sh
@@ -11,7 +11,7 @@
 #
 # Options:
 #   --build           Force rebuild of test container (no cache)
-#   --python-version  Python version for test container (e.g. 3.10)
+#   --python-version  Python version for test container (e.g. 3.11)
 #   --help            Show this help message
 
 set -euo pipefail
@@ -86,7 +86,7 @@ while [[ $# -gt 0 ]]; do
             echo ""
             echo "Options:"
             echo "  --build           Force rebuild of test container (no cache)"
-            echo "  --python-version  Python version for test container (e.g. 3.10)"
+            echo "  --python-version  Python version for test container (e.g. 3.11)"
             echo "  --help            Show this help message"
             echo ""
             echo "Tests to run (edit CXR_PYTHON_GPU_TESTS/CXR_NATIVE_GPU_TESTS in this script):"

--- a/src/core/cloudxr_tests/python/pyproject.toml
+++ b/src/core/cloudxr_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleopcore-cloudxr-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "CloudXR launcher and runtime unit tests for TeleopCore"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/python/pyproject.toml.in
+++ b/src/core/python/pyproject.toml.in
@@ -17,7 +17,7 @@ name = "isaacteleop"
 version = "@ISAAC_TELEOP_PYPROJECT_VERSION@"
 description = "Isaac Teleop - Teleoperation with Device I/O"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = "Apache-2.0"
 authors = [
     {name = "NVIDIA"}

--- a/src/core/python/stubgen_pyproject.toml
+++ b/src/core/python/stubgen_pyproject.toml
@@ -8,7 +8,7 @@
 name = "isaacteleop-stubgen"
 version = "0.0.0"  # Internal tooling - not versioned
 description = "Stub generation dependencies for Isaac Teleop pybind11 modules"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 dependencies = [
     "pybind11-stubgen",

--- a/src/core/retargeting_engine_tests/python/pyproject.toml
+++ b/src/core/retargeting_engine_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "isaacteleop-retargeting-engine"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Retargeting engine type system for Isaac Teleop"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/rig_tests/python/pyproject.toml
+++ b/src/core/rig_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleopcore-rig-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Rig launcher unit tests for TeleopCore"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/schema_tests/python/pyproject.toml
+++ b/src/core/schema_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "isaacteleop-schema-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Tests for Isaac Teleop schema types"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 [project.optional-dependencies]
 dev = [

--- a/src/core/teleop_session_manager_tests/python/pyproject.toml
+++ b/src/core/teleop_session_manager_tests/python/pyproject.toml
@@ -5,7 +5,7 @@
 name = "teleopcore-teleop-session-manager-tests"
 version = "0.0.0"  # Internal tests - not versioned
 description = "Teleop session manager tests for TeleopCore"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 [project.optional-dependencies]
 dev = [

--- a/src/viz/python_tests/pyproject.toml
+++ b/src/viz/python_tests/pyproject.toml
@@ -11,7 +11,7 @@
 name = "isaacteleop-viz-tests"
 version = "0.0.0"
 description = "Python tests for isaacteleop.viz bindings"
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.11,<3.14"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Drops Python 3.10 support.

Fixes #(issue)

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to change)


## Testing

CI will test the changes.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Compatibility**
  * Python support now starts at 3.11 and includes versions through 3.13.
  * Python 3.10 is no longer supported across packages, examples, builds, or prebuilt wheels.
  * ROS 2 teleoperation defaults to ROS 2 Jazzy with Python 3.12; ROS 2 Humble is no longer supported.

* **Documentation**
  * Updated compatibility badges, setup instructions, build presets, and version examples to reflect the new requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->