### PR TITLE
🍒 fix(camera_viz): monitor CloudXR and improve Orin setup

### DIFF
--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -31,6 +31,8 @@ Requirements
 
 - A workstation meeting the :doc:`system requirements </references/requirements>` (Ubuntu, NVIDIA
   GPU, CUDA driver) — every source hands frames to the renderer GPU-resident via CuPy.
+- For Jetson Orin, use
+  `JetPack 6.2.1 <https://developer.nvidia.com/embedded/jetpack-sdk-621>`_.
 - For the default XR mode, a headset to connect as the CloudXR client — follow the
   :doc:`quick start </getting_started/quick_start>` step :ref:`connect-xr-headset`. The viewer
   launches the CloudXR runtime itself; nothing to start separately. No headset handy?
@@ -48,11 +50,11 @@ run the sample's one-time setup:
    source examples/camera_viz/.venv/bin/activate
 
 There is no need to install the ``isaacteleop`` pip package yourself — ``setup`` creates the
-sample's own environment: it installs ``isaacteleop>=1.4`` (which bundles Televiz) and every other
-Python dependency from PyPI into ``.venv/`` via ``uv``, builds the native NVENC/NVDEC codec, and
-probes system packages (GStreamer plugins, cairo / girepository headers, JetPack ``cuda-nvrtc`` +
-``ld.so`` wiring). When something is missing it prints the exact ``apt-get`` line and prompts
-``[y/N]`` — answering ``n`` or running non-interactively aborts.
+sample's own environment: it installs ``isaacteleop>=1.4`` (which bundles Televiz) and
+every other Python dependency from PyPI into ``.venv/`` via ``uv``, builds the native NVENC/NVDEC
+codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack
+``cuda-nvrtc`` + ``ld.so`` wiring). When something is missing it prints the exact ``apt-get`` line
+and prompts ``[y/N]`` — answering ``n`` or running non-interactively aborts.
 
 By default ``setup`` provisions everything except ZED support; flags trim or extend that:
 

--- a/examples/camera_viz/camera_viz.py
+++ b/examples/camera_viz/camera_viz.py
@@ -443,7 +443,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         if effective_mode == "xr"
         else contextlib.nullcontext(None)
     )
-    launch_ctx.__enter__()
+    launcher = launch_ctx.__enter__()
     stop_launcher = True
     try:
         session = _make_session(cfg, mode_override=args.mode)
@@ -484,7 +484,9 @@ def main(argv: Optional[list[str]] = None) -> int:
 
         runner.start()
         try:
-            runner.wait()
+            runner.wait(
+                health_check=launcher.health_check if launcher is not None else None
+            )
         finally:
             # Skip session.destroy() when a worker thread is still alive —
             # it may be inside session.render() and destroying under it

--- a/examples/camera_viz/pipeline/runner.py
+++ b/examples/camera_viz/pipeline/runner.py
@@ -19,7 +19,7 @@ import logging
 import sys
 import threading
 import time
-from typing import Optional, Sequence
+from typing import Callable, Optional, Sequence
 
 import isaacteleop.viz as viz
 
@@ -169,11 +169,14 @@ class VizRunner:
                     logger.exception("source.stop() raised")
         return clean
 
-    def wait(self) -> None:
+    def wait(self, health_check: Optional[Callable[[], None]] = None) -> None:
         """Block until the render thread exits, then re-raise any captured
-        thread error. Polls so SIGINT is delivered."""
+        thread error. Polls so SIGINT is delivered and optional external
+        dependencies can report failure on the main thread."""
         while self._render_thread is not None and self._render_thread.is_alive():
             self._render_thread.join(timeout=0.1)
+            if health_check is not None:
+                health_check()
         # The submit thread may still be running (it exits on _stop set
         # by render's exit / signal handler / record_error). Give it the
         # same poll-loop courtesy so its error has a chance to land

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -301,8 +301,9 @@ fi
 # composition layers, compositor choice, CloudXR launcher helpers).
 # --wheel <path> installs a locally built wheel instead — only needed when
 # developing against an unreleased build (see the build-from-source docs).
-# Sender-only deploys don't install isaacteleop at all.
-ISAACTELEOP_PKG="isaacteleop>=1.4"
+# Sender-only deploys don't install isaacteleop at all. Python extras are
+# additive, so this includes the base package and its dependencies.
+ISAACTELEOP_PKG="isaacteleop[cloudxr]>=1.4"
 if [[ "$MODE" == full && -n "$WHEEL" ]]; then
     [[ -f "$WHEEL" ]] || {
         echo "_install_deps.sh: --wheel '$WHEEL' not found." >&2
@@ -388,6 +389,13 @@ if (( ${#EXTRA_UV[@]} > 0 )); then
     uv pip install --python "$PY" --upgrade "${EXTRA_UV[@]}" "${PKGS[@]}"
 else
     uv pip install --python "$PY" --upgrade "${PKGS[@]}"
+fi
+
+# A direct wheel requirement does not activate optional dependencies. Install
+# the CloudXR extra after the local wheel is present; without --upgrade, uv
+# reuses that wheel and adds only its missing optional dependencies.
+if [[ "$MODE" == full && -n "$WHEEL" ]]; then
+    uv pip install --python "$PY" "isaacteleop[cloudxr]"
 fi
 
 # ZED SDK ships get_python_api.py which downloads a matching pyzed wheel

--- a/examples/camera_viz/tests/test_runner_health.py
+++ b/examples/camera_viz/tests/test_runner_health.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime-health monitoring tests for VizRunner."""
+
+from __future__ import annotations
+
+import pytest
+
+from pipeline import VizRunner
+
+
+class _AliveThread:
+    def is_alive(self) -> bool:
+        return True
+
+    def join(self, timeout: float) -> None:
+        assert timeout == 0.1
+
+
+def test_wait_propagates_health_check_failure() -> None:
+    runner = VizRunner(object(), [], [])
+    runner._render_thread = _AliveThread()
+    checks = 0
+
+    def health_check() -> None:
+        nonlocal checks
+        checks += 1
+        raise RuntimeError("CloudXR runtime exited")
+
+    with pytest.raises(RuntimeError, match="CloudXR runtime exited"):
+        runner.wait(health_check=health_check)
+
+    assert checks == 1


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Backport the following `camera_viz` fixes from `main` into `release/1.4.x`:

- [bd922b43](https://github.com/NVIDIA/IsaacTeleop/commit/bd922b43e2759894aa2a1621952a3faba10ef8c3): Monitor the managed CloudXR runtime and WSS proxy while `camera_viz` is active. Unexpected failures are propagated to the main thread so the application terminates.
- [257a444d](https://github.com/NVIDIA/IsaacTeleop/commit/257a444dfc8022e29453658a39572dfc49d5d02a): Document JetPack 6.2.1 for camera streaming on Jetson Orin.
- [26cab2d6](https://github.com/NVIDIA/IsaacTeleop/commit/26cab2d6ad0b055cd94f7877b0c7b2b3b815d7b9): Install `isaacteleop[cloudxr]` dependencies for both PyPI and local-wheel setup paths.

Together, these changes make XR setup complete without a separate dependency-installation step and ensure `camera_viz` exits if a CloudXR process it manages stops unexpectedly.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- Ran `SKIP=check-copyright-year pre-commit run --all-files`.
- Ran the focused `VizRunner` health-check unit test.
- Built and installed an x86_64 CPython 3.12 wheel with CloudXR 6.3.0-rc3.
- Launched `camera_viz` in XR mode and sent `SIGABRT` to its managed CloudXR runtime.
- Verified that the runtime, `camera_viz`, and its shell wrapper all terminated.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)