### PR TITLE
Gracefully stop the Manus plugin on process signals

### DIFF
--- a/src/plugins/manus/app/main.cpp
+++ b/src/plugins/manus/app/main.cpp
@@ -3,7 +3,9 @@
 
 #include <manus/manus_hand_tracking_plugin.hpp>
 
+#include <atomic>
 #include <chrono>
+#include <csignal>
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
@@ -15,6 +17,18 @@ using namespace plugins::manus;
 
 namespace
 {
+
+static_assert(ATOMIC_BOOL_LOCK_FREE == 2, "lock-free atomic bool is required for signal safety");
+
+std::atomic<bool> g_stop_requested{ false };
+
+void signal_handler(int signal)
+{
+    if (signal == SIGINT || signal == SIGTERM)
+    {
+        g_stop_requested.store(true, std::memory_order_relaxed);
+    }
+}
 
 bool starts_with(const std::string& value, const std::string& prefix)
 {
@@ -101,6 +115,10 @@ try
     std::cout << "Manus Hand Plugin starting..." << std::endl;
 
     const ManusPluginConfig config = parse_args(argc, argv);
+
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
     auto& tracker = ManusTracker::instance(config);
 
     std::cout << "Plugin running. Press Ctrl+C to stop." << std::endl;
@@ -108,7 +126,7 @@ try
     // Target 90Hz frequency (~11.1ms period)
     const auto target_frame_duration = std::chrono::nanoseconds(1000000000 / 90);
 
-    while (true)
+    while (!g_stop_requested.load(std::memory_order_relaxed))
     {
         auto frame_start = std::chrono::steady_clock::now();
 
@@ -117,6 +135,7 @@ try
         std::this_thread::sleep_until(frame_start + target_frame_duration);
     }
 
+    // Normal exit runs the singleton tracker's destructor and shuts down the SDK.
     return 0;
 }
 catch (const std::exception& e)


### PR DESCRIPTION
## Summary
- handle SIGINT and SIGTERM in the Manus plugin process
- leave the update loop cleanly so the Manus SDK singleton can release its resources
- support reliable independent plugin service restarts

## Test plan
- [x] Build and install `manus_hand_plugin` and `manus_hand_tracker_printer`
- [x] Send SIGTERM and verify orderly Manus service shutdown with exit status 0
- [x] Send SIGINT and verify orderly Manus service shutdown with exit status 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The application now shuts down cleanly when interrupted or terminated.
  * Running processes exit their main loop gracefully, allowing normal cleanup and SDK shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->