### PR TITLE
[Televiz] fix cross-device ProjectionLayer::submit, expose the CUDA device id

### DIFF
--- a/src/viz/core/cpp/device_image.cpp
+++ b/src/viz/core/cpp/device_image.cpp
@@ -3,6 +3,7 @@
 
 #include "inc/viz/core/device_image.hpp"
 
+#include "inc/viz/core/cuda_error.hpp"
 #include "inc/viz/core/vk_context.hpp"
 
 #include <algorithm>
@@ -46,12 +47,12 @@ void check_vk(VkResult result, const char* what)
     }
 }
 
-void check_cuda(cudaError_t result, const char* what)
+// viz_device: the device this image's interop objects belong to, so a
+// failure can say "you are on GPU 0, these live on GPU 1" instead of
+// CUDA's bare "invalid argument" (cuda_error.hpp).
+void check_cuda(cudaError_t result, const char* what, int viz_device)
 {
-    if (result != cudaSuccess)
-    {
-        throw std::runtime_error(std::string("DeviceImage: ") + what + " failed: " + cudaGetErrorString(result));
-    }
+    viz::check_cuda(result, "DeviceImage", what, viz_device);
 }
 
 uint32_t find_memory_type(VkPhysicalDevice physical_device, uint32_t type_bits, VkMemoryPropertyFlags properties)
@@ -360,7 +361,7 @@ void DeviceImage::import_to_cuda()
 {
     // cudaSetDevice is per-host-thread; VkContext sets it on the
     // init thread, re-pin here for worker-thread create() callers.
-    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), "cudaSetDevice");
+    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), "cudaSetDevice", ctx_->cuda_device_id());
 
     VkMemoryRequirements reqs;
     vkGetImageMemoryRequirements(ctx_->device(), image_, &reqs);
@@ -371,7 +372,8 @@ void DeviceImage::import_to_cuda()
     ext_desc.size = reqs.size;
     ext_desc.flags = 0;
 
-    check_cuda(cudaImportExternalMemory(&cuda_external_memory_, &ext_desc), "cudaImportExternalMemory");
+    check_cuda(cudaImportExternalMemory(&cuda_external_memory_, &ext_desc), "cudaImportExternalMemory",
+               ctx_->cuda_device_id());
 
     // CUDA dup'd the fd internally; close ours so we don't double-free.
     close_fd(memory_fd_);
@@ -387,8 +389,9 @@ void DeviceImage::import_to_cuda()
     array_desc.numLevels = mip_levels_;
 
     check_cuda(cudaExternalMemoryGetMappedMipmappedArray(&cuda_mipmapped_array_, cuda_external_memory_, &array_desc),
-               "cudaExternalMemoryGetMappedMipmappedArray");
-    check_cuda(cudaGetMipmappedArrayLevel(&cuda_array_, cuda_mipmapped_array_, 0), "cudaGetMipmappedArrayLevel");
+               "cudaExternalMemoryGetMappedMipmappedArray", ctx_->cuda_device_id());
+    check_cuda(cudaGetMipmappedArrayLevel(&cuda_array_, cuda_mipmapped_array_, 0), "cudaGetMipmappedArrayLevel",
+               ctx_->cuda_device_id());
 }
 
 void DeviceImage::create_interop_semaphores()
@@ -436,8 +439,8 @@ void DeviceImage::create_interop_semaphores()
     if (err != cudaSuccess)
     {
         close_fd(fd);
-        throw std::runtime_error(std::string("DeviceImage: cudaImportExternalSemaphore(cuda_done_writing) failed: ") +
-                                 cudaGetErrorString(err));
+        throw std::runtime_error(cuda_error_message(
+            "DeviceImage", "cudaImportExternalSemaphore(cuda_done_writing)", err, ctx_->cuda_device_id()));
     }
     close_fd(fd);
 }
