### PR TITLE
Expose is_tracked for OpenXR tracking loss

### DIFF
--- a/examples/teleop_ros2/python/tests/test_messages.py
+++ b/examples/teleop_ros2/python/tests/test_messages.py
@@ -106,6 +106,7 @@ def _active_head() -> TensorGroup:
     head[HeadInputIndex.POSITION] = np.array([1.0, 2.0, 3.0], dtype=np.float32)
     head[HeadInputIndex.ORIENTATION] = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float32)
     head[HeadInputIndex.IS_VALID] = True
+    head[HeadInputIndex.IS_TRACKED] = True
     return head
 
 

--- a/src/core/live_trackers/cpp/live_head_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_head_tracker_impl.cpp
@@ -57,8 +57,12 @@ void LiveHeadTrackerImpl::update(int64_t monotonic_time_ns)
         throw std::runtime_error("[HeadTracker] xrLocateSpace failed: " + std::to_string(result));
     }
 
-    bool position_valid = (location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0;
-    bool orientation_valid = (location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0;
+    // OpenXR: VALID => pose may be read; TRACKED => actively tracked. Keep these
+    // separate so is_valid stays OpenXR-faithful (CloudXR may leave VALID set after disconnect).
+    const bool position_valid = (location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) != 0;
+    const bool orientation_valid = (location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT) != 0;
+    const bool position_tracked = (location.locationFlags & XR_SPACE_LOCATION_POSITION_TRACKED_BIT) != 0;
+    const bool orientation_tracked = (location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_TRACKED_BIT) != 0;
 
     if (!tracked_.data)
     {
@@ -66,9 +70,11 @@ void LiveHeadTrackerImpl::update(int64_t monotonic_time_ns)
     }
 
     tracked_.data->is_valid = position_valid && orientation_valid;
+    tracked_.data->is_tracked = tracked_.data->is_valid && position_tracked && orientation_tracked;
 
     if (tracked_.data->is_valid)
     {
+        // Pose is readable whenever VALID (including untracked placeholder / last pose).
         Point position(location.pose.position.x, location.pose.position.y, location.pose.position.z);
         Quaternion orientation(location.pose.orientation.x, location.pose.orientation.y, location.pose.orientation.z,
                                location.pose.orientation.w);
@@ -76,7 +82,7 @@ void LiveHeadTrackerImpl::update(int64_t monotonic_time_ns)
     }
     else
     {
-        // Keep pose populated whenever data is present; validity is indicated by is_valid.
+        // is_valid=false: pose contents are unspecified; leave a default filler.
         tracked_.data->pose = std::make_shared<Pose>();
     }
 

--- a/src/core/retargeting_engine_tests/python/test_sources.py
+++ b/src/core/retargeting_engine_tests/python/test_sources.py
@@ -249,6 +249,7 @@ class TestHeadSource:
         head_data = HeadPoseT(
             Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0)),
             True,
+            True,
         )
 
         inputs = _make_inputs(source, {"deviceio_head": [HeadPoseTrackedT(head_data)]})
@@ -266,6 +267,39 @@ class TestHeadSource:
             head[HeadInputIndex.ORIENTATION], [0.0, 0.0, 0.0, 1.0]
         )
         assert head[HeadInputIndex.IS_VALID] is True
+        assert head[HeadInputIndex.IS_TRACKED] is True
+
+    def test_head_source_compute_valid_but_untracked(self):
+        """VALID pose with is_tracked=False still emits Optional with both flags.
+
+        Matches post-disconnect head samples: Tracked.data stays non-null with a
+        readable placeholder pose (is_valid=True) while is_tracked is false so
+        consumers can freeze without violating OpenXR 'do not read if !valid'.
+        """
+        source = HeadSource(name="head")
+
+        head_data = HeadPoseT(
+            Pose(Point(0.1, 0.2, 0.3), Quaternion(0.0, 0.0, 0.0, 1.0)),
+            True,
+            False,
+        )
+
+        inputs = _make_inputs(source, {"deviceio_head": [HeadPoseTrackedT(head_data)]})
+        outputs = {
+            name: _make_output_group(gt) for name, gt in source.output_spec().items()
+        }
+        source.compute(inputs, outputs)
+
+        head = outputs["head"]
+        assert not head.is_none
+        np.testing.assert_array_almost_equal(
+            head[HeadInputIndex.POSITION], [0.1, 0.2, 0.3]
+        )
+        np.testing.assert_array_almost_equal(
+            head[HeadInputIndex.ORIENTATION], [0.0, 0.0, 0.0, 1.0]
+        )
+        assert head[HeadInputIndex.IS_VALID] is True
+        assert head[HeadInputIndex.IS_TRACKED] is False
 
     def test_head_source_compute_inactive(self):
         """Test that inactive head (TrackedT.data is None) produces absent output."""

