### PR TITLE
docs: derive install version specifiers from VERSION (#838)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,13 +16,19 @@ copyright += f", last updated on {build_time.strftime('%B %d, %Y')}"
 author = "NVIDIA"
 
 _version_file = os.path.join(os.path.dirname(__file__), "..", "..", "VERSION")
+# ``VERSION`` is ``MAJOR.MINOR.x`` on main and on every release branch and tag, so its
+# first two components name the release series a given build of the docs describes.
+# ``_pip_version_pin`` turns that into a specifier (``1.5.x`` -> ``~=1.5.0``, i.e.
+# >=1.5.0 <1.6.0) so each versioned docs build shows how to install its own series.
 if os.path.exists(_version_file):
     with open(_version_file) as f:
         full_version = f.read().strip()
     version = full_version
     release = full_version
+    _pip_version_pin = "~={}.0".format(".".join(full_version.split(".")[:2]))
 else:
     version = release = "0.0.0"
+    _pip_version_pin = "~=1.0"
 
 # -- General configuration -----------------------------------------------------
 
@@ -34,6 +40,12 @@ extensions = [
 ]
 
 exclude_patterns = ["build", "_templates", "Thumbs.db", ".DS_Store"]
+
+# sphinx-copybutton only targets highlighted blocks (``div.highlight pre``) by default,
+# which skips ``parsed-literal`` (rendered as a bare ``pre.literal-block``).  Commands
+# that interpolate a substitution have to use ``parsed-literal``, so widen the selector
+# to keep the copy button on them.
+copybutton_selector = "div.highlight pre, pre.literal-block"
 
 templates_path = ["_templates"]
 
@@ -85,12 +97,14 @@ _icons = _VERSION_ICON_MAP.get(_smv_name, _DEFAULT_ICONS)
 _client_slug = (_smv_name or "main").replace("/", "-")
 _web_client_url = f"https://nvidia.github.io/IsaacTeleop/client/{_client_slug}/"
 
-# Shared substitution + link targets injected into every page, so the
-# branch-specific web client URL lives in one place.  ``|web_client_url|``
-# expands the bare URL (usable in prose and ``parsed-literal`` blocks); the
+# Shared substitutions + link targets injected into every page, so the
+# branch-specific web client URL and version pin live in one place.
+# ``|web_client_url|`` expands the bare URL and ``|pip_version_pin|`` the
+# version specifier (both usable in prose and ``parsed-literal`` blocks); the
 # named targets back ```...`_`` references in the prose.
 rst_epilog = f"""
 .. |web_client_url| replace:: {_web_client_url}
+.. |pip_version_pin| replace:: {_pip_version_pin}
 .. _`nvidia.github.io/IsaacTeleop/client`: {_web_client_url}
 .. _`Isaac Teleop Web Client`: {_web_client_url}
 """

--- a/docs/source/getting_started/lerobot/data_collection_real.rst
+++ b/docs/source/getting_started/lerobot/data_collection_real.rst
@@ -36,14 +36,17 @@ Follow the necessary one-time steps to set up your environment and hardware:
    LeRobot extras cover the SO-101 motor bus (``feetech``), the IK solver for the XR path
    (``kinematics``), and dataset recording (``dataset``). For Isaac Teleop, ``cloudxr`` brings the
    CloudXR runtime bindings and ``retargeters-lite`` is the default retargeter path on both
-   x86_64 and aarch64; the full ``retargeters`` extra is optional:
+   x86_64 and aarch64; the full ``retargeters`` extra is optional. The ``isaacteleop`` pin follows
+   the release series this page documents — see :ref:`install-isaacteleop-pip-package` for the
+   other install options:
 
-   .. code-block:: bash
+   .. parsed-literal::
 
       uv venv --python 3.12 .venv
       source .venv/bin/activate
       uv pip install -e ".[feetech,kinematics,dataset]" "huggingface_hub>=1.5"
-      uv pip install "isaacteleop[cloudxr,retargeters-lite]~=1.3.131" "scipy>=1.14"
+      uv pip install "isaacteleop[cloudxr,retargeters-lite]\ |pip_version_pin|\ " "scipy>=1.14" \\
+            --extra-index-url https://pypi.nvidia.com --prerelease=allow
 
 #. Log in to the Hugging Face Hub — recorded datasets are pushed to the Hub by default (pass
    ``--dataset.push_to_hub=false`` to keep them local):