@@ -455,8 +458,12 @@ void DeviceImage::cuda_signal_write_done(cudaStream_t stream)
     const cudaError_t err = cudaSignalExternalSemaphoresAsync(&cuda_cuda_done_writing_, &params, 1, stream);
     if (err != cudaSuccess)
     {
-        throw std::runtime_error(std::string("DeviceImage: cudaSignalExternalSemaphoresAsync(cuda_done_writing) failed: ") +
-                                 cudaGetErrorString(err));
+        // The single most-reported viz error, and the least informative
+        // one CUDA produces: a cross-device signal is reported as
+        // "invalid argument". cuda_error_message names both devices and
+        // the fix when that is what happened.
+        throw std::runtime_error(cuda_error_message(
+            "DeviceImage", "cudaSignalExternalSemaphoresAsync(cuda_done_writing)", err, ctx_->cuda_device_id()));
     }
     cuda_done_writing_value_.store(reserved, std::memory_order_release);
 }

--- a/src/viz/core/cpp/inc/viz/core/cuda_error.hpp
+++ b/src/viz/core/cpp/inc/viz/core/cuda_error.hpp
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stdexcept>
+#include <string>
+
+namespace viz
+{
+
+// Failed-CUDA-call reporting for the interop paths.
+//
+// CUDA's own strings are useless on their own here: the whole
+// CUDA-Vulkan interop surface reports a cross-device call as a bare
+// "invalid argument", which reads like a bad parameter and sends people
+// looking at buffer shapes and stream handles. It is almost always the
+// same thing instead — the calling THREAD is on a different GPU than the
+// one viz's images and semaphores live on, because cudaSetDevice() is
+// per-thread state and viz's device is not necessarily device 0 (Vulkan
+// and CUDA enumerate GPUs in different orders, so auto-pick routinely
+// lands on a non-zero CUDA index on multi-GPU machines).
+//
+// So: name the two devices and the fix, in one line. Anything longer
+// gets skimmed past — the ids and the call to make are the payload.
+namespace detail
+{
+
+inline std::string cuda_device_mismatch_hint(int viz_device)
+{
+    int current = -1;
+    if (cudaGetDevice(&current) != cudaSuccess || current == viz_device || viz_device < 0)
+    {
+        return {};
+    }
+    const std::string viz_id = std::to_string(viz_device);
+    return "\n  cause: this thread is on GPU " + std::to_string(current) + ", viz is on GPU " + viz_id +
+           " (interop is same-device; cudaSetDevice is per-thread)."
+           "\n  fix: cudaSetDevice(" +
+           viz_id + ") on this thread — id = VizSession.cuda_device_id.";
+}
+
+} // namespace detail
+
+// Message for a failed CUDA call. ``subsystem`` is the reporting type
+// ("QuadLayer"), ``call`` the CUDA entry point plus any disambiguating
+// detail ("cudaSignalExternalSemaphoresAsync(cuda_done_writing)").
+// ``viz_device`` is the device the interop objects belong to (pass -1
+// when it is not known — the hint is then omitted).
+inline std::string cuda_error_message(const std::string& subsystem, const std::string& call, cudaError_t err, int viz_device)
+{
+    return subsystem + ": " + call + " failed: " + cudaGetErrorString(err) +
+           detail::cuda_device_mismatch_hint(viz_device);
+}
+
+// Throw std::runtime_error(cuda_error_message(...)) unless the call succeeded.
+inline void check_cuda(cudaError_t err, const std::string& subsystem, const std::string& call, int viz_device)
+{
+    if (err != cudaSuccess)
+    {
+        throw std::runtime_error(cuda_error_message(subsystem, call, err, viz_device));
+    }
+}
+
+} // namespace viz

