### PR TITLE
chore(cloudxr): bump runtime SDK version to 6.3.0-rc2

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.2.1
+CXR_RUNTIME_SDK_VERSION=6.3.0-rc2
 CXR_WEB_SDK_VERSION=6.3.0-rc2
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 


### PR DESCRIPTION
## Description

Bumps `CXR_RUNTIME_SDK_VERSION` 6.2.1 → 6.3.0-rc2 (NGC `cloudxr-dev/cloudxr-runtime-binary:6.3.0-rc2-public`), matching `CXR_WEB_SDK_VERSION`, at 6.3.0-rc2 since #841. Nothing compiles or links against the SDK — CMake extracts the tarball and bundles only the shared objects — so the pin is the whole change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

Dependency bump; none of the above apply.

## Testing

CI only. `Setup CloudXR SDK` passed on all 12 build jobs (x64 and arm64), and the `test-cloudxr` matrix exercises the 6.3 runtime end to end on the self-hosted GPU runners, covering the OpenXR extensions vendored in `deps/cloudxr/openxr_extensions/`.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not) — no test surface for a version pin
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
