### PR TITLE
docs(lerobot): document the SO-101 leader sim workflow

### DIFF
--- a/docs/source/getting_started/lerobot/data_collection_sim.rst
+++ b/docs/source/getting_started/lerobot/data_collection_sim.rst
@@ -8,7 +8,8 @@ Collect SO-101 demonstrations in simulation with `NVIDIA Isaac Lab
 <https://isaac-sim.github.io/IsaacLab>`_, on the cube-stacking task. You drive the simulated
 follower through Isaac Teleop (see :doc:`devices`) and record episodes to an HDF5 dataset.
 
-Two SO-101 stack tasks are registered in Isaac Lab:
+Three SO-101 stack tasks are registered in Isaac Lab — pick the one that matches your teleop
+device:
 
 .. list-table::
    :header-rows: 1
@@ -17,7 +18,9 @@ Two SO-101 stack tasks are registered in Isaac Lab:
    * - Task id
      - Use
    * - ``IsaacContrib-Stack-Cube-SO101-IK-Abs-v0``
-     - Absolute-pose IK + Isaac Teleop teleoperation (use this for data collection).
+     - Absolute-pose IK + Isaac Teleop teleoperation, driven by an **XR controller**.
+   * - ``IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0``
+     - Joint-space mirror, driven by a physical **SO-101 leader arm** (no headset or IK).
    * - ``IsaacContrib-Stack-Cube-SO101-v0``
      - Joint-position control baseline (no teleop).
 
@@ -26,7 +29,7 @@ Before you start
 
 .. important::
 
-   Both steps below are **required** — complete them first. The teleoperation and recording
+   The steps below are **required** — complete them first. The teleoperation and recording
    commands later on will not work until you have.
 
 **Step 1 — Install Isaac Lab.** Follow the `Isaac Lab installation guide`_ to set up the ``Lab``
@@ -34,12 +37,20 @@ repository, then run every script through its launcher: ``./isaaclab.sh -p <scri
 plain ``python`` inside the activated Isaac Lab environment). The SO-101 USD assets stream from
 the NVIDIA Nucleus server, so there is no manual asset download.
 
-**Step 2 — Set up CloudXR and connect a headset.** XR teleoperation needs CloudXR and a headset,
-the same as the real flow — follow the :doc:`/getting_started/quick_start` and the
-`CloudXR teleoperation in Isaac Lab`_ guide. CloudXR auto-launches by default; pick the profile
-with ``--cloudxr_env`` (``cloudxrjs`` for Quest/Pico, ``avp`` for Apple Vision Pro, ``none`` to
-disable). No physical headset? Open the CloudXR web client in a desktop browser, which emulates a
-headset.
+**Step 2 — Set up CloudXR.** Both teleop devices reach the simulator over the CloudXR / OpenXR
+transport, so the CloudXR runtime is always needed — follow the :doc:`/getting_started/quick_start`
+and the `CloudXR teleoperation in Isaac Lab`_ guide. Isaac Lab auto-launches the runtime; pick the
+profile with ``--cloudxr_env`` (``cloudxrjs`` for Quest/Pico, ``avp`` for Apple Vision Pro,
+``standalone`` for headless, ``none`` to disable auto-launch).
+
+A **headset** is needed only for the XR-controller path; no physical headset? Open the CloudXR web
+client in a desktop browser, which emulates a headset. The **SO-101 Leader** path needs no headset
+at all — omit ``--xr`` and the sim runs standalone in the Kit viewport.
+
+**Step 3 — (SO-101 Leader only) Build the** ``so101_leader`` **plugin.** The leader arm is served by
+an Isaac Teleop C++ plugin that is **not** part of the ``isaacteleop`` pip package or of Isaac Lab —
+you must build this repository from source to get it. See
+:ref:`Build and install the plugin <sim-so101-leader-build>` in the **SO-101 Leader** tab below.
 
 Collect Teleop Data
 -------------------
@@ -82,13 +93,196 @@ Collect Teleop Data
 
    .. tab-item:: SO-101 Leader
 