--- a/src/core/retargeting_engine_tests/python/test_transforms.py
+++ b/src/core/retargeting_engine_tests/python/test_transforms.py
@@ -291,11 +291,12 @@ class TestTransformOrientationsBatch:
 
 
 class TestHeadTransform:
-    def _make_head_input(self, position, orientation, is_valid=True):
+    def _make_head_input(self, position, orientation, is_valid=True, is_tracked=True):
         tg = TensorGroup(HeadInput())
         tg[HeadInputIndex.POSITION] = np.array(position, dtype=np.float32)
         tg[HeadInputIndex.ORIENTATION] = np.array(orientation, dtype=np.float32)
         tg[HeadInputIndex.IS_VALID] = is_valid
+        tg[HeadInputIndex.IS_TRACKED] = is_tracked
         return tg
 
     def test_identity_transform(self):
@@ -338,11 +339,14 @@ class TestHeadTransform:
 
     def test_passthrough_fields_preserved(self):
         node = HeadTransform("head_xform")
-        head_in = self._make_head_input([0, 0, 0], [0, 0, 0, 1], is_valid=False)
+        head_in = self._make_head_input(
+            [0, 0, 0], [0, 0, 0, 1], is_valid=False, is_tracked=False
+        )
         xform_in = _make_transform_input(_rotation_z_90_with_translation())
         result = _run_retargeter(node, {"head": head_in, "transform": xform_in})
         out = result["head"]
         assert out[HeadInputIndex.IS_VALID] is False
+        assert out[HeadInputIndex.IS_TRACKED] is False
 
 
 # ============================================================================
@@ -620,6 +624,7 @@ class TestHeadTransformNoAliasing:
             [0.0, 0.0, 0.0, 1.0], dtype=np.float32
         )
         head_in[HeadInputIndex.IS_VALID] = True
+        head_in[HeadInputIndex.IS_TRACKED] = True
         xform_in = _make_transform_input(_identity_4x4())
 
         # Save a copy of the original input values
@@ -917,6 +922,7 @@ class TestHeadTransformOptionalPropagation:
         tg[HeadInputIndex.POSITION] = np.array([1, 2, 3], dtype=np.float32)
         tg[HeadInputIndex.ORIENTATION] = np.array([0, 0, 0, 1], dtype=np.float32)
         tg[HeadInputIndex.IS_VALID] = True
+        tg[HeadInputIndex.IS_TRACKED] = True
         return tg
 
     def test_output_spec_is_optional(self):
@@ -981,6 +987,7 @@ class TestTransformOptionalNoneToggle:
             [0.0, 0.0, 0.0, 1.0], dtype=np.float32
         )
         active[HeadInputIndex.IS_VALID] = True
+        active[HeadInputIndex.IS_TRACKED] = True
 
         r2 = _run_retargeter(node, {"head": active, "transform": xform_90})
         assert not r2["head"].is_none

--- a/src/core/retargeting_engine_tests/python/transform_numpy_version_smoke.py
+++ b/src/core/retargeting_engine_tests/python/transform_numpy_version_smoke.py
@@ -48,6 +48,7 @@ def main() -> None:
         [0.0, 0.0, 0.0, 1.0], dtype=np.float32
     )
     head_in[HeadInputIndex.IS_VALID] = True
+    head_in[HeadInputIndex.IS_TRACKED] = True
 
     xform_in = TensorGroup(TransformMatrix())
     xform_in[0] = np.eye(4, dtype=np.float32)

--- a/src/core/schema/fbs/head.fbs
+++ b/src/core/schema/fbs/head.fbs
@@ -12,8 +12,11 @@ table HeadPose {
     // The concrete pose data
     pose: Pose (id: 0);
 
-    // Whether the head pose data is valid
+    // Whether the pose value is valid to read (OpenXR VALID bits)
     is_valid: bool (id: 1);
+
+    // Whether the pose is actively tracked (OpenXR TRACKED bits)
+    is_tracked: bool (id: 2);
 }
 
 // Tracked wrapper for the in-memory tracker API (data is null when head is inactive).

