### PR TITLE
feat(rig): one tmux window per rig, and a resolvable install prefix

### DIFF
--- a/docs/source/device/body_tracking.rst
+++ b/docs/source/device/body_tracking.rst
@@ -198,7 +198,7 @@ creates the tracker, queries the required OpenXR extensions, and prints the
 joint data each frame through ``DeviceIOSession``. The Python equivalent is
 ``examples/oxr/python/test_full_body_tracker.py``. Running
 ``python -m isaacteleop.rig rigs/full_body.yaml`` starts the CloudXR runtime,
-this printer, and the C++ MCAP recorder together in one tmux session (see
+this printer, and the C++ MCAP recorder together in one tmux window (see
 :ref:`rig-launcher`).
 
 Troubleshooting

--- a/docs/source/references/rig.rst
+++ b/docs/source/references/rig.rst
@@ -11,7 +11,7 @@ runtime, one or more **producer** plugins that publish device data, and one or
 more **consumer** apps (a Python ``TeleopSession`` script or a C++ example
 binary) that read the streams. Such a configured set is a *rig* — the same
 shape serves demos, production teleop, and data collection.
-``isaacteleop.rig`` starts a rig in a single tmux session from a small YAML
+``isaacteleop.rig`` starts a rig in a single tmux window from a small YAML
 file, instead of you juggling three terminals by hand:
 
 .. code-block:: bash
@@ -33,8 +33,9 @@ Prerequisites
 
 - ``tmux`` installed (``sudo apt install tmux``).
 - A built and installed Teleop tree (see :ref:`install-isaacteleop-pip-package`
-  and the build reference) — the rig references binaries under
-  ``install/plugins/`` and ``install/examples/``.
+  and the build reference) — the rigs reach their binaries through
+  ``{install}/plugins/`` and ``{install}/examples/`` (see
+  `The install prefix`_).
 - The ``isaacteleop`` wheel installed in the **current** Python environment.
   tmux panes do not inherit your venv; the launcher bakes the absolute path of
   its own interpreter (and your ``PYTHONPATH``, if set) into the pane commands,
@@ -54,7 +55,8 @@ Run a rig
 What happens:
 
 1. **Preflight** — the launcher verifies tmux is available, the referenced
-   binaries exist and are executable (with the exact ``cmake`` remedy if not),
+   binaries exist under the resolved install prefix and are executable (naming
+   the exact remedy if not — see `The install prefix`_),
    and the interpreter can import ``isaacteleop.cloudxr``. Nothing is created
    until preflight passes.
 2. **Runtime pane starts immediately** (a slim full-width strip on top —
@@ -81,20 +83,55 @@ What happens:
    :kbd:`Enter` in that pane to rerun. If the runtime never comes up (or
    its environment fails to load), the pane does *not* run the command; it
    prints a remedy and leaves the command pre-typed instead.
-5. The launcher then attaches (from a plain shell) or switches your current
-   client (from inside tmux — no nesting).
+5. The launcher then switches you to the rig window. Run from inside tmux,
+   the rig is a **new window in your current session** — your other windows
+   stay put and nothing nests. Run from a plain shell, it gets a session of
+   its own (named after the rig) and the launcher attaches to it.
 
-Re-running the same rig just switches to the existing session; it does
-**not** re-apply ``--no-runtime`` or pick up edits to the rig file. Start
-over with:
+Re-running the same rig just switches to the running one — in whichever
+session it lives; it does **not** re-apply ``--no-runtime`` or pick up edits
+to the rig file. Start over with:
 
 .. code-block:: bash
 
    python -m isaacteleop.rig rigs/se3_tracker.yaml --kill
 
-which kills the rig's tmux session and every process in it (equivalent to
-``tmux kill-session -t se3_tracker``, without needing to know the session
-name). Killing a rig that is not running is a no-op.
+which kills the rig's tmux window and every process in it (equivalent to
+``tmux kill-window -t se3_tracker``, without needing to know which session
+holds it). Only the rig's window: a session you launched the rig into keeps
+its other windows. Killing a rig that is not running is a no-op.
+
+The install prefix
+------------------
+
+Rig commands reference binaries as ``{install}/plugins/...`` and
+``{install}/examples/...``. ``{install}`` resolves at launch time to:
+
+1. ``$ISAAC_TELEOP_INSTALL_DIR``, if set — the knob for a tree installed with a
+   non-default ``CMAKE_INSTALL_PREFIX``;
+2. otherwise ``<cwd>/install``, the prefix this project's CMakeLists forces by
+   default (``cwd`` is the rig's, so for the shipped rigs that is
+   ``<repo>/install``).
+
+.. code-block:: bash
+
+   # a tree installed elsewhere, e.g. cmake --install build --prefix /opt/isaacteleop/install
+   ISAAC_TELEOP_INSTALL_DIR=/opt/isaacteleop/install \
+       python -m isaacteleop.rig rigs/se3_tracker.yaml
+
+A binary that is missing under the resolved prefix names the fix for the case
+you are actually in: a build tree that was configured but never installed gets
+the one ``cmake --install ... --prefix ...`` command (its own
+``CMAKE_INSTALL_PREFIX`` may point anywhere, so the prefix is passed
+explicitly); a set ``ISAAC_TELEOP_INSTALL_DIR`` that resolves to the wrong tree
+says so rather than telling you to rebuild; and every message without the
+variable set mentions it, since an install tree you already have is as likely
+as an unbuilt one.
+
+The prefix is made absolute before it reaches a pane, and quoted, so a path
+containing spaces works. A rig that spells the path out literally
+(``install/plugins/...``) still works whenever the default prefix is the right
+one — but it cannot follow the variable, which is the point of the placeholder.
 
 The rig YAML
 ------------
@@ -104,7 +141,7 @@ own:
 
 .. code-block:: yaml
 
-   name: se3_tracker              # rig id AND tmux session name (letters/digits/-/_)
+   name: se3_tracker              # rig id AND tmux window name (letters/digits/-/_)
    description: CloudXR runtime + SE3 controller tracker plugin + pose printer
    cwd: ..                        # pane working dir, relative to this file
    params:                        # shared values, substituted into the commands below
@@ -114,10 +151,10 @@ own:
    #   {python} -m isaacteleop.cloudxr --accept-eula
    producers:                     # publish device data into the runtime
      - name: se3 tracker plugin (requires headset + controller)
-       command: "install/plugins/controller_se3_tracker/controller_se3_tracker_plugin {hand} {collection_id}"
+       command: "{install}/plugins/controller_se3_tracker/controller_se3_tracker_plugin {hand} {collection_id}"
    consumers:                     # read the streams — a TeleopSession script or a C++ binary
      - name: se3 printer (requires headset)
-       command: "install/examples/schemaio/se3_printer {collection_id}"
+       command: "{install}/examples/schemaio/se3_printer {collection_id}"
 
 ``rigs/full_body.yaml`` shows the other supported shape — no ``producers``
 key, because its consumers read the tracking data directly from the runtime,
@@ -134,10 +171,10 @@ Top-level keys:
      - Meaning
    * - ``name``
      - yes
-     - Rig id **and** tmux session name. Letters, digits, ``-``, ``_`` only.
+     - Rig id **and** tmux window name. Letters, digits, ``-``, ``_`` only.
    * - ``description``
      - no
-     - Free text, printed when the session is created.
+     - Free text, printed when the rig is created.
    * - ``cwd``
      - no
      - Working directory for every pane and the base for relative command
@@ -159,9 +196,11 @@ Top-level keys:
        the pane title (a good place for hardware prerequisites); ``command``
        is a shell string run verbatim in the pane.
 
-Commands are plain shell strings. ``{python}`` always expands to the absolute
-path of the launching interpreter; every other ``{placeholder}`` must be
-declared under ``params`` (literal braces are written ``{{`` / ``}}``).
+Commands are plain shell strings. Two placeholders are reserved: ``{python}``
+expands to the absolute path of the launching interpreter and ``{install}`` to
+the install prefix (see `The install prefix`_). Every other ``{placeholder}``
+must be declared under ``params`` (literal braces are written ``{{`` / ``}}``);
+``python`` and ``install`` are rejected as param names.
 Unknown top-level keys, unknown entry keys, and unknown placeholders are hard
 errors — a typo fails loudly at load time instead of misbehaving in a pane.
 
