### PR TITLE
examples: add reBot B601-RS bring-up on Jetson built-in CAN

### DIFF
--- a/.claude/skills/rebot-orin-setup/SKILL.md
+++ b/.claude/skills/rebot-orin-setup/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: rebot-orin-setup
+description: >-
+  Use when initializing a reBot B601-RS (RobStride 6-DOF, seven motors) arm
+  from an NVIDIA Jetson AGX Orin using the Orin's built-in CAN (mttcan) via an external
+  SN65HVD230 transceiver — no USB-CAN/PCAN adapter. Covers the uv/motorbridge
+  env, bringing up can0 @ 1 Mbit, verifying the bus, reboot persistence,
+  motor-ID assignment, zero calibration, and the CAN bring-up troubleshooting
+  tree (loopback-passes-but-no-motors, pinmux, motor power).
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# reBot B601-RS on Jetson AGX Orin
+
+The procedure, assets, and troubleshooting tree live with the example:
+**[`examples/rebot/SKILL.md`](../../../examples/rebot/SKILL.md)**.
+
+Read that file and work from `examples/rebot/`.

--- a/docs/source/_static/rebot/orin-sn65hvd230-rebot-wiring.svg
+++ b/docs/source/_static/rebot/orin-sn65hvd230-rebot-wiring.svg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2782c244dcfb4635dabe8949b8b94eb2ac3972343803a3290fd5214be8cc33ef
+size 18396

--- a/docs/source/_static/rebot/sn65hvd230-can-board.jpg
+++ b/docs/source/_static/rebot/sn65hvd230-can-board.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1e0971c9dbb4125c6ab94afa52ebf919e21d71ac641a1e629937ed48277cbb26
+size 48347

--- a/docs/source/getting_started/lerobot/index.rst
+++ b/docs/source/getting_started/lerobot/index.rst
@@ -82,6 +82,7 @@ In this section
 - :doc:`data_collection_real` — record demonstrations on a physical SO-101.
 - :doc:`data_collection_sim` — record demonstrations in Isaac Lab.
 - :doc:`training_groot` — fine-tune a GR00T N1.7 policy on the collected data.
+- :doc:`rebot` — bring up a reBot B601-RS arm on a Jetson AGX Orin over built-in CAN.
 
 New to XR teleoperation? Start with the :doc:`Isaac Teleop Quick Start </getting_started/quick_start>`
 to set up CloudXR and connect a headset.
@@ -108,6 +109,7 @@ See also: the `Sim-to-Real SO-101 learning path`_.
    data_collection_real
    data_collection_sim
    training_groot
+   rebot
 
 ..
    References