--- a/src/core/schema/python/head_bindings.h
+++ b/src/core/schema/python/head_bindings.h
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 // Python bindings for the HeadPose FlatBuffer schema.
-// HeadPoseT is a table type (mutable object-API) with pose and is_valid fields.
+// HeadPoseT is a table type (mutable object-API) with pose, is_valid, and is_tracked.
 
 #pragma once
 
@@ -29,18 +29,20 @@ inline void bind_head(py::module& m)
                 return obj;
             }))
         .def(py::init(
-                 [](const Pose& pose, bool is_valid)
+                 [](const Pose& pose, bool is_valid, bool is_tracked)
                  {
                      auto obj = std::make_shared<HeadPoseT>();
                      obj->pose = std::make_shared<Pose>(pose);
                      obj->is_valid = is_valid;
+                     obj->is_tracked = is_tracked;
                      return obj;
                  }),
-             py::arg("pose"), py::arg("is_valid"))
+             py::arg("pose"), py::arg("is_valid"), py::arg("is_tracked") = false)
         .def_property_readonly(
             "pose", [](const HeadPoseT& self) -> const Pose* { return self.pose.get(); },
             py::return_value_policy::reference_internal)
         .def_readonly("is_valid", &HeadPoseT::is_valid)
+        .def_readonly("is_tracked", &HeadPoseT::is_tracked)
         .def("__repr__",
              [](const HeadPoseT& self)
              {
@@ -55,7 +57,8 @@ inline void bind_head(py::module& m)
                                 ", z=" + std::to_string(self.pose->orientation().z()) +
                                 ", w=" + std::to_string(self.pose->orientation().w()) + "))";
                  }
-                 return "HeadPoseT(pose=" + pose_str + ", is_valid=" + (self.is_valid ? "True" : "False") + ")";
+                 return "HeadPoseT(pose=" + pose_str + ", is_valid=" + (self.is_valid ? "True" : "False") +
+                        ", is_tracked=" + (self.is_tracked ? "True" : "False") + ")";
              });
 
     py::class_<HeadPoseRecordT, std::shared_ptr<HeadPoseRecordT>>(m, "HeadPoseRecord")

--- a/src/core/schema_tests/cpp/test_head.cpp
+++ b/src/core/schema_tests/cpp/test_head.cpp
@@ -168,6 +168,7 @@ TEST_CASE("HeadPoseRecord serialization with DeviceDataTimestamp", "[head][flatb
     core::Quaternion orientation(0.0f, 0.0f, 0.0f, 1.0f);
     record->data->pose = std::make_unique<core::Pose>(position, orientation);
     record->data->is_valid = true;
+    record->data->is_tracked = true;
     record->timestamp = std::make_shared<core::DeviceDataTimestamp>(1000000000LL, 2000000000LL, 3000000000LL);
 
     auto offset = core::HeadPoseRecord::Pack(builder, record.get());

--- a/src/core/schema_tests/cpp/test_head.cpp
+++ b/src/core/schema_tests/cpp/test_head.cpp
@@ -21,6 +21,7 @@
 #define VT(field) (field + 2) * 2
 static_assert(core::HeadPose::VT_POSE == VT(0));
 static_assert(core::HeadPose::VT_IS_VALID == VT(1));
+static_assert(core::HeadPose::VT_IS_TRACKED == VT(2));
 
 static_assert(core::HeadPoseRecord::VT_DATA == VT(0));
 
@@ -31,6 +32,7 @@ static_assert(core::HeadPoseRecord::VT_DATA == VT(0));
 #define TYPE(field) decltype(std::declval<core::HeadPose>().field())
 static_assert(std::is_same_v<TYPE(pose), const core::Pose*>);
 static_assert(std::is_same_v<TYPE(is_valid), bool>);
+static_assert(std::is_same_v<TYPE(is_tracked), bool>);
 
 
 TEST_CASE("HeadPoseT can handle is_valid value properly", "[head][native]")
@@ -40,10 +42,20 @@ TEST_CASE("HeadPoseT can handle is_valid value properly", "[head][native]")
     // Create HeadPoseT with default values, is_valid should be false.
     auto head_pose = std::make_unique<core::HeadPoseT>();
     CHECK(head_pose->is_valid == false);
+    CHECK(head_pose->is_tracked == false);
 
     // Set is_valid to true.
     head_pose->is_valid = true;
     CHECK(head_pose->is_valid == true);
+}
+
+TEST_CASE("HeadPoseT can handle is_tracked value properly", "[head][native]")
+{
+    auto head_pose = std::make_unique<core::HeadPoseT>();
+    CHECK(head_pose->is_tracked == false);
+
+    head_pose->is_tracked = true;
+    CHECK(head_pose->is_tracked == true);
 }
 
 TEST_CASE("HeadPoseT default construction", "[head][native]")
