### PR TITLE
docs(agents): require concise comments and docstrings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,31 @@ only point here — edit the rules in the doc, not the shims.
   must keep `[ ... ]`. Check the shebang (and, for sourced files, who sources
   them) first.
 
+## Comments and docstrings — say it once, briefly
+
+Comments earn their place by recording what the code cannot: a constraint, a
+measurement, a trap someone already paid for. They are not a place to narrate.
+
+- **Default to a few lines.** A block comment over ~8 lines, or a docstring
+  over ~6, needs a reason. If the explanation is genuinely long, it belongs in
+  a `README.md` / design doc that a reader can skip, not inline where they
+  cannot.
+- **State the fact, drop the argument.** "MuJoCo rewrites meshes into their
+  inertial frame, so STL axes need `mesh_pos`/`mesh_quat`" beats three
+  paragraphs re-deriving why. Keep measured numbers and file/line references;
+  cut the prose around them.
+- **Do not narrate history.** "An earlier revision did X and it was wrong" is
+  what `git log` is for. If the wrong approach is tempting enough to warn
+  about, write the warning as a rule — "do not derive this from the mesh" —
+  not as a changelog.
+- **No emphasis-by-shouting.** Occasional caps for a single load-bearing word
+  is fine; whole sentences in caps are noise once every third comment has them.
+- **One statement of a fact, in one place.** If a constraint is already in the
+  code, the test name, or an adjacent doc, do not restate it.
+
+This applies to `#`/`//` comments, docstrings, and comment blocks in
+`CMakeLists.txt`, `pyproject.toml` and scene XML.
+
 ## Commits — DCO sign-off for AI-drafted commits
 
 Any commit whose message is drafted or edited by an AI agent **must** include


### PR DESCRIPTION
## Description

Comments in this tree have been drifting toward essays: multi-paragraph re-derivations of a decision, whole sentences in capitals, and running commentary on which earlier revision got what wrong. That is expensive to read and it goes stale, because it describes a process rather than the code.

The rule keeps what comments are actually for — a constraint, a measurement, a trap someone already paid for — and cuts the prose around it. The ceilings (~8 lines for a block, ~6 for a docstring) are rough rather than hard, because the occasional long note is worth it and the point is to make the author justify it to themselves. Longer explanations belong in a `README.md` or design doc a reader can skip, not inline where they cannot.

Applied to a ~5,400-line example currently under review (#900) it removed ~500 lines with no loss of any measured number, file reference or documented trap — `app.py` 1008 → 756 lines, one scene XML 234 → 128.

Split out of #900, where it was bundled by mistake: it is a repo-wide policy change and should not wait behind an example, nor land inside one.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Documentation only; no code paths touched. `SKIP=check-copyright-year pre-commit run --all-files` clean.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not) — not applicable to a guidance document.
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for writing concise, factual, and non-repetitive comments and documentation.
  * Clarified expectations for comments across source code, configuration, and scene files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->