### PR TITLE
chore(cloudxr): bump runtime SDK version to 6.3.0-rc3

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.3.0-rc2
+CXR_RUNTIME_SDK_VERSION=6.3.0-rc3
 CXR_WEB_SDK_VERSION=6.3.0-rc2
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 


### PR DESCRIPTION
## Description

Follow-up to #873, which landed 6.3.0-rc2. Moves `CXR_RUNTIME_SDK_VERSION` to 6.3.0-rc3 — the newest runtime on NGC (`cloudxr-dev/cloudxr-runtime-binary:6.3.0-rc3-public`, uploaded 2026-07-31). Nothing compiles or links against the SDK — CMake extracts the tarball and bundles only the shared objects — so the pin is the whole change.

rc3 also publishes `CloudXR-exp-external-*` for both arches, which rc2 was not confirmed to, so it unblocks defaulting `ENABLE_CLOUDXR_EXP_BUNDLE` to ON (separate PR).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

Dependency bump; none of the above apply.

## Testing

CI only, as for #873: `Setup CloudXR SDK` covers the NGC artifact and packaging, and the `test-cloudxr` matrix exercises the runtime end to end on the self-hosted GPU runners across x64/arm64 and Python 3.11–3.13.

Note `CXR_WEB_SDK_VERSION` stays at 6.3.0-rc2 — the web client is a separate NGC resource (`cloudxr-js`) and a matching rc3 has not been confirmed to exist.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not) — no test surface for a version pin
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CloudXR runtime SDK to version 6.3.0-rc3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->