### PR TITLE
refactor(cloudxr): deprecate the start_wss_proxy knob

### DIFF
--- a/src/core/cloudxr_tests/python/test_launcher.py
+++ b/src/core/cloudxr_tests/python/test_launcher.py
@@ -188,6 +188,14 @@ class TestLauncherConstruction:
             assert isinstance(launcher.wss_log_path, Path)
             assert "wss." in str(launcher.wss_log_path)
 
+    def test_construction_start_wss_proxy_is_a_noop(self, tmp_path):
+        """The deprecated knob is still accepted, warns, and starts the proxy."""
+        with mock_launcher_deps(tmp_path, ready=True) as mocks:
+            with pytest.warns(DeprecationWarning, match="start_wss_proxy"):
+                CloudXRLauncher(start_wss_proxy=False)
+
+            mocks["wss"].assert_called_once()
+
 
 # ============================================================================
 # TestLauncherStop
@@ -367,6 +375,7 @@ class TestLaunchArgumentHelpers:
                 "/etc/cloudxr.env",
                 "--accept-eula",
                 "--no-launch-cloudxr-runtime",
+                "--no-launch-wss-proxy",
             ]
         )
         assert args.cloudxr_install_dir == "/opt/cloudxr"
@@ -374,6 +383,7 @@ class TestLaunchArgumentHelpers:
         assert args.cloudxr_env_config == "/etc/cloudxr.env"
         assert args.accept_eula is True
         assert args.launch_cloudxr_runtime is False
+        assert args.launch_wss_proxy is False
 
     def test_add_launcher_arguments_defaults(self) -> None:
         parser = argparse.ArgumentParser()
@@ -382,6 +392,7 @@ class TestLaunchArgumentHelpers:
         assert args.cloudxr_env_config is None
         assert args.accept_eula is False
         assert args.launch_cloudxr_runtime is True
+        assert args.launch_wss_proxy is None
 
     def test_add_cloudxr_device_profile_argument_default(self) -> None:
         parser = argparse.ArgumentParser()

--- a/src/core/cloudxr_tests/python/test_launcher.py
+++ b/src/core/cloudxr_tests/python/test_launcher.py
@@ -188,22 +188,6 @@ class TestLauncherConstruction:
             assert isinstance(launcher.wss_log_path, Path)
             assert "wss." in str(launcher.wss_log_path)
 
-    def test_construction_skips_wss_when_disabled(self, tmp_path):
-        """start_wss_proxy=False launches runtime only."""
-        with mock_launcher_deps(tmp_path, ready=True) as mocks:
-            launcher = CloudXRLauncher(start_wss_proxy=False)
-
-            mocks["popen"].assert_called_once()
-            mocks["wss"].assert_not_called()
-            assert launcher.wss_log_path is None
-            assert launcher._start_wss_proxy is False
-
-    def test_construction_rejects_wss_options_without_proxy(self, tmp_path):
-        """WSS-only options require start_wss_proxy=True."""
-        with mock_launcher_deps(tmp_path, ready=True):
-            with pytest.raises(ValueError, match="start_wss_proxy=False"):
-                CloudXRLauncher(start_wss_proxy=False, host_client=True)
-
 
 # ============================================================================
 # TestLauncherStop
@@ -370,7 +354,7 @@ class TestLaunchArgumentHelpers:
         args = parser.parse_args(["--cloudxr-install-dir", "/opt/cloudxr"])
         assert args.cloudxr_install_dir == "/opt/cloudxr"
 
-    def test_add_launcher_arguments_registers_both(self) -> None:
+    def test_add_launcher_arguments_registers_all(self) -> None:
         parser = argparse.ArgumentParser()
         CloudXRLauncher.add_launcher_arguments(parser)
         args = parser.parse_args(
@@ -383,7 +367,6 @@ class TestLaunchArgumentHelpers:
                 "/etc/cloudxr.env",
                 "--accept-eula",
                 "--no-launch-cloudxr-runtime",
-                "--no-launch-wss-proxy",
             ]
         )
         assert args.cloudxr_install_dir == "/opt/cloudxr"
@@ -391,7 +374,6 @@ class TestLaunchArgumentHelpers:
         assert args.cloudxr_env_config == "/etc/cloudxr.env"
         assert args.accept_eula is True
         assert args.launch_cloudxr_runtime is False
-        assert args.launch_wss_proxy is False
 
     def test_add_launcher_arguments_defaults(self) -> None:
         parser = argparse.ArgumentParser()
@@ -399,7 +381,7 @@ class TestLaunchArgumentHelpers:
         args = parser.parse_args([])
         assert args.cloudxr_env_config is None
         assert args.accept_eula is False
