### PR TITLE
🍒 chore(cloudxr): bump runtime SDK version to 6.3.0-rc3

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.2.1
+CXR_RUNTIME_SDK_VERSION=6.3.0-rc3
 CXR_WEB_SDK_VERSION=6.3.0-rc2
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Backport [0ec416b95](https://github.com/NVIDIA/IsaacTeleop/commit/0ec416b95ae4a29225e6b02ca5c88045d5b5ce28) into `release/1.4.x`.

On `main`, this followed #873, which landed CloudXR Runtime SDK 6.3.0-rc2. The 1.4 branch currently pins 6.2.1, so this advances it directly to 6.3.0-rc3.

RC3 is the newest runtime published on NGC and, unlike earlier versions, provides the experimental archives required by the `cloudxr_exp` wheel bundle.

The SDK is consumed as prebuilt shared objects. CMake extracts the archive and removes `include/` and `plugins/`, so this change only updates the runtime version pin.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- Ran `SKIP=check-copyright-year pre-commit run --all-files`.
- Built an x86_64 CPython 3.12 wheel locally with `ENABLE_CLOUDXR_EXP_BUNDLE=ON`.
- Verified the wheel by launching `camera_viz` in XR mode with the bundled RC3 runtime.
- The post-merge `release/1.4.x` CI run will validate private-NGC download and wheel packaging. Fork PR workflows cannot access the required NGC secret.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] Documentation changes are not required for this version-pin backport
- [x] Testing is described above
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)