@@ -218,5 +257,5 @@ Troubleshooting
      - The consumer self-launched a second runtime; add
        ``--no-launch-cloudxr-runtime`` to its command in the rig.
    * - Edits to the rig file seem ignored
-     - The session already existed; relaunch after
+     - The rig was already running; relaunch after
        ``python -m isaacteleop.rig <rig.yaml> --kill``.

--- a/rigs/full_body.yaml
+++ b/rigs/full_body.yaml
@@ -24,6 +24,6 @@ description: CloudXR runtime + full-body joint printer + MCAP recorder (PICO 4 U
 cwd: ..                        # -> Teleop repo root
 consumers:
   - name: full body printer (requires headset + motion trackers)
-    command: "install/examples/schemaio/full_body_printer"
+    command: "{install}/examples/schemaio/full_body_printer"
   - name: full body recorder (check printer pane first; Enter = new timestamped take)
-    command: "install/examples/mcap_record_replay/cpp/record_full_body 5 examples/mcap_record_replay/recordings/"
+    command: "{install}/examples/mcap_record_replay/cpp/record_full_body 5 examples/mcap_record_replay/recordings/"

--- a/rigs/se3_tracker.yaml
+++ b/rigs/se3_tracker.yaml
@@ -7,9 +7,11 @@
 # runtime, load its CloudXR env, then run their commands automatically. An
 # app that started before the headset connected exits with 'Failed to get
 # OpenXR system' — press Enter in its pane to rerun it once the headset is in.
-# Relative command paths and the pane working dir resolve against `cwd`
-# (relative to this file; default: this file's directory).
-name: se3_tracker              # rig id AND tmux session name (letters/digits/-/_ only)
+# {install} expands to the install prefix — $ISAAC_TELEOP_INSTALL_DIR if set,
+# else <cwd>/install (CMake's default prefix for this project). Other relative
+# command paths and the pane working dir resolve against `cwd` (relative to
+# this file; default: this file's directory).
+name: se3_tracker              # rig id AND tmux window name (letters/digits/-/_ only)
 description: CloudXR runtime + SE3 controller tracker plugin + pose printer
 cwd: ..                        # -> Teleop repo root
 params:                        # shared values, substituted into the commands below
@@ -21,10 +23,10 @@ params:                        # shared values, substituted into the commands be
 #   {python} -m isaacteleop.cloudxr --accept-eula
 producers:                     # publish device data into the runtime
   - name: se3 tracker plugin (requires headset + controller)
-    command: "install/plugins/controller_se3_tracker/controller_se3_tracker_plugin {hand} {collection_id}"
+    command: "{install}/plugins/controller_se3_tracker/controller_se3_tracker_plugin {hand} {collection_id}"
 consumers:                     # read the streams — a TeleopSession script or a C++ binary
   - name: se3 printer (requires headset)
-    command: "install/examples/schemaio/se3_printer {collection_id}"
+    command: "{install}/examples/schemaio/se3_printer {collection_id}"
 # NOTE: Python TeleopSession consumers self-launch a CloudXR runtime by default.
 # Add --no-launch-cloudxr-runtime to their command or they will KILL the runtime
 # pane (the runtime is a host singleton on WSS port 48322).

--- a/src/core/rig_tests/python/test_config.py
+++ b/src/core/rig_tests/python/test_config.py
@@ -12,10 +12,12 @@ from pathlib import Path
 import pytest
 from rig_py_test_ns.config import (
     DEFAULT_RUNTIME_COMMAND,
+    INSTALL_DIR_ENV,
     RigConfigError,
     ProcessConfig,
     find_runtime_footguns,
     load_rig_config,
+    resolve_install_dir,
     substitute_command,
 )
 
@@ -56,6 +58,16 @@ def test_load_se3_rig():
     # collection_id is single-sourced: both sides reference the placeholder.
     assert "{collection_id}" in config.producers[0].command
     assert "{collection_id}" in config.consumers[0].command
+
+
+def test_shipped_rigs_never_hard_code_the_install_prefix():
+    """A literal ``install/...`` silently breaks every non-default
+    CMAKE_INSTALL_PREFIX; {install} is the one spelling that follows it.
+    """
+    for rig in (SE3_RIG, FULL_BODY_RIG):
+        config = load_rig_config(rig)
+        for proc in (*config.producers, *config.consumers):
+            assert not proc.command.startswith("install/"), (rig, proc.command)
 
 
 def test_se3_rig_has_no_footguns():
@@ -158,12 +170,13 @@ def test_tmux_safe_name_is_accepted(tmp_path):
 @pytest.mark.parametrize("bad_name", ["se3 rig", "se3:rig", "se3.rig", "r'ig"])
 def test_tmux_unsafe_name_is_hard_error(tmp_path, bad_name):
     path = write_rig(tmp_path, MINIMAL.replace("name: mini", f'name: "{bad_name}"'))
-    with pytest.raises(RigConfigError, match="used as the tmux session name"):
+    with pytest.raises(RigConfigError, match="used as the tmux window name"):
         load_rig_config(path)
 
 
-def test_param_named_python_is_reserved(tmp_path):
-    path = write_rig(tmp_path, MINIMAL + "params:\n  python: /usr/bin/python\n")
+@pytest.mark.parametrize("reserved", ["python", "install"])
+def test_reserved_param_names_are_hard_errors(tmp_path, reserved):
+    path = write_rig(tmp_path, MINIMAL + f"params:\n  {reserved}: /some/where\n")
     with pytest.raises(RigConfigError, match="reserved"):
         load_rig_config(path)
 
@@ -192,7 +205,7 @@ def test_cwd_resolves_relative_to_yaml_directory(tmp_path):
 
 def test_python_placeholder_expands_to_sys_executable(tmp_path):
     result = substitute_command(
-        "{python} -m isaacteleop.cloudxr", {}, tmp_path / "c.yaml"
+        "{python} -m isaacteleop.cloudxr", {}, tmp_path / "c.yaml", tmp_path / "install"
     )
     assert result == f"{shlex.quote(sys.executable)} -m isaacteleop.cloudxr"
 
@@ -202,25 +215,26 @@ def test_params_substituted(tmp_path):
         "./plugin {hand} {collection_id}",
         {"hand": "left", "collection_id": "abc"},
         tmp_path / "c.yaml",
+        tmp_path / "install",
     )
     assert result == "./plugin left abc"
 
 
 def test_unknown_placeholder_is_hard_error(tmp_path):
     with pytest.raises(RigConfigError, match=r"unknown placeholder \{hand\}") as exc:
-        substitute_command("./plugin {hand}", {}, tmp_path / "c.yaml")
+        substitute_command("./plugin {hand}", {}, tmp_path / "c.yaml", tmp_path)
     # The remedy mentions brace escaping.
     assert "{{" in str(exc.value)
 
 
 def test_malformed_brace_is_hard_error_mentioning_escaping(tmp_path):
     with pytest.raises(RigConfigError, match=r"\{\{"):
-        substitute_command("echo ${VAR:-x}", {}, tmp_path / "c.yaml")
+        substitute_command("echo ${VAR:-x}", {}, tmp_path / "c.yaml", tmp_path)
 
 
 def test_escaped_braces_pass_through(tmp_path):
     assert (
-        substitute_command("echo {{literal}}", {}, tmp_path / "c.yaml")
+        substitute_command("echo {{literal}}", {}, tmp_path / "c.yaml", tmp_path)
         == "echo {literal}"
     )
 
@@ -277,3 +291,28 @@ def test_footgun_quiet_when_runtime_not_managed():
         find_runtime_footguns([_proc("{python} example.py")], runtime_managed=False)
         == []
     )
