### PR TITLE
build: add project C++ warning set and configure ruff lint rules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,13 @@ endif()
 # Build dependencies (OpenXR SDK, etc.)
 add_subdirectory(deps)
 
+# Project warning set. Deliberately after add_subdirectory(deps): directory-scope
+# compile options are inherited only by subdirectories added *after* this call, so
+# third-party trees keep their own flags while everything below (src/, examples/,
+# plugins) is held to ours. See cmake/CompilerWarnings.cmake.
+include(cmake/CompilerWarnings.cmake)
+isaac_teleop_enable_compiler_warnings()
+
 # Enable CTest at top level so tests from subdirectories are discoverable
 if(BUILD_TESTING)
     # Make sure to call this after `deps` is added so that Catch2 is available

--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ==============================================================================
+# Compiler warnings for first-party code
+# ==============================================================================
+# isaac_teleop_enable_compiler_warnings() applies the project's warning set to the
+# CALLING directory scope, which CMake then inherits into every subdirectory added
+# after the call. The top-level CMakeLists.txt therefore calls it *after*
+# add_subdirectory(deps) so third-party trees (OpenXR SDK, yaml-cpp, pybind11,
+# mcap, flatbuffers, Catch2, ...) keep building with their own flags and are never
+# held to warning levels we do not control.
+#
+# Known gap: the OAK plugin (OFF by default) fetches DepthAI, and transitively XLink,
+# via FetchContent from inside src/plugins/, so that tree DOES inherit these flags. It
+# builds as long as warnings are not errors; with ISAAC_TELEOP_WARNINGS_AS_ERRORS=ON it
+# fails with 41 errors in xlink-src on GCC 13 (unused-parameter, stringop-truncation,
+# parentheses, ...). Note stringop-truncation is a GCC default rather than part of this
+# set, so plain -Werror would break XLink even with ISAAC_TELEOP_ENABLE_WARNINGS=OFF.
+# Turning warnings-as-errors on in CI therefore needs OAK excluded, or a -Wno-
+# suppression scoped to the fetched tree.
+#
+# The OGLO and Noitom plugins also fetch from inside src/plugins/, but neither
+# contributes third-party translation units — OGLO uses header-only nlohmann/json plus
+# the system libdbus, and Noitom links a prebuilt libMocapApi.so — so both build clean
+# under -Werror.
+
+option(ISAAC_TELEOP_ENABLE_WARNINGS "Enable the project warning set on first-party C++ targets" ON)
+option(ISAAC_TELEOP_WARNINGS_AS_ERRORS "Promote the project warning set to errors (-Werror / /WX)" OFF)
+
+function(isaac_teleop_enable_compiler_warnings)
+    if(NOT ISAAC_TELEOP_ENABLE_WARNINGS)
+        message(STATUS "Compiler warnings: disabled (ISAAC_TELEOP_ENABLE_WARNINGS=OFF)")
+        return()
+    endif()
+
+    set(_gnu_like
+        -Wall
+        -Wextra
+        # Deliberately off: C-style aggregate init of OpenXR/Vulkan structs (which
+        # zero-fill the tail on purpose) trips this on essentially every call site.
+        # The native_openxr example already suppressed it for the same reason.
+        -Wno-missing-field-initializers
+        # Bug classes worth failing a build over.
+        -Wnon-virtual-dtor       # deleting through a base pointer without a virtual dtor
+        -Woverloaded-virtual     # a derived overload silently hiding a base virtual
+        -Wimplicit-fallthrough   # unannotated switch fallthrough
+        -Wextra-semi             # stray ';' after a member function definition
+    )
+
+    set(_msvc
+        /W4
+        /permissive-
+    )
+
+    if(ISAAC_TELEOP_WARNINGS_AS_ERRORS)
+        list(APPEND _gnu_like -Werror)
+        list(APPEND _msvc /WX)
+    endif()
+
+    add_compile_options(
+        "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU,Clang,AppleClang>>:${_gnu_like}>"
+        "$<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:MSVC>>:${_msvc}>"
+    )
+
+    message(STATUS "Compiler warnings: enabled (warnings as errors: ${ISAAC_TELEOP_WARNINGS_AS_ERRORS})")
+endfunction()

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -200,7 +200,7 @@ class VizRunner:
         with self._error_lock:
             if self._error is None:
                 self._error = exc
-        logger.error("VizRunner %s thread failed: %s", where, exc, exc_info=True)
+        logger.error("VizRunner %s thread failed: %s", where, exc, exc_info=exc)
         self._stop.set()
         with self._data_cond:
             self._data_cond.notify_all()

--- a/examples/camera_viz/sources/oakd.py
+++ b/examples/camera_viz/sources/oakd.py
@@ -30,7 +30,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 
 import numpy as np
 