--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -70,13 +70,28 @@ to clone the repository for a couple quick samples to run.
 2. Install the ``isaacteleop`` pip package
 -------------------------------------------
 
-In a new terminal, activate your preferred virtual or conda environment, then install the package
-from PyPI (or from a local wheel if you built from source):
+In a new terminal, activate your preferred virtual or conda environment, then install the latest
+stable release from PyPI:
 
 .. code-block:: bash
 
-   # From PyPI
-   pip install 'isaacteleop[cloudxr,retargeters]~=1.0.0' --extra-index-url https://pypi.nvidia.com
+   pip install 'isaacteleop[cloudxr,retargeters]~=1.0'
+
+Pre-release builds are published between stable releases. Picking one up takes the NVIDIA index
+and an opt-in to pre-release versions — shown here with `uv <https://docs.astral.sh/uv/>`__:
+
+.. code-block:: bash
+
+   uv pip install 'isaacteleop[cloudxr,retargeters]~=1.0' \
+         --extra-index-url https://pypi.nvidia.com --prerelease=allow
+
+The two commands above track the newest 1.x release. To follow this version of the documentation
+(|version|) exactly, pin to the series it describes instead:
+
+.. parsed-literal::
+
+   uv pip install 'isaacteleop[cloudxr,retargeters]\ |pip_version_pin|\ ' \\
+         --extra-index-url https://pypi.nvidia.com --prerelease=allow
 
 Instead of installing the package from PyPI, you can build from source and install the local wheel.
 See :doc:`build_from_source/index` for more details.


### PR DESCRIPTION
Cherry-pick of #838 onto `release/1.4.x`.

## Problem

The [quick start](https://nvidia.github.io/IsaacTeleop/release/1.4.x/getting_started/quick_start.html) install step hardcoded `~=1.0.0`. Because sphinx-multiversion builds the same source for every branch, that pin shipped verbatim on the `release/1.4.x` docs too — so a reader on the 1.4 pages was told to install the 1.0 series, which is not what the rest of the page describes. The LeRobot real-data page carried a separate stale pin, `~=1.3.131`.

## Changes

Docs only — three files, no behavior change.

- **`conf.py`** derives `_pip_version_pin` from the `VERSION` file (`MAJOR.MINOR.x` → `~=MAJOR.MINOR.0`) and exposes it through `rst_epilog` as the `|pip_version_pin|` substitution, so each versioned docs build shows its own series. On this branch `VERSION` is `1.4.x`, so it resolves to `~=1.4.0`.
- **`quick_start.rst`** now offers three install commands instead of one: latest stable from PyPI (`~=1.0`), latest pre-release (NVIDIA index + `--prerelease=allow`), and the series the page itself documents (`|pip_version_pin|`).
- **`data_collection_real.rst`** picks up the same substitution in place of its `~=1.3.131` pin.
- Substitutions require `parsed-literal`, which renders as a bare `pre.literal-block` and so was skipped by sphinx-copybutton's default selector; `copybutton_selector` is widened to keep the copy button on those blocks.

## Verification

Re-run on this branch, not inherited from #838:

- `git cherry-pick -x 2e154e7` applied with **no conflicts**, and the resulting patch is byte-identical to the one merged on `main` (`diff` of `git show` for both commits is empty). The `Signed-off-by` trailer is intact for the DCO check.
- `sphinx-build -b html source` — **build succeeded**, no warnings.
- Confirmed in the rendered HTML that the series-specific commands resolve against *this* branch's `VERSION`, not main's:
  - `quick_start.html` → `isaacteleop[cloudxr,retargeters]~=1.4.0`
  - `data_collection_real.html` → `isaacteleop[cloudxr,retargeters-lite]~=1.4.0`
  - The two remaining `~=1.0` occurrences are the intentional latest-stable / latest-pre-release commands.
- Grepped the rendered `getting_started/` tree for stale pins: no `~=1.0.0`, no `~=1.3.131`, no `~=1.5.x` leakage.
- `pre-commit run --files docs/source/conf.py docs/source/getting_started/quick_start.rst docs/source/getting_started/lerobot/data_collection_real.rst` — all hooks pass.
