### PR TITLE
fix(LoadIWER): reset module state between tests via jest.resetModules()

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/LoadIWER.test.ts
+++ b/deps/cloudxr/webxr_client/helpers/LoadIWER.test.ts
@@ -17,7 +17,7 @@
  * @jest-environment jsdom
  */
 
-import { loadIWERIfNeeded } from './LoadIWER';
+import type { IWERLoadResult } from './LoadIWER';
 
 type IWERTestWindow = Window &
   typeof globalThis & {
@@ -33,9 +33,13 @@ type IWERTestWindow = Window &
 describe('loadIWERIfNeeded', () => {
   const testWindow = window as IWERTestWindow;
   let originalXRDescriptor: PropertyDescriptor | undefined;
+  let loadIWERIfNeeded: () => Promise<IWERLoadResult>;
 
   beforeEach(() => {
     originalXRDescriptor = Object.getOwnPropertyDescriptor(navigator, 'xr');
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    ({ loadIWERIfNeeded } = require('./LoadIWER'));
   });
 
   afterEach(() => {


### PR DESCRIPTION
## Summary

- `pendingIWERLoad` is module-level state that persisted across test cases
- Test 1 (native XR path) cached `{ iwerLoaded: false }`, causing tests 2 and 3 to return that stale result instead of running the IWER loading path
- Replace the static top-level import with `jest.resetModules()` + `require('./LoadIWER')` in `beforeEach` so each test starts with a fresh module instance — no production code changes needed

## Test plan

- [ ] CI jest run passes all 3 `loadIWERIfNeeded` test cases
- [ ] `LoadIWER.ts` has no new exports (diff is test-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)