### PR TITLE
fix(camera_viz): monitor managed CloudXR runtime

### DIFF
--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -443,7 +443,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         if effective_mode == "xr"
         else contextlib.nullcontext(None)
     )
-    launch_ctx.__enter__()
+    launcher = launch_ctx.__enter__()
     stop_launcher = True
     try:
         session = _make_session(cfg, mode_override=args.mode)
@@ -484,7 +484,9 @@ def main(argv: Optional[list[str]] = None) -> int:
 
         runner.start()
         try:
-            runner.wait()
+            runner.wait(
+                health_check=launcher.health_check if launcher is not None else None
+            )
         finally:
             # Skip session.destroy() when a worker thread is still alive —
             # it may be inside session.render() and destroying under it

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -19,7 +19,7 @@ import logging
 import sys
 import threading
 import time
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 
 import isaacteleop.viz as viz
 
@@ -169,11 +169,14 @@ class VizRunner:
                     logger.exception("source.stop() raised")
         return clean
 
-    def wait(self) -> None:
+    def wait(self, health_check: Optional[Callable[[], None]] = None) -> None:
         """Block until the render thread exits, then re-raise any captured
-        thread error. Polls so SIGINT is delivered."""
+        thread error. Polls so SIGINT is delivered and optional external
+        dependencies can report failure on the main thread."""
         while self._render_thread is not None and self._render_thread.is_alive():
             self._render_thread.join(timeout=0.1)
+            if health_check is not None:
+                health_check()
         # The submit thread may still be running (it exits on _stop set
         # by render's exit / signal handler / record_error). Give it the
         # same poll-loop courtesy so its error has a chance to land

--- a/examples/camera_viz/tests/test_runner_health.py
+++ b/examples/camera_viz/tests/test_runner_health.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime-health monitoring tests for VizRunner."""
+
+from __future__ import annotations
+
+import pytest
+
+from pipeline import VizRunner
+
+
+class _AliveThread:
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float) -> None:
+        assert timeout == 0.1
+
+
+def test_wait_propagates_health_check_failure() -> None:
+    runner = VizRunner(object(), [], [])
+    runner._render_thread = _AliveThread()
+    checks = 0
+
+    def health_check() -> None:
+        nonlocal checks
+        checks += 1
+        raise RuntimeError("CloudXR runtime exited")
+
+    with pytest.raises(RuntimeError, match="CloudXR runtime exited"):
+        runner.wait(health_check=health_check)
+
+    assert checks == 1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Stop `camera_viz` when its managed CloudXR runtime exits unexpectedly.

- Poll `CloudXRLauncher.health_check()` while the visualization runner is active.
- Propagate runtime and WSS proxy failures to the main thread for controlled teardown.
- Leave externally managed runtimes unchanged when `--no-launch-cloudxr-runtime` is used.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- Added a unit test verifying that `VizRunner.wait()` propagates health-check failures.
- Ran the focused unit test successfully.
- Ran `SKIP=check-copyright-year pre-commit run --all-files`.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation (not applicable; there are no CLI or setup changes)
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CloudXR launch monitoring during camera visualization runs.
  * Runtime health checks now run while waiting for rendering to complete, allowing failures to be detected and reported promptly.

* **Tests**
  * Added coverage verifying health-check execution, error propagation, and render-thread wait behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->