### PR TITLE
state vcpkg toolchain needs a fresh build

### DIFF
--- a/docs/source/device/oak.rst
+++ b/docs/source/device/oak.rst
@@ -47,10 +47,19 @@ Prerequisites
 Configure and Build
 ~~~~~~~~~~~~~~~~~~~
 
+.. warning::
+
+   ``CMAKE_TOOLCHAIN_FILE`` is a CMake constraint: it is only read on the
+   **first** configure of a build tree and is silently ignored on any
+   re-configure. **If** ``build/`` **already exists, delete it before running
+   the commands below**, otherwise the vcpkg toolchain will not be picked up and
+   configure will fail.
+
 .. code-block:: bash
 
    cd IsaacTeleop
 
+   rm -rf build/   # required if build/ already exists or was previously configured without CMAKE_TOOLCHAIN_FILE
    cmake -B build -DBUILD_PLUGIN_OAK_CAMERA=ON \
        -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
    cmake --build build --target camera_plugin_oak --parallel


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Update doc to state that oak needs vcpkg toolchain configured on a fresh build so need to delete the existing one.
Fixes #893 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

N/A

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not) not applicable
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAK camera build instructions to clarify that toolchain settings apply only during initial configuration.
  * Added guidance to remove the existing build directory before running CMake.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->