### PR TITLE
docs: fix WebXR build setup commands

### DIFF
--- a/docs/source/getting_started/build_from_source/webxr.rst
+++ b/docs/source/getting_started/build_from_source/webxr.rst
@@ -31,11 +31,11 @@ From the project root:
 
 .. code-block:: bash
 
-   source deps/cloudxr/webxr_client/scripts/setup_cloudxr_env.sh
-   deps/cloudxr/webxr_client/scripts/download_cloudxr_sdk.sh
+   source scripts/setup_cloudxr_env.sh
+   scripts/download_cloudxr_sdk.sh
 
-This will automatically download the CloudXR.js SDK and place it in ``deps/cloudxr/nvidia-cloudxr-6.3.0-rc2.tgz``.  The
-`package.json` is configured to install the SDK from this local file.
+This will automatically download the CloudXR.js SDK and place it in ``deps/cloudxr/``. The
+`package.json` is configured to install the SDK from the downloaded local package.
 
 2. Install dependencies
 -----------------------
@@ -44,7 +44,7 @@ From the ``deps/cloudxr/webxr_client/`` directory:
 
 .. code-block:: bash
 
-   npm install ../nvidia-cloudxr-6.3.0-rc2.tgz
+   npm install
 
 3. Build & Run
 --------------


### PR DESCRIPTION
## Summary
- update WebXR SDK setup commands to use the repository-root scripts
- use the package.json dependency through the standard npm install flow

## Validation
- git diff --check
- confirmed both referenced scripts exist and package.json points to the downloaded local SDK package

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated WebXR build instructions to use local setup scripts for configuring the CloudXR.js environment and downloading the SDK.
  * Simplified dependency installation instructions to use `npm install` with the locally downloaded package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->