### PR TITLE
[Televiz] make RTP opt-in, fix isaacteleop resolution, refresh Televiz docs

### DIFF
--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -54,6 +54,14 @@ Our build system uses `uv`_ for Python version and dependency management. Instal
 
    curl -LsSf https://astral.sh/uv/install.sh | sh
 
+The installer drops ``uv`` in ``~/.local/bin``, which is not on ``PATH`` in most shells. Add it for
+the current shell — and to your ``~/.bashrc`` to make it stick — or every ``uv`` command below
+fails with ``uv: command not found``:
+
+.. code-block:: bash
+
+   export PATH="$HOME/.local/bin:$PATH"
+
 .. note::
    While the build system uses `uv`_, the final Python packages can be installed via any Python package manager
    such as `pip <https://pip.pypa.io/>`_ or `conda <https://conda.io/>`_.

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -4,10 +4,10 @@
 Televiz
 =======
 
-Televiz (``isaacteleop.viz``) is a lightweight compositor for Isaac Teleop. It composites camera and
-sensor feeds, plus 3D rendered content (gsplat, nvblox, neural reconstruction), into an XR headset, a
-desktop window, or an offscreen buffer, integrating directly with the device-tracking and retargeting
-pipeline.
+Televiz (``isaacteleop.viz``) is the visualization module for Isaac Teleop. It composites what the
+operator sees — camera and sensor feeds, plus 3D rendered content such as gsplat or nvblox — and
+presents it in stereo to an XR headset over :doc:`CloudXR </references/cloudxr>`. Desktop-window and
+offscreen output are also available, mainly for development and debugging.
 
 It is a **compositor**, not a capture or streaming layer: it consumes GPU frames and assembles them
 into a final image. Camera capture, decode, and network transport live in the application (see
@@ -15,8 +15,7 @@ into a final image. Camera capture, decode, and network transport live in the ap
 
 The compositor is implemented in C++ (``namespace viz``, built on Vulkan + OpenXR + CUDA with no
 external rendering-framework dependency) and exposed through a pybind11 binding. This page uses the
-Python API, which mirrors the C++ names one-to-one — see `C++ API`_ to link against the library
-directly.
+Python API, which mirrors the C++ names one-to-one — see `C++ API`_.
 
 .. contents:: On this page
    :local:

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -51,13 +51,32 @@ run the sample's one-time setup:
    source examples/camera_viz/.venv/bin/activate
 
 There is no need to install the ``isaacteleop`` pip package yourself — ``setup`` creates the
-sample's own environment: it installs ``isaacteleop>=1.4`` (which bundles Televiz) and
-every other Python dependency from PyPI into ``.venv/`` via ``uv``, builds the native NVENC/NVDEC
-codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack
-``cuda-nvrtc`` + ``ld.so`` wiring). When something is missing it prints the exact ``apt-get`` line
-and prompts ``[y/N]`` — answering ``n`` or running non-interactively aborts.
+sample's own environment: it installs ``isaacteleop[cloudxr]`` (which bundles Televiz) and every
+other Python dependency into ``.venv/`` via ``uv``, then probes the system packages it needs
+(cairo / girepository headers, GStreamer plugins and the native NVENC/NVDEC codec under
+``--with-rtp``, JetPack ``cuda-nvrtc`` + ``ld.so`` wiring). When something is missing it prints
+the exact ``apt-get`` line and prompts ``[y/N]`` — answering ``n`` or running non-interactively
+aborts. The ``cloudxr`` extra is not optional for this sample: XR is the default display mode
+and the viewer launches the CloudXR runtime itself.
 
-By default ``setup`` provisions everything except ZED support; flags trim or extend that:
+camera_viz needs an ``isaacteleop`` new enough to carry the features it uses, so ``setup`` works
+down a ladder to get one:
+
+#. the newest **final release** on the package index, if one meets that minimum;
+#. otherwise the newest **release candidate** — Isaac Teleop publishes an rc from every
+   release-branch commit, and PEP 440 keeps pre-releases out of a plain minimum-version
+   specifier;
+#. otherwise a **source build** of the surrounding checkout, after asking. This is a full
+   C++ / CUDA / Vulkan build and needs CMake, the CUDA toolkit, Vulkan headers,
+   ``glslangValidator``, and ``clang-format-14``.
+
+The ladder is automatic, so ``setup`` starts preferring final releases the moment one qualifies.
+Override it with ``--wheel PATH`` or ``--build-from-source``. The minimum version itself lives in
+:code-file:`scripts/_install_deps.sh <examples/camera_viz/scripts/_install_deps.sh>`.
+
+By default ``setup`` provisions the direct-mode path — USB / UVC and OAK-D camera support. Split
+mode (RTP) and ZED support are opt-in, since both pull in dependencies the direct path never
+needs. Flags trim or extend that:
 
 .. list-table::
    :header-rows: 1
@@ -69,9 +88,10 @@ By default ``setup`` provisions everything except ZED support; flags trim or ext
      - Skip USB / UVC webcam support (``opencv-python``).
    * - ``--no-oakd``
      - Skip OAK-D support (``depthai``).
-   * - ``--no-rtp``
-     - Skip split-mode dependencies: the GStreamer system packages and the native NVENC/NVDEC
-       codec build. Direct mode still works.
+   * - ``--with-rtp``
+     - Also install the split-mode dependencies: the GStreamer system packages, PyGObject, and the
+       native NVENC/NVDEC codec build. Required for ``loopback`` and for any config with
+       ``source: rtp``; implied by ``--sender-only``. Direct mode does not need it.
    * - ``--with-zed``
      - Also build + install the ZED SDK's Python API (``pyzed``). Requires the ZED SDK on the
        machine (default ``/usr/local/zed``; override with ``--zed-sdk PATH``).
@@ -82,8 +102,11 @@ By default ``setup`` provisions everything except ZED support; flags trim or ext
    * - ``--venv PATH``
      - Install into an existing virtual environment instead of creating ``.venv/``.
    * - ``--wheel PATH``
-     - Install a locally built ``isaacteleop`` wheel instead of the PyPI release — for developing
-       Isaac Teleop itself (see :doc:`/getting_started/build_from_source/index`).
+     - Install a locally built ``isaacteleop`` wheel instead of resolving one from the index — for
+       developing Isaac Teleop itself (see :doc:`/getting_started/build_from_source/index`).
+   * - ``--build-from-source``
+     - Skip the index entirely and build ``isaacteleop`` from the surrounding checkout, and
+       answer step 3's prompt without asking.
 
 First run — no camera required
 ------------------------------