+
+
+# ---------------------------------------------------------------------------
+# Install-prefix resolution
+# ---------------------------------------------------------------------------
+
+
+def test_install_dir_override_is_made_absolute(tmp_path, monkeypatch):
+    """Panes run from the rig's cwd, not the launching shell's directory, so
+    a relative override must be resolved before it reaches a pane.
+    """
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "elsewhere").mkdir()
+    resolved = resolve_install_dir(tmp_path / "rig-cwd", {INSTALL_DIR_ENV: "elsewhere"})
+    assert resolved == (tmp_path / "elsewhere").resolve()
+
+
+def test_install_prefix_with_spaces_stays_one_shell_word(tmp_path):
+    prefix = tmp_path / "in stall"
+    command = substitute_command(
+        "{install}/plugins/foo/foo_plugin", {}, tmp_path / "c.yaml", prefix
+    )
+    # Quoted as a single word, concatenated with the unquoted remainder:
+    # the pane shell (and our own preflight) see one intact path.
+    assert shlex.split(command) == [f"{prefix}/plugins/foo/foo_plugin"]

--- a/src/core/rig_tests/python/test_launcher.py
+++ b/src/core/rig_tests/python/test_launcher.py
@@ -15,23 +15,44 @@ from rig_py_test_ns.config import RigConfig, ProcessConfig
 from rig_py_test_ns.launcher import PreflightError, kill_rig, launch_rig
 
 
-class FakeTmux:
-    """Recording fake for the ``run_tmux`` seam; hands out canned pane ids."""
+#: Session the fake reports for windows created without -s, i.e. the session
+#: a launch from inside tmux joins.
+CURRENT_SESSION = "dev"
 
-    def __init__(self, existing_sessions: set[str] | None = None):
+
+class FakeTmux:
+    """Recording fake for the ``run_tmux`` seam; hands out canned ids.
+
+    *windows* is the tmux server's existing windows as ``{name: session}``;
+    ``None`` means no server at all, so the rig lookup fails like real tmux.
+    """
+
+    def __init__(self, windows: dict[str, str] | None = None):
         self.calls: list[list[str]] = []
-        self.sessions = existing_sessions or set()
+        self.windows = dict(windows or {})
+        self.server = windows is not None
         self._pane_counter = 0
+        self._window_counter = len(self.windows)
 
     def __call__(self, args):
         args = list(args)
         self.calls.append(args)
-        if args[0] == "has-session":
-            session = args[args.index("-t") + 1]
-            if session not in self.sessions:
+        if args[0] == "list-windows":
+            if not self.server:
                 raise subprocess.CalledProcessError(1, ["tmux", *args])
-            return ""
-        if args[0] in ("new-session", "split-window"):
+            return "\n".join(
+                f"@{i}\t{session}\t{name}"
+                for i, (name, session) in enumerate(self.windows.items(), start=1)
+            )
+        if args[0] in ("new-session", "new-window"):
+            self.server = True
+            self._pane_counter += 1
+            self._window_counter += 1
+            name = args[args.index("-n") + 1]
+            session = args[args.index("-s") + 1] if "-s" in args else CURRENT_SESSION
+            self.windows[name] = session
+            return f"%{self._pane_counter}\t@{self._window_counter}\t{session}"
+        if args[0] == "split-window":
             self._pane_counter += 1
             return f"%{self._pane_counter}"
         return ""
@@ -41,7 +62,8 @@ class FakeTmux:
 
     def pane_commands(self) -> list[str]:
         """The wrapper shell-command each pane was spawned running, plan order."""
-        return [c[-1] for c in self.calls if c[0] in ("new-session", "split-window")]
+        creators = ("new-session", "new-window", "split-window")
+        return [c[-1] for c in self.calls if c[0] in creators]
 
 
 def pretype_line(wrapper: str) -> str:
@@ -104,6 +126,8 @@ def clean_env(monkeypatch, tmp_path):
     # suite must never resolve to — and unlink in — a developer's real HOME.
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.delenv("CXR_INSTALL_DIR", raising=False)
+    # A developer's own install-prefix override must not leak into the suite.
+    monkeypatch.delenv("ISAAC_TELEOP_INSTALL_DIR", raising=False)
 
 
 # ---------------------------------------------------------------------------
@@ -115,33 +139,36 @@ def test_fresh_launch_call_plan(tmp_path):
     tmux = FakeTmux()
     launch_rig(make_config(tmp_path), run_tmux=tmux)
 
-    # Session created detached, addressed by pane id, in the rig cwd; the
-    # first pane is SPAWNED RUNNING the runtime wrapper (trailing
-    # shell-command), never a bare shell the launcher types into.
+    # Outside tmux the rig gets its own session, created detached, its
+    # window named after the rig, in the rig cwd; the first pane is SPAWNED
+    # RUNNING the runtime wrapper (trailing shell-command), never a bare
+    # shell the launcher types into.
     (new_session,) = tmux.named("new-session")
     assert new_session[:-1] == [
         "new-session",
         "-d",
         "-P",
         "-F",
-        "#{pane_id}",
+        "#{pane_id}\t#{window_id}\t#{session_name}",
         "-s",
         "test_rig",
         "-n",
-        "rig",
+        "test_rig",
         "-c",
         str(tmp_path),
     ]
     runtime_wrapper = new_session[-1]
 
-    # Session-scoped options only (-t <session>), never global (-g):
-    # pane-border-status plus the runtime strip height for main-horizontal.
+    # Window-scoped options only (-w -t <window id>), never global (-g) and
+    # never session-wide: the rig window may share a session with the user's
+    # own windows. pane-border-status plus the main-horizontal strip height.
     set_options = tmux.named("set-option")
-    assert ["set-option", "-t", "test_rig", "pane-border-status", "top"] in set_options
+    assert ["set-option", "-w", "-t", "@1", "pane-border-status", "top"] in set_options
     assert [
         "set-option",
+        "-w",
         "-t",
-        "test_rig",
+        "@1",
         "main-pane-height",
         "25%",
     ] in set_options
@@ -156,10 +183,11 @@ def test_fresh_launch_call_plan(tmp_path):
 
     # Interleaved tiled re-layouts keep splits from running out of space;
     # the final layout is main-horizontal: runtime = slim top strip,
-    # workers tiled below.
+    # workers tiled below. Targeted at the rig's own first pane — a session
+    # target would lay out whatever window is current in a shared session.
     layouts = [c[-1] for c in tmux.named("select-layout")]
     assert layouts == ["tiled", "tiled", "main-horizontal"]
-    assert all(c[c.index("-t") + 1] == "test_rig" for c in tmux.named("select-layout"))
+    assert all(c[c.index("-t") + 1] == "%1" for c in tmux.named("select-layout"))
 
     # The launcher never send-keys into a pane: keystrokes racing shell
     # startup are echoed raw by the tty and again by the line editor.
@@ -213,11 +241,14 @@ def test_fresh_launch_call_plan(tmp_path):
     assert "auto-runs once the runtime is up" in title_texts[1]
     assert "consumer: bar printer" in title_texts[2]
 
-    # Runtime pane focused; garnish message; attach last (TMUX unset).
+    # Runtime pane focused; garnish message; the rig window is selected and
+    # then attached to last (TMUX unset).
     assert tmux.named("select-pane")[-1] == ["select-pane", "-t", "%1"]
     assert tmux.named("display-message")
-    assert tmux.calls[-1][0] == "attach-session"
-    assert tmux.calls[-1][-1] == "test_rig"
+    assert tmux.calls[-2:] == [
+        ["select-window", "-t", "@1"],
+        ["attach-session", "-t", "test_rig"],
+    ]
 
 
 def test_instructions_printed_before_attach(tmp_path, capsys):
