### PR TITLE
fix(camera_viz): improve Orin XR setup

### DIFF
--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -31,6 +31,8 @@ Requirements
 
 - A workstation meeting the :doc:`system requirements </references/requirements>` (Ubuntu, NVIDIA
   GPU, CUDA driver) — every source hands frames to the renderer GPU-resident via CuPy.
+- For Jetson Orin, use
+  `JetPack 6.2.1 <https://developer.nvidia.com/embedded/jetpack-sdk-621>`_.
 - For the default XR mode, a headset to connect as the CloudXR client — follow the
   :doc:`quick start </getting_started/quick_start>` step :ref:`connect-xr-headset`. The viewer
   launches the CloudXR runtime itself; nothing to start separately. No headset handy?
@@ -48,11 +50,11 @@ run the sample's one-time setup:
    source examples/camera_viz/.venv/bin/activate
 
 There is no need to install the ``isaacteleop`` pip package yourself — ``setup`` creates the
-sample's own environment: it installs ``isaacteleop>=1.4`` (which bundles Televiz) and every other
-Python dependency from PyPI into ``.venv/`` via ``uv``, builds the native NVENC/NVDEC codec, and
-probes system packages (GStreamer plugins, cairo / girepository headers, JetPack ``cuda-nvrtc`` +
-``ld.so`` wiring). When something is missing it prints the exact ``apt-get`` line and prompts
-``[y/N]`` — answering ``n`` or running non-interactively aborts.
+sample's own environment: it installs ``isaacteleop>=1.4`` (which bundles Televiz) and
+every other Python dependency from PyPI into ``.venv/`` via ``uv``, builds the native NVENC/NVDEC
+codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack
+``cuda-nvrtc`` + ``ld.so`` wiring). When something is missing it prints the exact ``apt-get`` line
+and prompts ``[y/N]`` — answering ``n`` or running non-interactively aborts.
 
 By default ``setup`` provisions everything except ZED support; flags trim or extend that:
 

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -301,8 +301,9 @@ fi
 # composition layers, compositor choice, CloudXR launcher helpers).
 # --wheel <path> installs a locally built wheel instead — only needed when
 # developing against an unreleased build (see the build-from-source docs).
-# Sender-only deploys don't install isaacteleop at all.
-ISAACTELEOP_PKG="isaacteleop>=1.4"
+# Sender-only deploys don't install isaacteleop at all. Python extras are
+# additive, so this includes the base package and its dependencies.
+ISAACTELEOP_PKG="isaacteleop[cloudxr]>=1.4"
 if [[ "$MODE" == full && -n "$WHEEL" ]]; then
     [[ -f "$WHEEL" ]] || {
         echo "_install_deps.sh: --wheel '$WHEEL' not found." >&2
@@ -388,6 +389,13 @@ if (( ${#EXTRA_UV[@]} > 0 )); then
     uv pip install --python "$PY" --upgrade "${EXTRA_UV[@]}" "${PKGS[@]}"
 else
     uv pip install --python "$PY" --upgrade "${PKGS[@]}"
+fi
+
+# A direct wheel requirement does not activate optional dependencies. Install
+# the CloudXR extra after the local wheel is present; without --upgrade, uv
+# reuses that wheel and adds only its missing optional dependencies.
+if [[ "$MODE" == full && -n "$WHEEL" ]]; then
+    uv pip install --python "$PY" "isaacteleop[cloudxr]"
 fi
 
 # ZED SDK ships get_python_api.py which downloads a matching pyzed wheel


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Improve `camera_viz` setup on Jetson Orin.

- Document JetPack 6.2.1 for camera streaming on Jetson Orin.
- Install the `isaacteleop[cloudxr]` dependencies for both PyPI and local-wheel setup paths.
- Ensure XR mode has the required WebSocket dependency without a separate post-setup installation step.

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- Ran `bash -n examples/camera_viz/scripts/_install_deps.sh`.
- Ran `SKIP=check-copyright-year pre-commit run --all-files`.
- No automated test was added because this change adjusts dependency installation in the setup script.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Jetson Orin requirements to specify JetPack 6.2.1.
  * Clarified setup behavior, including dependency installation, system package checks, and failure conditions.

* **Bug Fixes**
  * Full and local-wheel installations now include optional CloudXR dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->