@@ -130,7 +153,8 @@ The source kind is selected by the ``type`` field of each entry in the YAML ``ca
    * - ``v4l2``
      - USB / UVC cameras — anything ``v4l2-ctl --list-formats-ext`` reports.
    * - ``oakd``
-     - OAK-D mono RGB / LEFT / RIGHT (stereo not yet wired).
+     - OAK-D RGB / LEFT / RIGHT; mono or ``stereo: true``. Stereo ships GRAY8 over USB to halve
+       bandwidth and is broadcast to RGBA on the GPU; ``stereo_rgb`` keeps color.
    * - ``zed``
      - ZED 2 / Mini / X One; mono or ``stereo: true`` (per-eye SDK retrieve, zero-copy on the GPU).
    * - ``video``
@@ -247,6 +271,10 @@ the viewer on the workstation (``source: rtp``).
 
 In split mode every camera entry must pin ``width``, ``height``, and ``fps`` in the YAML — the
 receiver sizes its decoder from the config, not from the wire.
+
+The workstation needs the RTP dependencies, which ``setup`` does not install by default — re-run
+it with ``--with-rtp`` if you provisioned for direct mode first. The robot side is handled by
+``deploy``, which implies the flag.
 
 Set ``source: rtp`` in the config, export the robot/streaming credentials once per shell, then
 deploy the sender and run the viewer:

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -18,7 +18,7 @@ SPDX-License-Identifier: Apache-2.0
 |---|---|
 | `synthetic` | GPU test pattern — no hardware. `stereo: true` adds a `disparity_px` offset between eyes |
 | `v4l2`      | USB / UVC — anything `v4l2-ctl --list-formats-ext` shows |
-| `oakd`      | OAK-D mono RGB / LEFT / RIGHT (stereo not yet wired) |
+| `oakd`      | OAK-D RGB / LEFT / RIGHT; mono or `stereo: true` (GRAY8 over USB, GPU-broadcast to RGBA; `stereo_rgb` for color). Needs the Luxonis udev rule — see below |
 | `zed`       | ZED 2 / Mini / X One; mono or `stereo: true` (per-eye SDK retrieve, zero-copy GPU) |
 | `video`     | Video-file replay (anything OpenCV/FFmpeg reads) — preview / testing without a camera. Loops by default; `stereo: true` splits side-by-side files into eyes (viewer only) |
 
@@ -33,11 +33,19 @@ examples/camera_viz/camera_viz.sh setup
 source examples/camera_viz/.venv/bin/activate
 ```
 
-`setup` installs `isaacteleop>=1.4` (which bundles Televiz) and every other Python dep from PyPI into `.venv/` via `uv` (no `--system-site-packages`), builds the native NVENC/NVDEC codec, and probes system packages (GStreamer plugins, cairo / girepository headers, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts. No need to build IsaacTeleop from source.
+`setup` creates `.venv/` via `uv` (no `--system-site-packages`) and installs `isaacteleop[cloudxr]` — which bundles Televiz — plus every other Python dep. The `cloudxr` extra is not optional here: XR is the default mode and the viewer launches the runtime itself. It then probes system packages (cairo / girepository headers, GStreamer plugins under `--with-rtp`, JetPack `cuda-nvrtc` + ld.so wiring). If anything's missing it prints the exact `apt-get` line and prompts `[y/N]` — `n` or non-interactive aborts. No need to build IsaacTeleop from source.
 
-Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`. Pass `--venv PATH` to install into an existing venv (symlinks `.venv` → PATH so `run` / `loopback` pick it up too).
+camera_viz needs an `isaacteleop` new enough to carry the features it uses, so `setup` works down a ladder to get one: newest **final release** meeting that minimum; else newest **release candidate** (an rc is published from every release-branch commit, and PEP 440 keeps pre-releases out of a plain minimum-version specifier); else a **source build** of this checkout, after asking. Final releases win automatically whenever one qualifies. The minimum itself lives in `scripts/_install_deps.sh`.
 
-> **Developing against a local build?** Pass `--wheel <path>` (e.g. `camera_viz.sh setup --wheel build/wheels/isaacteleop-*.whl`) to install a locally built wheel instead of the PyPI release. See the [build-from-source guide](../../docs/source/getting_started/build_from_source/index.rst).
+Flags: `--no-{v4l2,oakd}`, `--with-rtp` (split mode / `loopback`; implied by `--sender-only`), `--with-zed`, `--sender-only`, `--jetson`. Pass `--venv PATH` to install into an existing venv (symlinks `.venv` → PATH so `run` / `loopback` pick it up too).
+
+> **OAK-D?** The camera needs a udev rule, or `depthai` reports `Insufficient permissions to communicate with X_LINK_UNBOOTED device` and never finds it. `setup` prompts to install one when an OAK-D is attached and no rule covers it; declining is not fatal. By hand:
+> ```bash
+> echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"' | sudo tee /etc/udev/rules.d/80-movidius.rules
+> sudo udevadm control --reload-rules && sudo udevadm trigger   # then replug
+> ```
+
+> **Developing against a local build?** Pass `--wheel <path>` (e.g. `camera_viz.sh setup --wheel build/wheels/isaacteleop-*.whl`) for a wheel you already built, or `--build-from-source` to build this checkout without asking. See the [build-from-source guide](../../docs/source/getting_started/build_from_source/index.rst).
 
 ---
 
@@ -48,7 +56,7 @@ Flags: `--no-{v4l2,oakd,rtp}`, `--with-zed`, `--sender-only`, `--jetson`. Pass `
 ./camera_viz.sh run configs/v4l2.yaml --mode window    # desktop window instead
 ```
 
-Set `source: local`. Swap config for `oakd.yaml`, `zed.yaml`, `synthetic.yaml`, `synthetic_stereo.yaml`, `multi_camera.yaml`, `replay.yaml` (file replay — point `path:` at any recording).
+Set `source: local`. Swap config for `oakd.yaml`, `zed.yaml`, `realsense.yaml`, `synthetic.yaml`, `synthetic_stereo.yaml`, `synthetic_xr_3up.yaml`, `multi_camera.yaml`, `replay.yaml` (file replay — point `path:` at any recording).
 
 ## Mode 2 — Split (robot → workstation, RTP)
 