@@ -53,6 +65,7 @@ TEST_CASE("HeadPoseT default construction", "[head][native]")
     // Default values.
     CHECK(head_pose->pose == nullptr);
     CHECK(head_pose->is_valid == false);
+    CHECK(head_pose->is_tracked == false);
 }
 
 TEST_CASE("HeadPoseT can store pose data", "[head][native]")
@@ -96,6 +109,7 @@ TEST_CASE("HeadPoseT serialization and deserialization", "[head][flatbuffers]")
     core::Quaternion orientation(0.0f, 0.0f, 0.0f, 1.0f);
     head_pose->pose = std::make_unique<core::Pose>(position, orientation);
     head_pose->is_valid = true;
+    head_pose->is_tracked = true;
 
     // Serialize.
     auto offset = core::HeadPose::Pack(builder, head_pose.get());
@@ -110,6 +124,7 @@ TEST_CASE("HeadPoseT serialization and deserialization", "[head][flatbuffers]")
     CHECK(deserialized->pose()->position().y() == Catch::Approx(2.0f));
     CHECK(deserialized->pose()->position().z() == Catch::Approx(3.0f));
     CHECK(deserialized->is_valid() == true);
+    CHECK(deserialized->is_tracked() == true);
 }
 
 TEST_CASE("HeadPoseT can be unpacked from buffer", "[head][flatbuffers]")
@@ -122,6 +137,7 @@ TEST_CASE("HeadPoseT can be unpacked from buffer", "[head][flatbuffers]")
     core::Quaternion orientation(0.1f, 0.2f, 0.3f, 0.9f);
     original->pose = std::make_unique<core::Pose>(position, orientation);
     original->is_valid = true;
+    original->is_tracked = true;
 
     auto offset = core::HeadPose::Pack(builder, original.get());
     builder.Finish(offset);
@@ -136,6 +152,7 @@ TEST_CASE("HeadPoseT can be unpacked from buffer", "[head][flatbuffers]")
     CHECK(unpacked->pose->position().y() == Catch::Approx(6.0f));
     CHECK(unpacked->pose->position().z() == Catch::Approx(7.0f));
     CHECK(unpacked->is_valid == true);
+    CHECK(unpacked->is_tracked == true);
 }
 
 // =============================================================================
@@ -163,6 +180,7 @@ TEST_CASE("HeadPoseRecord serialization with DeviceDataTimestamp", "[head][flatb
     CHECK(deserialized->timestamp()->sample_time_raw_device_clock() == 3000000000LL);
     CHECK(deserialized->data()->pose()->position().x() == Catch::Approx(1.0f));
     CHECK(deserialized->data()->is_valid() == true);
+    CHECK(deserialized->data()->is_tracked() == true);
 }
 
 TEST_CASE("HeadPoseRecord can be unpacked with DeviceDataTimestamp", "[head][flatbuffers]")