-      .. admonition:: 🚧 Work in progress
-         :class: caution
+      A back-drivable **SO-101 leader arm** whose joint angles are mirrored 1:1 onto the simulated
+      follower — no headset, no inverse kinematics, no XR anchor. Use the joint-teleop task
+      ``IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0`` (not the IK task); its pipeline is
+      ``JointStateSource`` → ``JointStateRetargeter`` (``mode="joint"``) → ``TensorReorderer``.
 
-         Driving the simulated follower from an **SO-101 Leader** arm is **not yet supported in
-         Isaac Lab** — Isaac Lab has no joint-space leader device, and the SO-101 stack task is
-         wired only for the XR controller. Sim leader support is planned; until then, use the
-         leader arm on the real robot (:doc:`data_collection_real`).
+      The leader's encoders are streamed by Isaac Teleop's ``so101_leader`` plugin, a standalone
+      C++ binary you run in a **second terminal** alongside the sim. Isaac Lab does not spawn it
+      for you.
+
+      .. _sim-so101-leader-build:
+
+      **1. Build and install the plugin**
+
+      .. important::
+
+         ``so101_leader_plugin`` ships **only as source** — it is not in the ``isaacteleop`` pip
+         package, not in Isaac Lab, and not in any release archive. It is produced by building
+         this repository (`NVIDIA/IsaacTeleop <https://github.com/NVIDIA/IsaacTeleop>`_) from
+         source. If ``./install/plugins/so101_leader/so101_leader_plugin`` does not exist, this
+         step has not been completed.
+
+      Install the build prerequisites first — a missing ``clang-format-14`` is the most common
+      cause of a failed build, because the format check is enforced by default on Linux:
+
+      .. code-block:: bash
+
+         sudo apt-get update
+         sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf
+
+      Then clone, configure, build, and install (see
+      :doc:`/getting_started/build_from_source/index` for the full prerequisite list, the CMake
+      presets, and all build options):
+
+      .. code-block:: bash
+
+         git clone https://github.com/NVIDIA/IsaacTeleop.git
+         cd IsaacTeleop
+         cmake --preset py3.12                       # configure (use the preset matching your Python)
+         cmake --build --preset py3.12 --parallel    # build
+         cmake --install build/cmake-cpython-312     # install into ./install
+
+      The plugin lands at::
+
+         <IsaacTeleop>/install/plugins/so101_leader/so101_leader_plugin
+
+      Verify it before going further — with no arguments it runs the **synthetic** backend, so it
+      starts without any hardware attached:
+
+      .. code-block:: bash
+
+         ./install/plugins/so101_leader/so101_leader_plugin
+
+      Only the plugin is needed here; the rest of the build (Python wheel, examples) is harmless
+      but optional. To build just this target:
+
+      .. code-block:: bash
+
+         cmake --build --preset py3.12 --target so101_leader_plugin
+
+      .. admonition:: Build troubleshooting
+         :class: tip
+
+         .. list-table::
+            :header-rows: 1
+            :widths: 42 58
+
+            * - Symptom
+              - Fix
+            * - ``clang-format not found but ENABLE_CLANG_FORMAT_CHECK is ON`` (from
+                ``cmake/ClangFormat.cmake``)
+              - Install the pinned formatter: ``sudo apt-get install -y clang-format-14``. To skip
+                the gate instead, reconfigure with
+                ``cmake --preset py3.12 -DENABLE_CLANG_FORMAT_CHECK=OFF``.
+            * - ``so101_leader_plugin: No such file or directory``
+              - The build was never installed. Re-run ``cmake --install build/cmake-cpython-312``,
+                or run the binary from the build tree at
+                ``build/cmake-cpython-312/src/plugins/so101_leader/so101_leader_plugin``.
+            * - Configure fails downloading dependencies
+              - OpenXR SDK, yaml-cpp, pybind11, FlatBuffers, and MCAP are fetched by CMake
+                ``FetchContent`` — an internet connection (and any proxy settings) is required at
+                configure time.
+            * - ``Could NOT find Python`` / wrong interpreter
+              - Use the preset matching your interpreter (``py3.11``, ``py3.12``, ``py3.13``)
+                rather than overriding ``ISAAC_TELEOP_PYTHON_VERSION``.
+            * - Stale cache after changing options
+              - ``cmake --preset py3.12 --fresh`` wipes the cache and reconfigures.
+
+      **2. Set up and calibrate the leader arm**
+
+      Assemble the leader per `SO-101 support in LeRobot`_ / `SO-ARM100
+      <https://github.com/TheRobotStudio/SO-ARM100>`_: remove the gearbox gears so the joints
+      back-drive freely, give each servo a unique id ``1..6`` at a common baud rate, and make sure
+      your user can open the serial device (add it to the ``dialout`` group).
+
+      The plugin talks to the FEETECH STS3215 servos directly and has **no** ``lerobot`` or
+      FEETECH SDK dependency — calibrate with its own ``calibrate`` subcommand, which needs no
+      OpenXR runtime:
+
+      .. code-block:: bash
+
+         ./install/plugins/so101_leader/so101_leader_plugin calibrate /dev/ttyACM1 so101_leader.calib
+
+      It runs two interactive steps — hold the arm at mid-range and press ENTER (homing), then
+      sweep every joint through its full range and press ENTER — and writes the calibration file.
+      Pass a path ending in ``.json`` to write LeRobot's format instead; an **existing LeRobot
+      calibration** (``~/.cache/huggingface/lerobot/calibration/teleoperators/so101_leader/<id>.json``)
+      can be handed to the plugin as-is. See :ref:`so101-leader-plugin` and the
+      :code-file:`plugin README <src/plugins/so101_leader/README.md>` for the file format and the
+      LeRobot interoperability details.
+
+      .. note::
+
+         Calibration matters more in sim than on real hardware: the joint angles are applied to
+         the follower **absolutely**, in radians, so an uncalibrated leader maps to the wrong pose
+         rather than merely a shifted one.
+
+      **3. Launch the simulation**
+
+      Start Isaac Lab first — it brings up the CloudXR runtime that the plugin connects through.
+      Without ``--xr`` the sim runs standalone in the Kit viewport and teleoperation starts
+      automatically:
+
+      .. code-block:: bash
+
+         ./isaaclab.sh -p scripts/environments/teleoperation/teleop_se3_agent.py \
+             --task IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0 \
+             --num_envs 1 \
+             --viz kit
+
+      Add ``--xr`` if you also want the immersive headset view; the leader arm still drives the
+      follower and the retargeting pipeline is unchanged.
+
+      **4. Start the plugin**
+
+      In a second terminal, source the environment file the CloudXR runtime writes on startup —
+      this points the OpenXR loader at CloudXR — then start the plugin on the leader's serial port
+      with the calibration file:
+
+      .. code-block:: bash
+
+         source ~/.cloudxr/run/cloudxr.env
+         ./install/plugins/so101_leader/so101_leader_plugin /dev/ttyACM1 so101_leader so101_leader.calib
+
+      Arguments are positional: ``[device_path] [collection_id] [calibration_file]``. The
+      ``collection_id`` must stay ``so101_leader`` — that is the tensor collection the task's
+      ``JointStateSource`` subscribes to. Omit the device path to stream the synthetic trajectory
+      instead, which is a good way to confirm the sim side is wired up before touching hardware.
+      See :ref:`run-cloudxr-server` and :ref:`load-cloudxr-environment-variables` for the full
+      runtime setup.
+
+      Back-drive the leader by hand and the simulated follower mirrors it. With the Kit viewport
+      focused, ``B`` starts/resumes teleoperation, ``P`` pauses (the follower holds position), and
+      ``R`` resets the environment.
+
+      **5. Record a dataset**
+
+      ``record_demos.py`` runs the same teleoperation while saving episodes to HDF5, with the
+      plugin running in its second terminal exactly as above:
+
+      .. code-block:: bash
+
+         ./isaaclab.sh -p scripts/tools/record_demos.py \
+             --task IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0 \
+             --dataset_file ./datasets/so101_leader_stack_demos.hdf5 \
+             --num_demos 10 \
+             --step_hz 30 \
+             --viz kit
+
+      .. admonition:: Runtime troubleshooting
+         :class: tip
+
+         .. list-table::
+            :header-rows: 1
+            :widths: 42 58
+
+            * - Symptom
+              - Fix
+            * - Plugin exits with an OpenXR/runtime error
+              - The CloudXR runtime is not up, or ``~/.cloudxr/run/cloudxr.env`` was not sourced in
+                the plugin's terminal. Launch the sim first, then source the file and retry.
+            * - ``Permission denied`` on ``/dev/ttyACM*``
+              - Add your user to the ``dialout`` group (``sudo usermod -aG dialout $USER``) and log
+                back in.
+            * - Plugin runs, follower does not move
+              - The ``collection_id`` must be ``so101_leader``, and teleoperation must be started
+                (press ``B`` in the Kit viewport, or send **start** from the headset when using
+                ``--xr``).
+            * - Follower moves to the wrong pose or hits limits
+              - Re-run ``calibrate`` and pass the resulting file; flip ``sign`` for any joint that
+                moves the wrong way.
 
 Convert to LeRobot Dataset
 --------------------------