@@ -98,7 +106,7 @@ cameras:
     width: 2560               # video: optional — defaults to the file's size
     height: 720
     fps: 30
-    stereo: false             # zed / synthetic / video only — per-eye capture + SBS XR
+    stereo: false             # zed / oakd / synthetic / video — per-eye capture + SBS XR
     # … type-specific fields (e.g. synthetic: disparity_px; video: path, loop)
     rtp:
       port: 5000              # left eye when stereo
@@ -134,9 +142,10 @@ Multiple cameras → multiple `cameras:` entries; each gets its own `rtp.port` (
 
 | Mode | Behavior |
 |---|---|
-| `world` | Placed once in front of you; stays put |
-| `head`  | Follows your head every frame |
-| `lazy`  | World-locked, re-snaps when you look away (default) |
+| `world`  | Placed once in front of you; stays put |
+| `head`   | Follows your head every frame |
+| `gimbal` | Translation follows you, yaw stays as first seen — walk and it comes along, turn your head and you look around it. For wide cylinder feeds |
+| `lazy`   | World-locked, re-snaps when you look away (default) |
 
 Lazy knobs under `placements.<name>`: `look_away_angle_deg`, `reposition_distance`, `reposition_delay_s`, `transition_duration_s`.
 

--- a/examples/camera_viz/camera_viz.sh
+++ b/examples/camera_viz/camera_viz.sh
@@ -165,6 +165,17 @@ _require_local_config() {
     }
 }
 
+# RTP deps are opt-in at setup time (``--with-rtp``), so a venv provisioned
+# for direct mode has no ``gi``. Fail here with the fix rather than letting
+# the sender die on an ImportError several log lines later.
+_require_rtp_deps() {
+    "$LOCAL_VENV/bin/python" -c "import gi" >/dev/null 2>&1 && return 0
+    log_error "the RTP path needs dependencies this venv doesn't have"
+    log_info "Re-run setup with --with-rtp:"
+    log_info "  ./camera_viz.sh setup --with-rtp"
+    exit 1
+}
+
 # Write a copy of CONFIG with ``source: rtp`` forced on. Used by loopback
 # so the receiver doesn't need the user to edit the YAML between runs.
 # Caller is responsible for rm-ing the returned path.
@@ -192,6 +203,11 @@ PY
 
 cmd_run() {
     _require_local_config run "${1:-}"
+    # ``source: rtp`` makes the viewer an RTP receiver, so it needs the same
+    # opt-in deps as the sender. Direct-mode configs don't.
+    if grep -qE '^[[:space:]]*source:[[:space:]]*["'\'']?rtp' "$1"; then
+        _require_rtp_deps
+    fi
     log_step "Starting camera_viz — Ctrl-C to exit"
     "$LOCAL_VENV/bin/python" "$HERE/camera_viz.py" "$@"
 }
@@ -219,6 +235,7 @@ _loopback_cleanup() {
 
 cmd_loopback() {
     _require_local_config loopback "${1:-}"
+    _require_rtp_deps
     _LOOPBACK_RECV_CONFIG="$(_rewrite_source_rtp "$1")"
     trap '_loopback_cleanup' EXIT
 
@@ -379,7 +396,8 @@ camera_viz.sh — local development + Jetson deployment for camera_viz
 
 LOCAL
     setup [--venv PATH] [--sender-only] [--jetson]
-          [--no-v4l2] [--no-oakd] [--no-rtp] [--with-zed]
+          [--no-v4l2] [--no-oakd] [--with-rtp] [--with-zed]
+          [--wheel PATH | --build-from-source]
                           Create .venv, install Python deps via uv into
                           the venv, build native codec. Python deps stay
                           inside .venv (no --system-site-packages).
@@ -393,11 +411,21 @@ LOCAL
                           PATH instead of creating one in-place.
                           examples/camera_viz/.venv is symlinked → PATH
                           so run / loopback pick it up too.
+                          --with-rtp adds the split-mode deps (GStreamer
+                          system packages, PyGObject, native codec).
+                          Needed for loopback, deploy, and any config
+                          with ``source: rtp``. Implied by --sender-only.
                           --sender-only skips isaacteleop + vulkan deps
                           (use on Jetson sender hosts).
                           --jetson adds JetPack-only checks: unversioned
                           CUDA lib symlinks + ld.so wiring that JetPack
                           skips. Off on desktop.
+                          isaacteleop is taken from the package index,
+                          preferring a final release and falling back to
+                          a release candidate. If neither is available,
+                          setup offers to build it from this checkout;
+                          --build-from-source picks that without asking,
+                          --wheel PATH installs a wheel you already built.
 
     loopback CONFIG       Run camera_streamer + camera_viz on 127.0.0.1.
 

--- a/examples/camera_viz/scripts/_install_deps.sh
+++ b/examples/camera_viz/scripts/_install_deps.sh
@@ -6,14 +6,32 @@
 # ``camera_viz.sh setup`` (local) and ``camera_viz.sh deploy`` (over SSH).
 #
 # Modes:
-#   --full         viewer + sender (workstation). Installs isaacteleop from PyPI
+#   --full         viewer + sender (workstation). Obtains isaacteleop from the
+#                  package index, preferring a final release over a release
+#                  candidate, and offers a source build if neither is available
 #                  (or a local --wheel).
 #   --sender-only  sender path only. No isaacteleop, no vulkan deps.
 #
-# Flags: --venv, --wheel, --python, --no-v4l2, --no-oakd, --no-rtp,
-#        --with-zed, --zed-sdk.
+# Flags: --venv, --wheel, --python, --no-v4l2, --no-oakd, --with-rtp,
+#        --with-zed, --zed-sdk, --build-from-source.
 
 set -euo pipefail
+
+# Output helpers. Same palette as camera_viz.sh so ``setup`` reads as one tool
+# whether it runs locally or over ssh during ``deploy``. Color is dropped when
+# stdout isn't a terminal, so piped logs and systemd journals stay clean.
+if [[ -t 1 ]]; then
+    _C_STEP=$'\033[1m'; _C_DIM=$'\033[2m'; _C_WARN=$'\033[33m'; _C_ERR=$'\033[31m'; _C_RESET=$'\033[0m'
+else
+    _C_STEP=""; _C_DIM=""; _C_WARN=""; _C_ERR=""; _C_RESET=""
+fi
+# step: one line per unit of work. note: indented detail under a step.
+# Errors say "error:", not the script's filename — callers run camera_viz.sh,
+# and _install_deps.sh is an implementation detail to them.
+step() { echo "${_C_STEP}▸ $*${_C_RESET}"; }
+note() { echo "${_C_DIM}  $*${_C_RESET}"; }
+warn() { echo "${_C_WARN}warning:${_C_RESET} $*" >&2; }
+die()  { echo "${_C_ERR}error:${_C_RESET} $*" >&2; exit 1; }
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
 CAMERA_VIZ_DIR="$(cd "$HERE/.." && pwd)"
@@ -32,9 +50,15 @@ PYTHON_VERSION=3.12
 WHEEL=
 WITH_V4L2=true
 WITH_OAKD=true
-WITH_RTP=true
+# Opt-in: the RTP path pulls GStreamer system packages, a PyGObject source
+# build, and the native codec — none of which direct mode needs.
+# --sender-only forces it on below (streaming is the sender's whole job).
+WITH_RTP=false
 WITH_ZED=false
 ZED_SDK_DIR=/usr/local/zed
+# Skip the index probes and build isaacteleop from this checkout. Also the
+# non-interactive answer to the tier-3 prompt below.
+BUILD_FROM_SOURCE=false
 # Jetson-specific provisioning: apt-install cuda-nvrtc and create the
 # unversioned CUDA lib symlinks + ld.so cache entry that JetPack skips.
 # Off on desktop where the normal CUDA installer covers both.
@@ -50,12 +74,19 @@ while (( $# )); do
         --python)       PYTHON_VERSION=$2; shift 2;;
         --no-v4l2)      WITH_V4L2=false; shift;;
         --no-oakd)      WITH_OAKD=false; shift;;
-        --no-rtp)       WITH_RTP=false; shift;;
+        --with-rtp)     WITH_RTP=true; shift;;
         --with-zed)     WITH_ZED=true; shift;;
         --zed-sdk)      ZED_SDK_DIR=$2; shift 2;;
