### PR TITLE
fix(examples): track the 1.4 series instead of an exact 1.3.9rc1 pin

### DIFF
--- a/examples/deviceio_live_view/python/pyproject.toml
+++ b/examples/deviceio_live_view/python/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"  # Internal example - not versioned
 description = "Isaac Teleop live DeviceIO viewer with viser visualization"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "isaacteleop[cloudxr]==1.3.9rc1",
+    "isaacteleop[cloudxr]~=1.4.0",
     "numpy>=1.23.0",
     "viser>=0.2.0",
 ]

--- a/examples/mcap_record_replay/python/pyproject.toml
+++ b/examples/mcap_record_replay/python/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.0.0"  # Internal example - not versioned
 description = "Isaac Teleop MCAP record / replay example with viser visualization"
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "isaacteleop[cloudxr]==1.3.9rc1",
+    "isaacteleop[cloudxr]~=1.4.0",
     "mcap>=1.2.0",
     "numpy>=1.23.0",
     "viser>=0.2.0",


### PR DESCRIPTION
## Problem

`examples/mcap_record_replay/python/` and `examples/deviceio_live_view/python/` both pin `isaacteleop[cloudxr]==1.3.9rc1` — a frozen pre-release from a *different* minor series than the branch that ships them. The example sources have moved on since: `common.py:42` and `deviceio_viser.py:26` both import `BodyJointIndex`, which 1.3.9rc1 does not export, so the documented `uv sync && uv run python record_hand.py` flow dies before the script starts:

```
File "examples/mcap_record_replay/python/common.py", line 41, in <module>
  from isaacteleop.retargeting_engine.tensor_types.indices import (
ImportError: cannot import name 'BodyJointIndex' from 'isaacteleop.retargeting_engine.tensor_types.indices'
```

## Fix

Replace the exact pin with `~=1.4.0` in both examples, so each tracks its own release line instead of a snapshot of someone else's. The lag between an example and the wheel it resolves against is now one publish cycle rather than two minor versions.

No `--prerelease=allow` is needed: pypi.nvidia.com currently has no stable 1.4, and uv falls back to pre-releases when a range contains only pre-releases, so a plain `uv sync` resolves 1.4.111rc1.

## Verification

- Reproduced the `ImportError` above against `==1.3.9rc1` on this branch's sources, in both examples.
- `uv lock` on both example `pyproject.toml`s resolves `isaacteleop==1.4.111rc1` across the declared `>=3.10,<3.14` range, with no pre-release flag.
- Installed that wheel into a clean 3.11 venv and imported every module in both examples — all 12 clean: `common`, `record_hand`, `replay_hand`, `record_controller`, `replay_controller`, `record_full_body`, `replay_full_body`, `live_hand`, `live_controller`, `live_full_body`, `deviceio_viser`, `live_deviceio`.

## Notes

The pre-release fallback is uv-specific. `pip install 'isaacteleop~=1.4.0'` fails with `No matching distribution found` until a stable 1.4 ships, where the old explicit-pre-release pin would have resolved; `--pre` restores it. That only matters to someone bypassing the documented flow — these files are already uv-specific via `[[tool.uv.index]]`, and the docs say `uv sync` — but it is a real narrowing, so worth stating.

Two other matches for `1.3.9rc1` on this branch are deliberately untouched: `test_oob_teleop_env.py` uses it as a fixture for web-client URL mapping, and `examples/teleop_ros2/Dockerfile` pins dynamically to whatever local wheel it just built.

`main` needs the same fix as `~=1.5.0`; it is not a clean cherry-pick because `requires-python` differs between the branches (`>=3.11` there vs `>=3.10` here), so the dependency line should be ported rather than the file.
