### PR TITLE
docs: use branch-specific CloudXR client links

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -27,7 +27,7 @@ Just grab the instance IP and connect from your headset.
 
    **Server (Brev):** CloudXR + Isaac Teleop retargeting + Isaac Lab sim on a cloud GPU.
 
-   **Client (you):** open the `web client <https://nvidia.github.io/IsaacTeleop/client>`__
+   **Client (you):** open the `Isaac Teleop Web Client`_
    in your headset or browser, enter the Brev instance IP, accept the certificate, and click
    **Connect** — see step :ref:`connect-xr-headset`.
 
@@ -212,7 +212,7 @@ running the CloudXR runtime and wss proxy in containerized environment; or using
    :open:
 
    No physical headset required for a quick test: open
-   `https://nvidia.github.io/IsaacTeleop/client <https://nvidia.github.io/IsaacTeleop/client>`__
+   `nvidia.github.io/IsaacTeleop/client`_
    in a **desktop browser** — IWER (Immersive Web Emulator Runtime) loads automatically and
    emulates a Meta Quest 3 headset.
 


### PR DESCRIPTION
## Summary
- route Quick Start web-client links through the existing branch-aware Sphinx targets
- ensure main and release documentation open their matching CloudXR.js deployment

Closes #584

## Test plan
- [x] Build main-context docs with Sphinx warnings treated as errors
- [x] Build release/1.4.x-context docs with Sphinx warnings treated as errors
- [x] Verify generated links resolve to `/client/main/` and `/client/release-1.4.x/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the quick-start guide to use a reusable Isaac Teleop Web Client reference in setup and headset connection instructions.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->