-        *) echo "_install_deps.sh: unknown arg: $1" >&2; exit 1;;
+        --build-from-source) BUILD_FROM_SOURCE=true; shift;;
+        *) die "unknown arg: $1";;
     esac
 done
+
+# A sender-only host exists to stream RTP, so --with-rtp is implied there.
+# Without this a bare ``--sender-only`` would install a sender that can't send.
+if [[ "$MODE" == sender ]]; then
+    WITH_RTP=true
+fi
 
 # major picks the cupy wheel (cupy-cuda12x / cupy-cuda13x).
 # major.minor picks the apt nvrtc package (cuda-nvrtc-12-6 on Orin/JP6,
@@ -147,14 +178,15 @@ check_system_deps() {
     fi
 
     cat >&2 <<EOF
-_install_deps.sh: missing system packages required by camera_viz (RTP path):
+Missing system packages for the RTP path:
   ${pkgs[*]}
 
 The exact command:
   sudo apt-get update
   sudo apt-get install -y --no-install-recommends ${pkgs[*]}
 
-(--no-rtp skips the GStreamer-based RTP path entirely.)
+(Only the RTP path needs these — it is opt-in via --with-rtp, and always on
+for --sender-only. Direct mode works without them.)
 EOF
 
     local ans=""
@@ -172,7 +204,7 @@ EOF
             sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends "${pkgs[@]}"
             ;;
         *)
-            echo "_install_deps.sh: aborted. Install the listed packages and re-run." >&2
+            die "aborted — install the packages above and re-run"
             exit 1
             ;;
     esac