--- a/src/viz/core_tests/cpp/CMakeLists.txt
+++ b/src/viz/core_tests/cpp/CMakeLists.txt
@@ -6,6 +6,7 @@ cmake_minimum_required(VERSION 3.20)
 # Unit tests for viz::core. Shared probes/fixtures (test_helpers.hpp) come
 # from viz::test_support.
 add_executable(viz_core_tests
+    test_cuda_error.cpp
     test_device_image.cpp
     test_frame_sync.cpp
     test_host_image.cpp

--- a/src/viz/core_tests/cpp/test_cuda_error.cpp
+++ b/src/viz/core_tests/cpp/test_cuda_error.cpp
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// [unit] tests for the CUDA failure messages. The point of
+// cuda_error.hpp is diagnosis, so what is asserted here is the CONTENT:
+// a cross-device failure must name both devices and the fix, because
+// CUDA itself reports that case as a bare "invalid argument".
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+#include <viz/core/cuda_error.hpp>
+
+#include <algorithm>
+#include <cuda_runtime.h>
+#include <stdexcept>
+
+using Catch::Matchers::ContainsSubstring;
+using viz::check_cuda;
+using viz::cuda_error_message;
+
+namespace
+{
+
+// The hint needs a live CUDA driver to read the current device, and it
+// only fires when that device differs from viz's. Pick a device id that
+// cannot be current so the mismatch branch is deterministic.
+bool cuda_driver_present()
+{
+    int current = -1;
+    return cudaGetDevice(&current) == cudaSuccess;
+}
+
+} // namespace
+
+TEST_CASE("cuda_error_message states the failing call and CUDA's reason", "[unit][cuda_error]")
+{
+    const std::string msg = cuda_error_message(
+        "QuadLayer", "cudaSignalExternalSemaphoresAsync(cuda_done_writing)", cudaErrorInvalidValue, /*viz_device=*/-1);
+    CHECK_THAT(msg, ContainsSubstring("QuadLayer"));
+    CHECK_THAT(msg, ContainsSubstring("cudaSignalExternalSemaphoresAsync(cuda_done_writing)"));
+    CHECK_THAT(msg, ContainsSubstring(cudaGetErrorString(cudaErrorInvalidValue)));
+    // viz_device < 0 means "unknown" — no diagnosis, no invented advice.
+    CHECK_THAT(msg, !ContainsSubstring("cause:"));
+}
+
+TEST_CASE("cuda_error_message diagnoses a cross-device call", "[unit][cuda_error]")
+{
+    if (!cuda_driver_present())
+    {
+        SKIP("No CUDA driver — cudaGetDevice is what the hint reads");
+    }
+    int current = -1;
+    REQUIRE(cudaGetDevice(&current) == cudaSuccess);
+
+    // A device id that is not the current one: the situation a submit
+    // from a foreign thread lands in.
+    const int viz_device = current + 1;
+    const std::string msg = cuda_error_message(
+        "ProjectionLayer", "cudaSignalExternalSemaphoresAsync(cuda_done_writing)", cudaErrorInvalidValue, viz_device);
+
+    CHECK_THAT(msg, ContainsSubstring("GPU " + std::to_string(current))); // where the caller is
+    CHECK_THAT(msg, ContainsSubstring("GPU " + std::to_string(viz_device))); // where viz is
+    CHECK_THAT(msg, ContainsSubstring("per-thread")); // why it is not a bad argument
+    CHECK_THAT(msg, ContainsSubstring("cudaSetDevice(" + std::to_string(viz_device) + ")")); // the fix
+    CHECK_THAT(msg, ContainsSubstring("cuda_device_id")); // where to get the id
+    // Informative, not a wall of text: the diagnosis is two lines.
+    CHECK(std::count(msg.begin(), msg.end(), '\n') == 2);
+}
+
+TEST_CASE("cuda_error_message stays quiet when the devices agree", "[unit][cuda_error]")
+{
+    if (!cuda_driver_present())
+    {
+        SKIP("No CUDA driver — cudaGetDevice is what the hint reads");
+    }
+    int current = -1;
+    REQUIRE(cudaGetDevice(&current) == cudaSuccess);
+
+    // Same device: the failure is something else entirely, and a device
+    // lecture would send the reader down the wrong path.
+    const std::string msg =
+        cuda_error_message("QuadLayer", "cudaStreamSynchronize(submit)", cudaErrorInvalidValue, current);
+    CHECK_THAT(msg, !ContainsSubstring("cause:"));
+}
+
+TEST_CASE("check_cuda throws only on failure", "[unit][cuda_error]")
+{
+    CHECK_NOTHROW(check_cuda(cudaSuccess, "QuadLayer", "cudaSetDevice", 0));
+    CHECK_THROWS_AS(check_cuda(cudaErrorInvalidValue, "QuadLayer", "cudaSetDevice", 0), std::runtime_error);
+}

--- a/src/viz/layers/cpp/image_layer_base.cpp
+++ b/src/viz/layers/cpp/image_layer_base.cpp
@@ -3,6 +3,7 @@
 
 #include "inc/viz/layers/image_layer_base.hpp"
 
+#include <viz/core/cuda_error.hpp>
 #include <viz/core/vk_context.hpp>
 
 #include <cuda_runtime.h>
@@ -15,17 +16,17 @@ namespace viz
 namespace
 {
 
-void check_cuda(cudaError_t result, const char* layer_type, const char* what)
+// viz_device: the device the layer's interop images live on — lets a
+// cross-device failure say so instead of just "invalid argument"
+// (viz/core/cuda_error.hpp).
+void check_cuda(cudaError_t result, const char* layer_type, const char* what, int viz_device)
 {
-    if (result != cudaSuccess)
-    {
-        throw std::runtime_error(std::string(layer_type) + ": " + what + " failed: " + cudaGetErrorString(result));
-    }
+    viz::check_cuda(result, layer_type, what, viz_device);
 }
 
 // Queue an async D2D copy of ``buf`` → ``image.cuda_array()`` on
 // ``stream``. Shared between the mono and stereo submit paths.
-void enqueue_copy(const VizBuffer& buf, DeviceImage& image, cudaStream_t stream, const std::string& layer_type)
+void enqueue_copy(const VizBuffer& buf, DeviceImage& image, cudaStream_t stream, const std::string& layer_type, int viz_device)
 {
     const size_t row_bytes = static_cast<size_t>(buf.width) * bytes_per_pixel(buf.format);
     const size_t src_pitch = (buf.pitch == 0) ? row_bytes : buf.pitch;
@@ -33,7 +34,7 @@ void enqueue_copy(const VizBuffer& buf, DeviceImage& image, cudaStream_t stream,
         image.cuda_array(), 0, 0, buf.data, src_pitch, row_bytes, buf.height, cudaMemcpyDeviceToDevice, stream);
     if (err != cudaSuccess)
     {
-        throw std::runtime_error(layer_type + "::submit: cudaMemcpy2DToArrayAsync failed: " + cudaGetErrorString(err));
+        throw std::runtime_error(cuda_error_message(layer_type, "submit: cudaMemcpy2DToArrayAsync", err, viz_device));
     }
 }
 
@@ -211,8 +212,8 @@ void ImageLayerBase::submit(const VizBuffer& src, cudaStream_t stream)
     }
     DeviceImage& image = *slots_[slot];
 
-    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), layer_type_.c_str(), "cudaSetDevice");
-    enqueue_copy(src, image, stream, layer_type_);
+    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), layer_type_.c_str(), "cudaSetDevice", ctx_->cuda_device_id());
+    enqueue_copy(src, image, stream, layer_type_, ctx_->cuda_device_id());
     image.cuda_signal_write_done(stream);
 
     // Wait for the D2D copy to complete before returning. Sources publish