@@ -226,7 +257,7 @@ def test_instructions_printed_before_attach(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "runs automatically once the runtime is up" in out
     assert "press Enter in its pane to rerun" in out
-    assert "tmux kill-session -t test_rig" in out
+    assert "tmux kill-window -t test_rig:test_rig" in out
     assert "test rig" in out  # the rig description is shown
 
 
@@ -256,40 +287,89 @@ def test_no_runtime_stays_tiled_without_main_pane(tmp_path):
     assert not any("main-pane-height" in c for c in tmux.named("set-option"))
 
 
-def test_switch_client_when_inside_tmux(tmp_path, monkeypatch):
+def test_inside_tmux_the_rig_joins_the_current_session(tmp_path, monkeypatch):
+    """Launched from inside tmux the rig is a window in the session the
+    client is already in — never a second session it has to be switched to.
+    """
     monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
-    tmux = FakeTmux()
+    tmux = FakeTmux({"editor": CURRENT_SESSION})
     launch_rig(make_config(tmp_path), run_tmux=tmux)
-    assert tmux.calls[-1] == ["switch-client", "-t", "test_rig"]
+
+    assert not tmux.named("new-session")
+    (new_window,) = tmux.named("new-window")
+    assert new_window[:-1] == [
+        "new-window",
+        "-d",  # built out of sight, switched to only once laid out
+        "-P",
+        "-F",
+        "#{pane_id}\t#{window_id}\t#{session_name}",
+        "-n",
+        "test_rig",
+        "-c",
+        str(tmp_path),
+    ]
+    # The user's own window is untouched: options and layouts target the
+    # rig's window/pane ids, not the session.
+    assert all("test_rig" not in c[3:] for c in tmux.named("set-option"))
+    assert tmux.calls[-2:] == [
+        ["select-window", "-t", "@2"],
+        ["switch-client", "-t", CURRENT_SESSION],
+    ]
     assert not tmux.named("attach-session")
 
 
 # ---------------------------------------------------------------------------
-# Idempotent session reuse
+# Idempotent rig reuse
 # ---------------------------------------------------------------------------
 
 
-def test_existing_session_is_reused(tmp_path, capsys):
-    tmux = FakeTmux(existing_sessions={"test_rig"})
+def test_running_rig_is_switched_to(tmp_path, capsys):
+    tmux = FakeTmux({"test_rig": "test_rig"})
     launch_rig(make_config(tmp_path), run_tmux=tmux)
-    assert [c[0] for c in tmux.calls] == ["has-session", "attach-session"]
+    assert [c[0] for c in tmux.calls] == [
+        "list-windows",
+        "select-window",
+        "attach-session",
+    ]
     out = capsys.readouterr().out
     assert "--kill" in out  # points at the built-in kill, not raw tmux
-    assert "ignored for an existing session" not in out  # nothing was ignored
+    assert "ignored for a running rig" not in out  # nothing was ignored
 
 
-def test_existing_session_notes_ignored_settings(tmp_path, capsys):
-    tmux = FakeTmux(existing_sessions={"test_rig"})
+def test_running_rig_is_found_in_any_session(tmp_path, capsys, monkeypatch):
+    """A rig launched from another session is switched to, not duplicated."""
+    monkeypatch.setenv("TMUX", "/tmp/tmux-1000/default,1234,0")
+    tmux = FakeTmux({"editor": "dev", "test_rig": "other"})
+    launch_rig(make_config(tmp_path), run_tmux=tmux)
+    assert not tmux.named("new-window")
+    assert tmux.calls[-2:] == [
+        ["select-window", "-t", "@2"],
+        ["switch-client", "-t", "other"],
+    ]
+    assert "already running in session 'other'" in capsys.readouterr().out
+
+
+def test_rig_lookup_matches_the_window_name_exactly(tmp_path):
+    """Never a tmux ``-t`` target: its prefix/fnmatch fallback would make a
+    window named ``test_rig_2`` count as the ``test_rig`` rig.
+    """
+    tmux = FakeTmux({"test_rig_2": "dev"})
+    launch_rig(make_config(tmp_path), run_tmux=tmux)
+    assert tmux.named("new-session")  # launched, not mistaken for running
+
+
+def test_running_rig_notes_ignored_settings(tmp_path, capsys):
+    tmux = FakeTmux({"test_rig": "test_rig"})
     launch_rig(make_config(tmp_path), no_runtime=True, run_tmux=tmux)
     out = capsys.readouterr().out
-    assert "--no-runtime ignored for an existing session" in out
+    assert "--no-runtime ignored for a running rig" in out
     assert "kill it first" in out
 
 
-def test_existing_session_reattaches_despite_launch_preflight_failures(tmp_path):
-    """Reattach must win before any launch-only preflight: edits to a
-    running rig's YAML (ghost binary, missing cwd, undeclared placeholder)
-    must never block getting back into the live session.
+def test_running_rig_is_switched_to_despite_launch_preflight_failures(tmp_path):
+    """Switching to a live rig must win before any launch-only preflight:
+    edits to a running rig's YAML (ghost binary, missing cwd, undeclared
+    placeholder) must never block getting back into the live window.
     """
     config = make_config(
         tmp_path,
@@ -298,9 +378,13 @@ def test_existing_session_reattaches_despite_launch_preflight_failures(tmp_path)
             ProcessConfig("ghost", "install/plugins/ghost/ghost_plugin {undeclared}"),
         ),
     )
-    tmux = FakeTmux(existing_sessions={"test_rig"})
+    tmux = FakeTmux({"test_rig": "test_rig"})
     launch_rig(config, run_tmux=tmux)  # must not raise
-    assert [c[0] for c in tmux.calls] == ["has-session", "attach-session"]
+    assert [c[0] for c in tmux.calls] == [
+        "list-windows",
+        "select-window",
+        "attach-session",
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -308,21 +392,25 @@ def test_existing_session_reattaches_despite_launch_preflight_failures(tmp_path)
 # ---------------------------------------------------------------------------
 
 
-def test_kill_rig_kills_the_existing_session(tmp_path, capsys):
-    tmux = FakeTmux(existing_sessions={"test_rig"})
+def test_kill_rig_kills_only_the_rig_window(tmp_path, capsys):
+    """The rig's session may be the user's, full of unrelated work: kill the
+    rig's window (which ends the session only when it was its last window).
+    """
+    tmux = FakeTmux({"editor": "dev", "test_rig": "dev"})
     kill_rig(make_config(tmp_path), run_tmux=tmux)
     assert tmux.calls == [
-        ["has-session", "-t", "test_rig"],
-        ["kill-session", "-t", "test_rig"],
+        ["list-windows", "-a", "-F", "#{window_id}\t#{session_name}\t#{window_name}"],
+        ["kill-window", "-t", "@2"],
     ]
-    assert "killed session 'test_rig'" in capsys.readouterr().out
-
-
-def test_kill_rig_is_idempotent_when_no_session(tmp_path, capsys):
-    tmux = FakeTmux()  # no sessions
-    kill_rig(make_config(tmp_path), run_tmux=tmux)
     assert not tmux.named("kill-session")
-    assert "no session 'test_rig' to kill" in capsys.readouterr().out
+    assert "killed rig 'test_rig' in session 'dev'" in capsys.readouterr().out
+
+
+def test_kill_rig_is_idempotent_when_not_running(tmp_path, capsys):
+    tmux = FakeTmux()  # no tmux server at all
+    kill_rig(make_config(tmp_path), run_tmux=tmux)
+    assert not tmux.named("kill-window")
+    assert "no rig 'test_rig' to kill" in capsys.readouterr().out
 
 
 # ---------------------------------------------------------------------------
@@ -529,12 +617,12 @@ def test_no_runtime_preserves_external_sentinel(tmp_path):
 
 
 def test_reattach_preserves_live_sentinel(tmp_path):
-    # Reattaching to an existing session must not clear the sentinel its
-    # (live) runtime owns — the delete sits after the reattach early-return.
+    # Switching to a running rig must not clear the sentinel its (live)
+    # runtime owns — the delete sits after that early-return.
     sentinel = _default_sentinel(tmp_path)
     sentinel.parent.mkdir(parents=True)
     sentinel.touch()
-    tmux = FakeTmux(existing_sessions={"test_rig"})
+    tmux = FakeTmux({"test_rig": "test_rig"})
     launch_rig(make_config(tmp_path), run_tmux=tmux)
     assert sentinel.exists()
 
@@ -743,3 +831,41 @@ def test_footgun_warning_suppressed_with_no_runtime(tmp_path, capsys):
     )
     launch_rig(config, no_runtime=True, run_tmux=FakeTmux())
     assert "--no-launch-cloudxr-runtime" not in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# Install-prefix resolution ({install})
+# ---------------------------------------------------------------------------
+
+
+def make_install_config(tmp_path: Path, prefix: Path, **kwargs) -> RigConfig:
+    """A rig whose panes reach their binaries through ``{install}``."""
+    make_exe(prefix, "plugins/foo/foo_plugin")
+    return make_config(
+        tmp_path,
+        producers=(ProcessConfig("foo plugin", "{install}/plugins/foo/foo_plugin"),),
+        consumers=(),
+        **kwargs,
+    )
+
+
+def test_install_placeholder_expands_to_the_default_prefix(tmp_path):
+    tmux = FakeTmux()
+    launch_rig(make_install_config(tmp_path, tmp_path / "install"), run_tmux=tmux)
+    assert (
+        pretyped_command(tmux.pane_commands()[1])
+        == f"{tmp_path}/install/plugins/foo/foo_plugin"
+    )
+
+
+def test_install_placeholder_follows_the_env_override(tmp_path, monkeypatch):
+    """A tree installed with a non-default CMAKE_INSTALL_PREFIX is reachable
+    without editing the rig file.
+    """
+    prefix = tmp_path / "opt" / "isaacteleop" / "install"
+    monkeypatch.setenv("ISAAC_TELEOP_INSTALL_DIR", str(prefix))
+    tmux = FakeTmux()
+    launch_rig(make_install_config(tmp_path, prefix), run_tmux=tmux)
+    assert (
+        pretyped_command(tmux.pane_commands()[1]) == f"{prefix}/plugins/foo/foo_plugin"
+    )

--- a/src/python/isaacteleop/rig/__main__.py
+++ b/src/python/isaacteleop/rig/__main__.py
@@ -4,7 +4,7 @@
 """Entry point for ``python -m isaacteleop.rig``.
 
 Launches a teleop rig (CloudXR runtime + producer plugins + consumer apps)
