### PR TITLE
fix(examples): build isaacteleop from the checkout, not a pinned wheel

### DIFF
--- a/cmake/InstallPythonExample.cmake
+++ b/cmake/InstallPythonExample.cmake
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 # ==============================================================================
@@ -6,9 +6,10 @@
 # ==============================================================================
 # Macro to install a Python example directory with a generated pyproject.toml.
 #
-# Reads the source pyproject.toml (which stays tool-agnostic) and appends a
-# [tool.uv] block only to the installed copy so that `uv run` works out of the
-# box in the install tree.
+# Reads the source pyproject.toml and appends a [tool.uv] block only to the
+# installed copy so that `uv run` works out of the box in the install tree. On the
+# way it pins isaacteleop to the version this build produced and drops any
+# [tool.uv.sources], so the installed example resolves the wheel next to it.
 #
 # Usage:
 #   install_python_example(DESTINATION examples/oxr/python)
@@ -33,6 +34,18 @@ macro(install_python_example)
     # Read the bare pyproject.toml and append uv configuration for the
     # installed environment.
     file(READ "${CMAKE_CURRENT_SOURCE_DIR}/python/pyproject.toml" _PYPROJECT_BASE)
+
+    # A source-tree [tool.uv.sources] path is relative to the pyproject, so from
+    # the installed copy it points at the install prefix, which is not a Python
+    # project. Matched at line start, so prose naming the header is left alone.
+    string(REGEX REPLACE "\n\\[tool\\.uv\\.sources\\][^[]*" "\n" _PYPROJECT_BASE "${_PYPROJECT_BASE}")
+
+    # Pin to the wheel this build produced. Unversioned, uv would prefer the
+    # newest release on an index whenever the local wheel is a pre-release --
+    # which every CI build is (see IsaacTeleopVersion.cmake).
+    # TODO(#880): no test covers the generated pyproject.
+    string(REGEX REPLACE "\"(isaacteleop(\\[[^]]*\\])?)\""
+        "\"\\1==${ISAAC_TELEOP_PYPROJECT_VERSION}\"" _PYPROJECT_BASE "${_PYPROJECT_BASE}")
     set(_TOOL_UV_BLOCK "[tool.uv]
 find-links = [\"../../../wheels\"]
 python-preference = \"only-managed\"

--- a/docs/source/references/mcap_record_replay.rst
+++ b/docs/source/references/mcap_record_replay.rst
@@ -131,7 +131,9 @@ additional source nodes (``HeadSource``, ``ControllersSource``, …) in
 ``common.py``.
 
 For a live browser view of **all** human DeviceIO trackers at once (hands, head,
-controllers, and full body), see ``examples/deviceio_live_view/python/``.
+controllers, and full body), see ``examples/deviceio_live_view/python/``.  It is
+set up the same way as this example — the ``uv sync`` notes under `Recording`_
+apply to it too.
 
 A C++ recorder lives at ``examples/mcap_record_replay/cpp/``:
 
@@ -145,7 +147,7 @@ A C++ recorder lives at ``examples/mcap_record_replay/cpp/``:
 Recording
 ^^^^^^^^^
 
-From the installed example directory:
+From the example directory:
 
 .. code-block:: bash
 
@@ -155,8 +157,20 @@ From the installed example directory:
    uv run python record_hand.py 10         # record for 10 seconds
    uv run python record_hand.py 10 out.mcap  # custom output path
 
+The example never downloads a published wheel — it runs against the
+``isaacteleop`` next to it.  Above, ``uv sync`` builds it from this checkout; the
+first sync compiles the extension modules and takes a few minutes, later ones
+reuse the cached build, and the install is editable, so edits under
+``src/python/`` need no rebuild.  From
+``install/examples/mcap_record_replay/python`` (after ``cmake --install``) it
+picks up the wheel you just built instead — see
+:doc:`/getting_started/build_from_source/index`.
+
 An active OpenXR runtime / headset must be connected, just like any other
-live ``TeleopSession``.
+live ``TeleopSession``.  Recording also needs the CloudXR runtime natives, which
+a from-source build bundles only when the CloudXR SDK tarball is available —
+CMake fetches it automatically, and warns rather than fails if it cannot.  Replay
+has no such requirement.
 
 Replaying
 ^^^^^^^^^

--- a/examples/deviceio_live_view/python/pyproject.toml
+++ b/examples/deviceio_live_view/python/pyproject.toml
@@ -6,11 +6,16 @@ name = "deviceio-live-view-example"
 version = "0.0.0"  # Internal example - not versioned
 description = "Isaac Teleop live DeviceIO viewer with viser visualization"
 requires-python = ">=3.11,<3.14"
+# No version on isaacteleop: the example runs against the one next to it -- this
+# checkout, or the wheel install_python_example() pins into the installed copy.
 dependencies = [
-    "isaacteleop[cloudxr]==1.3.9rc1",
+    "isaacteleop[cloudxr]",
     "numpy>=1.23.0",
     "viser>=0.2.0",
 ]
 
-[[tool.uv.index]]
-url = "https://pypi.nvidia.com"
+[tool.uv.sources]
+# Editable, so edits under src/python/ need no rebuild. Dropped from the
+# installed copy, which has no repo above it.
+# TODO(#880): nothing runs this example in CI; neither path is covered.
+isaacteleop = { path = "../../..", editable = true }

--- a/examples/mcap_record_replay/python/pyproject.toml
+++ b/examples/mcap_record_replay/python/pyproject.toml
@@ -6,12 +6,17 @@ name = "mcap-record-replay-example"
 version = "0.0.0"  # Internal example - not versioned
 description = "Isaac Teleop MCAP record / replay example with viser visualization"
 requires-python = ">=3.11,<3.14"
+# No version on isaacteleop: the example runs against the one next to it -- this
+# checkout, or the wheel install_python_example() pins into the installed copy.
 dependencies = [
-    "isaacteleop[cloudxr]==1.3.9rc1",
+    "isaacteleop[cloudxr]",
     "mcap>=1.2.0",
     "numpy>=1.23.0",
     "viser>=0.2.0",
 ]
 
-[[tool.uv.index]]
-url = "https://pypi.nvidia.com"
+[tool.uv.sources]
+# Editable, so edits under src/python/ need no rebuild. Dropped from the
+# installed copy, which has no repo above it.
+# TODO(#880): nothing runs this example in CI; neither path is covered.
+isaacteleop = { path = "../../..", editable = true }


### PR DESCRIPTION
## Problem

`examples/mcap_record_replay/python/` and `examples/deviceio_live_view/python/` pin `isaacteleop[cloudxr]==1.3.9rc1` — a frozen pre-release from two minor series back. Both `common.py` and `deviceio_viser.py` import `BodyJointIndex`, which that wheel does not export, so `uv sync && uv run python record_hand.py` dies with `ImportError: cannot import name 'BodyJointIndex'` before the script starts.

## Approach: no version in the example at all

Both examples ship inside the repo, so neither should ever name a version — they should run against the `isaacteleop` beside them. The requirement becomes bare `isaacteleop[cloudxr]`, and each tree resolves it its own way:

- **In a checkout**, `[tool.uv.sources]` builds it from here via #735's scikit-build-core backend. Editable, so edits under `src/python/` take effect with no rebuild.
- **In the install tree**, `install_python_example()` pins the exact version the build produced and resolves it through the `find-links = ["../../../wheels"]` it already writes. It also drops the `[tool.uv.sources]` block, whose relative path would otherwise land on the install prefix itself and make `uv sync` fail outright.

Generating the pin instead of writing it by hand means `VERSION` can move without anyone editing an example, and there is no specifier left to drift.

The pin is load-bearing, not decorative. An unconstrained requirement resolves to the newest release on an index whenever the local wheel carries a pre-release version — which every CI build does (`X.Y.PATCHa` on main, `X.Y.PATCHrc` on release branches, per `cmake/IsaacTeleopVersion.cmake`). Measured against an install tree holding only pre-release wheels:

| requirement | resolves from |
|---|---|
| `==1.3.9rc1` (the bug) | `https://pypi.nvidia.com/` |
| bare `isaacteleop` | `https://pypi.org/simple` — a stale stable |
| `==<built version>` | `../../../wheels` ← the local wheel |

Because the pin comes from the shared macro, it applies to every example the macro installs — `oxr`, `retargeting`, `teleop_session_manager`, `haptic_feedback`, `teleop_ros2` — so all of them now resolve the wheel next to them rather than whatever an index offers. That is a wider blast radius than the two examples in the title; flagging it deliberately. Project *names* are untouched (`isaacteleop-haptic-feedback-examples` stays as-is) — the regex matches only a complete quoted requirement.

## Validation

Full `cmake --build` + `cmake --install`, then from the real install tree:

```
$ grep isaacteleop install/examples/mcap_record_replay/python/pyproject.toml
    "isaacteleop[cloudxr]==1.5+local",
$ cd install/examples/mcap_record_replay/python && uv sync --python 3.11
$ uv run python -c "import importlib.metadata as m; print(m.version('isaacteleop'))"
1.5+local                                   # source = { registry = "../../../wheels" }
$ uv run python replay_hand.py --help
usage: replay_hand.py [-h] [--host HOST] [--port PORT] [--loop] [mcap]
```

And from the source tree, `uv lock` resolves `source = { editable = "../../../" }`. The macro change is a no-op for examples that carry no `[tool.uv.sources]`: their generated pyprojects differ only by the added pin.

## No tests here — tracked in #880

Neither resolution path is covered by a test, and that is the honest state of the repo rather than an oversight in this PR: examples are separate uv projects that no build imports, and GPU example tests have to be hand-listed in a bash array in `scripts/run_tests_with_cloudxr.sh`. A survey while writing this PR found nine of fifteen examples with no tests at all, five never built by CMake, and **six `examples/oxr/python/test_*.py` files that are copied into the CloudXR test container and never invoked**.

That is filed as #880 and referenced as a `TODO` from both `cmake/InstallPythonExample.cmake` and the example pyprojects. I have a working ctest harness for the headless half (runs every script with `--help`, builds each pipeline, checks the generated install pyproject, both packaging guards mutation-checked) — held back so this PR stays one change, and ready to land against #880.

## Caveat, independent of this PR

Recording and live view need the CloudXR runtime natives. A from-source build bundles them only when `deps/cloudxr/CloudXR-<version>-Linux-<arch>-sdk.tar.gz` is fetchable, and `ENABLE_CLOUDXR_BUNDLE_CHECK` defaults `OFF`, so a failed fetch is a CMake warning — which `uv sync` hides — not an error. Today `deps/cloudxr/.env.default` pins `6.3.0-rc2` (bumped in `01e1b804`) and public NGC 404s for it, while the previous pin `6.2.1` downloads keyless. The wheel built above has an empty `cloudxr/native/`. That affects every from-source build on main and is not introduced here — but until rc2 is public, a contributor without `NGC_API_KEY` gets replay only. Happy to set `ENABLE_CLOUDXR_BUNDLE_CHECK` so the failure is loud if reviewers prefer.

## Relationship to #878

#878 fixes the same bug on `release/1.4.x` with `~=1.4.0`. That branch has no root `pyproject.toml` — #735 landed after it was cut — so neither the source build nor a generated pin is expressible there without backporting more machinery.