@@ -221,7 +222,8 @@ void ImageLayerBase::submit(const VizBuffer& src, cudaStream_t stream)
     // mailbox and overwrite src.data while our async memcpy is still
     // reading from it. Cost is ~0.5 ms per 1080p submit on the caller's
     // thread; the render path is unaffected.
-    check_cuda(cudaStreamSynchronize(stream), layer_type_.c_str(), "cudaStreamSynchronize(submit)");
+    check_cuda(
+        cudaStreamSynchronize(stream), layer_type_.c_str(), "cudaStreamSynchronize(submit)", ctx_->cuda_device_id());
 
     // memory_order_release pairs with the renderer's acquire load.
     latest_.store(slot, std::memory_order_release);
@@ -246,7 +248,7 @@ void ImageLayerBase::submit(const VizBuffer& left, const VizBuffer& right, cudaS
     DeviceImage& image_l = *slots_[slot];
     DeviceImage& image_r = *slots_right_[slot];
 
-    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), layer_type_.c_str(), "cudaSetDevice");
+    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), layer_type_.c_str(), "cudaSetDevice", ctx_->cuda_device_id());
     // Both copies on the same stream + a single signal on the left's
     // semaphore. Stream ordering guarantees the right copy completes
     // before the signal fires, so the renderer waiting on the left's