-in a tmux session from a YAML rig file.
+in a tmux window from a YAML rig file.
 """
 
 from __future__ import annotations
@@ -49,7 +49,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--kill",
         action="store_true",
         help=(
-            "Kill the rig's tmux session (and every process in it) instead "
+            "Kill the rig's tmux window (and every process in it) instead "
             "of launching, e.g. to relaunch after editing the rig file."
         ),
     )

--- a/src/python/isaacteleop/rig/config.py
+++ b/src/python/isaacteleop/rig/config.py
@@ -7,7 +7,7 @@ A *rig* file describes one tmux teleop rig: the CloudXR runtime pane plus
 producer plugins and consumer apps. See ``rigs/se3_tracker.yaml`` in the
 Teleop repository for an annotated exemplar. Top-level keys::
 
-    name:         rig id AND tmux session name (required)
+    name:         rig id AND tmux window name (required)
     description:  free text (optional)
     cwd:          working dir for every pane, relative to the YAML file's
                   directory (optional; default: the YAML's directory)
@@ -21,8 +21,9 @@ Teleop repository for an annotated exemplar. Top-level keys::
 At least one producer or consumer is required. Unknown keys are a hard
 error. Commands are shell strings typed verbatim into panes; ``{key}``
 placeholders are substituted from ``params`` (literal braces must be
-escaped as ``{{`` / ``}}``). The reserved ``{python}`` placeholder expands
-to the launching interpreter (:data:`sys.executable`).
+escaped as ``{{`` / ``}}``). Two placeholders are reserved: ``{python}``
+expands to the launching interpreter (:data:`sys.executable`) and
+``{install}`` to the install prefix (see :func:`resolve_install_dir`).
 """
 
 from __future__ import annotations
@@ -39,6 +40,21 @@ import yaml
 #: Reserved placeholder expanding to the launching interpreter.
 PYTHON_PLACEHOLDER = "python"
 
+#: Reserved placeholder expanding to the install prefix that holds the
+#: plugin and example binaries (see :func:`resolve_install_dir`).
+INSTALL_PLACEHOLDER = "install"
+
+#: Override for the prefix ``{install}`` expands to — the value passed as
+#: ``CMAKE_INSTALL_PREFIX`` when the tree was installed somewhere other
+#: than the project default.
+INSTALL_DIR_ENV = "ISAAC_TELEOP_INSTALL_DIR"
+
+#: Reserved param names -> what they always expand to (used in the error).
+_RESERVED_PLACEHOLDERS = {
+    PYTHON_PLACEHOLDER: "the launching interpreter",
+    INSTALL_PLACEHOLDER: f"the install prefix (override: ${INSTALL_DIR_ENV})",
+}
+
 #: Default runtime pane command (used when the rig has no ``runtime:`` key).
 DEFAULT_RUNTIME_COMMAND = "{python} -m isaacteleop.cloudxr --accept-eula"
 
@@ -51,7 +67,7 @@ _TOP_LEVEL_KEYS = frozenset(
 )
 _ENTRY_KEYS = frozenset({"name", "command"})
 
-#: ``name:`` doubles as the tmux session name, so keep it shell/tmux-safe
+#: ``name:`` doubles as the tmux window name, so keep it shell/tmux-safe
 #: (tmux targets treat ``.`` and ``:`` specially; spaces need quoting).
 _NAME_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 
@@ -144,10 +160,10 @@ def _parse_params(value: Any, source: Path) -> dict[str, str]:
             raise RigConfigError(
                 f"{source}: 'params' keys must be strings (got {key!r})"
             )
-        if key == PYTHON_PLACEHOLDER:
+        if key in _RESERVED_PLACEHOLDERS:
             raise RigConfigError(
-                f"{source}: param '{PYTHON_PLACEHOLDER}' is reserved "
-                "(it always expands to the launching interpreter)"
+                f"{source}: param '{key}' is reserved (it always expands to "
+                f"{_RESERVED_PLACEHOLDERS[key]})"
             )
         if isinstance(val, (dict, list)):
             raise RigConfigError(f"{source}: param '{key}' must be a scalar")
@@ -200,7 +216,7 @@ def load_rig_config(path: str | Path) -> RigConfig:
     name = _require_str(data["name"], "'name'", source)
     if not _NAME_PATTERN.match(name):
         raise RigConfigError(
-            f"{source}: name '{name}' is used as the tmux session name — "
+            f"{source}: name '{name}' is used as the tmux window name — "
             "use letters/digits/-/_ only"
         )
     description = ""
@@ -234,11 +250,34 @@ def load_rig_config(path: str | Path) -> RigConfig:
     )
 
 
