### PR TITLE
docs(oak): fix the OAK build instructions

### DIFF
--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -227,7 +227,9 @@ The CMake options (defined in root :code-file:`CMakeLists.txt` and :code-file:`c
      - ``ON``
    * - **OAK camera plugin**
      - ``BUILD_PLUGIN_OAK_CAMERA``
-     - ``OFF``; requires Hunter/DepthAI when ``ON``
+     - ``OFF``; when ``ON``, builds DepthAI v3.x and pulls its dependencies through
+       vcpkg, so it also needs ``CMAKE_TOOLCHAIN_FILE`` on a fresh build directory.
+       See :doc:`/device/oak`.
    * - **Teleop ROS2 example only**
      - ``BUILD_EXAMPLE_TELEOP_ROS2``
      - ``OFF``; when ``ON``, only ``examples/teleop_ros2`` (e.g. Docker)
@@ -264,12 +266,16 @@ Build without Python bindings:
    cmake -B build -DBUILD_PYTHON_BINDINGS=OFF
    cmake --build build
 
-Build with OAK camera plugin (pulls Hunter/DepthAI):
+Build with the OAK camera plugin. It needs the vcpkg toolchain, and CMake only
+reads ``CMAKE_TOOLCHAIN_FILE`` on a build tree's **first** configure, so delete
+``build/`` first if it already exists (see :doc:`/device/oak`):
 
 .. code-block:: bash
 
-   cmake -B build -DBUILD_PLUGIN_OAK_CAMERA=ON
-   cmake --build build
+   rm -rf build
+   cmake -B build -DBUILD_PLUGIN_OAK_CAMERA=ON \
+       -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
+   cmake --build build --target camera_plugin_oak --parallel
 
 Build only the teleop_ros2 example (e.g. for Docker, as in :code-file:`build-ubuntu.yml <.github/workflows/build-ubuntu.yml>` teleop-ros2-docker job):
 

--- a/docs/source/references/build.rst
+++ b/docs/source/references/build.rst
@@ -12,7 +12,7 @@ The layout below reflects the actual ``CMakeLists.txt`` hierarchy (root ``CMakeL
    IsaacTeleop/
    ├── CMakeLists.txt              # Top-level: deps, core, examples, plugins, etc.
    ├── cmake/
-   │   ├── SetupHunter.cmake       # BUILD_PLUGINS, Hunter for OAK/DepthAI
+   │   ├── DepthAIVcpkgManifest.cmake  # OAK/DepthAI vcpkg manifest (pre-project)
    │   ├── SetupPython.cmake       # BUILD_PYTHON_BINDINGS, uv-managed Python
    │   ├── ClangFormat.cmake       # clang_format_check / clang_format_fix
    │   └── ...
@@ -174,5 +174,5 @@ Reference
 - Core modules and options: ``src/core/CMakeLists.txt``
 - Dependencies: ``deps/third_party/CMakeLists.txt``
 - Python and uv: ``cmake/SetupPython.cmake``
-- Plugins and Hunter: ``cmake/SetupHunter.cmake``
+- OAK/DepthAI vcpkg manifest: ``cmake/DepthAIVcpkgManifest.cmake``
 - CI (Ubuntu, matrix build_type/python_version/arch): ``.github/workflows/build-ubuntu.yml``

--- a/src/plugins/oak/README.md
+++ b/src/plugins/oak/README.md
@@ -34,9 +34,13 @@ echo 'export VCPKG_ROOT=~/.vcpkg' >> ~/.bashrc && source ~/.bashrc
 
 ### Configure and Build
 
+CMake reads `CMAKE_TOOLCHAIN_FILE` only on a build tree's **first** configure, so an
+existing `build/` has to go — otherwise vcpkg is never picked up and configure fails.
+
 ```bash
 cd IsaacTeleop
 
+rm -rf build   # required if build/ was configured without CMAKE_TOOLCHAIN_FILE
 cmake -B build -DBUILD_PLUGIN_OAK_CAMERA=ON \
     -DCMAKE_TOOLCHAIN_FILE=$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake
 cmake --build build --target camera_plugin_oak --parallel


### PR DESCRIPTION
Replaces #914, which was opened from a personal fork and so could never go green: fork PRs get no secrets, the CloudXR SDK download 404s on `NGC_API_KEY`, and all 12 `build-ubuntu` jobs fail. Same commit, same content, now from a branch on this repository. GitHub cannot retarget an existing PR's head repository, hence the new PR.

Rebased onto `main` after #916. Most of the original is gone: the OAK page's Configure-and-Build section was fixed on `main` in the meantime, and the preset wording it added no longer applies now that presets are removed. What remains is what is still wrong on `main` today.

The OAK entry under "Examples" in `build_from_source/index.rst` omits the vcpkg toolchain, so the command as written fails at configure time. It now carries the toolchain flag, the `camera_plugin_oak` target, and the `rm -rf build` that the OAK page already documents — CMake reads `CMAKE_TOOLCHAIN_FILE` only on a build tree's **first** configure. The options-table entry gets the same context instead of "requires Hunter/DepthAI".

The plugin README had the correct command but not that constraint, so it picks up a one-line note too.

Finally, the stale Hunter references go: `cmake/SetupHunter.cmake` does not exist, and OAK/DepthAI has been vcpkg plus FetchContent for a while.

Docs only.

## Carried over from #914's review

CodeRabbit suggested adding `-DBUILD_PYTHON_BINDINGS=OFF` to the standalone OAK configure command. That was declined on #914 as working as intended, and the flag is deliberately still absent here.

## Testing

- The documented command (`rm -rf build` → configure with the toolchain flag) configures against current `main` on Ubuntu 24.04 aarch64: vcpkg resolves DepthAI's deps, DepthAI 3.7.1 is fetched, and the OAK plugin target is generated.
- `sphinx -W` builds clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAK camera plugin build instructions for DepthAI v3.x dependencies through vcpkg.
  * Added guidance for configuring fresh build directories with `CMAKE_TOOLCHAIN_FILE`.
  * Documented how to remove an existing build directory before reconfiguring.
  * Updated CMake project references to reflect the current vcpkg-based setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->