@@ -106,3 +300,4 @@ Convert to LeRobot Dataset
 .. _Isaac Lab installation guide: https://isaac-sim.github.io/IsaacLab/develop/source/setup/installation/index.html#isaaclab-installation-root
 .. _CloudXR teleoperation in Isaac Lab: https://isaac-sim.github.io/IsaacLab/develop/source/how-to/cloudxr_teleoperation.html
 .. _convert_dataset.py: https://github.com/isaac-sim/IsaacLab/blob/develop/scripts/imitation_learning/locomanipulation_sdg/gr00t/convert_dataset.py
+.. _SO-101 support in LeRobot: https://huggingface.co/docs/lerobot/en/so101

--- a/docs/source/getting_started/lerobot/index.rst
+++ b/docs/source/getting_started/lerobot/index.rst
@@ -94,7 +94,7 @@ The guides below are still being written:
 | ☑ Implement teleop devices: XR controller and SO-101 Leader
 | ☑ Data collection in real
 | ☑ Data collection in sim (XR controller)
-| ☐ Data collection in sim (SO-101 Leader)
+| ☑ Data collection in sim (SO-101 Leader)
 | ☐ Export sim demos to the LeRobot dataset format
 | ☐ Model training with GR00T N1.7
 | ☐ Sim-to-Real — update the `Sim-to-Real SO-101 learning path`_ to use Isaac Teleop