-def substitute_command(command: str, params: Mapping[str, str], source: Path) -> str:
+def resolve_install_dir(cwd: Path, env: Mapping[str, str]) -> Path:
+    """Return the install prefix ``{install}`` expands to.
+
+    ``$ISAAC_TELEOP_INSTALL_DIR`` wins — that is the knob for a tree
+    installed with a non-default ``CMAKE_INSTALL_PREFIX`` (say
+    ``/opt/isaacteleop/install``). Otherwise ``<cwd>/install``, the prefix
+    the project's own CMakeLists forces by default.
+
+    Always absolute: ``cwd`` already is, and a relative override is resolved
+    here — against the launching shell's directory, since the panes run from
+    the rig's ``cwd:`` and would otherwise read it as a different path.
+    """
+    override = env.get(INSTALL_DIR_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return cwd / "install"
+
+
+def substitute_command(
+    command: str, params: Mapping[str, str], source: Path, install_dir: Path
+) -> str:
     """Expand ``{key}`` placeholders in a command string.
 
-    ``{python}`` expands to the quoted launching interpreter; every other
-    placeholder must be declared in *params*.
+    ``{python}`` expands to the quoted launching interpreter and
+    ``{install}`` to the quoted *install_dir*; every other placeholder must
+    be declared in *params*. Both are quoted as single shell words, so a
+    prefix containing spaces still concatenates correctly with the rest of
+    the path (``'/o p/install'/plugins/x``).
 
     Raises:
         RigConfigError: On an unknown placeholder or malformed braces
@@ -247,6 +286,7 @@ def substitute_command(command: str, params: Mapping[str, str], source: Path) ->
     # A plain dict raises KeyError from format_map on unknown placeholders.
     table = dict(params)
     table[PYTHON_PLACEHOLDER] = shlex.quote(sys.executable)
+    table[INSTALL_PLACEHOLDER] = shlex.quote(str(install_dir))
     try:
         return command.format_map(table)
     except KeyError as exc:

--- a/src/python/isaacteleop/rig/launcher.py
+++ b/src/python/isaacteleop/rig/launcher.py
@@ -3,9 +3,12 @@
 
 """tmux orchestration for teleop rigs.
 
-Launches one tmux session per rig: the CloudXR runtime pane starts
-immediately; each producer/consumer pane waits for the runtime to come up,
-sources the CloudXR env it writes, and then RUNS its command automatically.
+Launches one tmux WINDOW per rig, named after the rig: run from inside
+tmux the window joins the current session, run from a plain shell it gets
+a session of its own (also named after the rig). The CloudXR runtime pane
+starts immediately; each producer/consumer pane waits for the runtime to
+come up, sources the CloudXR env it writes, and then RUNS its command
+automatically.
 When the command exits (the classic early exit: started before a headset
 connected, so 'Failed to get OpenXR system'), the pane prints the exit
 status and drops to an interactive shell with the same command pre-typed —
@@ -39,9 +42,11 @@ from pathlib import Path
 from typing import Callable, Mapping, Sequence
 
 from .config import (
+    INSTALL_DIR_ENV,
     RigConfig,
     RigError,
     find_runtime_footguns,
+    resolve_install_dir,
     substitute_command,
 )
 
@@ -52,11 +57,41 @@ RunTmux = Callable[[Sequence[str]], str]
 #: ``footgun`` marks a Python app missing --no-launch-cloudxr-runtime.
 _Pane = tuple[str, str, str, str, bool]
 
+#: A live rig: (tmux window id, name of the session holding it).
+_RigWindow = tuple[str, str]
+
+#: Field separator for multi-field ``-F`` formats. Session and window names
+#: may contain spaces; no tmux id or name field contains a tab.
+_SEP = "\t"
+
+#: ``-F`` format for a freshly created rig window.
+_NEW_WINDOW_FORMAT = f"#{{pane_id}}{_SEP}#{{window_id}}{_SEP}#{{session_name}}"
+
+#: ``-F`` format for the ``list-windows -a`` rig lookup.
+_LIST_WINDOWS_FORMAT = f"#{{window_id}}{_SEP}#{{session_name}}{_SEP}#{{window_name}}"
+
 _BUILD_REMEDY = (
     "build and install first:\n"
     "  cmake -B build -DBUILD_EXAMPLES=ON -DBUILD_PYTHON_BINDINGS=ON\n"
     "  cmake --build build --parallel && cmake --install build"
 )
+
+#: An install tree the user already has (another checkout, a deployment) is
+#: as likely as an unbuilt one — a remedy that only says "build" sends them
+#: rebuilding what they have. Appended whenever the override is unset.
+_INSTALL_DIR_HINT = (
+    f"\nor point {INSTALL_DIR_ENV} at an install tree you already have:\n"
+    f"  {INSTALL_DIR_ENV}=/path/to/install python -m isaacteleop.rig <rig.yaml>"
+)
+
+#: Marker of a configured CMake build tree.
+_CMAKE_CACHE = "CMakeCache.txt"
+
+#: Directories that hold build trees: a hand-made ``cmake -B build``, and the
+#: managed preset/wheel trees, which are one level down (``build-cmake/
+#: cpython-311``). Only used to sharpen an error message, so an unknown
+#: layout costs nothing but a less specific remedy.
+_BUILD_DIRS = ("build", "build-cmake", "build-wheel")
 
 #: Maximum time [s] a worker pane waits for the runtime before giving up on
 #: auto-loading the CloudXR env (matches the runtime's own startup timeout
@@ -100,7 +135,7 @@ def _check_tmux_installed() -> None:
         )
 
 
-def _check_python_can_import_cloudxr(env: Mapping[str, str]) -> None:
+def _check_python_can_import_cloudxr(env: Mapping[str, str], install_dir: Path) -> None:
     """Verify the pane interpreter can import isaacteleop.cloudxr.
 
     tmux panes spawn fresh shells that do not inherit the caller's venv, so
@@ -116,15 +151,65 @@ def _check_python_can_import_cloudxr(env: Mapping[str, str]) -> None:
         raise PreflightError(
             f"{sys.executable} cannot import 'isaacteleop.cloudxr' — run from the "
             "environment where the isaacteleop wheel is installed "
-            "(pip install install/wheels/isaacteleop-*.whl)"
+            f"(pip install {install_dir}/wheels/isaacteleop-*.whl)"
         )
 
 
-def _check_commands_exist(panes: Sequence[tuple[str, str]], cwd: Path) -> None:
+def _configured_build_tree(cwd: Path) -> Path | None:
+    """Return the most recently configured build tree under *cwd*, if any.
+
+    Each of :data:`_BUILD_DIRS` itself, else one level down.
+    """
+    found: list[Path] = []
+    for name in _BUILD_DIRS:
+        root = cwd / name
+        if (root / _CMAKE_CACHE).is_file():
+            found.append(root)
+            continue
+        try:
+            found.extend(p for p in root.iterdir() if (p / _CMAKE_CACHE).is_file())
+        except OSError:
+            continue  # missing, unreadable, or not a directory
+    if not found:
+        return None
+    return max(found, key=lambda p: (p / _CMAKE_CACHE).stat().st_mtime)
+
+
+def _missing_binary_remedy(cwd: Path, install_dir: Path, env: Mapping[str, str]) -> str:
+    """Name the fix for a missing binary: bad override, built-not-installed,
+    or nothing built at all.
+
+    An override that points at the wrong tree looks exactly like a missing
+    build, so say which prefix was actually used and where it came from. A
+    build tree with no install is just as indistinguishable, and the fix
+    there is one command — not the full rebuild the generic remedy implies.
+    The build tree's own ``CMAKE_INSTALL_PREFIX`` may point anywhere (a
+    wheel build aims at a temp dir), so the install line always passes
+    ``--prefix`` explicitly.
+    """
+    if env.get(INSTALL_DIR_ENV):
+        return (
+            f"{INSTALL_DIR_ENV} resolves {{install}} to {install_dir} — point it at a "
+            f"tree built with 'cmake --install build', or unset it for {cwd / 'install'}"
+        )
+    build = _configured_build_tree(cwd)
+    if build is not None:
+        return (
+            f"{build} is configured but nothing is installed at {install_dir} — "
+            f"install it:\n"
+            f"  cmake --build {build} --parallel\n"
+            f"  cmake --install {build} --prefix {install_dir}" + _INSTALL_DIR_HINT
+        )
+    return _BUILD_REMEDY + _INSTALL_DIR_HINT
+
+
+def _check_commands_exist(
+    panes: Sequence[tuple[str, str]], cwd: Path, remedy: str
+) -> None:
     """Require path-like first command tokens to exist and be executable.
 
     Mirrors the old run_se3_demo.sh preflight. *panes* is a sequence of