-        assert args.launch_wss_proxy is True
+        assert args.launch_cloudxr_runtime is True
 
     def test_add_cloudxr_device_profile_argument_default(self) -> None:
         parser = argparse.ArgumentParser()
@@ -424,18 +406,6 @@ class TestLaunchArgumentHelpers:
         CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
         args = parser.parse_args(["--no-launch-cloudxr-runtime"])
         assert args.launch_cloudxr_runtime is False
-
-    def test_add_launch_wss_proxy_argument_defaults_true(self) -> None:
-        parser = argparse.ArgumentParser()
-        CloudXRLauncher.add_launch_wss_proxy_argument(parser)
-        args = parser.parse_args([])
-        assert args.launch_wss_proxy is True
-
-    def test_add_launch_wss_proxy_argument_no_launch(self) -> None:
-        parser = argparse.ArgumentParser()
-        CloudXRLauncher.add_launch_wss_proxy_argument(parser)
-        args = parser.parse_args(["--no-launch-wss-proxy"])
-        assert args.launch_wss_proxy is False
 
     def test_launch_context_skips_when_disabled(self) -> None:
         args = argparse.Namespace(launch_cloudxr_runtime=False)
@@ -470,23 +440,6 @@ class TestLaunchArgumentHelpers:
             ) as launcher:
                 assert launcher is not None
                 assert launcher._device_profile == "auto-native"
-            mocks["proc"].poll.return_value = 0
-
-    @_windows_skip
-    def test_launch_context_passes_start_wss_proxy_kwarg(self, tmp_path) -> None:
-        args = argparse.Namespace(
-            launch_cloudxr_runtime=True,
-            cloudxr_install_dir="/opt/cloudxr",
-            cloudxr_device_profile="Quest3",
-            launch_wss_proxy=True,
-        )
-        with mock_launcher_deps(tmp_path) as mocks:
-            with CloudXRLauncher.launch_context(
-                args, start_wss_proxy=False
-            ) as launcher:
-                assert launcher is not None
-                assert launcher._start_wss_proxy is False
-                mocks["wss"].assert_not_called()
             mocks["proc"].poll.return_value = 0
 
     def test_resolve_accept_eula_none_falls_back_to_args(self) -> None:

--- a/src/python/isaacteleop/cloudxr/launcher.py
+++ b/src/python/isaacteleop/cloudxr/launcher.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import threading
 import time
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -83,6 +84,7 @@ class CloudXRLauncher:
         setup_oob: bool = False,
         usb_local: bool = False,
         host_client: bool = False,
+        start_wss_proxy: bool | None = None,
     ) -> None:
         """Launch the CloudXR runtime and the WSS proxy.
 
@@ -112,6 +114,9 @@ class CloudXRLauncher:
             host_client: Serve the web client at ``/client/`` on the WSS
                 proxy port.  Assets are fetched once from GitHub Pages into
                 ``TELEOP_WEB_CLIENT_STATIC_DIR`` or ``~/.cloudxr/static-client``.
+            start_wss_proxy: Deprecated no-op kept so existing callers do
+                not hit a :class:`TypeError`; the proxy always starts with
+                the runtime.  Any value emits a deprecation notice.
 
         Raises:
             RuntimeError: If the EULA is not accepted or the runtime
@@ -124,6 +129,8 @@ class CloudXRLauncher:
         self._setup_oob = setup_oob
         self._usb_local = usb_local
         self._host_client = host_client
+        if start_wss_proxy is not None:
+            self._warn_start_wss_proxy_deprecated()
 
         if self._usb_local or self._host_client:
             from .oob_teleop_env import require_web_client_static_dir  # noqa: PLC0415
@@ -206,6 +213,19 @@ class CloudXRLauncher:
         self._wss_log_path = wss_log_path
         self._start_wss_proxy_thread(wss_log_path)
         logger.info("CloudXR WSS proxy started (log=%s)", wss_log_path)
+
+    # TODO(1.6): drop start_wss_proxy, --launch-wss-proxy and this helper.
+    @staticmethod
+    def _warn_start_wss_proxy_deprecated() -> None:
+        """Announce that the ``start_wss_proxy`` no-op is on its way out."""
+        message = (
+            "start_wss_proxy is deprecated and does nothing; the WSS proxy "
+            "always starts with the runtime.  It is removed in 1.6."
+        )
+        warnings.warn(message, DeprecationWarning, stacklevel=3)
+        # Python drops DeprecationWarning raised outside __main__, which is
+        # every --launch-wss-proxy run, so log it as well.
+        logger.warning(message)
 
     # ------------------------------------------------------------------
     # CLI helpers for embedding applications and examples
@@ -293,6 +313,23 @@ class CloudXRLauncher:
         )
 
     @staticmethod
+    def add_launch_wss_proxy_argument(parser: argparse.ArgumentParser) -> None:
+        """Register the deprecated no-op ``--launch-wss-proxy`` on ``parser``.
+
+        Defaults to ``None`` so an explicit flag is distinguishable from an
+        absent one and only the former warns.
+        """
+        parser.add_argument(
+            "--launch-wss-proxy",
+            action=argparse.BooleanOptionalAction,
+            default=None,
+            help=(
+                "Deprecated no-op, removed in 1.6: the WSS TLS proxy always "
+                "starts with the runtime."
+            ),
+        )
+
+    @staticmethod
     def add_launcher_arguments(parser: argparse.ArgumentParser) -> None:
         """Register CloudXR launcher CLI arguments on ``parser``."""
         CloudXRLauncher.add_cloudxr_install_dir_argument(parser)
@@ -300,6 +337,7 @@ class CloudXRLauncher:
         CloudXRLauncher.add_cloudxr_env_config_argument(parser)
         CloudXRLauncher.add_accept_eula_argument(parser)
         CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
+        CloudXRLauncher.add_launch_wss_proxy_argument(parser)
 
     @staticmethod
     def _resolve_install_dir(
@@ -356,6 +394,7 @@ class CloudXRLauncher:
         setup_oob: bool = False,
         usb_local: bool = False,
         host_client: bool = False,
+        start_wss_proxy: bool | None = None,
     ) -> contextlib.AbstractContextManager[CloudXRLauncher | None]:
         """Start :class:`CloudXRLauncher` when ``args.launch_cloudxr_runtime`` is true.
 
