### PR TITLE
feat(cloudxr): move to runtime 6.3.0-rc3 and bundle the experimental runtime in CI

### DIFF
--- a/.github/actions/setup-cloudxr-sdk/action.yml
+++ b/.github/actions/setup-cloudxr-sdk/action.yml
@@ -39,6 +39,8 @@ runs:
       shell: bash
       env:
         CXR_RUNTIME_SDK_VERSION: ${{ steps.parse.outputs.runtime_version }}
+        # Staged here because the configure step re-runs this script without a key.
+        CXR_DOWNLOAD_EXP: '1'
         NGC_API_KEY: ${{ inputs.ngc-api-key }}
       run: |
         ./scripts/download_cloudxr_runtime_sdk.sh

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -161,6 +161,7 @@ jobs:
           -DBUILD_PLUGIN_OAK_CAMERA=ON \
           -DBUILD_VIZ=ON \
           -DENABLE_CLOUDXR_BUNDLE_CHECK=ON \
+          -DENABLE_CLOUDXR_EXP_BUNDLE=ON \
           -DBUNDLE_ROBOTIC_GROUNDING=${{ steps.setup-v2d-src.outputs.bundled || 'false' }} \
           -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake \
           "${coverage_args[@]}"

--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.3.0-rc2
+CXR_RUNTIME_SDK_VERSION=6.3.0-rc3
 CXR_WEB_SDK_VERSION=6.3.0-rc2
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 


### PR DESCRIPTION
## Description

Pins the CloudXR runtime to 6.3.0-rc3 (from 6.2.1) and configures `build-ubuntu` with `-DENABLE_CLOUDXR_EXP_BUNDLE=ON`, so CI wheels carry `isaacteleop.cloudxr_exp` with its native runtime. rc3 is the first version that publishes `CloudXR-exp-external-*` for both arches.

The option's default stays `OFF`: the experimental tarball lives on private NGC until GA, so a keyless source build cannot obtain it. `setup-cloudxr-sdk` requests it because that step holds the job's only NGC key.

Nothing in the tree compiles or links against the SDK — CMake bundles the prebuilt shared objects — so the version pin is a one-line change.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

CI, verified from the built wheel rather than the check marks: arm64 py3.12 contains `isaacteleop/cloudxr_exp/native/` with its ten runtime files, and wheels grow 15.7 MB → 29.2 MB. The `test-cloudxr` matrix exercises the runtime on the GPU runners across x64/arm64 and Python 3.11–3.13.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not) — no test surface for a version pin or a CI configure flag; verified via the wheel contents
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