@@ -258,11 +260,12 @@ void ImageLayerBase::submit(const VizBuffer& left, const VizBuffer& right, cudaS
     // here. If a producer wrote either buffer on a different stream, the
     // caller is responsible for syncing it before submit; otherwise the
     // memcpy below may read pre-write state on that eye.
-    enqueue_copy(left, image_l, stream, layer_type_);
-    enqueue_copy(right, image_r, stream, layer_type_);
+    enqueue_copy(left, image_l, stream, layer_type_, ctx_->cuda_device_id());
+    enqueue_copy(right, image_r, stream, layer_type_, ctx_->cuda_device_id());
     image_l.cuda_signal_write_done(stream);
 
-    check_cuda(cudaStreamSynchronize(stream), layer_type_.c_str(), "cudaStreamSynchronize(submit-stereo)");
+    check_cuda(cudaStreamSynchronize(stream), layer_type_.c_str(), "cudaStreamSynchronize(submit-stereo)",
+               ctx_->cuda_device_id());
 
     latest_.store(slot, std::memory_order_release);
 }

--- a/src/viz/layers/cpp/projection_layer.cpp
+++ b/src/viz/layers/cpp/projection_layer.cpp
@@ -3,6 +3,7 @@
 
 #include "inc/viz/layers/projection_layer.hpp"
 
+#include <viz/core/cuda_error.hpp>
 #include <viz/core/vk_context.hpp>
 #include <viz/session/viz_session.hpp>
 
@@ -16,12 +17,12 @@ namespace viz
 namespace
 {
 
-void check_cuda(cudaError_t result, const char* what)
+// viz_device: the device the layer's interop images live on — lets a
+// cross-device failure say so instead of just "invalid argument"
+// (viz/core/cuda_error.hpp).
+void check_cuda(cudaError_t result, const char* what, int viz_device)
 {
-    if (result != cudaSuccess)
-    {
-        throw std::runtime_error(std::string("ProjectionLayer: ") + what + " failed: " + cudaGetErrorString(result));
-    }
+    viz::check_cuda(result, "ProjectionLayer", what, viz_device);
 }
 
 } // namespace
@@ -139,7 +140,7 @@ void ProjectionLayer::enqueue_copy(const VizBuffer& src, DeviceImage& dst, cudaS
                                         /*wOffset=*/0,
                                         /*hOffset=*/0, src.data, src_pitch, row_bytes, src.height,
                                         cudaMemcpyDeviceToDevice, stream),
-               "cudaMemcpy2DToArrayAsync");
+               "cudaMemcpy2DToArrayAsync", ctx_->cuda_device_id());
 }
 
 uint8_t ProjectionLayer::pick_free_slot() const noexcept
@@ -218,6 +219,18 @@ void ProjectionLayer::submit(const VizBuffer& left_color,
         }
     }
 
+    // ── Make viz's GPU current on THIS thread ────────────────────────
+    // cudaSetDevice is per-host-thread, and both the mapped arrays and
+    // the cuda_done_writing semaphores below belong to the device
+    // VkContext matched to the Vulkan physical device — which is not
+    // necessarily CUDA device 0 (Vulkan and CUDA do not agree on device
+    // order). A caller submitting from a thread that never touched that
+    // device — any worker thread on a multi-GPU machine — would
+    // otherwise fail inside cudaSignalExternalSemaphoresAsync with a
+    // bare "invalid argument" that points nowhere near the cause.
+    // ImageLayerBase::submit takes the same guard; this is the parity.
+    check_cuda(cudaSetDevice(ctx_->cuda_device_id()), "cudaSetDevice", ctx_->cuda_device_id());
+
     // ── Pick a free slot ─────────────────────────────────────────────
     const uint8_t slot = pick_free_slot();
     if (slot == kSlotNone)
