### PR TITLE
🍒 ci: bundle the experimental CloudXR runtime in build-ubuntu

### DIFF
--- a/.github/actions/setup-cloudxr-sdk/action.yml
+++ b/.github/actions/setup-cloudxr-sdk/action.yml
@@ -39,6 +39,8 @@ runs:
       shell: bash
       env:
         CXR_RUNTIME_SDK_VERSION: ${{ steps.parse.outputs.runtime_version }}
+        # Staged here because the configure step re-runs this script without a key.
+        CXR_DOWNLOAD_EXP: '1'
         NGC_API_KEY: ${{ inputs.ngc-api-key }}
       run: |
         ./scripts/download_cloudxr_runtime_sdk.sh

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -150,6 +150,7 @@ jobs:
           -DBUILD_PLUGIN_OAK_CAMERA=ON \
           -DBUILD_VIZ=ON \
           -DENABLE_CLOUDXR_BUNDLE_CHECK=ON \
+          -DENABLE_CLOUDXR_EXP_BUNDLE=ON \
           -DBUNDLE_ROBOTIC_GROUNDING=${{ steps.setup-v2d-src.outputs.bundled || 'false' }} \
           -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake \
           "${coverage_args[@]}"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Cherry-pick [8f5c606](https://github.com/NVIDIA/IsaacTeleop/commit/8f5c606cb522f50622e14925d0e8c01ffb6a5743) from `main` into `release/1.4.x`.

This ensures the IsaacTeleop 1.4 Ubuntu CI wheels include the experimental CloudXR runtime:

- Request the experimental SDK archive while the NGC API key is available.
- Configure the Ubuntu wheel build with `ENABLE_CLOUDXR_EXP_BUNDLE=ON`.
- Use the existing bundle check to prevent publishing a wheel without the requested runtime.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- Ran `SKIP=check-copyright-year pre-commit run --all-files`.
- The Ubuntu CI build validates that the experimental runtime is included in the wheel.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] Documentation changes are not required for this CI backport
- [x] CI validates the wheel contents
- [x] I have signed off all commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)