### PR TITLE
cherrypick: upgrade IWER to 2.3.0, force-install over unsupported native XR, and prevent duplicate installs

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/LoadIWER.test.ts
+++ b/deps/cloudxr/webxr_client/helpers/LoadIWER.test.ts
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @jest-environment jsdom
+ */
+
+import type { IWERLoadResult } from './LoadIWER';
+
+type IWERTestWindow = Window &
+  typeof globalThis & {
+    IWER?: {
+      XRDevice: jest.Mock;
+      metaQuest3: object;
+    };
+    IWER_DevUI?: {
+      DevUI: object;
+    };
+  };
+
+describe('loadIWERIfNeeded', () => {
+  const testWindow = window as IWERTestWindow;
+  let originalXRDescriptor: PropertyDescriptor | undefined;
+  let loadIWERIfNeeded: () => Promise<IWERLoadResult>;
+
+  beforeEach(() => {
+    originalXRDescriptor = Object.getOwnPropertyDescriptor(navigator, 'xr');
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    ({ loadIWERIfNeeded } = require('./LoadIWER'));
+  });
+
+  afterEach(() => {
+    if (originalXRDescriptor) {
+      Object.defineProperty(navigator, 'xr', originalXRDescriptor);
+    } else {
+      delete (navigator as Navigator & { xr?: XRSystem }).xr;
+    }
+    delete testWindow.IWER;
+    delete testWindow.IWER_DevUI;
+    jest.restoreAllMocks();
+  });
+
+  it('returns native immersive support without loading IWER', async () => {
+    const isSessionSupported = jest.fn().mockResolvedValue(true);
+    Object.defineProperty(navigator, 'xr', {
+      configurable: true,
+      value: { isSessionSupported },
+    });
+
+    const appendChild = jest.spyOn(document.head, 'appendChild');
+
+    await expect(loadIWERIfNeeded()).resolves.toEqual({
+      supportsImmersive: true,
+      iwerLoaded: false,
+    });
+
+    expect(appendChild).not.toHaveBeenCalled();
+  });
+
+  it('forces the fallback runtime over a native XRSystem without immersive support', async () => {
+    const isSessionSupported = jest.fn().mockResolvedValue(false);
+    Object.defineProperty(navigator, 'xr', {
+      configurable: true,
+      value: { isSessionSupported },
+    });
+
+    const device = {
+      installDevUI: jest.fn(),
+      installRuntime: jest.fn(),
+    };
+    testWindow.IWER = {
+      XRDevice: jest.fn(() => device),
+      metaQuest3: {},
+    };
+    testWindow.IWER_DevUI = { DevUI: {} };
+
+    const appendChild = jest
+      .spyOn(document.head, 'appendChild')
+      .mockImplementation(<T extends Node>(node: T): T => {
+        if (node instanceof HTMLScriptElement) {
+          queueMicrotask(() => node.onload?.(new Event('load')));
+        }
+        return node;
+      });
+
+    await expect(loadIWERIfNeeded()).resolves.toEqual({
+      supportsImmersive: true,
+      iwerLoaded: true,
+    });
+
+    expect(isSessionSupported).toHaveBeenNthCalledWith(1, 'immersive-vr');
+    expect(isSessionSupported).toHaveBeenNthCalledWith(2, 'immersive-ar');
+    expect(device.installRuntime).toHaveBeenCalledWith({ forceInstall: true });
+    expect(appendChild).toHaveBeenCalledTimes(2);
+  });
+
+  it('shares one IWER installation across concurrent callers', async () => {
+    let appendedScripts = 0;
+    let constructedDevices = 0;
+    let runtimeInstalls = 0;
+
+    const device = {
+      installDevUI: jest.fn(),
+      installRuntime: jest.fn(() => {
+        runtimeInstalls++;
+      }),
+    };
+    testWindow.IWER = {
+      XRDevice: jest.fn(() => {
+        constructedDevices++;
+        return device;
+      }),
+      metaQuest3: {},
+    };
+    testWindow.IWER_DevUI = { DevUI: {} };
+
+    jest.spyOn(document.head, 'appendChild').mockImplementation(<T extends Node>(node: T): T => {
+      appendedScripts++;
+      if (node instanceof HTMLScriptElement) {
+        queueMicrotask(() => node.onload?.(new Event('load')));
+      }
+      return node;
+    });
+
+    const [first, second] = await Promise.all([loadIWERIfNeeded(), loadIWERIfNeeded()]);
+
+    expect(first).toEqual({ supportsImmersive: true, iwerLoaded: true });
+    expect(second).toEqual(first);
+    expect(appendedScripts).toBe(2);
+    expect(constructedDevices).toBe(1);
+    expect(runtimeInstalls).toBe(1);
+  });
+});