@@ -261,7 +274,7 @@ void ProjectionLayer::submit(const VizBuffer& left_color,
 
     // BLOCK on stream completion so the caller can re-use src buffers
     // immediately. Same contract as QuadLayer::submit. ~sub-ms cost.
-    check_cuda(cudaStreamSynchronize(stream), "cudaStreamSynchronize");
+    check_cuda(cudaStreamSynchronize(stream), "cudaStreamSynchronize", ctx_->cuda_device_id());
 
     latest_.store(slot, std::memory_order_release);
     submitted_this_frame_.store(true, std::memory_order_release);

--- a/src/viz/python/session_bindings.cpp
+++ b/src/viz/python/session_bindings.cpp
@@ -71,6 +71,10 @@ void bind_session(py::module_& m)
         .def_readwrite("xr_far_z", &viz::VizSession::Config::xr_far_z)
         .def_readwrite("required_extensions", &viz::VizSession::Config::required_extensions)
         .def_readwrite("gpu_timing", &viz::VizSession::Config::gpu_timing)
+        .def_readwrite("physical_device_index", &viz::VizSession::Config::physical_device_index,
+                       "Vulkan physical device index to render on; -1 (default) auto-picks. Set it to keep viz on "
+                       "the same GPU as the app's CUDA work — check the result with VizSession.cuda_device_id. "
+                       "Raises for kXr (the runtime picks) or alongside an external context.")
         .def_property(
             "clear_color",
             [](const viz::VizSession::Config& c)
@@ -206,7 +210,12 @@ Construct via ``VizSession.create(config)``. Add layers with
             "vk_device", [](const viz::VizSession& s) { return reinterpret_cast<uintptr_t>(s.get_vk_device()); })
         .def_property_readonly("vk_physical_device", [](const viz::VizSession& s)
                                { return reinterpret_cast<uintptr_t>(s.get_vk_physical_device()); })
-        .def_property_readonly("vk_queue_family_index", &viz::VizSession::get_vk_queue_family_index);
+        .def_property_readonly("vk_queue_family_index", &viz::VizSession::get_vk_queue_family_index)
+        .def_property_readonly("cuda_device_id", &viz::VizSession::get_cuda_device_id,
+                               "CUDA device index this session's Vulkan device lives on (matched by UUID). NOT "
+                               "necessarily 0 — Vulkan and CUDA order GPUs differently. Allocate the buffers you "
+                               "submit on THIS device: interop is same-device only, and a mismatch costs a peer "
+                               "copy per submit. -1 after destroy().");
 }
 
 } // namespace viz_py