@@ -367,7 +406,13 @@ class CloudXRLauncher:
         (``args.cloudxr_install_dir`` etc.); pass an explicit keyword only to
         override what came in on the command line. For ``accept_eula``, pass
         ``False`` to force-disable even when the CLI flag is set.
+        ``start_wss_proxy`` is a deprecated no-op removed in 1.6.
         """
+        if (
+            start_wss_proxy is not None
+            or getattr(args, "launch_wss_proxy", None) is not None
+        ):
+            CloudXRLauncher._warn_start_wss_proxy_deprecated()
         if not args.launch_cloudxr_runtime:
             return contextlib.nullcontext(None)
         return CloudXRLauncher(

--- a/src/python/isaacteleop/cloudxr/launcher.py
+++ b/src/python/isaacteleop/cloudxr/launcher.py
@@ -430,8 +430,8 @@ class CloudXRLauncher:
     def health_check(self) -> None:
         """Verify that the runtime process and WSS proxy are healthy.
 
-        Returns immediately when the runtime is running and the WSS proxy's
-        background thread is alive.  Raises :class:`RuntimeError` with
+        Returns immediately when the runtime is running and the WSS proxy
+        thread, once started, is alive.  Raises :class:`RuntimeError` with
         diagnostic details when any monitored component has stopped
         unexpectedly, allowing embedding applications to perform a
         controlled teardown.

--- a/src/python/isaacteleop/cloudxr/launcher.py
+++ b/src/python/isaacteleop/cloudxr/launcher.py
@@ -83,13 +83,11 @@ class CloudXRLauncher:
         setup_oob: bool = False,
         usb_local: bool = False,
         host_client: bool = False,
-        start_wss_proxy: bool = True,
     ) -> None:
-        """Launch the CloudXR runtime and optionally the WSS proxy.
+        """Launch the CloudXR runtime and the WSS proxy.
 
