### PR TITLE
docs(camera_viz): document Thor JetPack

### DIFF
--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -31,8 +31,9 @@ Requirements
 
 - A workstation meeting the :doc:`system requirements </references/requirements>` (Ubuntu, NVIDIA
   GPU, CUDA driver) — every source hands frames to the renderer GPU-resident via CuPy.
-- For Jetson Orin, use
-  `JetPack 6.2.1 <https://developer.nvidia.com/embedded/jetpack-sdk-621>`_.
+- For Jetson platforms, use
+  `JetPack 6.2.1 <https://developer.nvidia.com/embedded/jetpack-sdk-621>`_ on Orin or
+  `JetPack 7.1 <https://developer.nvidia.com/embedded/jetpack/downloads/archive-7.1>`_ on Thor.
 - For the default XR mode, a headset to connect as the CloudXR client — follow the
   :doc:`quick start </getting_started/quick_start>` step :ref:`connect-xr-headset`. The viewer
   launches the CloudXR runtime itself; nothing to start separately. No headset handy?


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Clarify the supported JetPack versions for camera streaming on Jetson platforms.

- Document JetPack 6.2.1 for Jetson Orin.
- Document JetPack 7.1 for Jetson Thor.
- Clarify that the existing Orin requirement does not exclude Thor.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- Ran `SKIP=check-copyright-year pre-commit run --all-files`.
- No automated tests were added because this change only clarifies platform requirements.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated camera streaming requirements to support both Jetson Orin and Thor platforms.
  * Clarified the required JetPack versions: 6.2.1 for Orin and 7.1 for Thor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->