--- a/docs/source/getting_started/lerobot/rebot.rst
+++ b/docs/source/getting_started/lerobot/rebot.rst
@@ -1,0 +1,352 @@
+.. SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+.. SPDX-License-Identifier: Apache-2.0
+
+reBot B601-RS on Jetson AGX Orin
+================================
+
+The `reBot B601-RS <https://github.com/Welt-liu/reBot-B601-Agent-Guide>`_ is a 6-DOF arm built from
+`RobStride <https://www.robstride.com>`_ quasi-direct-drive actuators, which together with the
+gripper put seven motors on a single CAN bus. This page brings one up from an **NVIDIA Jetson AGX
+Orin** using the Orin's **built-in CAN controller** (``mttcan``) and a cheap external transceiver —
+no USB-CAN or PCAN adapter.
+
+Start from the vendor's `reBot Arm B601-RS Quick Start
+<https://wiki.seeedstudio.com/rebot_b601_rs_getting_started>`_ for assembly, the power supply, and
+the safety notes. That guide drives the arm through a PCAN-USB adapter and a Miniforge/conda
+environment; this page swaps both out for the Orin's own CAN controller and a uv environment.
+Everything downstream of the bus — scanning for motors, assigning IDs, the gateway, Motorbridge
+Studio — is identical either way; the only thing that changes is **how** ``can0`` comes into
+existence.
+
+.. important::
+
+   This procedure has only been tested against the **B601-RS** (RobStride) model, **not the
+   B601-DM** (Damiao). The two builds use different actuators, so at minimum every
+   ``motorbridge-cli`` call below would need ``--vendor damiao`` instead of ``--vendor robstride``,
+   and motorbridge reaches Damiao hardware over its own ``dm-serial`` / ``dm-device`` transports
+   rather than SocketCAN. For that model, start from the
+   `B601-DM quick start <https://wiki.seeedstudio.com/rebot_b601_dm_getting_started>`_.
+
+The working example, including the assets referenced below, lives in :code-dir:`examples/rebot`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 36 64
+
+   * - Path
+     - What it is
+   * - :code-file:`SKILL.md <examples/rebot/SKILL.md>`
+     - The full procedure and troubleshooting tree, written as an agent skill.
+   * - :code-file:`start-gateway.sh <examples/rebot/start-gateway.sh>`
+     - Launches the motorbridge WebSocket gateway for Studio.
+   * - :code-file:`assets/set_can_pinmux.py <examples/rebot/assets/set_can_pinmux.py>`
+     - Routes the header pins to the CAN controller, via ``/dev/mem``. Required on every boot;
+       idempotent; needs sudo.
+   * - :code-file:`assets/can0-rebot.service <examples/rebot/assets/can0-rebot.service>`
+     - systemd oneshot that redoes the pinmux and brings ``can0`` up at 1 Mbit on boot.
+
+What you need
+-------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 74
+
+   * - Item
+     - Notes
+   * - reBot B601-RS arm
+     - Seven RobStride motors (six joints plus the gripper) on one CAN bus, plus its own
+       **24–48 V** motor supply. The arm does not ship with one.
+   * - Jetson AGX Orin devkit
+     - JetPack 6 / L4T R36.x. Verified on R36.5.2, ``5.15.199-tegra``, aarch64.
+   * - SN65HVD230 CAN transceiver
+     - The Orin has a CAN *controller* but no *transceiver* — see below.
+   * - Jumper wires
+     - Orin 40-pin header (J30) to the transceiver's 4-pin header.
+
+The CAN transceiver
+-------------------
+
+The Orin's on-chip CAN controller speaks logic-level TX/RX; it cannot drive a differential CAN bus
+on its own. A **3.3 V** transceiver bridges the two. The Waveshare SN65HVD230 board is the common
+choice — it is 3.3 V native, which matches the Orin's I/O directly.
+
+.. figure:: ../../_static/rebot/sn65hvd230-can-board.jpg
+   :alt: Waveshare SN65HVD230 CAN transceiver board
+   :width: 360px
+   :align: center
+
+   The Waveshare SN65HVD230 CAN board. The 4-pin header carries ``3.3V``, ``GND``, ``RX`` and
+   ``TX``; the screw terminal carries ``CANH`` and ``CANL``.
+
+- Product page: `SN65HVD230 CAN Board <https://www.waveshare.com/sn65hvd230-can-board.htm>`_
+- Buy: `search Amazon for "Waveshare SN65HVD230" <https://www.amazon.com/s?k=Waveshare+SN65HVD230>`_
+
+.. warning::
+
+   Power the board from **3.3 V**, not 5 V. The SN65HVD230 is a 3.3 V part and the Orin's header
+   pins are not 5 V tolerant.
+
+Wiring
+------
+
+Connect the Orin's 40-pin header (**J30**) to the transceiver. The Waveshare header labels are
+written from the host's point of view, so this is **straight-through — do not cross TX and RX**:
+
+.. figure:: ../../_static/rebot/orin-sn65hvd230-rebot-wiring.svg
+   :alt: Wiring from the Orin J30 header through the SN65HVD230 transceiver to the reBot arm
+   :width: 100%
+
+   The complete signal path. The Orin drives logic-level TX/RX; the transceiver turns it into the
+   differential pair the arm's motors share.
+
+**Pin 1 is at the top right of J30**, so the numbering runs right to left — count from the far end
+of the header, not the near one.
+
+The Orin exposes two independent CAN controllers on the same header. The ``can1`` pins are listed
+here for reference — driving a second arm from them takes work the example does not do yet, covered
+in :ref:`rebot-two-arms`:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 18 18 20 18
+
+   * - Signal
+     - ``can0`` pin
+     - ``can1`` pin
+     - Direction
+     - SN65HVD230
+   * - ``CANx_DOUT``
+     - 31
+     - 33
+     - Orin → board
+     - ``TX``
+   * - ``CANx_DIN``
+     - 29
+     - 37
+     - board → Orin
+     - ``RX``
+   * - **3.3 V**
+     - 17
+     - 1
+     - —
+     - ``3V3``
+   * - GND
+     - 30
+     - 34
+     - —
+     - ``GND``
+
+3.3 V is available on pins 1 and 17 only, so two transceivers take one each. Ground is not scarce —
+pins 6, 9, 14, 20, 25, 30, 34 and 39 all work.
+
+Then wire the transceiver to the arm: ``CANH`` → ``CAN_H`` and ``CANL`` → ``CAN_L``. For background
+on wiring a transceiver to a Jetson and the SocketCAN setup that follows, see Ramin Nabati's
+writeup, `Enabling CAN on NVIDIA Jetson Xavier Developer Kit
+<https://medium.com/@ramin.nabati/enabling-can-on-nvidia-jetson-xavier-developer-kit-aaaa3c4d99c9>`_.
+It targets the Xavier devkit, so confirm the pin numbers against your own carrier board's pinout —
+the table above is for the AGX Orin devkit.
+
+.. note::
+
+   Everything on this page targets ``can0``. A second arm on ``can1`` is not supported by the
+   example as shipped — see :ref:`rebot-two-arms`.
+
+Two checks with a multimeter save hours of debugging:
+
+- **Termination** — ~60 Ω across ``CANH``–``CANL`` with the bus unpowered. ~120 Ω means only one
+  terminator is present; an open circuit means a broken link.
+- **Motor power** — 24–48 V at the arm's power connector. RobStride motors run their CAN off the
+  motor rail, so an unpowered arm produces **no CAN replies at all**, which looks exactly like a
+  wiring fault.
+
+Bring up the bus
+----------------
+
+Install the example's dependencies and check the CLI is reachable:
+
+.. code-block:: bash
+
+   cd examples/rebot
+   uv sync
+   uv run motorbridge-cli --help
+
+The Orin's 40-pin header pins are not routed to the CAN controller out of the box — the pinmux
+registers have to be programmed before ``can0`` can carry any traffic. Do that first:
+
+.. code-block:: bash
+
+   sudo ./assets/set_can_pinmux.py
+
+It prints each register's value before and after the write, so a wrong read-back is immediately
+visible. It uses only the system Python, so it needs no ``uv run``, and it is idempotent — safe to
+re-run any time you want to confirm the pinmux.
+
+.. warning::
+
+   The pinmux lives in live registers and is **cleared on every reboot**. Re-run the script after
+   each boot, or install the systemd unit below, which does it for you.
+
+Then create ``can0`` at the RobStride bitrate of 1 Mbit and bring it up:
+
+.. code-block:: bash
+
+   sudo modprobe can can_raw mttcan
+   sudo ip link set can0 type can bitrate 1000000 restart-ms 100
+   sudo ip link set up can0
+   ip -details link show can0
+
+You want ``state UP``, ``can state ERROR-ACTIVE``, and ``bitrate 1000000``. With the arm powered,
+scan for the seven motors:
+
+.. code-block:: bash
+
+   uv run motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7
+
+A healthy bus reports ``scan done: 7 motor(s) found``.
+
+.. tip::
+
+   Leave ``--end-id`` at 7 unless you are hunting a motor whose ID you do not know. Every ID that
+   does not answer costs the full probe timeout (80 ms, plus a 120 ms parameter-read fallback), and
+   the range is swept once per RobStride host-id candidate — five by default. Sweeping 1–127 spends
+   roughly two minutes mostly waiting on silence, which reads exactly like a hung CLI.
+
+Neither the pinmux nor the ``ip link`` configuration survives a reboot. Install the script somewhere
+stable and enable the unit, which redoes both on every boot:
+
+.. code-block:: bash
+
+   # Not optional: the unit runs this script by absolute path.
+   sudo install -D -m 755 assets/set_can_pinmux.py /opt/rebot/set_can_pinmux.py
+   sudo cp assets/can0-rebot.service /etc/systemd/system/
+   sudo systemctl daemon-reload && sudo systemctl enable --now can0-rebot.service
+   systemctl --no-pager status can0-rebot.service
+
+A healthy oneshot reports ``active (exited)``. Skipping the first line — easy to do when updating an
+already-installed unit — gets you a unit that fails on every boot and a bus that never comes up:
+
+.. code-block:: text
+
+   set_can_pinmux.py (code=exited, status=2)
+   python3: can't open file '/opt/rebot/set_can_pinmux.py': [Errno 2] No such file or directory
+
+Install the script and ``sudo systemctl restart can0-rebot.service``.
+
+Calibrate and drive
+-------------------
+
+Start the motorbridge WebSocket gateway and connect
+`Motorbridge Studio <https://motorbridge.github.io/motorbridge-studio/>`_ to it:
+
+.. code-block:: bash
+
+   ./start-gateway.sh
+
+Confirm 7/7 motors online, pose the arm at its home position, and set the current position as zero
+for all seven joints.
+
+.. warning::
+
+   The gateway takes **exclusive** ownership of the CAN bus — stop it before running any
+   ``motorbridge-cli`` command, or the CLI will find nothing.
+
+   ``start-gateway.sh`` binds ``127.0.0.1:9002``, which reaches Studio only from a browser on the
+   Orin itself. Driving the arm from another machine means binding wider, and the gateway refuses
+   that unless ``MOTORBRIDGE_WS_TOKEN`` is set — from then on that token is the only thing between
+   your network and a moving arm, so make it a real one:
+
+   .. code-block:: bash
+
+      MOTORBRIDGE_WS_TOKEN=<token> BIND=0.0.0.0:9002 ./start-gateway.sh
+
+   A browser cannot set WebSocket request headers, so Studio has to carry the token in the URL:
+   ``ws://<orin-ip>:9002/?motorbridge_ws_token=<token>``.
+
+Let an agent do it
+------------------
+
+:code-file:`examples/rebot/SKILL.md` is written as an agent skill: it carries the full procedure
+plus a troubleshooting tree covering the failure modes that actually bite (loopback passes but no
+motors answer, ``MUX UNCLAIMED`` pinmux red herrings, wedged TX FIFOs). Paste this into Claude Code,
+or any agent that can fetch a URL, from the Orin itself — the prompt is self-contained, so the agent
+does not need a checkout of this repository to start:
+
+.. code-block:: text
+
+   Bring up the reBot B601-RS arm on this Jetson AGX Orin using the Orin's built-in
+   CAN (mttcan) and an SN65HVD230 transceiver — no USB-CAN adapter.
+
+   Follow the procedure at
+   https://github.com/NVIDIA/IsaacTeleop/blob/main/examples/rebot/SKILL.md
+   Read it first, then work through it in order: environment, CAN0 pinmux, can0
+   bring-up at 1 Mbit, bus verification, reboot persistence, motor IDs 1-7, and
+   zero calibration.
+
+   The arm is wired to CAN0 on J30 pins 31 (TX) and 29 (RX). I have a multimeter.
+   Any step needing sudo, hand me the exact command to run myself.
+   If the scan finds no motors, work the troubleshooting tree in that file before
+   changing anything — start by confirming motor power.
+
+Troubleshooting
+---------------
+
+The full tree is in :code-file:`examples/rebot/SKILL.md`. The rule that resolves most cases:
+
+.. important::
+
+   On a single-node CAN bus, "nothing replies" almost always means **no other powered node is
+   ACKing**. Check motor power before touching software or pinmux.
+
+A controller loopback test proves the driver is alive but says nothing about your pins,
+transceiver, or wiring — it never leaves the chip:
+
+.. code-block:: bash
+
+   sudo apt install can-utils   # JetPack ships without it; the tools themselves need no root
+   sudo ip link set can0 down
+   sudo ip link set can0 type can bitrate 1000000 loopback on && sudo ip link set can0 up
+   ( timeout 2 candump -n 1 can0 & ); sleep 0.4; cansend can0 123#DEADBEEF
+   sudo ip link set can0 down
+   sudo ip link set can0 type can bitrate 1000000 loopback off restart-ms 100 && sudo ip link set can0 up
+
+If that echoes but a real scan stays silent, the problem is downstream of the controller: motor
+power, transceiver supply, wiring, or the pinmux. Re-run ``sudo ./assets/set_can_pinmux.py`` — it
+reports the value it read *before* writing, so a register that comes back wrong is a pinmux that
+was never set, or one a reboot cleared.
+
+.. _rebot-two-arms:
+
+Future work: a second arm on ``can1``
+-------------------------------------
+
+The Orin has two independent CAN controllers, so in principle a second arm needs nothing more than
+a second SN65HVD230 on the ``can1`` pins listed in `Wiring`_. **This path is not implemented — the
+example targets ``can0`` only, and making it work is on you.** What follows is the shape of the
+work, not a procedure to follow.
+
+The blocker is the pinmux. ``set_can_pinmux.py`` programs the **CAN0** pins only (``0x0c303010``
+and ``0x0c303018``); the CAN1 pins live in their own registers in the same AON block, which the
+script never touches. Until ``REGS`` covers them, ``can1`` goes ``UP`` and stays deaf — the netdev
+exists because ``mttcan`` registers both, whether or not the pins are routed.
+
+That last detail is also why the shipped unit is ``can0``-only. A unit that brought ``can1`` up
+unconditionally would leave every single-arm machine with a live interface wired to nothing: noise
+in ``ip -br link``, a candidate for bus-off, and a bus that looks ready when its pins are not even
+routed.
+
+Three things to sort out, in order:
+
+#. **Pinmux.** Find the CAN1 register offsets and add them to ``REGS`` in
+   :code-file:`assets/set_can_pinmux.py <examples/rebot/assets/set_can_pinmux.py>`. Without this
+   nothing below matters.
+#. **Bring-up and persistence.** ``ip link`` takes ``can1`` exactly as it takes ``can0``. For
+   reboot persistence, derive a second unit from
+   :code-file:`assets/can0-rebot.service <examples/rebot/assets/can0-rebot.service>` with the
+   interface name replaced and its ``ExecStartPre`` pointing at a CAN1-capable pinmux step. If you
+   run both routinely, a systemd template unit (``can-rebot@.service``, enabled as
+   ``can-rebot@can0`` and ``can-rebot@can1``) collapses the two files back into one.
+#. **Two gateways.** A gateway owns exactly one bus, so each arm needs its own on its own port —
+   ``./start-gateway.sh --channel can0`` on the default port alongside
+   ``BIND=127.0.0.1:9003 ./start-gateway.sh --channel can1``. Motor IDs may repeat across the two
+   arms; the buses never see each other, so each keeps its own 1–7.