--- a/src/viz/session/cpp/inc/viz/session/viz_session.hpp
+++ b/src/viz/session/cpp/inc/viz/session/viz_session.hpp
@@ -66,6 +66,19 @@ public:
         // alpha=0 lets a non-opaque background show through.
         float clear_color[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
+        // Which Vulkan physical device to render on, as an index into
+        // vkEnumeratePhysicalDevices. -1 (default) auto-picks the
+        // highest-scoring suitable device. Set it to put viz on the same
+        // GPU as the rest of an app — auto-pick knows nothing about where
+        // the app's CUDA work already lives, and a split costs a peer
+        // copy on every submit. Pair with get_cuda_device_id() to check
+        // where you landed.
+        //
+        // Rejected (throws) for kXr, where the OpenXR runtime dictates
+        // the device, and with external_context, which was already
+        // created on some device.
+        int physical_device_index = -1;
+
         // Optional pre-built Vulkan context. If non-null, MUST already
         // have the backend's extensions enabled (VK_KHR_swapchain +
         // surface for kWindow, OpenXR-Vulkan for kXr) — backend init
@@ -185,6 +198,16 @@ public:
     uint32_t get_vk_queue_family_index() const noexcept;
     VkRenderPass get_render_pass() const noexcept;
     const VkContext* get_vk_context() const noexcept;
+
+    // CUDA device index this session's Vulkan device lives on, matched by
+    // UUID (VkContext::match_cuda_device_to_vulkan). NOT necessarily 0:
+    // Vulkan and CUDA enumerate GPUs in different orders, so on a
+    // multi-GPU machine the auto-picked Vulkan device routinely maps to a
+    // non-zero CUDA index. Callers producing buffers for submit() should
+    // allocate and launch on THIS device — anything else costs a peer
+    // copy per submit, and CUDA-Vulkan interop is same-device only.
+    // -1 before init / after destroy.
+    int get_cuda_device_id() const noexcept;
 
     // True when the display target has been asked to close (window-X
     // clicked, etc.). Always false in kOffscreen / kXr.

--- a/src/viz/session/cpp/viz_session.cpp
+++ b/src/viz/session/cpp/viz_session.cpp
@@ -56,6 +56,25 @@ std::unique_ptr<VizSession> VizSession::create(const Config& config)
     {
         throw std::invalid_argument("VizSession: window dimensions must be non-zero");
     }
+    // Reject rather than silently ignore: in both of these cases the
+    // device is already decided by someone else, and quietly dropping the
+    // request would leave the caller believing it landed on the GPU it
+    // asked for (see the header).
+    if (config.physical_device_index >= 0)
+    {
+        if (config.mode == DisplayMode::kXr)
+        {
+            throw std::invalid_argument(
+                "VizSession: physical_device_index is not supported in kXr — the OpenXR "
+                "runtime dictates the Vulkan device");
+        }
+        if (config.external_context != nullptr)
+        {
+            throw std::invalid_argument(
+                "VizSession: physical_device_index conflicts with external_context — the "
+                "context already has a device");
+        }
+    }
     std::unique_ptr<VizSession> s(new VizSession(config));
     s->init();
     return s;
@@ -82,6 +101,7 @@ void VizSession::init()
         vk_cfg.instance_extensions = backend_->required_instance_extensions();
         vk_cfg.device_extensions = backend_->required_device_extensions();
         vk_cfg.optional_device_extensions = backend_->optional_device_extensions();
+        vk_cfg.physical_device_index = config_.physical_device_index;
 
         // kXr: hand XrInstance + systemId to VkContext so it takes the
         // xrCreateVulkan*KHR path — lets the runtime interpose on
@@ -500,6 +520,11 @@ VkPhysicalDevice VizSession::get_vk_physical_device() const noexcept
 uint32_t VizSession::get_vk_queue_family_index() const noexcept
 {
     return ctx_ptr_ ? ctx_ptr_->queue_family_index() : UINT32_MAX;
+}
+
+int VizSession::get_cuda_device_id() const noexcept
+{
+    return ctx_ptr_ ? ctx_ptr_->cuda_device_id() : -1;
 }
 
 VkRenderPass VizSession::get_render_pass() const noexcept

--- a/src/viz/session_tests/cpp/test_viz_session.cpp
+++ b/src/viz/session_tests/cpp/test_viz_session.cpp
@@ -4,6 +4,7 @@
 // VizSession config + lifecycle tests.
 
 #include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_exception.hpp>
 #include <catch2/matchers/catch_matchers_string.hpp>
 #include <viz/core/vk_context.hpp>
 #include <viz/layers/projection_layer.hpp>
@@ -12,9 +13,11 @@
 #include <viz/test_support/test_helpers.hpp>
 
 #include <chrono>
+#include <cuda_runtime.h>
 #include <stdexcept>
 
 using Catch::Matchers::ContainsSubstring;
+using Catch::Matchers::MessageMatches;
 using viz::DisplayMode;
 using viz::ProjectionLayer;
 using viz::QuadLayer;
@@ -45,6 +48,72 @@ TEST_CASE("VizSession::Config defaults are sensible", "[unit][viz_session]")
     CHECK(cfg.xr_far_z == 100.0f);
     CHECK(cfg.gpu_timing == false);
     CHECK(cfg.xr_system_wait_seconds == 0);
+    CHECK(cfg.physical_device_index == -1); // auto-pick
+}
+
+// physical_device_index is meaningless where the device is already
+// decided elsewhere. Reject, don't silently ignore — a caller that
+// believes it pinned viz to a GPU and didn't gets a peer copy on every
+// submit and no indication why.
+TEST_CASE("VizSession::create rejects physical_device_index it cannot honor", "[unit][viz_session]")
+{
+    SECTION("kXr — the OpenXR runtime dictates the device")
+    {
+        VizSession::Config cfg{};
+        cfg.mode = DisplayMode::kXr;
+        cfg.physical_device_index = 0;
+        CHECK_THROWS_MATCHES(VizSession::create(cfg), std::invalid_argument,
+                             MessageMatches(ContainsSubstring("physical_device_index") && ContainsSubstring("kXr")));
+    }
+    SECTION("external_context — that context already has a device")
+    {
+        VkContext foreign; // never initialized: the conflict check runs first
+        VizSession::Config cfg{};
+        cfg.mode = DisplayMode::kOffscreen;
+        cfg.external_context = &foreign;
+        cfg.physical_device_index = 0;
+        CHECK_THROWS_MATCHES(
+            VizSession::create(cfg), std::invalid_argument,
+            MessageMatches(ContainsSubstring("physical_device_index") && ContainsSubstring("external_context")));
+    }
+    SECTION("-1 (auto-pick) is accepted everywhere — no false rejection")
+    {
+        VizSession::Config cfg{};
+        cfg.mode = DisplayMode::kXr;
+        cfg.physical_device_index = -1;
+        // Fails for the usual no-runtime reason, NOT for the device index.
+        CHECK_THROWS_MATCHES(
+            VizSession::create(cfg), std::runtime_error, !MessageMatches(ContainsSubstring("physical_device_index")));
+    }
+}
+
+// The id CUDA producers need to allocate on the right GPU. Interop is
+// same-device only, so an app that guesses 0 here silently pays a peer
+// copy per submit (or fails outright in the semaphore signal).
+TEST_CASE("VizSession reports the CUDA device its Vulkan device lives on", "[gpu][viz_session]")
+{
+    if (!is_gpu_available())
+    {
+        SKIP("No Vulkan-capable GPU available");
+    }
+
+    VizSession::Config cfg{};
+    cfg.mode = DisplayMode::kOffscreen;
+    cfg.external_context = &shared_vk_context();
+    auto session = VizSession::create(cfg);
+
+    const int cuda_device = session->get_cuda_device_id();
+    CHECK(cuda_device >= 0);
+    // Matched by UUID to the Vulkan physical device, so it agrees with
+    // the context's own answer — and with the device CUDA calls on this
+    // thread now target (VkContext::init made it current).
+    CHECK(cuda_device == session->get_vk_context()->cuda_device_id());
+    int current = -1;
+    REQUIRE(cudaGetDevice(&current) == cudaSuccess);
+    CHECK(current == cuda_device);
+
+    session->destroy();
+    CHECK(session->get_cuda_device_id() == -1); // no context left to ask
 }
 
 // XR-only methods must throw on a non-XR session.