-    (name, substituted command) pairs.
+    (name, substituted command) pairs; *remedy* is appended to the error.
     """
     for name, command in panes:
         try:
@@ -142,7 +227,7 @@ def _check_commands_exist(panes: Sequence[tuple[str, str]], cwd: Path) -> None:
         path = Path(first) if os.path.isabs(first) else cwd / first
         if not (path.is_file() and os.access(path, os.X_OK)):
             raise PreflightError(
-                f"'{name}': {path} not found or not executable — {_BUILD_REMEDY}"
+                f"'{name}': {path} not found or not executable — {remedy}"
             )
 
 
@@ -232,23 +317,23 @@ def launch_rig(
     no_runtime: bool = False,
     run_tmux: RunTmux | None = None,
 ) -> None:
-    """Launch (or re-attach to) the tmux session for a teleop rig.
+    """Launch (or switch to) the tmux window for a teleop rig.
 
     The rig file is the single source of configuration: params live in its
     ``params:`` block and are substituted into every command that
     references them (edit the file to change them).
 
-    An existing session is re-attached BEFORE any launch-only preflight
-    (plan substitution, cwd/command checks): edits to a running rig's YAML
-    can never block getting back into the live session.
+    A running rig is switched to BEFORE any launch-only preflight (plan
+    substitution, cwd/command checks): edits to a running rig's YAML can
+    never block getting back into the live window.
 
     Args:
         config: The parsed rig (see :func:`~.config.load_rig_config`).
         no_runtime: Skip the runtime pane (a CloudXR runtime is already
             running elsewhere, e.g. after ``python -m isaacteleop.cloudxr``).
         run_tmux: Injectable tmux seam for tests. When ``None`` the real
-            tmux is used: tmux-on-PATH is checked immediately (the session
-            probe needs it) and the interpreter-can-import-
+            tmux is used: tmux-on-PATH is checked immediately (the rig-window
+            lookup needs it) and the interpreter-can-import-
             isaacteleop.cloudxr probe runs with the launch-only preflight.
 
     Raises:
@@ -262,24 +347,27 @@ def launch_rig(
         _check_tmux_installed()
         run_tmux = _run_tmux
 
-    # Reattach must win before any launch-only preflight below: a broken
-    # edit to a running rig's YAML must never block reattachment.
-    session = config.name
-    if _session_exists(run_tmux, session):
+    # Switching to a live rig must win before any launch-only preflight
+    # below: a broken edit to a running rig's YAML must never block it.
+    existing = _find_rig_window(run_tmux, config.name)
+    if existing is not None:
+        window_id, session = existing
         message = (
-            f"session '{session}' already exists — switching to it "
+            f"rig '{config.name}' is already running in session '{session}' — "
+            f"switching to it "
             f"(kill with: python -m isaacteleop.rig {config.source} --kill)"
         )
         if no_runtime:
             message += (
-                "\nnote: --no-runtime ignored for an existing session; "
+                "\nnote: --no-runtime ignored for a running rig; "
                 "kill it first to relaunch with new settings"
             )
         print(message)
-        _goto_session(run_tmux, session, env)
+        _goto_rig_window(run_tmux, window_id, session, env)
         return
 
     params = config.params
+    install_dir = resolve_install_dir(config.cwd, env)
 
     # Resolve the pane plan. Runtime first (starts immediately); producers
     # and consumers auto-run once the runtime env is ready.
@@ -295,7 +383,7 @@ def launch_rig(
                 "runtime",
                 runtime_name,
                 raw,
-                substitute_command(raw, params, config.source),
+                substitute_command(raw, params, config.source, install_dir),
                 False,
             )
         )
@@ -306,7 +394,9 @@ def launch_rig(
                     role,
                     proc.name,
                     proc.command,
-                    substitute_command(proc.command, params, config.source),
+                    substitute_command(
+                        proc.command, params, config.source, install_dir
+                    ),
                     bool(find_runtime_footguns([proc], runtime_managed=not no_runtime)),
                 )
             )
@@ -318,13 +408,14 @@ def launch_rig(
     _check_commands_exist(
         [(name, resolved) for role, name, _, resolved, _ in plan if role != "runtime"],
         config.cwd,
+        _missing_binary_remedy(config.cwd, install_dir, env),
     )
     for warning in find_runtime_footguns(
         [*config.producers, *config.consumers], runtime_managed=not no_runtime
     ):
         print(warning, file=sys.stderr)
     if using_real_tmux and any("{python}" in raw for _, _, raw, _, _ in plan):
-        _check_python_can_import_cloudxr(env)
+        _check_python_can_import_cloudxr(env, install_dir)
 
     runtime_resolved = plan[0][3] if not no_runtime else None
     cloudxr_run_dir = _cloudxr_run_dir(runtime_resolved, env)
@@ -342,43 +433,70 @@ def launch_rig(
                 f"cannot remove stale {stale}: {exc} — fix permissions on "
                 f"{cloudxr_run_dir} (was the runtime run with sudo?)"
             ) from exc
-    _create_session(run_tmux, session, config.cwd, plan, env, cloudxr_run_dir)
-    _print_instructions(session, config.description, plan)
-    _goto_session(run_tmux, session, env)
+    window_id, session = _create_rig_window(
+        run_tmux, config.name, config.cwd, plan, env, cloudxr_run_dir
+    )
+    _print_instructions(config.name, session, config.description, plan)
+    _goto_rig_window(run_tmux, window_id, session, env)
 
 
 def kill_rig(config: RigConfig, *, run_tmux: RunTmux | None = None) -> None:
-    """Kill the rig's tmux session (and every process running in it).
+    """Kill the rig's tmux window (and every process running in it).
 
-    Idempotent: killing a rig whose session does not exist just reports
-    that there is nothing to do.
+    Only the rig's own window: the session it lives in may be the user's,
+    full of unrelated work. A rig that owns its session takes the session
+    down with it — tmux ends a session whose last window is killed.
+
+    Idempotent: killing a rig that is not running just reports that there
+    is nothing to do.
 
     Args:
-        config: The parsed rig; its ``name`` is the tmux session name.
+        config: The parsed rig; its ``name`` is the tmux window name.
         run_tmux: Injectable tmux seam for tests (real tmux when ``None``).
     """
     if run_tmux is None:
         _check_tmux_installed()
         run_tmux = _run_tmux
-    session = config.name
-    if not _session_exists(run_tmux, session):
-        print(f"no session '{session}' to kill")
+    existing = _find_rig_window(run_tmux, config.name)
+    if existing is None:
+        print(f"no rig '{config.name}' to kill")
         return
-    run_tmux(["kill-session", "-t", session])
-    print(f"killed session '{session}'")
+    window_id, session = existing
+    run_tmux(["kill-window", "-t", window_id])
+    print(f"killed rig '{config.name}' in session '{session}'")
 
 
-def _session_exists(run_tmux: RunTmux, session: str) -> bool:
-    """Return whether the tmux session already exists (has-session probe)."""
+def _find_rig_window(run_tmux: RunTmux, name: str) -> _RigWindow | None:
+    """Return the running rig's (window id, session name), or ``None``.
+
+    Searches every session (``-a``), so a rig launched from another session
+    is switched to rather than duplicated. The match is an exact window-name
+    comparison in Python, never a tmux ``-t`` target: tmux target resolution
+    falls back to prefix and fnmatch matching, so ``-t rig`` would also find
+    ``rig_tracker``. tmux exits non-zero when no server is running.
+    """
     try:
-        run_tmux(["has-session", "-t", session])
+        listing = run_tmux(["list-windows", "-a", "-F", _LIST_WINDOWS_FORMAT])
     except subprocess.CalledProcessError:
-        return False
-    return True
+        return None
+    for line in listing.splitlines():
+        window_id, _, rest = line.partition(_SEP)
+        session, _, window_name = rest.partition(_SEP)
+        if window_name == name:
+            return window_id, session
+    return None
 
 
-def _goto_session(run_tmux: RunTmux, session: str, env: Mapping[str, str]) -> None:
-    """Attach from a plain shell; switch the client when already inside tmux."""
+def _goto_rig_window(
+    run_tmux: RunTmux, window_id: str, session: str, env: Mapping[str, str]
+) -> None:
+    """Make the rig window current, then attach to (or switch to) its session.
+
+    ``select-window`` first so the session is already showing the rig when
+    the client lands on it — including the case where the rig window sits in
+    the session the client is attached to, where switching alone is a no-op.
+    """
+    run_tmux(["select-window", "-t", window_id])
     if env.get("TMUX"):
         run_tmux(["switch-client", "-t", session])
     else:
@@ -482,22 +600,27 @@ def _worker_pane_command(
     )
 
 