### PR DESCRIPTION
## Description

  Replaces the "Work in progress" placeholder in the **SO-101 Leader** tab of
  `getting_started/lerobot/data_collection_sim.rst` with the full leader-arm flow, now that
  Isaac Lab registers `IsaacContrib-Stack-Cube-SO101-Joint-Teleop-v0`. Isaac Lab's SO-101
  docs will point here.

  Addresses QA feedback that the workflow assumed `so101_leader_plugin` already existed and
  gave no recovery path when the build failed:

  - States plainly that the binary is produced **only** by building this repo from source —
    it is not in the `isaacteleop` pip package, not in Isaac Lab, not in any release archive.
    Also surfaced as a required step in "Before you start", so users hit it before any run command.
  - Links to the build-from-source instructions and lists the build prerequisites, including
    `clang-format-14` (enforced by default on Linux).
  - Gives the installed location: `<IsaacTeleop>/install/plugins/so101_leader/so101_leader_plugin`,
    plus a hardware-free synthetic-backend run to verify it.
  - Adds a **build troubleshooting** table covering the reported
    `ClangFormat.cmake: clang-format not found but ENABLE_CLANG_FORMAT_CHECK is ON` error
    (install `clang-format-14`, or `-DENABLE_CLANG_FORMAT_CHECK=OFF`), the missing binary,
    FetchContent/network failures, wrong Python preset, and stale caches.
  - Documents calibrate → launch sim → start plugin (after `source ~/.cloudxr/run/cloudxr.env`)
    → `record_demos.py`, and adds a **runtime troubleshooting** table.
  - Updates the task table with the joint-teleop task, and clarifies in "Before you start" that
    CloudXR is always required but a headset is only needed for the XR-controller path.

  Note: Isaac Lab's `isaac_teleop.rst` currently lists `uv pip install lerobot` as a plugin
  prerequisite. That is incorrect — `FeetechBus` speaks the SMS/STS wire protocol directly with
  no SDK or `lerobot` dependency, and calibration is the plugin's own `calibrate` subcommand
  (LeRobot calibration JSON is accepted, but optional). This page documents the accurate version;
  the Isaac Lab side should be corrected when it is pointed here.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

N/A

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