@@ -172,6 +190,7 @@ TEST_CASE("HeadPoseRecord can be unpacked with DeviceDataTimestamp", "[head][fla
     auto original = std::make_shared<core::HeadPoseRecordT>();
     original->data = std::make_shared<core::HeadPoseT>();
     original->data->is_valid = true;
+    original->data->is_tracked = false;
     original->timestamp = std::make_shared<core::DeviceDataTimestamp>(111LL, 222LL, 333LL);
 
     auto offset = core::HeadPoseRecord::Pack(builder, original.get());
@@ -185,4 +204,5 @@ TEST_CASE("HeadPoseRecord can be unpacked with DeviceDataTimestamp", "[head][fla
     CHECK(unpacked->timestamp->sample_time_local_common_clock() == 222LL);
     CHECK(unpacked->timestamp->sample_time_raw_device_clock() == 333LL);
     CHECK(unpacked->data->is_valid == true);
+    CHECK(unpacked->data->is_tracked == false);
 }

--- a/src/core/schema_tests/python/test_head.py
+++ b/src/core/schema_tests/python/test_head.py
@@ -1,11 +1,12 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
 """Unit tests for HeadPoseT in isaacteleop.schema.
 
 HeadPoseT is a FlatBuffers table that represents head pose data:
 - pose: The Pose struct (position and orientation)
-- is_valid: Whether the head pose data is valid
+- is_valid: Whether the pose value is valid to read (OpenXR VALID)
+- is_tracked: Whether the pose is actively tracked (OpenXR TRACKED)
 
 Timestamps are carried by HeadPoseRecord, not HeadPoseT.
 
@@ -34,17 +35,27 @@ class TestHeadPoseTConstruction:
         assert head_pose is not None
         assert head_pose.pose is not None
         assert head_pose.is_valid is False
+        assert head_pose.is_tracked is False
 
     def test_parameterized_construction(self):
-        """Test construction with pose and is_valid."""
+        """Test construction with pose, is_valid, and is_tracked."""
         pose = Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0))
-        head_pose = HeadPoseT(pose, True)
+        head_pose = HeadPoseT(pose, True, True)
 
         assert head_pose.pose.position.x == pytest.approx(1.0)
         assert head_pose.pose.position.y == pytest.approx(2.0)
         assert head_pose.pose.position.z == pytest.approx(3.0)
         assert head_pose.pose.orientation.w == pytest.approx(1.0)
         assert head_pose.is_valid is True
+        assert head_pose.is_tracked is True
+
+    def test_parameterized_construction_defaults_is_tracked_false(self):
+        """Two-arg constructor keeps is_tracked=False for back-compat."""
+        pose = Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0))
+        head_pose = HeadPoseT(pose, True)
+
+        assert head_pose.is_valid is True
+        assert head_pose.is_tracked is False
 
 
 class TestHeadPoseTRepr:
@@ -60,11 +71,12 @@ class TestHeadPoseTRepr:
     def test_repr_with_values(self):
         """Test __repr__ with parameterized construction."""
         pose = Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0))
-        head_pose = HeadPoseT(pose, True)
+        head_pose = HeadPoseT(pose, True, True)
 
         repr_str = repr(head_pose)
         assert "HeadPoseT" in repr_str
         assert "is_valid=True" in repr_str
+        assert "is_tracked=True" in repr_str
 
 
 class TestHeadPoseRecordTimestamp:
@@ -73,7 +85,7 @@ class TestHeadPoseRecordTimestamp:
     def test_construction_with_timestamp(self):
         """Test HeadPoseRecord carries DeviceDataTimestamp."""
         pose = Pose(Point(1.0, 2.0, 3.0), Quaternion(0.0, 0.0, 0.0, 1.0))
-        data = HeadPoseT(pose, True)
+        data = HeadPoseT(pose, True, True)
         ts = DeviceDataTimestamp(1000000000, 2000000000, 3000000000)
         record = HeadPoseRecord(data, ts)
 
@@ -81,6 +93,7 @@ class TestHeadPoseRecordTimestamp:
         assert record.timestamp.sample_time_local_common_clock == 2000000000
         assert record.timestamp.sample_time_raw_device_clock == 3000000000
         assert record.data.is_valid is True
+        assert record.data.is_tracked is True
 
     def test_default_construction(self):
         """Test default HeadPoseRecord has no data."""

--- a/src/python/isaacteleop/retargeting_engine/deviceio_source_nodes/head_source.py
+++ b/src/python/isaacteleop/retargeting_engine/deviceio_source_nodes/head_source.py
@@ -31,10 +31,14 @@ class HeadSource(IDeviceIOSource):
     Stateless converter: DeviceIO HeadPoseT → HeadInput tensor.
 
     Inputs:
-        - "deviceio_head": Raw HeadPoseT flatbuffer object from DeviceIO
+        - "deviceio_head": Raw HeadPoseTrackedT wrapper from DeviceIO
 
-    Outputs (Optional — absent when head tracking is invalid):
-        - "head": OptionalTensorGroup (check ``.is_none`` before access)
+    Outputs (Optional — absent only when ``tracked.data is None``):
+        - "head": OptionalTensorGroup. When present, consumers must check
+          ``HeadInputIndex.IS_VALID`` before reading the pose, and
+          ``HeadInputIndex.IS_TRACKED`` before treating it as live tracking.
+          A present sample may carry a readable but untracked placeholder
+          (``is_valid=True``, ``is_tracked=False``), e.g. after CloudXR disconnect.
 
     Usage:
         # In TeleopSession, manually poll tracker and pass tracked object
@@ -86,14 +90,16 @@ class HeadSource(IDeviceIOSource):
         return {"deviceio_head": DeviceIOHeadPoseTracked()}
 
     def output_spec(self) -> RetargeterIOType:
-        """Declare standard head pose output (Optional — may be absent)."""
+        """Declare standard head pose output (Optional — absent iff data is None)."""
         return {"head": OptionalType(HeadInput())}
 
     def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
         """
         Convert DeviceIO HeadPoseTrackedT to standard HeadInput tensor.
 
-        Calls ``set_none()`` on the output when head tracking is inactive.
+        Calls ``set_none()`` on the output only when ``tracked.data is None``.
+        When data is present, pose/is_valid/is_tracked are always emitted —
+        consumers must gate on ``IS_VALID`` / ``IS_TRACKED`` before use.
 
         Args:
             inputs: Dict with "deviceio_head" containing HeadPoseTrackedT wrapper
@@ -130,6 +136,7 @@ class HeadSource(IDeviceIOSource):
         output[HeadInputIndex.POSITION] = position
         output[HeadInputIndex.ORIENTATION] = orientation
         output[HeadInputIndex.IS_VALID] = head_pose.is_valid
+        output[HeadInputIndex.IS_TRACKED] = head_pose.is_tracked
 
     def transformed(self, transform_input: OutputSelector) -> RetargeterSubgraph:
         """

--- a/src/python/isaacteleop/retargeting_engine/tensor_types/standard_types.py
+++ b/src/python/isaacteleop/retargeting_engine/tensor_types/standard_types.py
@@ -99,7 +99,8 @@ def HeadInput() -> TensorGroupType:
     Fields:
         - head_position: (3,) float32 array - XYZ position
         - head_orientation: (4,) float32 array - XYZW quaternion
-        - head_is_valid: bool - Whether head tracking data is valid
+        - head_is_valid: bool - Whether the pose value is valid to read (OpenXR VALID)
+        - head_is_tracked: bool - Whether the pose is actively tracked (OpenXR TRACKED)
 
     Returns:
         TensorGroupType for head tracking data
@@ -116,6 +117,7 @@ def HeadInput() -> TensorGroupType:
                 "head_orientation", shape=(4,), dtype=DLDataType.FLOAT, dtype_bits=32
             ),
             BoolType("head_is_valid"),
+            BoolType("head_is_tracked"),
         ],
     )
 

--- a/src/python/isaacteleop/retargeting_engine/utilities/head_transform.py
+++ b/src/python/isaacteleop/retargeting_engine/utilities/head_transform.py
@@ -5,7 +5,7 @@
 Head Transform Node - Applies a 4x4 transform to head pose data.
 
 Transforms head position and orientation using a homogeneous transformation
-matrix while preserving the validity field.
+matrix while preserving the validity and tracked fields.
 
 The transform matrix is received as a tensor input from the graph, typically
 provided by a TransformSource node.
@@ -34,13 +34,13 @@ class HeadTransform(BaseRetargeter):
     Applies a 4x4 homogeneous transform to head pose data.
 
     Transforms the head position (R @ p + t) and orientation (R_quat * q)
-    while passing through is_valid unchanged.
+    while passing through is_valid and is_tracked unchanged.
 
     The transform matrix is provided as a tensor input, allowing it to be
     sourced from a TransformSource node in the graph.
 
     Inputs:
-        - "head": OptionalType(HeadInput) tensor (position, orientation, is_valid)
+        - "head": OptionalType(HeadInput) tensor (position, orientation, is_valid, is_tracked)
         - "transform": TransformMatrix tensor containing the (4, 4) matrix
 
     Outputs:
@@ -85,7 +85,7 @@ class HeadTransform(BaseRetargeter):
 
         Position is transformed as: p' = R @ p + t
         Orientation is transformed as: q' = R_quat * q
-        All other fields (is_valid) are copied unchanged.
+        All other fields (is_valid, is_tracked) are copied unchanged.
 
         Args:
             inputs: Dict with "head" and "transform" TensorGroups.


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

Require VALID and TRACKED bits for head is_valid so CloudXR client disconnect no longer leaves a placeholder pose marked valid.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate head-pose validity and active-tracking status indicators.
  * Valid pose data remains available during temporary tracking loss, while tracking status accurately reflects inactivity.
  * Exposed tracking status through head-pose inputs, outputs, transformations, and Python interfaces.

* **Bug Fixes**
  * Improved handling of invalid head poses by providing a default pose when pose data is unavailable.

* **Documentation**
  * Clarified the difference between valid pose data and active tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->