### PR TITLE
docs: fix WebXR setup script paths (#852)

### DIFF
--- a/docs/source/getting_started/build_from_source/webxr.rst
+++ b/docs/source/getting_started/build_from_source/webxr.rst
@@ -31,11 +31,11 @@ From the project root:
 
 .. code-block:: bash
 
-   source deps/cloudxr/webxr_client/scripts/setup_cloudxr_env.sh
-   deps/cloudxr/webxr_client/scripts/download_cloudxr_sdk.sh
+   source scripts/setup_cloudxr_env.sh
+   scripts/download_cloudxr_sdk.sh
 
-This will automatically download the CloudXR.js SDK and place it in ``deps/cloudxr/nvidia-cloudxr-6.3.0-rc2.tgz``.  The
-`package.json` is configured to install the SDK from this local file.
+This will automatically download the CloudXR.js SDK and place it in ``deps/cloudxr/``. The
+`package.json` is configured to install the SDK from the downloaded local package.
 
 2. Install dependencies
 -----------------------
@@ -44,7 +44,7 @@ From the ``deps/cloudxr/webxr_client/`` directory:
 
 .. code-block:: bash
 
-   npm install ../nvidia-cloudxr-6.3.0-rc2.tgz
+   npm install
 
 3. Build & Run
 --------------


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Cherry-pick https://github.com/NVIDIA/IsaacTeleop/pull/852 to v1.4.x. Fixes doc instruction.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Doc builds and is correct.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