### PR DESCRIPTION
`VkContext` binds CUDA to the GPU matching its Vulkan physical device — not
necessarily CUDA device 0, since Vulkan and CUDA enumerate GPUs in different
orders. Three fixes for what follows from that.

**`ProjectionLayer::submit` now pins viz's device** before touching CUDA, as
`ImageLayerBase::submit` already did. Without it, any app submitting from a
worker thread (session created on the main thread, frames submitted from a
render thread) died on a multi-GPU box with
`cudaSignalExternalSemaphoresAsync(cuda_done_writing) failed: invalid argument`.

**`VizSession::get_cuda_device_id()` / `.cuda_device_id`** — producers had no
way to learn which GPU to allocate on and had to guess 0. Interop is
same-device only, and a wrong guess costs a peer copy per submit (1.17 ms vs
0.05 ms for a 1080p RGBD submit, 2x RTX 6000 Ada) when it doesn't fail
outright. `Config::physical_device_index` is also plumbed through to move viz
instead; it's rejected, not ignored, for kXr and `external_context`.

**Better CUDA errors** (`viz/core/cuda_error.hpp`) — CUDA reports every
cross-device interop call as a bare "invalid argument". Failures now append two
lines naming both devices and the fix, and stay silent when the devices agree.
Wired through every CUDA failure site in `device_image`, `image_layer_base` and
`projection_layer`.

Tests: message content and length, the quiet case, config default, both
`physical_device_index` rejections, and the accessor cross-checked against the
context and `cudaGetDevice`. Full viz suites pass (core 201/51, session 399/44,
layers 410/42).

Found via a televiz crash on a dual-GPU workstation; the app-side workarounds in gr00t become no-ops once this ships in a wheel.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Vulkan physical-device selection for sessions.
  * Exposed the CUDA device associated with each session.
  * Added Python access to both device-selection and CUDA-device information.
  * Added clearer guidance when device selection is incompatible with XR or external contexts.

* **Bug Fixes**
  * Improved CUDA error messages with device identifiers and actionable diagnostics.

* **Tests**
  * Added coverage for CUDA error reporting and session device-selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->