@@ -210,9 +242,8 @@ check_cuda_symlinks() {
     fi
 
     {
-        echo "_install_deps.sh: Jetson CUDA libs aren't wired into ld.so / unversioned"
-        echo "symlinks are missing. cupy will fail to dlopen libnvrtc.so without these."
-        echo "Exact commands:"
+        echo "Jetson CUDA libs aren't wired into ld.so and the unversioned symlinks"
+        echo "are missing; cupy cannot dlopen libnvrtc.so without them. Exact commands:"
         for c in "${cmds[@]}"; do
             echo "  $c"
         done
@@ -244,26 +275,80 @@ check_cuda_symlinks() {
             fi
             ;;
         *)
-            echo "_install_deps.sh: aborted. Run the listed commands and re-run setup." >&2
+            die "aborted — run the commands above and re-run setup"
             exit 1
             ;;
     esac
 }
 check_cuda_symlinks
 
+# An OAK-D enumerates as a Movidius USB device (vendor 03e7) that udev leaves
+# root-only, so depthai fails with "Insufficient permissions to communicate with
+# X_LINK_UNBOOTED device". Only prompt when one is actually attached and nothing
+# already grants access. Existing rules are matched by content, not file name:
+# the vendor rule ships as 50-movidius.rules, 80-movidius.rules and others
+# depending on who installed it, and writing our own would just duplicate it.
+OAKD_UDEV_RULE='SUBSYSTEM=="usb", ATTRS{idVendor}=="03e7", MODE="0666"'
+OAKD_UDEV_PATH=/etc/udev/rules.d/80-movidius.rules
+
+check_oakd_udev() {
+    $WITH_OAKD || return 0
+    command -v udevadm >/dev/null 2>&1 || return 0
+    # shellcheck disable=SC2144  # the glob is the point: any attached 03e7 device
+    grep -l '^03e7$' /sys/bus/usb/devices/*/idVendor >/dev/null 2>&1 || return 0
+    if grep -rlq '03e7' /etc/udev/rules.d/ /lib/udev/rules.d/ 2>/dev/null; then
+        return 0
+    fi
+
+    cat >&2 <<EOF
+An OAK-D is attached but no udev rule grants access to it, so depthai will fail
+with "Insufficient permissions to communicate with X_LINK_UNBOOTED device".
+
+The exact commands:
+  echo '$OAKD_UDEV_RULE' | sudo tee $OAKD_UDEV_PATH
+  sudo udevadm control --reload-rules && sudo udevadm trigger
+EOF
+
+    local ans=""
+    if [[ -e /dev/tty ]]; then
+        read -r -p "Install the OAK-D udev rule now? [y/N] " ans </dev/tty || ans=""
+    fi
+    case "${ans,,}" in
+        y|yes)
+            step "installing the OAK-D udev rule"
+            if ! sudo -n true 2>/dev/null; then
+                echo "    sudo password required (one-time)"
+            fi
+            echo "$OAKD_UDEV_RULE" | sudo tee "$OAKD_UDEV_PATH" >/dev/null
+            sudo udevadm control --reload-rules
+            sudo udevadm trigger
+            note "installed $OAKD_UDEV_PATH — replug the camera for it to take effect"
+            ;;
+        *)
+            # Unlike the apt deps, this doesn't block the install: the venv is
+            # still valid and the rule can be added later.
+            warn "skipped the OAK-D udev rule; the camera will not be detected until it is installed"
+            ;;
+    esac
+}
+check_oakd_udev
+
 # Bootstrap uv from astral.sh if missing (Jetson images don't ship it).
+# The PATH export below only reaches this process, so record when the caller's
+# shell will still be missing uv and say so at the end.
+UV_OFF_PATH=false
 if ! command -v uv >/dev/null 2>&1; then
+    UV_OFF_PATH=true
     if [[ -x "$HOME/.local/bin/uv" ]]; then
         export PATH="$HOME/.local/bin:$PATH"
     else
-        echo "==> installing uv (no system uv found)"
+        step "installing uv (none found on PATH)"
         if ! command -v curl >/dev/null 2>&1; then
             if ! command -v apt-get >/dev/null 2>&1; then
-                echo "_install_deps.sh: 'curl' required to bootstrap uv. Install curl and re-run setup." >&2
-                exit 1
+                die "curl is required to bootstrap uv — install it and re-run setup"
             fi
             cat >&2 <<EOF
-_install_deps.sh: 'curl' required to bootstrap uv.
+curl is required to bootstrap uv.
 
 The exact command:
   sudo apt-get update
@@ -275,7 +360,7 @@ EOF
             fi
             case "${curl_ans,,}" in
                 y|yes)
-                    echo "==> installing curl (required to bootstrap uv)"
+                    step "installing curl (needed to bootstrap uv)"
                     if ! sudo -n true 2>/dev/null; then
                         echo "    sudo password required (one-time)"
                     fi
@@ -283,41 +368,130 @@ EOF
                     sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends curl
                     ;;
                 *)
-                    echo "_install_deps.sh: 'curl' required to bootstrap uv. Install curl and re-run setup." >&2
-                    exit 1
+                    die "curl is required to bootstrap uv — install it and re-run setup"
                     ;;
             esac
         fi
         curl -LsSf https://astral.sh/uv/install.sh | sh
         export PATH="$HOME/.local/bin:$PATH"
         command -v uv >/dev/null || {
-            echo "_install_deps.sh: uv install failed — check ~/.local/bin/uv." >&2
-            exit 1
+            die "uv install failed — check ~/.local/bin/uv"
         }
     fi
 fi
 
-# isaacteleop comes from PyPI by default. camera_viz needs >= 1.4 (shaped
-# composition layers, compositor choice, CloudXR launcher helpers).
-# --wheel <path> installs a locally built wheel instead — only needed when
-# developing against an unreleased build (see the build-from-source docs).
-# Sender-only deploys don't install isaacteleop at all. Python extras are
-# additive, so this includes the base package and its dependencies.
-ISAACTELEOP_PKG="isaacteleop[cloudxr]>=1.4"
-if [[ "$MODE" == full && -n "$WHEEL" ]]; then
-    [[ -f "$WHEEL" ]] || {
-        echo "_install_deps.sh: --wheel '$WHEEL' not found." >&2
+# isaacteleop: newest final release meeting the floor below, else newest
+# release candidate, else a source build of this checkout. --wheel skips the
+# ladder; sender-only deploys skip isaacteleop entirely (README has the detail).
+#
+# Bump the floor in both specifiers. The rc one has to name a pre-release --
+# PEP 440 excludes them from a plain >=X.Y, and release/X.Y.x publishes an rc
+# per commit while a final can lag. The cloudxr extra is required, not
+# optional: XR is the default mode. uv accepts <path>[extra], so the extra
+# rides along on the wheel and source-build tiers.
+ISAACTELEOP_EXTRAS="[cloudxr]"
+ISAACTELEOP_STABLE="isaacteleop${ISAACTELEOP_EXTRAS}>=1.4"
+ISAACTELEOP_PRE="isaacteleop${ISAACTELEOP_EXTRAS}>=1.4.0rc1"
+ISAACTELEOP_PKG="$ISAACTELEOP_STABLE"
+
+# Resolves against the index without consulting the venv, so an already-installed
+# copy cannot make a tier look satisfiable. --no-deps keeps it to one fetch.
+isaacteleop_available() {
+    echo "$1" | uv pip compile - --no-deps --quiet \
+        --python-version "$PYTHON_VERSION" >/dev/null 2>&1
+}
+
+resolve_isaacteleop_pkg() {
+    if [[ -n "$WHEEL" ]]; then
+        [[ -f "$WHEEL" ]] || die "--wheel '$WHEEL' not found"
+        ISAACTELEOP_PKG="${WHEEL}${ISAACTELEOP_EXTRAS}"
+        step "isaacteleop: local wheel"
+        note "$WHEEL"
+        return 0
+    fi
+
+    if ! $BUILD_FROM_SOURCE; then
+        step "isaacteleop: resolving from the package index"
+        if isaacteleop_available "$ISAACTELEOP_STABLE"; then
+            ISAACTELEOP_PKG="$ISAACTELEOP_STABLE"
+            note "final release ($ISAACTELEOP_STABLE)"
+            return 0
+        fi
+        if isaacteleop_available "$ISAACTELEOP_PRE"; then
+            ISAACTELEOP_PKG="$ISAACTELEOP_PRE"
+            note "no final release for $ISAACTELEOP_STABLE — using a release candidate ($ISAACTELEOP_PRE)"
+            return 0
+        fi
+        note "nothing matching $ISAACTELEOP_STABLE is installable from the index"
+    fi
+
+    # An rsync'd robot tree and a standalone copy of examples/camera_viz/ have
+    # no repo root to build from.
+    if [[ -z "$REPO_ROOT" || ! -f "$REPO_ROOT/pyproject.toml" ]]; then
+        cat >&2 <<EOF
+No way to obtain $ISAACTELEOP_STABLE.
+
+Nothing suitable is published to the configured package index, and this copy
+of camera_viz is not inside an IsaacTeleop checkout, so there is nothing to
+build from either. Either:
+  * clone https://github.com/NVIDIA/IsaacTeleop and re-run setup from its
+    examples/camera_viz/ directory, or
+  * build a wheel elsewhere and pass --wheel <path>.
+EOF
         exit 1
-    }
-    ISAACTELEOP_PKG="$WHEEL"
+    fi
+
+    cat >&2 <<EOF
+
+isaacteleop can be built from this checkout instead:
+  $REPO_ROOT
+
+That is a full C++ / CUDA / Vulkan build and takes a while. It needs CMake,
+the CUDA toolkit, Vulkan headers, glslangValidator, and clang-format-14 (the
+format gate runs as part of the build).
+EOF
+
+    if ! $BUILD_FROM_SOURCE; then
+        local ans=""
+        if [[ -e /dev/tty ]]; then
+            # As with the apt prompt: do NOT redirect stderr, ``read -p`` writes
+            # the prompt there.
+            read -r -p "Build isaacteleop from source now? [y/N] " ans </dev/tty || ans=""
+        fi
+        case "${ans,,}" in
+            y|yes) ;;
+            *)
+                die "aborted — pass --build-from-source to skip this prompt";;
+        esac
+    fi
+
+    # Same mechanism as --wheel: uv builds the sdist/tree and installs the result.
+    ISAACTELEOP_PKG="${REPO_ROOT}${ISAACTELEOP_EXTRAS}"
+}
+
+# The configuration banner: what this run is going to do, before it does any
+# of it. Everything below is one ``step`` per unit of work.
+EXTRAS=()
+$WITH_V4L2 && EXTRAS+=(v4l2)
+$WITH_OAKD && EXTRAS+=(oakd)
+$WITH_RTP  && EXTRAS+=(rtp)
+$WITH_ZED  && EXTRAS+=(zed)
+step "camera_viz setup — ${MODE} mode"
+note "venv    $VENV_DIR"
+note "python  $PYTHON_VERSION"
+note "cuda    ${cuda_major}.${cuda_minor} → cupy-cuda${cuda_major}x"
+EXTRAS_LIST=none
+if (( ${#EXTRAS[@]} )); then
+    EXTRAS_LIST=$(printf '%s, ' "${EXTRAS[@]}"); EXTRAS_LIST=${EXTRAS_LIST%, }
+fi
+note "extras  $EXTRAS_LIST"
+
+if [[ "$MODE" == full ]]; then
+    resolve_isaacteleop_pkg
 fi
 
-echo "==> mode:   $MODE"
-echo "==> venv:   $VENV_DIR"
-echo "==> python: $PYTHON_VERSION"
-[[ "$MODE" == full ]] && echo "==> isaacteleop: $ISAACTELEOP_PKG"
-
 if [[ ! -d "$VENV_DIR" ]]; then
+    step "creating venv"
     # Strict venv isolation: no --system-site-packages. PyGObject + every
     # other Python dep is installed into the venv via uv below. Sender mode
     # still defaults to system python3 because Jetson images sometimes
@@ -325,10 +499,7 @@ if [[ ! -d "$VENV_DIR" ]]; then
     # — but the venv itself stays isolated.
     if [[ "$MODE" == sender ]]; then
         sys_py="$(command -v python3 || true)"
-        [[ -x "$sys_py" ]] || {
-            echo "_install_deps.sh: system python3 required in --sender-only mode" >&2
-            exit 1
-        }
+        [[ -x "$sys_py" ]] || die "system python3 required in --sender-only mode"
         uv venv "$VENV_DIR" --python "$sys_py"
     else
         uv venv "$VENV_DIR" --python "$PYTHON_VERSION"
@@ -336,25 +507,25 @@ if [[ ! -d "$VENV_DIR" ]]; then
 fi
 PY="$VENV_DIR/bin/python"
 
-echo "==> cuda:   ${cuda_major}.${cuda_minor} (cupy-cuda${cuda_major}x, cuda-nvrtc-${cuda_major}-${cuda_minor})"
-
 # cupy ships separate packages per CUDA major (cupy-cuda12x, cupy-cuda13x...);
 # they coexist on disk and CuPy warns about "multiple CuPy packages installed."
 # If a prior setup picked a different major, uninstall the stale variant now.
 target_cupy="cupy-cuda${cuda_major}x"
 for v in cupy-cuda11x cupy-cuda12x cupy-cuda13x; do
     if [[ "$v" != "$target_cupy" ]] && uv pip show --python "$PY" "$v" >/dev/null 2>&1; then
-        echo "==> removing stale $v (target is $target_cupy)"
+        step "removing stale $v (target is $target_cupy)"
         uv pip uninstall --python "$PY" "$v" >/dev/null
     fi
 done
 
-# Broken-install guard: if dist-info is present but `import cupy` fails
-# (interrupted setup, manual `rm -rf cupy/`), uv treats the package as
-# installed and won't reinstall on the regular install line.
+# Broken-install guard: dist-info present but the package unusable (interrupted
+# setup, manual `rm -rf cupy/`) reads as installed to uv, so it never reinstalls.
+# Probe an attribute, not just the import: a directory left without __init__.py
+# imports as an empty namespace package, where `import cupy` succeeds and
+# `cupy.zeros` does not.
 if uv pip show --python "$PY" "$target_cupy" >/dev/null 2>&1 \
-        && ! "$PY" -c "import cupy" >/dev/null 2>&1; then
-    echo "==> $target_cupy metadata present but import fails — reinstalling"
+        && ! "$PY" -c "import cupy; cupy.zeros" >/dev/null 2>&1; then
+    step "reinstalling $target_cupy (installed but not usable)"
     uv pip uninstall --python "$PY" "$target_cupy" >/dev/null
 fi
 
@@ -378,36 +549,28 @@ if [[ "$MODE" == full && -f "$WHEEL" ]]; then
     if [[ -n "$installed_dist" ]]; then
         installed_mtime=$(stat -c %Y "$installed_dist" 2>/dev/null || echo 0)
         if (( wheel_mtime > installed_mtime )); then
-            echo "==> wheel newer than installed copy — forcing reinstall of isaacteleop"
+            note "wheel is newer than the installed copy — forcing reinstall"
             EXTRA_UV+=(--reinstall-package isaacteleop)
         fi
     fi
 fi
 
-echo "==> installing: ${PKGS[*]}"
+step "installing ${#PKGS[@]} packages"
+note "${PKGS[*]}"
 if (( ${#EXTRA_UV[@]} > 0 )); then
     uv pip install --python "$PY" --upgrade "${EXTRA_UV[@]}" "${PKGS[@]}"
 else
     uv pip install --python "$PY" --upgrade "${PKGS[@]}"
 fi
 
-# A direct wheel requirement does not activate optional dependencies. Install
-# the CloudXR extra after the local wheel is present; without --upgrade, uv
-# reuses that wheel and adds only its missing optional dependencies.
-if [[ "$MODE" == full && -n "$WHEEL" ]]; then
-    uv pip install --python "$PY" "isaacteleop[cloudxr]"
-fi
-
 # ZED SDK ships get_python_api.py which downloads a matching pyzed wheel
 # and then tries ``pip install`` it (which fails in uv venvs, no pip).
 # We let that fail and install the wheel ourselves.
 if $WITH_ZED; then
-    [[ -f "$ZED_SDK_DIR/get_python_api.py" ]] || {
-        echo "_install_deps.sh: --with-zed but no $ZED_SDK_DIR/get_python_api.py." >&2
-        echo "  Install the ZED SDK first or pass --zed-sdk <dir>." >&2
-        exit 1
-    }
-    echo "==> fetching pyzed via $ZED_SDK_DIR/get_python_api.py"
+    [[ -f "$ZED_SDK_DIR/get_python_api.py" ]] || die \
+        "--with-zed given but $ZED_SDK_DIR/get_python_api.py is missing.
+       Install the ZED SDK, or point at it with --zed-sdk <dir>."
+    step "fetching pyzed from $ZED_SDK_DIR"
     uv pip install --python "$PY" --quiet requests
     tmp=$(mktemp -d)
     pushd "$tmp" >/dev/null
@@ -416,8 +579,7 @@ if $WITH_ZED; then
     if [[ -z "$pyzed_whl" ]]; then
         popd >/dev/null
         rm -rf "$tmp"
-        echo "_install_deps.sh: get_python_api.py did not produce a wheel." >&2
-        exit 1
+        die "get_python_api.py did not produce a wheel"
     fi
     uv pip install --python "$PY" --upgrade "$tmp/$pyzed_whl"
     popd >/dev/null
@@ -429,11 +591,11 @@ fi
 if $WITH_RTP; then
     CODEC_DIR="$CAMERA_VIZ_DIR/codec"
     if [[ -d "$CODEC_DIR" ]]; then
-        echo "==> building native codec"
+        step "building native NVENC/NVDEC codec"
         # shellcheck disable=SC1091
         source "$VENV_DIR/bin/activate"
         if ! "$CODEC_DIR/build.sh"; then
-            echo "_install_deps.sh: codec build failed — GStreamer encoder will be used at runtime" >&2
+            warn "codec build failed — falling back to the GStreamer encoder at runtime"
         fi
         deactivate
     fi
@@ -441,23 +603,51 @@ fi
 
 # Smoke imports. ``gi`` is in the list under RTP to confirm PyGObject
 # built and installed cleanly into the venv.
-echo "==> import smoke"
 SMOKE_MODS="cupy yaml scipy.spatial.transform"
-[[ "$MODE" == full ]] && SMOKE_MODS="isaacteleop.viz $SMOKE_MODS"
+# ``websockets`` comes from the cloudxr extra and is what the XR default mode
+# needs to launch the runtime; check it here so a missing extra fails setup
+# rather than the first ``run --mode xr``.
+[[ "$MODE" == full ]] && SMOKE_MODS="isaacteleop.viz websockets $SMOKE_MODS"
 $WITH_RTP && SMOKE_MODS="$SMOKE_MODS gi"
-"$PY" - <<PY
-import sys
+step "verifying imports"
+note "$SMOKE_MODS"
+# Prints only failures; the step line above already said what is being checked.
+"$PY" - <<PY || die "the venv is incomplete — see the failed imports above"
+import importlib, sys
 mods = "$SMOKE_MODS".split()
 fail = []
 for m in mods:
     try:
-        __import__(m)
+        mod = importlib.import_module(m)
     except Exception as e:
-        fail.append((m, e))
-for m, e in fail:
-    print(f"  FAIL {m}: {e}", file=sys.stderr)
-print("  OK" if not fail else "  some imports failed (see above)")
+        fail.append((m, f"{type(e).__name__}: {e}"))
+        continue
+    # A partially-installed package leaves its directory without __init__.py,
+    # and Python imports that as an empty namespace package: the import
+    # succeeds and every attribute is missing. __file__ is None only for
+    # namespace packages, and none of these are one, so it flags exactly that.
+    if getattr(mod, "__file__", None) is None:
+        fail.append((m, "imported as an empty namespace package — install is incomplete"))
+for m, why in fail:
+    print(f"  {m}: {why}", file=sys.stderr)
 sys.exit(0 if not fail else 1)
 PY
 
-echo "_install_deps.sh: done."
+# Close on what the user can do next, not on the fact that the script ended.
+step "setup complete"
+if [[ "$MODE" == full ]]; then
+    # Absolute paths: setup may be invoked from anywhere (repo root, the sample
+    # dir, or over ssh), and a bare ``./camera_viz.sh`` only resolves in the
+    # sample dir. Don't hand out a command that depends on the reader's cwd.
+    note "cd $CAMERA_VIZ_DIR"
+    note "./camera_viz.sh run configs/synthetic.yaml --mode window"
+else
+    note "sender ready — start it with camera_streamer.py <config>"
+fi
+
+# camera_viz itself calls .venv/bin/python directly, but the docs' uv commands
+# won't work until the caller's shell can see the uv we bootstrapped.
+if $UV_OFF_PATH; then
+    warn "uv is at ~/.local/bin/uv, which is not on your PATH. To use it directly:"
+    echo '         export PATH="$HOME/.local/bin:$PATH"   # add to ~/.bashrc to persist' >&2
+fi

--- a/src/python/isaacteleop/cloudxr/wss.py
+++ b/src/python/isaacteleop/cloudxr/wss.py
@@ -30,17 +30,11 @@ from .oob_teleop_env import (
 )
 from .oob_teleop_hub import OOB_WS_PATH
 
-try:
-    import websockets
-    from websockets.asyncio.client import connect as ws_connect
-    from websockets.asyncio.server import serve as ws_serve
-    from websockets.datastructures import Headers
-    from websockets.http11 import Response
-except ImportError:
-    sys.exit(
-        "Missing dependency: websockets >= 14\n"
-        "Install with: uv pip install --find-links=install/wheels 'isaacteleop[cloudxr]'"
-    )
+import websockets
+from websockets.asyncio.client import connect as ws_connect
+from websockets.asyncio.server import serve as ws_serve
+from websockets.datastructures import Headers
+from websockets.http11 import Response
 
 
 def _patch_request_parser_for_cors():


### PR DESCRIPTION
  Fixes camera_viz setup on a clean machine, and refreshes the Televiz / camera_streaming docs.

  **Setup**

  * **RTP is opt-in via `--with-rtp`** (was `--no-rtp`), matching `--with-zed`. The GStreamer stack, PyGObject source build, and native codec are split-mode-only, so
  direct-mode setup no longer pays for them. `--sender-only` implies the flag — streaming is the sender's whole job, and a bare `--sender-only` would otherwise install a
  sender that cannot send. `loopback` and `source: rtp` configs preflight the deps and point at the fix instead of dying on an `ImportError`.

  * **`isaacteleop` is resolved down a ladder** instead of a fixed pin: newest final release satisfying `>= 1.4`, else newest release candidate, else a source build of the
  checkout (after asking; `--build-from-source` skips the prompt). `release/X.Y.x` branches publish rc builds continuously while a final can lag, and PEP 440 keeps
  pre-releases out of a plain `>= 1.4` — so the old `isaacteleop>=1.4` pin was unsatisfiable and setup failed outright. Availability is probed with `uv pip compile`, which
  resolves against the configured index without consulting the venv, so a stale install can't make a tier look satisfiable. Finals win automatically once one ships, with no
  edit.

  * **Install `isaacteleop[cloudxr]`.** XR is the default display mode and the viewer launches the CloudXR runtime itself, so the extra isn't optional here — without it `run
  --mode xr` died on missing `websockets`.

  * **Catch broken installs that import cleanly.** An interrupted install leaves a package directory without `__init__.py`, which Python imports as an empty namespace
  package: `import cupy` succeeds and every attribute is missing. The smoke check now rejects any module whose `__file__` is `None`, and cupy's repair guard probes an
  attribute rather than importability. Previously both passed a venv that failed at the first frame with `AttributeError`.

  * **Reworked setup output:** a config banner up front (mode, venv, python, cuda, extras), then one step per unit of work; errors prefixed `error:` instead of the internal
  script name; a closing line saying what to run next instead of `done.`

  * **Dropped the `websockets` `ImportError` guard** in `cloudxr/wss.py` — its `--find-links=install/wheels` advice only applied to source builds, and the plain
  `ImportError` is more useful.

  **Docs**

  * `televiz.rst` — leads with what Televiz is (the visualization module) and its target (stereo XR over CloudXR); window/offscreen noted as development and debugging aids.
  Documents `--pre` for pre-release installs rather than a version that needs editing every release.
  * `camera_streaming.rst` — documents the resolution ladder, `--with-rtp`, and `--build-from-source`; corrects the setup description now that the codec build and GStreamer
  probing are RTP-only.
  * `camera_viz/README.md` — refreshed for 1.4: OAK-D stereo is wired (mono / stereo / stereo_rgb), added the `gimbal` lock mode, listed the `realsense` and 
  `synthetic_xr_3up` configs, documented the new flags.

  ## Type of change

  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)
  - [x] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Documentation update

  `--no-rtp` is removed rather than aliased, and RTP now defaults off — anyone passing `--no-rtp` gets a hard error, and anyone relying on setup provisioning RTP by default 
  must add `--with-rtp`. `deploy` is unaffected (`--sender-only` implies the flag).

  ## Testing

  Ubuntu 22.04, x86_64, RTX 6000 Ada, CUDA 13.1.

  * **Flag matrix** — `--full`, `--full --with-rtp`, `--sender-only`, `--sender-only --with-rtp` resolve `WITH_RTP` correctly; `--no-rtp` errors out rather than being
  silently ignored.
  * **Resolution ladder**, all six paths against live PyPI: final available → tier 1; rc-only (today's state) → tier 2, resolving `1.5.41rc1`; neither + checkout +
  non-interactive → aborts with the `--build-from-source` hint; neither + `--build-from-source` → builds from `$REPO_ROOT`; neither + not a checkout → clone/`--wheel`
  guidance; `--wheel` short-circuits.
  * **Broken-install detection** — namespace-package check flags a directory without `__init__.py`, passes healthy modules, and reports genuinely-missing ones distinctly;
  the cupy probe passes a healthy venv and trips on the broken shape that caused the original `AttributeError`.
  * **RTP config detection** — verified against all nine shipped configs; the `# local | rtp` trailing comment doesn't false-positive.
  * **Docs** — `sphinx -b html` builds with zero warnings; all cross-references resolve.
  * **Static** — `bash -n` on both scripts, `py_compile` on `wss.py`.
  * **Live** — `camera_viz.sh run configs/zed.yaml --mode xr` reproduced the missing-`websockets` failure this fixes.

  Not covered: a full clean-machine `setup` end-to-end, and the Jetson `deploy` path.

  ## Checklist

  - [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
  - [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
  - [x] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix/feature works (or explained why not)
  - [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for OAK-D stereo cameras, RTP streaming, XR gimbal lock mode, and expanded camera configurations.
  * Added setup options for RTP support and building Isaac Teleop from source.
  * Added improved dependency detection and installation fallback guidance.

* **Bug Fixes**
  * Improved validation and diagnostics for RTP, WebSockets, and CuPy installations.
  * Clarified CloudXR and split-mode setup requirements.
  * Standardized setup progress, warning, and error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->