--- a/examples/rebot/SKILL.md
+++ b/examples/rebot/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: rebot-orin-setup
+description: >-
+  Use when initializing a reBot B601-RS (RobStride 6-DOF, seven motors) arm
+  from an NVIDIA Jetson AGX Orin using the Orin's built-in CAN (mttcan) via an external
+  SN65HVD230 transceiver — no USB-CAN/PCAN adapter. Covers the uv/motorbridge
+  env, bringing up can0 @ 1 Mbit, verifying the bus, reboot persistence,
+  motor-ID assignment, zero calibration, and the CAN bring-up troubleshooting
+  tree (loopback-passes-but-no-motors, pinmux, motor power).
+---
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# reBot B601-RS on Jetson AGX Orin — built-in CAN setup
+
+Jetson/ARM adaptation of the upstream
+[reBot AGENTS.md guide](https://github.com/Welt-liu/reBot-B601-Agent-Guide/blob/main/en/AGENTS.md)
+and the vendor's
+[B601-RS quick start](https://wiki.seeedstudio.com/rebot_b601_rs_getting_started)
+(assembly, power supply, safety). Both assume a **USB-CAN (PCAN) adapter**; this skill uses the
+Orin's **on-chip CAN (`mttcan`)** instead. motorbridge only ever talks to a SocketCAN channel
+named `can0`, so the *only* real change is **how `can0` is created** — everything
+downstream (scan, id-set, gateway, Studio) is identical.
+
+**Tested against the B601-RS (RobStride) only, not the B601-DM (Damiao).** The DM build needs
+`--vendor damiao` in place of `--vendor robstride`, and motorbridge reaches Damiao hardware over
+its `dm-serial` / `dm-device` transports rather than SocketCAN — so the CAN bring-up below does not
+carry over. See the
+[B601-DM quick start](https://wiki.seeedstudio.com/rebot_b601_dm_getting_started).
+
+## When to use
+
+- Bringing up a new B601-RS arm on an AGX Orin (JetPack 6 / L4T R36.x).
+- Wiring is `Orin J30 (40-pin) → SN65HVD230 → arm CAN`, no USB-CAN adapter.
+- Debugging "motors don't show up on CAN" on a Jetson.
+
+## Environment assumptions
+
+- AGX Orin devkit, JetPack 6 (verified on L4T R36.5.2, `5.15.199-tegra`, aarch64).
+- `uv` on `PATH`; this directory's `pyproject.toml` pins `motorbridge` ≥ 0.5.
+- `sudo` needs a TTY — an agent's non-interactive shell cannot enter a password.
+  For any `sudo` step, have the user run it with the `! ` prefix in their terminal.
+
+## Assets (in this directory)
+
+- `assets/set_can_pinmux.py` — route the header pins to the CAN controller via
+  `/dev/mem` (idempotent). Required on every boot.
+- `assets/can0-rebot.service` — systemd oneshot to bring up `can0` @ 1 Mbit on boot.
+- `start-gateway.sh` — launch the motorbridge WS gateway for Studio.
+
+---
+
+## Hardware wiring (confirm before software)
+
+**Pin 1 is at the top right of J30** — the numbering runs right to left.
+
+`Orin J30 → SN65HVD230` (Waveshare labels are host-side → **straight-through, not crossed**):
+
+| Signal | `can0` pin | `can1` pin | → Waveshare |
+|---|---|---|---|
+| `CANx_DOUT` (TX) | 31 | 33 | `TX` |
+| `CANx_DIN` (RX)  | 29 | 37 | `RX` |
+| **3.3 V** (not 5 V) | 17 | 1 | `3V3` |
+| GND | 30 | 34 | `GND` |
+
+3.3 V is on pins 1 and 17 only; grounds are on 6, 9, 14, 20, 25, 30, 34, 39. Some
+board revisions silkscreen `CTX`/`CRX` rather than `TX`/`RX`.
+
+`SN65HVD230 → arm`: `CANH→CAN_H`, `CANL→CAN_L`. Termination target **~60 Ω**
+across CANH–CANL (bus off). A second arm needs only a second transceiver on the
+`can1` pins; every command below then uses `can1` in place of `can0`.
+
+**Motor power:** the arm needs its own ~24–48 V motor supply. RobStride motors run
+their CAN off this rail — **no motor power ⇒ no CAN replies at all.**
+
+---
+
+## Procedure
+
+### Step 1 — Environment
+
+```bash
+cd examples/rebot
+uv sync
+uv run motorbridge-cli --help
+```
+
+### Step 2 — Bring up built-in can0 (replaces the guide's PCAN-driver step)
+
+Run via `! ` (needs sudo). The pinmux comes first — the header pins are not routed
+to the CAN controller out of the box, and the registers are **cleared on every
+reboot**:
+
+```bash
+sudo ./assets/set_can_pinmux.py     # want: pinmux set: SUCCESS
+sudo modprobe can can_raw mttcan
+sudo ip link set can0 type can bitrate 1000000 restart-ms 100
+sudo ip link set up can0
+ip -details link show can0     # want: state UP, can state ERROR-ACTIVE, bitrate 1000000
+```
+
+### Step 3 — Verify
+
+```bash
+sudo apt install can-utils   # JetPack ships without it; candump/cansend themselves need no root
+
+# Controller self-test — INTERNAL loopback; proves driver only, NOT pins/transceiver/wiring:
+sudo ip link set can0 down
+sudo ip link set can0 type can bitrate 1000000 loopback on && sudo ip link set can0 up
+( timeout 2 candump -n 1 can0 & ); sleep 0.4; cansend can0 123#DEADBEEF   # expect echo
+sudo ip link set can0 down
+sudo ip link set can0 type can bitrate 1000000 loopback off restart-ms 100 && sudo ip link set can0 up
+
+# Real scan (motors MUST be powered):
+uv run motorbridge-cli scan --vendor robstride --channel can0 --start-id 1 --end-id 7
+# want: scan done: 7 motor(s) found
+```
+
+Keep `--end-id 7` here. A dead ID costs 80 ms + a 120 ms param-read fallback, and
+the range is swept once per host-id candidate (five by default), so `--end-id 127`
+takes ~2 minutes of silence and looks hung.
+
+### Step 4 — Persist across reboots
+
+Neither the pinmux nor the `ip link` bring-up survives a reboot. The unit redoes
+both, running the script by absolute path, so install the script first:
+
+```bash
+# Not optional: the unit runs this script by absolute path.
+sudo install -D -m 755 assets/set_can_pinmux.py /opt/rebot/set_can_pinmux.py
+sudo cp assets/can0-rebot.service /etc/systemd/system/
+sudo systemctl daemon-reload && sudo systemctl enable --now can0-rebot.service
+systemctl --no-pager status can0-rebot.service       # want: active (exited)
+```
+
+### Step 5 — Motor IDs (1–7)
+
+Pre-assembled arm (Studio shows 7/7 online) already has IDs 1–7 → skip to Step 6.
+Otherwise, one motor on the bus at a time:
+
+```bash
+uv run motorbridge-cli scan   --vendor robstride --channel can0 --start-id 1 --end-id 127
+uv run motorbridge-cli id-set --vendor robstride --channel can0 --motor-id <current> --new-id <target>
+```
+
+The wide range is deliberate here — an unassigned motor's ID is unknown, so it has
+to be swept. Expect ~2 minutes with no output; it is not hung. Do not narrow it
+just because the verification scan in Step 3 uses `--end-id 7`.
+
+`id-set` may report `store_parameters failed` (timeout) — the ID still writes; re-scan to confirm.
+Only use motorbridge-cli subcommands from the guide; others may spin the motors.
+
+### Step 6 — Zero calibration
+
+```bash
+./start-gateway.sh                                                    # 127.0.0.1:9002, no token
+MOTORBRIDGE_WS_TOKEN=<token> BIND=0.0.0.0:9002 ./start-gateway.sh     # reachable off-box
+```
+
+Gateway **exclusively owns the bus** (stop it before any `motorbridge-cli`). Open
+Motorbridge Studio (<https://motorbridge.github.io/motorbridge-studio/>), confirm 7/7
+online, pose the arm at home, set current position as zero for all 7 joints, verify ~0.
+
+Studio is a browser app, so the loopback default reaches it only from a browser on the
+Orin. Bind wider and the gateway demands a token; a browser cannot set WebSocket request
+headers, so pass it in the URL: `ws://<orin-ip>:9002/?motorbridge_ws_token=<token>`.
+
+---
+
+## Troubleshooting tree
+
+**Golden rule: on a single-node CAN bus, "nothing replies" almost always means no
+other *powered* node is ACKing. Check motor power FIRST, before any software/pinmux work.**
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| scan 0 motors; `cansend`→`No buffer space available`; `TX packets=0` | Nothing ACKing | Motor power off (most common), CANH/CANL swap, no termination, unpowered transceiver |
+| Loopback passes but real bus silent | Loopback is internal-only | Check motor power, transceiver 3V3, wiring, pinmux register |
+| pinctrl shows CAN0 pins `MUX UNCLAIMED` | Red herring (pinctrl consumer state, not HW reg) | Read regs directly: `0x0c303010` should be `0xc400`, `0x0c303018` should be `0xc458`. `sudo ./assets/set_can_pinmux.py` sets them and prints the read-back. |
+| Bus worked, dead after a reboot | Pinmux cleared on boot | Re-run `sudo ./assets/set_can_pinmux.py`, or install `can0-rebot.service` (Step 4) |
+| `scan` sits silent for minutes | Not hung — a wide `--end-id` waits 200 ms on every dead ID, times five host-id candidates | Use `--end-id 7` unless discovering unknown IDs |
+| `can0-rebot.service` fails, `status=2`, `can't open file '/opt/rebot/set_can_pinmux.py'` | Unit installed without the pinmux script (common when updating an existing unit) | `sudo install -D -m 755 assets/set_can_pinmux.py /opt/rebot/set_can_pinmux.py && sudo systemctl restart can0-rebot.service` |
+| `RTNETLINK ... Device or resource busy` | Interface already up | `sudo ip link set canX down` first |
+| Stuck TX after ENOBUFS | TX FIFO wedged | `sudo ip link set can0 down && up` |
+| `busybox: command not found` | Not on JetPack | Use `set_can_pinmux.py` (Python `/dev/mem`) instead of `busybox devmem` |
+| `candump`/`cansend: command not found` | JetPack ships without can-utils | `sudo apt install can-utils`. The tools open `AF_CAN`/`SOCK_RAW`, which is not `CAP_NET_RAW`-gated — do not reach for `sudo` |
+
+**Multimeter quick-checks:** CANH–CANL (bus off) ~60 Ω good / ~120 Ω one terminator /
+open = broken / ~0 short-or-swap · arm power connector ~24–48 V (0 V ⇒ e-stop/fuse/loose
+plug) · transceiver `3V3`→`GND` ~3.3 V.
+
+**CAN0 pinmux registers (AGX Orin AON block):**
+`can0_dout` = `0x0c303010` → `0xc400`; `can0_din` = `0x0c303018` → `0xc458`.

--- a/examples/rebot/assets/can0-rebot.service
+++ b/examples/rebot/assets/can0-rebot.service
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[Unit]
+Description=reBot: bring up Jetson built-in CAN (can0) @ 1 Mbit for RobStride arm
+After=multi-user.target
+
+[Service]
+# can0 only, deliberately: set_can_pinmux.py does not program the CAN1 pins, and
+# mttcan registers both netdevs, so bringing can1 up here would leave every
+# single-arm machine with a live interface wired to nothing.
+Type=oneshot
+RemainAfterExit=yes
+# mttcan is normally auto-loaded; ensure it and raw CAN are present.
+ExecStartPre=-/sbin/modprobe mttcan
+ExecStartPre=-/sbin/modprobe can_raw
+# The CAN0 pinmux lives in live registers and is cleared on every boot, so it has
+# to be reprogrammed before the interface is any use. Absolute path required: a
+# system unit's %h is /root. Install with:
+#   sudo install -D -m 755 set_can_pinmux.py /opt/rebot/set_can_pinmux.py
+# No leading '-': if the pinmux fails, fail loudly rather than bring up a dead bus.
+ExecStartPre=/usr/bin/python3 /opt/rebot/set_can_pinmux.py
+# Ensure a clean state, then configure + bring up at 1 Mbit (RobStride bitrate).
+ExecStartPre=-/sbin/ip link set can0 down
+ExecStart=/sbin/ip link set can0 type can bitrate 1000000 restart-ms 100
+ExecStartPost=/sbin/ip link set can0 up
+
+[Install]
+WantedBy=multi-user.target

--- a/examples/rebot/assets/set_can_pinmux.py
+++ b/examples/rebot/assets/set_can_pinmux.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Set AGX Orin CAN0 pinmux (DOUT/DIN) live via /dev/mem.
+
+Equivalent to NVIDIA's documented:
+  busybox devmem 0x0c303010 w 0xc400   # CAN0_DOUT (TX)
+  busybox devmem 0x0c303018 w 0xc458   # CAN0_DIN  (RX)
+
+Cleared on every reboot, so it must run before each bring-up; can0-rebot.service
+does this. Run with sudo. Idempotent, and doubles as a verifier — the read-back
+must equal the wanted value.
+"""
+
+import mmap
+import os
+import struct
+
+BASE = 0x0C303000  # AGX Orin AON pinmux block (page-aligned)
+PAGE = 0x1000
+REGS = {
+    0x10: 0xC400,  # CAN0_DOUT_PAA0 -> function can0 (output)
+    0x18: 0xC458,  # CAN0_DIN_PAA1  -> function can0 (input enabled)
+}
+
+fd = os.open("/dev/mem", os.O_RDWR | os.O_SYNC)
+mem = mmap.mmap(
+    fd, PAGE, mmap.MAP_SHARED, mmap.PROT_READ | mmap.PROT_WRITE, offset=BASE
+)
+ok = True
+for off, val in REGS.items():
+    before = struct.unpack("<I", mem[off : off + 4])[0]
+    mem[off : off + 4] = struct.pack("<I", val)
+    after = struct.unpack("<I", mem[off : off + 4])[0]
+    status = "OK" if after == val else "FAILED (write blocked?)"
+    if after != val:
+        ok = False
+    print(
+        f"0x{BASE + off:08x}: 0x{before:08x} -> 0x{after:08x} (wanted 0x{val:04x})  {status}"
+    )
+mem.close()
+os.close(fd)
+print("pinmux set: " + ("SUCCESS" if ok else "FAILED"))
+# can0-rebot.service runs this as a bare ExecStartPre and must not go on to bring
+# up a bus whose pins were never routed.
+if not ok:
+    raise SystemExit(1)

--- a/examples/rebot/pyproject.toml
+++ b/examples/rebot/pyproject.toml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Standalone pyproject so `uv run` resolves motorbridge without pulling it into
+# the IsaacTeleop wheel's runtime requirements. motorbridge ships the CAN
+# transport plus the `motorbridge-cli` / `motorbridge-gateway` entry points.
+
+[project]
+name = "rebot"
+version = "0.0.0"
+description = "reBot B601-RS (RobStride 7-DOF) arm bring-up on Jetson AGX Orin"
+requires-python = ">=3.11,<3.14"
+dependencies = [
+    "motorbridge>=0.5",
+]

--- a/examples/rebot/start-gateway.sh
+++ b/examples/rebot/start-gateway.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Start the motorbridge WS gateway for the reBot B601-RS arm, then point
+# Motorbridge Studio (https://motorbridge.github.io/motorbridge-studio/) at it.
+#
+# The gateway takes exclusive ownership of the CAN bus — stop it before running
+# any motorbridge-cli command.
+set -euo pipefail
+
+here="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+
+# Loopback needs no token. The gateway refuses any wider bind unless
+# MOTORBRIDGE_WS_TOKEN is set, so reaching the arm from another machine is a
+# deliberate two-variable opt-in and never a default:
+#   MOTORBRIDGE_WS_TOKEN=<token> BIND=0.0.0.0:9002 ./start-gateway.sh
+: "${BIND:=127.0.0.1:9002}"
+
+# Router mode starts fine without CAN, so a missing bus is a warning. Only an
+# absent or explicitly-down interface is reported; CAN links often read
+# "unknown" while perfectly usable.
+can_state="$(cat /sys/class/net/can0/operstate 2>/dev/null || true)"
+if [[ -z "$can_state" ]]; then
+  echo "warning: can0 not found — no motors will respond (see SKILL.md, Step 2)" >&2
+elif [[ "$can_state" == "down" ]]; then
+  echo "warning: can0 is down — run: sudo ip link set can0 up" >&2
+fi
+
+echo "gateway listening on ws://$BIND"
+exec uv run --project "$here" motorbridge-gateway --bind "$BIND" "$@"


### PR DESCRIPTION
## Description

The vendor quick start for the reBot B601-RS drives the arm through a PCAN-USB adapter and a Miniforge/conda environment. On an AGX Orin neither is needed — the SoC has its own CAN controller (`mttcan`), so an SN65HVD230 transceiver on the 40-pin header replaces the adapter, and uv replaces conda.

`examples/rebot/` adds a standalone uv project pinning `motorbridge`, a gateway launcher, a `/dev/mem` pinmux helper, and a systemd unit that restores `can0` at 1 Mbit across reboots. `SKILL.md` carries the procedure and the CAN troubleshooting tree as an agent skill, so the bring-up can be handed to a coding agent. The docs page covers the transceiver, J30 wiring, bus verification, and zero calibration.

Tested against the B601-RS (RobStride) only — the B601-DM is a Damiao build that motorbridge reaches over `dm-serial`/`dm-device` rather than SocketCAN.

Reviewer note: `_static/rebot/sn65hvd230-can-board.jpg` is Waveshare's product photo, taken from their product page.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- `uv sync` in `examples/rebot/` → motorbridge 0.5.1; `uv run motorbridge-cli --help` and `./start-gateway.sh` both start.
- `sphinx-build -b html docs/source` → build succeeded, 0 warnings.
- `SKIP=check-copyright-year pre-commit run --files <staged>` → all hooks pass.

The on-hardware steps (can0 bring-up, motor scan, zero calibration) are unchanged from a working B601-RS setup on an AGX Orin (L4T R36.5.2) and were not re-run for this PR.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a complete setup guide for the reBot B601-RS 6-DOF arm on Jetson AGX Orin.
  - Documented wiring, CAN configuration, motor discovery, calibration, dual-arm operation, gateway setup, and troubleshooting.
  - Added a ready-to-use example with CAN initialization, pin configuration, persistent startup, and WebSocket gateway launchers.

- **Documentation**
  - Added getting-started documentation and an example README covering installation, Studio connection, tokens, and repository usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->