-def _create_session(
+def _create_rig_window(
     run_tmux: RunTmux,
-    session: str,
+    rig: str,
     cwd: Path,
     plan: Sequence[_Pane],
     env: Mapping[str, str],
     cloudxr_run_dir: Path,
-) -> None:
-    """Create the session, each pane spawned running its wrapper command.
+) -> _RigWindow:
+    """Create the rig window, each pane spawned running its wrapper command.
 
-    Pane ids are captured via ``-PF '#{pane_id}'`` (never indices) so the
-    layout is immune to base-index / pane-base-index user settings. Layout:
-    ``main-horizontal`` with the runtime as the main pane — a full-width
-    strip of :data:`RUNTIME_PANE_HEIGHT` on top (it only prints status and
-    the web-client URL) — and the workers tiled below. Under ``--no-runtime``
-    all panes are peers and stay ``tiled``.
+    Inside tmux the window joins the client's current session; otherwise it
+    gets a new session of its own. Returns (window id, session name).
+
+    Pane and window ids are captured via ``-PF`` (never indices or names) so
+    the layout is immune to base-index settings AND to the window sharing a
+    session with the user's other windows: every option and layout call
+    below must target the rig's own window, not whatever window happens to
+    be current. Layout: ``main-horizontal`` with the runtime as the main
+    pane — a full-width strip of :data:`RUNTIME_PANE_HEIGHT` on top (it only
+    prints status and the web-client URL) — and the workers tiled below.
+    Under ``--no-runtime`` all panes are peers and stay ``tiled``.
 
     Every pane's setup runs as its SPAWN COMMAND (the trailing tmux
     shell-command), never as keystrokes typed by the launcher: keystrokes
@@ -523,24 +646,46 @@ def _create_session(
                 _worker_pane_command(command, cloudxr_run_dir, role, name, footgun)
             )
 
-    first_pane = run_tmux(
-        [
-            "new-session",
-            "-d",
-            "-P",
-            "-F",
-            "#{pane_id}",
-            "-s",
-            session,
-            "-n",
-            "rig",
-            "-c",
-            str(cwd),
-            pane_commands[0],
-        ]
-    )
-    # Session-scoped only (-t <session>, no -g): never touch global tmux config.
-    run_tmux(["set-option", "-t", session, "pane-border-status", "top"])
+    if env.get("TMUX"):
+        # -d: build the panes out of sight, then switch once everything is
+        # laid out (_goto_rig_window) instead of jumping the user's client
+        # into a window that is still splitting.
+        created = run_tmux(
+            [
+                "new-window",
+                "-d",
+                "-P",
+                "-F",
+                _NEW_WINDOW_FORMAT,
+                "-n",
+                rig,
+                "-c",
+                str(cwd),
+                pane_commands[0],
+            ]
+        )
+    else:
+        created = run_tmux(
+            [
+                "new-session",
+                "-d",
+                "-P",
+                "-F",
+                _NEW_WINDOW_FORMAT,
+                "-s",
+                rig,
+                "-n",
+                rig,
+                "-c",
+                str(cwd),
+                pane_commands[0],
+            ]
+        )
+    first_pane, window_id, session = created.split(_SEP)
+
+    # Window-scoped (-w -t <window id>), never global (-g) or session-wide:
+    # the rig must not restyle the user's other windows.
+    run_tmux(["set-option", "-w", "-t", window_id, "pane-border-status", "top"])
 
     pane_ids = [first_pane]
     for i in range(1, len(plan)):
@@ -562,12 +707,22 @@ def _create_session(
         )
         # Redistribute after every split so chained splits never hit tmux's
         # "pane too small" limit, no matter how many panes the rig has.
-        run_tmux(["select-layout", "-t", session, "tiled"])
+        # select-layout takes a pane target: any rig pane names the window.
+        run_tmux(["select-layout", "-t", pane_ids[0], "tiled"])
     if len(plan) > 1 and plan[0][0] == "runtime":
         # Final layout: the runtime (pane 0 → the main pane) as a slim
         # full-width strip on top, workers tiled in the space below.
-        run_tmux(["set-option", "-t", session, "main-pane-height", RUNTIME_PANE_HEIGHT])
-        run_tmux(["select-layout", "-t", session, "main-horizontal"])
+        run_tmux(
+            [
+                "set-option",
+                "-w",
+                "-t",
+                window_id,
+                "main-pane-height",
+                RUNTIME_PANE_HEIGHT,
+            ]
+        )
+        run_tmux(["select-layout", "-t", pane_ids[0], "main-horizontal"])
     # else (--no-runtime): all panes are peer workers — stay tiled.
 
     for pane_id, (role, name, _, _, _) in zip(pane_ids, plan):
@@ -588,11 +743,14 @@ def _create_session(
             "before the headset was in, press Enter in it to rerun",
         ]
     )
+    return window_id, session
 
 
-def _print_instructions(session: str, description: str, plan: Sequence[_Pane]) -> None:
+def _print_instructions(
+    rig: str, session: str, description: str, plan: Sequence[_Pane]
+) -> None:
     """Print the pane rundown BEFORE attaching (it survives detach)."""
-    header = f"Rig session '{session}' created"
+    header = f"Rig '{rig}' created in tmux session '{session}'"
     if description:
         header += f": {description}"
     print(header)
@@ -608,4 +766,4 @@ def _print_instructions(session: str, description: str, plan: Sequence[_Pane]) -
         "their command automatically once the runtime is up; if a command exited "
         "before the headset connected, press Enter in its pane to rerun."
     )
-    print(f"Kill the session with --kill (or: tmux kill-session -t {session})")
+    print(f"Kill the rig with --kill (or: tmux kill-window -t {session}:{rig})")


### PR DESCRIPTION
## Description

Two changes to `isaacteleop.rig`, both about where a rig lives.

**A rig is now a tmux window, not a session.** Launched from inside tmux it joins your current session as a window named after the rig, so the shell you launched from and the rigs you started share one session; from a plain shell it still gets a session of its own. Rig identity moving from session to window makes the previously-equivalent session-scoped tmux targets wrong — `pane-border-status`, `main-pane-height` and both `select-layout` calls would hit whatever window is current in a shared session, and `--kill` would take that session down along with every unrelated process in it. Those now target the rig's own window id and first pane, and `--kill` is `kill-window` (which still ends the session when the rig owned it). Lookup is an exact window-name match over `list-windows -a`, avoiding tmux's prefix/fnmatch target fallback.

**Rig commands stop hard-coding the install prefix.** The reserved `{install}` placeholder resolves to `$ISAAC_TELEOP_INSTALL_DIR`, else `<cwd>/install`, so a tree built with a non-default `CMAKE_INSTALL_PREFIX` needs no rig-file edit. A missing binary now names the fix for the case you are in: a build tree configured but never installed, an override pointing at the wrong tree, or nothing built. Rig files with literal `install/...` paths keep working when the default prefix is the right one.

Relates to #888 (the rig row of its duplication table); the CloudXR run-dir/sentinel de-duplication it asks for is not in here.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

Breaking in one narrow sense: `--kill` kills the rig's window rather than a whole session, and a rig launched inside tmux no longer creates a session of its own. Anything scripted against `tmux kill-session -t <rig>` or `has-session -t <rig>` needs updating; nothing in this repo was.

## Testing

- `pytest src/core/rig_tests/python` — 76 pass. The fake tmux now models windows across sessions; new cases cover only what nothing else catches: kill hitting one window, exact window-name matching (tmux's fnmatch fallback would match `foo_2` for rig `foo`), joining the current session, cross-session lookup, a relative `ISAAC_TELEOP_INSTALL_DIR` being made absolute, and a prefix containing spaces staying one shell word. Error-message wording is deliberately not asserted.
- Live tmux 3.4: launching inside a session adds the rig window beside the existing one, window-scoped options and the 25% runtime strip apply to the rig window only, `--kill` removes just it; standalone launch creates its own session and a relaunch switches to it instead of duplicating.
- Install prefix end-to-end with a throwaway tree: a good override spawns panes with the absolute overridden path (checked via `#{pane_start_command}`), a wrong one produces the env-var remedy, a relative one is resolved against the launching shell.
- `SKIP=check-copyright-year pre-commit run --all-files` clean; docs build not re-run (prose-only edits to `rig.rst`).

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rig commands now run in a dedicated tmux window, or reuse a window in the current tmux session.
  * Added configurable install-directory support through `ISAAC_TELEOP_INSTALL_DIR`.
  * Rig commands can use the `{install}` placeholder to locate installed binaries.

* **Bug Fixes**
  * Stopping a rig now closes only its window instead of the entire tmux session.
  * Improved preflight checks and error messages for missing or misconfigured installations.

* **Documentation**
  * Updated rig setup, command examples, troubleshooting, and CLI guidance to reflect the new tmux window behavior and install configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
