### PR TITLE
release/1.4.x: fix(client): repair status box regressions from the workstation notice

### DIFF
--- a/deps/cloudxr/webxr_client/src/App.tsx
+++ b/deps/cloudxr/webxr_client/src/App.tsx
@@ -685,14 +685,23 @@ function AppContent() {
   // static colors at render time rather than subscribing.
   const [systemNoticeLevel, setSystemNoticeLevel] = useState<'warning' | 'info'>('warning');
 
+  /** Exact text this component last wrote to the shared 2D status box. */
+  const systemNoticeTextRef = useRef<string | null>(null);
+
   /** Take the notice down, in both surfaces, and cancel any pending auto-dismiss. */
   const dismissSystemNotice = () => {
     systemNotice.value = null;
     setSystemNoticeVisible(false);
-    // showStatus() sets .show and never clears itself, so without this the 2D
-    // status box keeps the notice after dismissal, after the timeout, and
-    // across a disconnect into the next connection.
-    cloudXR2DUI?.hideError();
+    // showStatus() sets .show and never clears itself, so the 2D box needs an
+    // explicit retraction. Clear it only while it still holds our notice: the
+    // box is shared, and handleDisconnect() runs this on the way out of a
+    // failed session -- moments after CloudXR reported the failure into that
+    // same box. Blanking unconditionally erased that error, and because it is
+    // reported imperatively there is no React state to bring it back.
+    if (systemNoticeTextRef.current !== null) {
+      cloudXR2DUI?.hideStatusIfShowing(systemNoticeTextRef.current);
+      systemNoticeTextRef.current = null;
+    }
     if (systemNoticeTimerRef.current !== null) {
       clearTimeout(systemNoticeTimerRef.current);
       systemNoticeTimerRef.current = null;
@@ -735,17 +744,16 @@ function AppContent() {
         clearTimeout(systemNoticeTimerRef.current);
       }
       systemNoticeTimerRef.current = window.setTimeout(() => {
-        systemNotice.value = null;
-        setSystemNoticeVisible(false);
         systemNoticeTimerRef.current = null;
+        dismissSystemNotice();
       }, SYSTEM_NOTICE_AUTO_DISMISS_MS);
 
       // Mirror to the 2D banner so the notice is visible when testing from a
-      // desktop browser, where the in-XR panel never renders.
-      cloudXR2DUI?.showStatus(
-        formatSystemNotice(notice),
-        notice.level === 'warning' ? 'error' : 'info'
-      );
+      // desktop browser, where the in-XR panel never renders. Remember the exact
+      // text so dismissal can retract it without clobbering a later message.
+      const mirroredText = formatSystemNotice(notice);
+      systemNoticeTextRef.current = mirroredText;
+      cloudXR2DUI?.showStatus(mirroredText, notice.level === 'warning' ? 'error' : 'info');
       return;
     }
 

--- a/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
+++ b/deps/cloudxr/webxr_client/src/CloudXR2DUI.tsx
@@ -1271,6 +1271,23 @@ export class CloudXR2DUI {
   }
 
   /**
+   * Hides the status box only if it still shows `message`.
+   *
+   * The box is a single shared slot: capability results, CloudXR errors, and
+   * host workstation notices all write to it, and each overwrites the last. A
+   * caller retracting its own message must not blank whatever replaced it --
+   * for example a CloudXR error raised moments earlier, which is reported
+   * imperatively and has no React state to re-render it afterwards.
+   *
+   * @param message - The exact text the caller previously displayed
+   */
+  public hideStatusIfShowing(message: string): void {
+    if (this.errorMessageText?.textContent === message) {
+      this.hideError();
+    }
+  }
+
+  /**
    * Cleans up event listeners and resources
    * Should be called when the component unmounts
    */

--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -641,10 +641,6 @@ limitations under the License.
         font-size: 0.9rem;
         font-weight: 500;
         line-height: 1.4;
-        /* Messages are set via textContent and separate entries with newlines
-           (browser capability failures, host workstation notices), so newlines
-           must render while long lines still wrap. */
-        white-space: pre-line;
       }
 
       .error-message-box.show {
@@ -676,6 +672,17 @@ limitations under the License.
         display: inline-block;
         margin-right: 8px;
         font-weight: bold;
+      }
+
+      /* Messages are set via textContent and separate entries with newlines
+         (browser capability failures, host workstation notices), so newlines
+         must render while long lines still wrap.
+
+         Scoped to the text span, not the box: the icon and text spans sit on
+         separate source lines, and pre-line on the container would render that
+         markup newline as a line break, pushing every message below the icon. */
+      .error-message-box #errorMessageText {
+        white-space: pre-line;
       }
 
       /* Load Recording status feedback */


### PR DESCRIPTION
## Description

  Two regressions in the shared 2D status box, both introduced by #844.

  **CloudXR errors were erased on disconnect.** The box is a single shared slot,
  but `dismissSystemNotice()` cleared it unconditionally. On a failed session
  CloudXR reports the error via `onError` → `showError()`, then immediately calls
  `onExitImmersiveXR` → `handleDisconnect()` → `dismissSystemNotice()`, which
  blanked the error that had just been written. Because that error is reported
  imperatively rather than through React state, nothing re-rendered it and the
  operator saw a disconnect with no explanation.

  The notice now records the exact text it wrote and retracts it only while the 
  box still shows it, via a new `CloudXR2DUI.hideStatusIfShowing()`. Messages from
  any other source are left alone. The auto-dismiss timeout is routed through the
  same path, which also fixes it clearing only the XR banner and leaving the 2D
  mirror up.

  **Every message rendered below the warning icon.** `white-space: pre-line` was
  set on `.error-message-box` to preserve newlines in multi-line notices, but the
  box holds an icon span and a text span on separate source lines, so that markup
  newline rendered as a real line break. The rule is now scoped to
  `#errorMessageText`, the element that actually receives the newline-separated
  text.

  Thanks to @yanziz-nvidia for tracing the error-clearing path.

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