--- a/deps/cloudxr/webxr_client/helpers/LoadIWER.ts
+++ b/deps/cloudxr/webxr_client/helpers/LoadIWER.ts
@@ -23,8 +23,10 @@ declare global {
   }
 }
 
-const IWER_version = '2.2.1';
-const IWER_DEVUI_version = '2.2.0';
+// Both versions are loaded from CDN; bump them together when upgrading IWER.
+const IWER_version = '2.3.0';
+const IWER_DEVUI_version = '2.3.0';
+let pendingIWERLoad: Promise<IWERLoadResult> | null = null;
 
 export interface IWERLoadResult {
   supportsImmersive: boolean;
@@ -32,6 +34,19 @@ export interface IWERLoadResult {
 }
 
 export async function loadIWERIfNeeded(): Promise<IWERLoadResult> {
+  if (pendingIWERLoad) {
+    return pendingIWERLoad;
+  }
+  pendingIWERLoad = loadIWER();
+  const result = await pendingIWERLoad;
+  if (!result.supportsImmersive) {
+    // Clear so a later call can retry after a transient failure.
+    pendingIWERLoad = null;
+  }
+  return result;
+}
+
+async function loadIWER(): Promise<IWERLoadResult> {
   let supportsImmersive = false;
   let iwerLoaded = false;
 
@@ -50,7 +65,7 @@ export async function loadIWERIfNeeded(): Promise<IWERLoadResult> {
     const script = document.createElement('script');
     script.src = `https://unpkg.com/iwer@${IWER_version}/build/iwer.min.js`;
     script.async = true;
-    script.integrity = 'sha384-3G2UIBh0RX9Imd3PFwcHyXbqRYAeQo9FDMgQTOLcflo9H6LDHaxADB24vKC3b+OY';
+    script.integrity = 'sha384-m8Xcl9WwdP6j/5Fv7MAs7IvvW3PmWCbNZlbF8IsJAnujyeMZi0/xgUE4mM7Tbm/j';
     script.crossOrigin = 'anonymous';
 
     await new Promise<void>(resolve => {
@@ -69,7 +84,7 @@ export async function loadIWERIfNeeded(): Promise<IWERLoadResult> {
         devUIScript.src = `https://unpkg.com/@iwer/devui@${IWER_DEVUI_version}/build/iwer-devui.min.js`;
         devUIScript.async = true;
         devUIScript.integrity =
-          'sha384-gPhqycVT+bNyiNIH8kMEWFjaysw6xH9NGYwuduRzK71Ro0Tp3hXByxqAI9sWrc9T';
+          'sha384-TAu5gWlv92O6gkVclV8HYctTEswyA/0eoS6ULHjjLCShUVts4kDlUg6iLEKmL1r8';
         devUIScript.crossOrigin = 'anonymous';
 
         await new Promise<void>(devUIResolve => {
@@ -95,7 +110,9 @@ export async function loadIWERIfNeeded(): Promise<IWERLoadResult> {
             console.warn('IWER DevUI not found after script load, continuing without DevUI.');
           }
 
-          await device.installRuntime();
+          // This fallback runs only after the native XRSystem reports no immersive
+          // support. IWER 2.3 otherwise preserves that unusable navigator.xr.
+          await device.installRuntime({ forceInstall: true });
           window.xrDevice = device;
           supportsImmersive = true;
           iwerLoaded = true;

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -68,7 +68,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "html-webpack-plugin": "^5.6.7",
-    "iwer": "^2.2.1",
+    "iwer": "^2.3.0",
     "jest": "^30",
     "jest-environment-jsdom": "^30.4.1",
     "prettier": "3.5.3",


### PR DESCRIPTION
* Update IWER to 2.3.0
* Drop sandbox guidance from IWER update
* Force IWER fallback over unsupported native XR




---------

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Updates the Isaac Teleop web client IWER dependency from 2.2.1 to 2.3.0 (DevUI 2.2.0 → 2.3.0) and fixes two issues:

Force-install over unsupported native XR — IWER 2.3 preserves an existing navigator.xr by default, even when it reports no immersive support. This PR passes forceInstall: true on the fallback path so the emulated runtime replaces the unusable native one.

Prevent duplicate device installs from concurrent callers — React's useEffect (which calls loadIWERIfNeeded) can be invoked concurrently in development (Strict Mode double-invocation). Without a guard, two overlapping calls each install a separate IWER device, leaving window.xrDevice pointing at an inactive one. A single-flight pendingIWERLoad promise ensures all concurrent callers share one installation.

Also updates the CDN SHA-384 integrity hashes for both IWER and DevUI.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

npm test -- --runInBand — 63 tests passed (including regression tests for the force-install path and the concurrent-callers guard)
npm run build
SKIP=check-copyright-year pre-commit run --all-files

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