@@ -120,7 +120,7 @@ class _OakdDevice:
     closes it.
     """
 
-    _SOCKET_MAP = {
+    _SOCKET_MAP: ClassVar[dict[str, str]] = {
         "RGB": "CAM_A",
         "CAM_A": "CAM_A",
         "LEFT": "CAM_B",

--- a/examples/camera_viz/sources/synthetic.py
+++ b/examples/camera_viz/sources/synthetic.py
@@ -234,27 +234,29 @@ class SyntheticStereoSource(FrameSource):
             diag_l = (x_grid_l + y_grid) / float(w + h)
             diag_r = (x_grid_r + y_grid) / float(w + h)
 
+            # Defined once, above the loop: taking phase as a parameter avoids
+            # rebuilding a closure over it on every generated frame.
+            def fill(buf, diag, phase):
+                r = (cp.sin((diag + phase) * 6.2831853) * 127.0 + 128.0).astype(
+                    cp.uint8
+                )
+                g = (
+                    cp.sin((diag + phase + 0.3333) * 6.2831853) * 127.0 + 128.0
+                ).astype(cp.uint8)
+                b = (
+                    cp.sin((diag + phase + 0.6667) * 6.2831853) * 127.0 + 128.0
+                ).astype(cp.uint8)
+                buf[..., 0] = r
+                buf[..., 1] = g
+                buf[..., 2] = b
+                buf[..., 3] = 255
+
             while not self._stop.is_set():
                 t = (time.monotonic_ns() - self._t0_ns) * 1e-9
                 phase = (t * self._hue_speed_hz) % 1.0
 
-                def fill(buf, diag):
-                    r = (cp.sin((diag + phase) * 6.2831853) * 127.0 + 128.0).astype(
-                        cp.uint8
-                    )
-                    g = (
-                        cp.sin((diag + phase + 0.3333) * 6.2831853) * 127.0 + 128.0
-                    ).astype(cp.uint8)
-                    b = (
-                        cp.sin((diag + phase + 0.6667) * 6.2831853) * 127.0 + 128.0
-                    ).astype(cp.uint8)
-                    buf[..., 0] = r
-                    buf[..., 1] = g
-                    buf[..., 2] = b
-                    buf[..., 3] = 255
-
-                fill(self._left[self._write_idx], diag_l)
-                fill(self._right[self._write_idx], diag_r)
+                fill(self._left[self._write_idx], diag_l, phase)
+                fill(self._right[self._write_idx], diag_r, phase)
                 cp.cuda.Stream.null.synchronize()
 
                 with self._lock:

--- a/examples/camera_viz/sources/zed.py
+++ b/examples/camera_viz/sources/zed.py
@@ -310,7 +310,7 @@ class _ZedCamera:
 
         # Pyzed Mats are pitched GPU buffers — one per eye, reused every
         # grab() / retrieve_image() pair.
-        for eye, slot in self._slots.items():
+        for slot in self._slots.values():
             slot.zed_mat = sl.Mat()
 
         self._camera = camera

--- a/examples/camera_viz/transports/rtp_h264_sender.py
+++ b/examples/camera_viz/transports/rtp_h264_sender.py
@@ -252,7 +252,7 @@ class RtpH264Sender:
                     raise RuntimeError(
                         f"RtpH264Sender: encode failed {consecutive_encode_failures} "
                         f"times in a row; surfacing to supervisor for full restart"
-                    )
+                    ) from e
                 continue
 
             for pkt in packets:

--- a/examples/cloudxr_mujoco_teleop/visualize_hands_mujoco_example.py
+++ b/examples/cloudxr_mujoco_teleop/visualize_hands_mujoco_example.py
@@ -37,6 +37,7 @@ from scipy.spatial.transform import Rotation as R
 import isaacteleop.deviceio as deviceio
 import isaacteleop.oxr as oxr
 from isaacteleop.cloudxr import CloudXRLauncher
+import itertools
 
 
 # Route MuJoCo warnings to stderr instead of writing MUJOCO_LOG.TXT in CWD.
@@ -74,7 +75,7 @@ LITTLE = (21, 22, 23, 24, 25)
 def _finger_chain(root: int, joints: tuple) -> list:
     """[(root,j0), (j0,j1), (j1,j2), ...] — adjacent-pair bone segments."""
     chain = [(root, joints[0])]
-    for a, b in zip(joints[:-1], joints[1:]):
+    for a, b in itertools.pairwise(joints):
         chain.append((a, b))
     return chain
 

--- a/examples/native_openxr/xdev_list/main.cpp
+++ b/examples/native_openxr/xdev_list/main.cpp
@@ -7,6 +7,7 @@
 #include <openxr/openxr.h>
 
 #include <XR_MNDX_xdev_space.h>
+#include <cstring>
 #include <exception>
 #include <iostream>
 #include <stdexcept>
@@ -93,13 +94,6 @@ std::vector<XrXDevIdMNDX> enumerate_xdevs(const OpenXRBundle& openxr_bundle, XrX
 }
 
 /*!
- * Print information about available XDevs using XR_MNDX_xdev_space extension
- */
-static void print_xdev_info(const OpenXRBundle& openxr_bundle)
-{
-}
-
-/*!
  * XDev List Application - Prints information about available XDevs
  */
 class XDevListApp : public HeadlessApp
@@ -156,7 +150,10 @@ public:
                 throw std::runtime_error("Failed to get properties for XDev " + std::to_string(xdevId));
             }
 
-            std::string serial_str = properties.serial ? properties.serial : "";
+            // serial is a fixed char[256], never a pointer, so a null check would always be true.
+            // Bound the length so a runtime that fills the array without a terminator cannot
+            // walk past it.
+            std::string serial_str(properties.serial, ::strnlen(properties.serial, sizeof(properties.serial)));
             if (serial_str == "Head Device (0)" || serial_str == "Head Device (1)")
             {
                 std::cout << "[CREATE HAND] XDev ID=" << xdevId << " Name=\"" << properties.name << "\""
@@ -168,7 +165,7 @@ public:
             else
             {
                 std::cout << "[SKIP] XDev ID=" << xdevId << " Name=\"" << properties.name << "\""
-                          << " Serial=\"" << (properties.serial ? properties.serial : "") << "\"" << std::endl;
+                          << " Serial=\"" << serial_str << "\"" << std::endl;
             }
         }
 
@@ -179,7 +176,7 @@ public:
     }
 };
 
-int main(int argc, char* argv[])
+int main(int /*argc*/, char* argv[])
 try
 {
     XDevListApp app;

--- a/examples/noitom/noitom_retargeting.py
+++ b/examples/noitom/noitom_retargeting.py
@@ -1264,7 +1264,7 @@ def compute_robot_reference_positions(
     parsed = _parse_upper_body(frame)
     if parsed is None:
         return {}
-    torso, left, right, _pelvis_world = parsed
+    _torso, left, right, _pelvis_world = parsed
     yaw_delta = _resolve_yaw_delta(current_yaw - calib.body_yaw_isaac, settings)
     anchor = settings.robot_pelvis_world.astype(np.float64)
     positions: dict[int, np.ndarray] = {int(BodyJoint.PELVIS): anchor.copy()}
@@ -1754,7 +1754,7 @@ def _solve_wrist_target(
     yaw_delta = _resolve_yaw_delta(_compute_torso_yaw(torso) - calib_yaw, settings)
 
     if settings.use_posture_based_arms:
-        shoulder_robot, elbow_robot, wrist_robot = _arm_fk_robot_blended(
+        _shoulder_robot, elbow_robot, wrist_robot = _arm_fk_robot_blended(
             arm, neutral, settings, yaw_delta, is_left
         )
         forearm = wrist_robot - elbow_robot

--- a/examples/oxr/cpp/oxr_session_sharing.cpp
+++ b/examples/oxr/cpp/oxr_session_sharing.cpp
@@ -11,7 +11,7 @@
 #include <memory>
 #include <thread>
 
-int main(int argc, char** argv)
+int main(int /*argc*/, char** argv)
 try
 {
     std::cout << "OpenXR Session Sharing Example" << std::endl;

--- a/examples/oxr/cpp/oxr_simple_api_demo.cpp
+++ b/examples/oxr/cpp/oxr_simple_api_demo.cpp
@@ -20,7 +20,7 @@
  * Internal lifecycle methods (initialize, update, cleanup) are hidden!
  */
 
-int main(int argc, char** argv)
+int main(int /*argc*/, char** argv)
 try
 {
     std::cout << "OpenXR Simple API Demo" << std::endl;

--- a/examples/retargeting/python/wuji_hand_retargeter_demo.py
+++ b/examples/retargeting/python/wuji_hand_retargeter_demo.py
@@ -54,6 +54,7 @@ import pickle
 import signal
 import sys
 import time
+from typing import ClassVar
 
 import numpy as np
 
@@ -147,7 +148,7 @@ class _ReplayUnpickler(pickle.Unpickler):
     recording may have been produced elsewhere or shared.
     """
 