-        Configures the environment, spawns the runtime subprocess, and
-        optionally starts the WSS TLS proxy.  Blocks until the runtime
-        signals readiness (up to
+        Configures the environment, spawns the runtime subprocess, and starts
+        the WSS TLS proxy.  Blocks until the runtime signals readiness (up to
         :data:`~isaacteleop.cloudxr.runtime.RUNTIME_STARTUP_TIMEOUT_SEC`)
         or raises :class:`RuntimeError` on failure.
 
@@ -114,16 +112,10 @@ class CloudXRLauncher:
             host_client: Serve the web client at ``/client/`` on the WSS
                 proxy port.  Assets are fetched once from GitHub Pages into
                 ``TELEOP_WEB_CLIENT_STATIC_DIR`` or ``~/.cloudxr/static-client``.
-            start_wss_proxy: Start the in-process WSS TLS proxy after the
-                runtime is ready (default: ``True``).  Pass ``False`` when
-                an external proxy is already running or only the runtime
-                subprocess is needed.
 
         Raises:
             RuntimeError: If the EULA is not accepted or the runtime
                 fails to start within the timeout.
-            ValueError: If *start_wss_proxy* is ``False`` while any WSS-only
-                option (*setup_oob*, *usb_local*, or *host_client*) is set.
         """
         self._install_dir = install_dir
         self._env_config = str(env_config) if env_config is not None else None
@@ -132,15 +124,6 @@ class CloudXRLauncher:
         self._setup_oob = setup_oob
         self._usb_local = usb_local
         self._host_client = host_client
-        self._start_wss_proxy = start_wss_proxy
-
-        if not self._start_wss_proxy and (
-            self._setup_oob or self._usb_local or self._host_client
-        ):
-            raise ValueError(
-                "start_wss_proxy=False is incompatible with setup_oob, "
-                "usb_local, and host_client (those features require the WSS proxy)"
-            )
 
         if self._usb_local or self._host_client:
             from .oob_teleop_env import require_web_client_static_dir  # noqa: PLC0415
@@ -218,14 +201,11 @@ class CloudXRLauncher:
             )
         logger.info("CloudXR runtime ready")
 
-        if self._start_wss_proxy:
-            wss_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
-            wss_log_path = logs_dir_path / f"wss.{wss_ts}.log"
-            self._wss_log_path = wss_log_path
-            self._start_wss_proxy_thread(wss_log_path)
-            logger.info("CloudXR WSS proxy started (log=%s)", wss_log_path)
-        else:
-            logger.info("CloudXR WSS proxy disabled; runtime only")
+        wss_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+        wss_log_path = logs_dir_path / f"wss.{wss_ts}.log"
+        self._wss_log_path = wss_log_path
+        self._start_wss_proxy_thread(wss_log_path)
+        logger.info("CloudXR WSS proxy started (log=%s)", wss_log_path)
 
     # ------------------------------------------------------------------
     # CLI helpers for embedding applications and examples
@@ -313,25 +293,6 @@ class CloudXRLauncher:
         )
 
     @staticmethod
-    def add_launch_wss_proxy_argument(parser: argparse.ArgumentParser) -> None:
-        """Register ``--launch-wss-proxy`` on ``parser``.
-
-        Uses :class:`argparse.BooleanOptionalAction`, so callers may pass
-        ``--no-launch-wss-proxy`` when an external WSS proxy is already
-        running or only the runtime subprocess is needed.
-        """
-        parser.add_argument(
-            "--launch-wss-proxy",
-            action=argparse.BooleanOptionalAction,
-            default=True,
-            help=(
-                "Start the in-process WSS TLS proxy after the runtime is ready "
-                "(default: true). Pass --no-launch-wss-proxy when an external proxy "
-                "is already running or only the runtime subprocess is needed."
-            ),
-        )
-
-    @staticmethod
     def add_launcher_arguments(parser: argparse.ArgumentParser) -> None:
         """Register CloudXR launcher CLI arguments on ``parser``."""
         CloudXRLauncher.add_cloudxr_install_dir_argument(parser)
@@ -339,7 +300,6 @@ class CloudXRLauncher:
         CloudXRLauncher.add_cloudxr_env_config_argument(parser)
         CloudXRLauncher.add_accept_eula_argument(parser)
         CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
-        CloudXRLauncher.add_launch_wss_proxy_argument(parser)
 
     @staticmethod
     def _resolve_install_dir(
@@ -386,16 +346,6 @@ class CloudXRLauncher:
         return bool(getattr(args, "accept_eula", False))
 
     @staticmethod
-    def _resolve_start_wss_proxy(
-        args: argparse.Namespace,
-        start_wss_proxy: bool | None = None,
-    ) -> bool:
-        """Return ``start_wss_proxy`` or ``args.launch_wss_proxy`` when registered."""
-        if start_wss_proxy is not None:
-            return start_wss_proxy
-        return bool(getattr(args, "launch_wss_proxy", True))
-
-    @staticmethod
     def launch_context(
         args: argparse.Namespace,
         *,
@@ -406,19 +356,17 @@ class CloudXRLauncher:
         setup_oob: bool = False,
         usb_local: bool = False,
         host_client: bool = False,
-        start_wss_proxy: bool | None = None,
     ) -> contextlib.AbstractContextManager[CloudXRLauncher | None]:
         """Start :class:`CloudXRLauncher` when ``args.launch_cloudxr_runtime`` is true.
 
         Returns :func:`contextlib.nullcontext` when ``args.launch_cloudxr_runtime`` is
         false so callers can always use ``with CloudXRLauncher.launch_context(args):``.
 
-        ``install_dir``, ``env_config``, ``device_profile``, ``accept_eula``, and
-        ``start_wss_proxy`` default to the values registered by
-        :meth:`add_launcher_arguments` (``args.cloudxr_install_dir`` etc.); pass an
-        explicit keyword only to override what came in on the command line. For
-        ``accept_eula``, pass ``False`` to force-disable even when the CLI flag
-        is set.
+        ``install_dir``, ``env_config``, ``device_profile``, and ``accept_eula``
+        default to the values registered by :meth:`add_launcher_arguments`
+        (``args.cloudxr_install_dir`` etc.); pass an explicit keyword only to
+        override what came in on the command line. For ``accept_eula``, pass
+        ``False`` to force-disable even when the CLI flag is set.
         """
         if not args.launch_cloudxr_runtime:
             return contextlib.nullcontext(None)
@@ -432,9 +380,6 @@ class CloudXRLauncher:
             setup_oob=setup_oob,
             usb_local=usb_local,
             host_client=host_client,
-            start_wss_proxy=CloudXRLauncher._resolve_start_wss_proxy(
-                args, start_wss_proxy
-            ),
         )
 
     # ------------------------------------------------------------------
@@ -485,15 +430,15 @@ class CloudXRLauncher:
     def health_check(self) -> None:
         """Verify that the runtime process and WSS proxy are healthy.
 
-        Returns immediately when the runtime is running and, when the WSS
-        proxy was started, its background thread is alive.  Raises
-        :class:`RuntimeError` with diagnostic details when any monitored
-        component has stopped unexpectedly, allowing embedding applications
-        to perform a controlled teardown.
+        Returns immediately when the runtime is running and the WSS proxy's
+        background thread is alive.  Raises :class:`RuntimeError` with
+        diagnostic details when any monitored component has stopped
+        unexpectedly, allowing embedding applications to perform a
+        controlled teardown.
 
         Raises:
             RuntimeError: If the launcher has not been started, or if
-                the runtime process or (when enabled) the WSS proxy has stopped.
+                the runtime process or the WSS proxy has stopped.
         """
         if self._runtime_proc is None:
             raise RuntimeError("CloudXR launcher is not running")
@@ -504,11 +449,7 @@ class CloudXRLauncher:
                 f"CloudXR runtime process exited unexpectedly (exit code {exit_code})"
             )
 
-        if (
-            self._start_wss_proxy
-            and self._wss_thread is not None
-            and not self._wss_thread.is_alive()
-        ):
+        if self._wss_thread is not None and not self._wss_thread.is_alive():
             raise RuntimeError("CloudXR WSS proxy thread stopped unexpectedly")
 
     @property


### PR DESCRIPTION
## Description

`CloudXRLauncher(start_wss_proxy=False)` and `--no-launch-wss-proxy` have no callers. Outside the tests that exercise the flag itself, nothing in the tree passes either one — no example, no rig file, no doc page. Meanwhile `add_launcher_arguments` is called from 32 example scripts, so all 32 advertise a flag nobody uses and that, if used, hands you a runtime with no web-client path and no error explaining the silence. The flag's only other contribution is a `ValueError` about its own incompatibility with `setup_oob` / `usb_local` / `host_client`.

The first commit removed it outright. Per review, this now deprecates instead: the parameter and the CLI flag stay as accepted-and-ignored no-ops that announce their own removal in 1.6. The proxy always starts with the runtime, so an out-of-tree integration that already passes `False` gets a notice rather than a `TypeError`, and there's no second code path to keep working. A `TODO(1.6)` marks the removal.

Both default to `None` so an absent knob is distinguishable from an explicit one, and only the latter warns. The notice is both a `DeprecationWarning` and a `WARNING` log line — Python's default filters drop the former unless `stacklevel` lands in `__main__`, which no `--launch-wss-proxy` run does.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

_(none of the above — deprecation of an unused option)_

## Testing

`pytest src/core/cloudxr_tests/python/test_launcher.py` (30 passed) and `src/core/rig_tests/python/` (68 passed); `SKIP=check-copyright-year pre-commit run --all-files`. The `test_oob_teleop_*` async tests need `pytest-asyncio`, which isn't in the venv I ran locally; untouched by this change.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation (no doc referenced this flag)
- [x] I have added tests that prove my fix/feature works (one: the knob is still accepted, warns, and doesn't stop the proxy)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