-    _ALLOWED = {
+    _ALLOWED: ClassVar[set[tuple[str, str]]] = {
         ("numpy", "ndarray"),
         ("numpy", "dtype"),
         ("numpy.core.multiarray", "_reconstruct"),  # numpy < 2

--- a/examples/schemaio/full_body_printer.cpp
+++ b/examples/schemaio/full_body_printer.cpp
@@ -73,7 +73,7 @@ void print_body_pose(const core::FullBodyPoseT& data, size_t sample_count)
 
 } // namespace
 
-int main(int argc, char** argv)
+int main(int /*argc*/, char** argv)
 try
 {
     std::cout << "Full Body Printer (XR_BD_body_tracking)" << std::endl;

--- a/examples/schemaio/pedal_printer.cpp
+++ b/examples/schemaio/pedal_printer.cpp
@@ -37,7 +37,7 @@ void print_pedal_data(const core::Generic3AxisPedalOutputT& data, size_t sample_
     std::cout << std::endl;
 }
 
-int main(int argc, char** argv)
+int main(int /*argc*/, char** argv)
 try
 {
     std::cout << "Pedal Printer (collection: " << COLLECTION_ID << ")" << std::endl;

--- a/examples/schemaio/pedal_pusher.cpp
+++ b/examples/schemaio/pedal_pusher.cpp
@@ -67,7 +67,7 @@ private:
     core::SchemaPusher m_pusher;
 };
 
-int main(int argc, char** argv)
+int main(int /*argc*/, char** argv)
 try
 {
     std::cout << "Schema Pusher (collection: " << COLLECTION_ID << ")" << std::endl;

--- a/examples/teleop/python/joint_space_device_example.py
+++ b/examples/teleop/python/joint_space_device_example.py
@@ -108,7 +108,7 @@ def build_pipeline(
     head = retargeter.connect(
         {JointStateRetargeter.JOINTS: source.output(JointStateSource.JOINTS)}
     )
-    action_labels = _POSE_LABELS + ["gripper_value"]
+    action_labels = [*_POSE_LABELS, "gripper_value"]
     reorderer = TensorReorderer(
         input_config={"ee_pose": _POSE_LABELS, "gripper_command": ["gripper_value"]},
         output_order=action_labels,

--- a/examples/teleop_session_manager/python/message_channel_example.py
+++ b/examples/teleop_session_manager/python/message_channel_example.py
@@ -30,7 +30,9 @@ def _positive_int(value: str) -> int:
     try:
         n = int(value)
     except ValueError:
-        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+        raise argparse.ArgumentTypeError(
+            f"expected a positive integer, got {value!r}"
+        ) from None
     if n <= 0:
         raise argparse.ArgumentTypeError(f"must be a positive integer, got {n}")
     return n
@@ -44,7 +46,7 @@ def _parse_uuid_bytes(uuid_text: str) -> bytes:
         raise argparse.ArgumentTypeError(
             f"--channel-uuid: invalid UUID {uuid_text!r} (expected canonical form, "
             "e.g. 550e8400-e29b-41d4-a716-446655440000)"
-        )
+        ) from None
 
 
 def _enqueue_outbound_message(sink, payload: bytes) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,66 @@ packages = { isaacteleop = "src/python/isaacteleop" }
 [tool.scikit-build.editable]
 mode = "redirect"
 rebuild = false
+
+# ==============================================================================
+# Ruff
+# ==============================================================================
+# The ruff + ruff-format pre-commit hooks previously ran with no configuration at
+# all, i.e. only ruff's built-in default rules (E4/E7/E9 + F). The `select` below
+# widens that to the correctness-oriented rule groups; formatting stays on
+# ruff-format's defaults (88 cols), which is what the tree is already formatted to.
+#
+# Everything in `select` is currently clean, so the hook is enforceable as-is.
+# Each `ignore` is a deliberate call, not a backlog marker -- see its comment.
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+    "E4", "E7", "E9",  # pycodestyle errors (ruff's default subset)
+    "F",               # pyflakes
+    "B",               # flake8-bugbear -- real bug shapes
+    "C4",              # flake8-comprehensions
+    "PIE",             # flake8-pie
+    "PERF",            # perflint
+    "PLE", "PLW",      # pylint errors + warnings
+    "LOG", "G",        # logging correctness
+    "ASYNC",           # async pitfalls
+    "RUF",             # ruff-specific
+]
+
+ignore = [
+    # Adding strict= to a zip() converts a silent truncation into a runtime
+    # exception, so it is a behaviour change per call site, not a mechanical fix.
+    # Worth adopting deliberately (15 sites) rather than in a lint sweep.
+    "B905",
+    # Sorting __all__ alphabetically destroys the semantic grouping comments the
+    # package __init__ files use ("# Hand types.", "# Controller types.", ...).
+    "RUF022",
+    # RUF100 is evaluated against `select` above, so it flags every noqa written
+    # for a rule this config does not (yet) enable -- BLE001, PLC0415, N803 and
+    # friends. Re-enable once those groups are adopted.
+    "RUF100",
+    # The tree deliberately uses en/em dashes and arrows in prose and comments.
+    "RUF001", "RUF002", "RUF003",
+    # Module-level singletons (EnvConfig, the CloudXR runtime handles) are an
+    # intentional design choice here.
+    "PLW0603",
+    # Rebinding a loop variable to its normalized form, and small wrapper lambdas,
+    # both read better than the suggested rewrites in the places they occur.
+    "PLW2901", "PLW0108",
+    # The suggested comprehensions inline filtering logic that is clearer as an
+    # explicit loop (see EnvConfig._merge_env).
+    "PERF401", "PERF403",
+    # Targets trio/anyio. The one flagged call is a sub-millisecond os.path.isfile
+    # in an asyncio poll loop that already sleeps between iterations; routing it
+    # through an executor would cost more than the stat it replaces.
+    "ASYNC240",
+    # Flags any async def taking a `timeout` parameter; that is the established
+    # signature for the adb/runtime helpers and their callers.
+    "ASYNC109",
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests legitimately assert on private state and re-import inside test bodies.
+"**/tests/**" = ["SLF001"]

--- a/scripts/check_copyright_year.py
+++ b/scripts/check_copyright_year.py
@@ -30,6 +30,7 @@ def git_last_modified_year(path: Path) -> int | None:
             text=True,
             cwd=path.parent,
             timeout=5,
+            check=False,
         )
         if result.returncode != 0:
             return None
@@ -41,6 +42,7 @@ def git_last_modified_year(path: Path) -> int | None:
             text=True,
             cwd=root,
             timeout=5,
+            check=False,
         )
         if result.returncode != 0 or not result.stdout.strip():
             return None

--- a/scripts/check_lfs_pointers.py
+++ b/scripts/check_lfs_pointers.py
@@ -37,6 +37,7 @@ def _staged_content(path: str) -> bytes | None:
     proc = subprocess.run(
         ["git", "show", f":{path}"],
         capture_output=True,
+        check=False,
     )
     if proc.returncode != 0:
         return None

--- a/src/core/cloudxr_tests/python/test_runtime.py
+++ b/src/core/cloudxr_tests/python/test_runtime.py
@@ -166,7 +166,7 @@ class TestResolveCloudxrRuntimeModule:
             "isaacteleop.cloudxr.runtime._is_exp_available", lambda: False
         )
         with pytest.raises(
-            RuntimeError, match="cloudxr_exp|ENABLE_CLOUDXR_EXP"
+            RuntimeError, match=r"cloudxr_exp|ENABLE_CLOUDXR_EXP"
         ) as excinfo:
             resolve_cloudxr_runtime_module()
         # The message must blame the missing *artifact*: cloudxr_exp is authored
@@ -240,7 +240,7 @@ class TestResolveCloudxrRuntimeModule:
         monkeypatch.setattr(
             "isaacteleop.cloudxr.runtime._is_exp_available", lambda: False
         )
-        with pytest.raises(RuntimeError, match="cloudxr_exp|ENABLE_CLOUDXR_EXP"):
+        with pytest.raises(RuntimeError, match=r"cloudxr_exp|ENABLE_CLOUDXR_EXP"):
             resolve_cloudxr_runtime_module()
 
 
@@ -270,7 +270,7 @@ class TestGetSdkPath:
         self._select(monkeypatch, "isaacteleop.cloudxr")
         _patch_find_spec(monkeypatch, {"isaacteleop.cloudxr": roots})
 
-        with pytest.raises(RuntimeError, match="libcloudxr.so") as excinfo:
+        with pytest.raises(RuntimeError, match=r"libcloudxr\.so") as excinfo:
             get_sdk_path()
         for root in roots:
             assert root in str(excinfo.value)

--- a/src/core/retargeting_engine_tests/python/test_base_retargeter.py
+++ b/src/core/retargeting_engine_tests/python/test_base_retargeter.py
@@ -508,7 +508,7 @@ class TestRetargeterOutputSelector:
 class ParametricScaleRetargeter(BaseRetargeter):
     """Retargeter with a tunable scale parameter."""
 
-    def __init__(self, name: str, config_file: str = None) -> None:
+    def __init__(self, name: str, config_file: str | None = None) -> None:
         # Create parameter with sync function
         parameters = [
             FloatParameter(

--- a/src/core/retargeting_engine_tests/python/test_haptic_sink.py
+++ b/src/core/retargeting_engine_tests/python/test_haptic_sink.py
@@ -122,9 +122,10 @@ class TestAcceptedType:
         sink = HapticSink("sink", device)
 
         leaf = ValueInput("upstream", TactileVector(5))
-        with pytest.raises(Exception):
-            # Compatibility check raises a TypeError or AssertionError depending
-            # on which TensorType detects the mismatch first; either is fine.
+        # Which exception surfaces depends on which TensorType detects the mismatch
+        # first; NDArrayType currently raises ValueError. Naming the accepted set
+        # beats a bare Exception, which would also swallow an unrelated failure.
+        with pytest.raises((TypeError, AssertionError, ValueError)):
             sink.connect({"left": leaf.output("value")})
 
 

--- a/src/core/retargeting_engine_tests/python/test_joint_state_retargeter.py
+++ b/src/core/retargeting_engine_tests/python/test_joint_state_retargeter.py
@@ -441,7 +441,7 @@ class TestPipeline:
         )
         reorderer = TensorReorderer(
             input_config={"ee_pose": pose_labels, "gripper_command": ["gripper_value"]},
-            output_order=pose_labels + ["gripper_value"],
+            output_order=[*pose_labels, "gripper_value"],
             name="action_reorderer",
             input_types={"ee_pose": "array", "gripper_command": "scalar"},
         )

--- a/src/core/retargeting_engine_tests/python/test_parameter_state.py
+++ b/src/core/retargeting_engine_tests/python/test_parameter_state.py
@@ -158,13 +158,12 @@ class TestParameterState:
     def test_load_nonexistent_file_doesnt_error(self):
         """Test loading from nonexistent file doesn't error."""
         param = FloatParameter(name="value", description="Value", default_value=1.0)
-        try:
-            ParameterState(
-                name="test", parameters=[param], config_file="/nonexistent/path.json"
-            )
-        except Exception as e:
-            # Should not raise error during construction
-            assert False, f"Unexpected exception raised: {e}"
+        # Must not raise during construction; letting any exception propagate
+        # fails the test with the original traceback (and unlike `assert False`,
+        # this still holds under `python -O`).
+        ParameterState(
+            name="test", parameters=[param], config_file="/nonexistent/path.json"
+        )
 
     def test_load_from_file_after_save(self):
         """Test loading from saved file."""

--- a/src/core/rig_tests/python/test_launcher.py
+++ b/src/core/rig_tests/python/test_launcher.py
@@ -79,18 +79,18 @@ def make_exe(tmp_path: Path, rel: str) -> str:
 def make_config(tmp_path: Path, **kwargs) -> RigConfig:
     producer = make_exe(tmp_path, "install/plugins/foo/foo_plugin")
     consumer = make_exe(tmp_path, "install/examples/bar/bar_printer")
-    defaults = dict(
-        name="test_rig",
-        description="test rig",
-        cwd=tmp_path,
-        params={"hand": "right", "collection_id": "cid"},
-        runtime=None,
-        producers=(
+    defaults = {
+        "name": "test_rig",
+        "description": "test rig",
+        "cwd": tmp_path,
+        "params": {"hand": "right", "collection_id": "cid"},
+        "runtime": None,
+        "producers": (
             ProcessConfig("foo plugin", f"{producer} {{hand}} {{collection_id}}"),
         ),
-        consumers=(ProcessConfig("bar printer", f"{consumer} {{collection_id}}"),),
-        source=tmp_path / "rig.yaml",
-    )
+        "consumers": (ProcessConfig("bar printer", f"{consumer} {{collection_id}}"),),
+        "source": tmp_path / "rig.yaml",
+    }
     defaults.update(kwargs)
     return RigConfig(**defaults)
 

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -603,8 +603,6 @@ class FailingPollSource(MockDeviceIOSource):
 class MockOpenXRHandles:
     """Mock OpenXR session handles."""
 
-    pass
-
 
 class MockOpenXRSession:
     """Mock OpenXR session that supports context manager protocol."""
@@ -985,7 +983,7 @@ class TestValidateExternalInputs:
         config = make_config(pipeline)
         session = TeleopSession(config)
 
-        with pytest.raises(ValueError, match="external.*non-DeviceIO"):
+        with pytest.raises(ValueError, match=r"external.*non-DeviceIO"):
             session._validate_external_inputs(None)
 
     def test_external_leaves_missing_some_inputs(self):
@@ -1573,7 +1571,7 @@ class TestStep:
         with mock_session_dependencies():
             session = TeleopSession(config)
             with session:
-                with pytest.raises(ValueError, match="external.*non-DeviceIO"):
+                with pytest.raises(ValueError, match=r"external.*non-DeviceIO"):
                     session.step()
 
     def test_step_checks_plugin_health_every_60_frames(self):

--- a/src/plugins/plugin_utils/wrist_pose_source.cpp
+++ b/src/plugins/plugin_utils/wrist_pose_source.cpp
@@ -7,6 +7,7 @@
 #include <oxr_utils/pose_conversions.hpp>
 
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 #include <string>
 
@@ -197,7 +198,10 @@ void WristPoseSource::initialize_xdev_hand_trackers()
             continue;
         }
 
-        std::string serial_str = properties.serial ? properties.serial : "";
+        // serial is a fixed char[256], never a pointer, so a null check would always be true.
+        // Bound the length so a runtime that fills the array without a terminator cannot
+        // walk past it.
+        std::string serial_str(properties.serial, ::strnlen(properties.serial, sizeof(properties.serial)));
         seen_serials.push_back(serial_str);
 
         if (serial_str == "Head Device (0)")

--- a/src/plugins/rebot_devarm_leader/CMakeLists.txt
+++ b/src/plugins/rebot_devarm_leader/CMakeLists.txt
@@ -14,5 +14,16 @@ target_link_libraries(rebot_devarm_leader_plugin PRIVATE
     isaacteleop_schema
 )
 
+# The CAN bus implementations are SocketCAN, so their bodies live behind
+# #ifdef __linux__ and compile to throwing stubs elsewhere. Clang then correctly
+# reports the (still-declared) private members as unused. The warning is real but
+# unactionable off Linux, so suppress it only there and only for this target;
+# on Linux the fields are used and the warning stays live. GCC has no such warning.
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_compile_options(rebot_devarm_leader_plugin PRIVATE
+        $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-unused-private-field>
+    )
+endif()
+
 install(TARGETS rebot_devarm_leader_plugin RUNTIME DESTINATION plugins/rebot_devarm_leader)
 install(FILES plugin.yaml README.md DESTINATION plugins/rebot_devarm_leader)

--- a/src/postprocessing/egocentric_hand_reconstruction/quality_control/detect_jumpy_hand_from_world_results.py
+++ b/src/postprocessing/egocentric_hand_reconstruction/quality_control/detect_jumpy_hand_from_world_results.py
@@ -379,7 +379,7 @@ def _load_track_info_detection_lost(
     for b, s in enumerate(stats):
         # Find vis_mask for this track: track_info has track_id -> {index, vis_mask}; index matches our b
         vis_mask = None
-        for tid, info in tracks.items():
+        for info in tracks.values():
             if info.get("index") == b:
                 vis_mask = info.get("vis_mask")
                 break

--- a/src/postprocessing/egocentric_hand_reconstruction/scripts/download_video_from_bucket.py
+++ b/src/postprocessing/egocentric_hand_reconstruction/scripts/download_video_from_bucket.py
@@ -91,12 +91,12 @@ def main() -> int:
         print("Set ACCESS_KEY_ID and SECRET_ACCESS_KEY.")
         return 1
 
-    client_kwargs = dict(
-        aws_access_key_id=access_key_id,
-        aws_secret_access_key=secret_access_key,
-        region_name=region,
-        config=Config(connect_timeout=5),
-    )
+    client_kwargs = {
+        "aws_access_key_id": access_key_id,
+        "aws_secret_access_key": secret_access_key,
+        "region_name": region,
+        "config": Config(connect_timeout=5),
+    }
     if endpoint_url:
         client_kwargs["endpoint_url"] = endpoint_url
 

--- a/src/python/isaacteleop/cloudxr/env_config.py
+++ b/src/python/isaacteleop/cloudxr/env_config.py
@@ -13,6 +13,7 @@ import os
 import shlex
 import warnings
 from pathlib import Path
+from typing import ClassVar
 
 
 class EnvConfig:
@@ -43,7 +44,7 @@ class EnvConfig:
     )
 
     # Default env var name -> default value. Empty string or None means "resolve later"
-    _DEFAULT_ENV: dict[str, str | None] = {
+    _DEFAULT_ENV: ClassVar[dict[str, str | None]] = {
         "XR_RUNTIME_JSON": None,  # resolved from openxr_run_dir()
         "NV_CXR_RUNTIME_DIR": None,  # resolved from openxr_run_dir()
         "NV_CXR_OUTPUT_DIR": None,  # resolved from ensure_logs_dir()

--- a/src/python/isaacteleop/cloudxr/launcher.py
+++ b/src/python/isaacteleop/cloudxr/launcher.py
@@ -589,6 +589,7 @@ class CloudXRLauncher:
                     ["fuser", "-k", "-TERM", ipc_socket],
                     capture_output=True,
                     timeout=5,
+                    check=False,
                 )
                 if result.returncode == 0:
                     time.sleep(1)

--- a/src/python/isaacteleop/cloudxr/oob_teleop_adb.py
+++ b/src/python/isaacteleop/cloudxr/oob_teleop_adb.py
@@ -637,7 +637,9 @@ def open_url_on_headset(url: str) -> tuple[int, str]:
         redact_control_token(" ".join(shlex.quote(c) for c in full)),
     )
     try:
-        proc = subprocess.run(full, capture_output=True, text=True, timeout=30)
+        proc = subprocess.run(
+            full, capture_output=True, text=True, timeout=30, check=False
+        )
     except subprocess.TimeoutExpired as e:
         partial = (
             (e.stderr or e.stdout or b"")

--- a/src/python/isaacteleop/haptic_devices/controller.py
+++ b/src/python/isaacteleop/haptic_devices/controller.py
@@ -79,9 +79,7 @@ class ControllerHapticDevice(IHapticDevice):
             )
         # Latest-wins per endpoint within a frame; emitted and cleared by flush.
         self._pending: dict[Endpoint, _Pulse] = {}
-        self._error_logged: dict[Endpoint, bool] = {
-            endpoint: False for endpoint in self._endpoints
-        }
+        self._error_logged: dict[Endpoint, bool] = dict.fromkeys(self._endpoints, False)
 
     def accepted_type(self) -> TensorGroupType:
         return ControllerHapticPulse()

--- a/src/python/isaacteleop/haptic_devices/push_tensor.py
+++ b/src/python/isaacteleop/haptic_devices/push_tensor.py
@@ -86,9 +86,7 @@ class PushTensorHapticDevice(IHapticDevice):
         )
         # Latest-wins per endpoint within a frame; emitted and cleared by flush.
         self._pending: dict[Endpoint, list[float]] = {}
-        self._error_logged: dict[Endpoint, bool] = {
-            endpoint: False for endpoint in self._endpoints
-        }
+        self._error_logged: dict[Endpoint, bool] = dict.fromkeys(self._endpoints, False)
 
     def accepted_type(self) -> TensorGroupType:
         return self._accepted_type

--- a/src/python/isaacteleop/retargeters/dex_hand_retargeter.py
+++ b/src/python/isaacteleop/retargeters/dex_hand_retargeter.py
@@ -323,7 +323,7 @@ class DexHandRetargeter(BaseRetargeter):
 
             return None
         except Exception as e:
-            logger.error(f"Error updating YAML {yaml_path}: {e}")
+            logger.error("Error updating YAML %s: %s", yaml_path, e)
             return None
 
     def _compute_hand(self, poses: Dict[str, np.ndarray]) -> np.ndarray:
@@ -418,7 +418,7 @@ class DexHandRetargeter(BaseRetargeter):
             with torch.enable_grad(), torch.inference_mode(False):
                 return self._dex_hand.retarget(ref_value)  # type: ignore
         except Exception as e:
-            logger.error(f"Error in retargeting: {e}")
+            logger.error("Error in retargeting: %s", e)
             return np.zeros(len(self._dex_hand.optimizer.robot.dof_joint_names))
 
 

--- a/src/python/isaacteleop/retargeting_engine/deviceio_source_nodes/interface.py
+++ b/src/python/isaacteleop/retargeting_engine/deviceio_source_nodes/interface.py
@@ -71,7 +71,6 @@ class IDeviceIOSource(BaseRetargeter):
         Returns:
             The ITracker instance (e.g., HeadTracker, HandTracker, ControllerTracker)
         """
-        pass
 
     @abstractmethod
     def poll_tracker(self, deviceio_session: Any) -> RetargeterIO:
@@ -87,4 +86,3 @@ class IDeviceIOSource(BaseRetargeter):
             Dict mapping input names to TensorGroups containing raw tracker data,
             matching this source's input_spec().
         """
-        pass

--- a/src/python/isaacteleop/retargeting_engine/interface/base_retargeter.py
+++ b/src/python/isaacteleop/retargeting_engine/interface/base_retargeter.py
@@ -111,7 +111,6 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
         Returns:
             Dict[str, TensorGroupType] - Input specification
         """
-        pass
 
     @abstractmethod
     def output_spec(self) -> RetargeterIOType:
@@ -121,7 +120,6 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
         Returns:
             Dict[str, TensorGroupType] - Output specification
         """
-        pass
 
     @abstractmethod
     def _compute_fn(
@@ -153,7 +151,6 @@ class BaseRetargeter(BaseExecutable, GraphExecutable):
             outputs: Output tensor groups to populate (Dict[str, TensorGroup])
             context: Compute context containing graph time and future metadata
         """
-        pass
 
     # ========================================================================
     # Public convenience API — not part of any abstract contract

--- a/src/python/isaacteleop/retargeting_engine/interface/output_combiner.py
+++ b/src/python/isaacteleop/retargeting_engine/interface/output_combiner.py
@@ -109,7 +109,7 @@ class OutputCombiner(GraphExecutable):
         if outputs is not None:
             return outputs
 
-        outputs = dict()
+        outputs = {}
         for custom_name, selector in self.output_mapping.items():
             source_outputs = selector.module._compute_with_cache(cache)
             outputs[custom_name] = source_outputs[selector.output_name]

--- a/src/python/isaacteleop/retargeting_engine/interface/tensor_type.py
+++ b/src/python/isaacteleop/retargeting_engine/interface/tensor_type.py
@@ -66,7 +66,6 @@ class TensorType(ABC):
         Returns:
             True if the instances are compatible, False otherwise
         """
-        pass
 
     @abstractmethod
     def validate_value(self, value: Any) -> None:
@@ -83,7 +82,6 @@ class TensorType(ABC):
         Raises:
             TypeError: If the value does not conform to this tensor type
         """
-        pass
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(name='{self._name}')"

--- a/src/python/isaacteleop/retargeting_engine/interface/tunable_parameter.py
+++ b/src/python/isaacteleop/retargeting_engine/interface/tunable_parameter.py
@@ -27,22 +27,18 @@ class ParameterSpec(ABC):
     @abstractmethod
     def validate(self, value: Any) -> bool:
         """Check if a value is valid for this parameter."""
-        pass
 
     @abstractmethod
     def get_default_value(self) -> Any:
         """Get the default value for this parameter."""
-        pass
 
     @abstractmethod
     def serialize(self, value: Any) -> Any:
         """Serialize a value to a JSON-compatible format."""
-        pass
 
     @abstractmethod
     def deserialize(self, value: Any) -> Any:
         """Deserialize a value from a JSON-compatible format."""
-        pass
 
 
 @dataclass

--- a/src/python/isaacteleop/retargeting_engine_ui/multi_retargeter_tuning_ui.py
+++ b/src/python/isaacteleop/retargeting_engine_ui/multi_retargeter_tuning_ui.py
@@ -368,7 +368,7 @@ class MultiRetargeterTuningUIImGui:
                 imgui.set_next_window_size(400, 500, imgui.FIRST_USE_EVER)
 
             # Create independent floating window
-            expanded, opened = imgui.begin(f"{name}##floating", closable=False)
+            expanded, _opened = imgui.begin(f"{name}##floating", closable=False)
             if expanded:
                 self._render_retargeter_params(name, param_state)
             imgui.end()

--- a/src/python/isaacteleop/rig/launcher.py
+++ b/src/python/isaacteleop/rig/launcher.py
@@ -111,6 +111,7 @@ def _check_python_can_import_cloudxr(env: Mapping[str, str]) -> None:
         [sys.executable, "-c", "import isaacteleop.cloudxr"],
         env=dict(env),
         capture_output=True,
+        check=False,
     )
     if probe.returncode != 0:
         raise PreflightError(


### PR DESCRIPTION
## Description

Two related build-hygiene changes that were previously unenforced.

**1. `build:` project C++ warning set with opt-in warnings-as-errors**

Adds `cmake/CompilerWarnings.cmake`, included from the root `CMakeLists.txt` *after*
`add_subdirectory(deps)`. Directory-scope compile options are only inherited by
subdirectories added after the call, so first-party targets get the flags while the
third-party trees (OpenXR SDK, yaml-cpp, pybind11, mcap, flatbuffers, Catch2) keep
their own.

Flags on GNU/Clang: `-Wall -Wextra -Wno-missing-field-initializers -Wnon-virtual-dtor
-Woverloaded-virtual -Wimplicit-fallthrough -Wextra-semi`. MSVC gets `/W4 /permissive-`.
Two options: `ISAAC_TELEOP_ENABLE_WARNINGS` (ON) and `ISAAC_TELEOP_WARNINGS_AS_ERRORS`
(OFF, opt in per build/CI).

Fixes everything the set surfaced:

- `properties.serial` is a fixed `char[256]`, never a pointer, so the
  `properties.serial ? ... : ""` guard was always-true dead code
  (`-Wpointer-bool-conversion`, 3 sites). Replaced with a `strnlen`-bounded
  `std::string` construction, which additionally guards against a runtime that fills
  the array without a terminator.
- Removed the empty, unused `print_xdev_info` (`-Wunused-function`).
- Commented out the unused `argc` parameter name in six `main()` definitions.

`robstride_bus`'s private members are used only inside `#ifdef __linux__`, so Clang
reports them unused when the file compiles to its throwing stub. That warning is
correct but unactionable off Linux (GCC has no equivalent), so it is suppressed for
that one target on non-Linux only.

**2. `chore:` ruff lint rules, and the fixes they surfaced**

The `ruff` and `ruff-format` pre-commit hooks were running with no configuration at
all, so only ruff's built-in defaults (E4/E7/E9 + F) were ever enforced. Adds a
`[tool.ruff]` section selecting the correctness-oriented groups: B, C4, PIE, PERF,
PLE, PLW, LOG, G, ASYNC and RUF. Formatting is unchanged (ruff-format defaults, which
the tree already matches). Everything in `select` is currently clean, so the hook is
enforceable as-is. Each entry in `ignore` is a deliberate call with its reason inline.

Bug-shaped findings fixed:

- `B023`: a closure captured the loop variable `phase` in the synthetic camera source.
  Hoisting it above the loop and passing `phase` explicitly also stops rebuilding the
  closure on every generated frame.
- `RUF043`: pytest `match="libcloudxr.so"` treated `.` as a regex wildcard where a
  literal filename was meant; the remaining patterns are intentional regexes and are
  now raw strings.
- `RUF012`: three mutable class attributes annotated `ClassVar`, one of them on the
  `EnvConfig` singleton.
- `LOG014`: pass the caught exception via `exc_info=exc` rather than relying on ambient
  `sys.exc_info()`.
- `RUF013` implicit Optional, `B904` exception chaining, `B011` `assert False` (removed
  by `python -O`), `B017` blind `pytest.raises(Exception)`, `G004` eager f-string log
  formatting, `PLW1510` implicit `subprocess` check, plus safe C4/PIE/PERF/RUF autofixes.

`TRY004` (`ValueError` -> `TypeError` in `TeleopSessionConfig` validation) was left
alone: it is a public API behaviour change, not a lint fix.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Validated on two toolchains.

**Apple Clang 21 / arm64 (macOS)** — 88 first-party TUs configure on that host. Clean
build with `ISAAC_TELEOP_WARNINGS_AS_ERRORS=ON`. `ctest` 158/160, the two failures being
environment gaps (no wuji-sdk wheel, no CloudXR SDK tarball) confirmed pre-existing by
re-running with these changes stashed.

**GCC 13.3 / x86_64, Ubuntu 24.04, RTX PRO 6000 Blackwell, CUDA 13.0** —

```
cmake --preset py3.12 -DCMAKE_BUILD_TYPE=Release -DISAAC_TELEOP_WARNINGS_AS_ERRORS=ON
cmake --build --preset py3.12 --parallel 24 --clean-first
```

- 328 first-party TUs, **zero warnings**, clean under `-Werror`. This covers the targets
  macOS cannot reach: `rebot_devarm_leader` on its real SocketCAN path (so the
  `-Wno-unused-private-field` suppression above is confirmed to be needed only off
  Linux), and the whole Televiz tree with `BUILD_VIZ` auto-ON (Vulkan + CUDA + glslang
  all present).
- `BUILD_PLUGIN_OGLO=ON` and `BUILD_PLUGIN_NOITOM_MOCAP=ON` also build clean under
  `-Werror`.
- `ctest`: 308/309. The one failure, `cloudxr_test_launcher`, is the missing CloudXR SDK
  (no NGC key on this host, so the download 404s and `get_sdk_path()` raises) — the same
  environment gap as on macOS, not a code failure.
- `SKIP=check-copyright-year pre-commit run --all-files`: all hooks pass.

**Known limitation — `BUILD_PLUGIN_OAK_CAMERA=ON` does not build with
`ISAAC_TELEOP_WARNINGS_AS_ERRORS=ON`.** DepthAI pulls XLink via FetchContent from inside
`src/plugins/oak/`, so that third-party tree *does* inherit the flags — 41 errors, all in
`xlink-src` (16 `unused-parameter`, 11 `stringop-truncation`, 5 `unused-variable`, 3
`parentheses`, 2 `unused-but-set-variable`, 2 `implicit-fallthrough`, 1
`unused-but-set-parameter`, 1 `switch`). Note `stringop-truncation` is a GCC default
rather than part of this warning set, so plain `-Werror` would break XLink regardless.
This is why `ISAAC_TELEOP_WARNINGS_AS_ERRORS` defaults to OFF and CI is left at the
default; enabling it in CI needs OAK excluded or a suppression scoped to the fetched
tree. The header comment in `cmake/CompilerWarnings.cmake` records the gap.

MSVC is unvalidated.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

Documentation: no user-facing behaviour changes, so no doc updates. The two new CMake
options are documented in the header comment of `cmake/CompilerWarnings.cmake`.

Tests: no new tests — this is a build-configuration and lint-configuration change, and
it is exercised by the existing suite building and passing under `-Werror` on both
toolchains above.
