### PR TITLE
docs(cloudxr): say Quest3 is the WebXR profile, not a Quest restriction

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -108,16 +108,16 @@ The first launch downloads the CloudXR Web Client SDK and asks you to review and
 accept the EULA on the terminal; answer the prompt once and the acceptance is
 remembered for subsequent runs.
 
-.. TODO: ``Quest3`` is the profile every WebXR client uses — Quest, PICO, and the
-   desktop-browser IWER emulator — so the name reads as a hardware restriction it
-   does not impose. Either rename the profile or add a generic alias (e.g.
-   ``webxr``) in the runtime, then update the default and the values listed below.
+.. TODO: rename ``Quest3`` or add a generic alias (e.g. ``webxr``) in the
+   runtime, then update the default and the values listed below.
 
-The CloudXR runtime uses the ``Quest3`` device profile by default; Apple Vision
-Pro needs ``auto-native``. The profile is set on the *runtime*, so applications
-inherit whatever the runtime they connect to was started with. To override it,
-or any other setting, write a ``KEY=value`` env file and pass it to the example
-with ``--cloudxr-env-config``:
+The CloudXR runtime uses the ``Quest3`` device profile by default. The name is
+narrower than the profile: ``Quest3`` serves every WebXR client — Quest, PICO,
+and the desktop-browser IWER emulator — so PICO users should keep it. Apple
+Vision Pro connects natively and needs ``auto-native`` instead. The profile is
+set on the *runtime*, so applications inherit whatever the runtime they connect
+to was started with. To override it, or any other setting, write a ``KEY=value``
+env file and pass it to the example with ``--cloudxr-env-config``:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Description

Triage of NVBug 6582650, filed by a PICO user who read `NV_DEVICE_PROFILE=Quest3` as "my headset is being served the wrong profile". `Quest3` is in fact the profile every WebXR client uses — Quest, PICO, and the desktop-browser IWER emulator. That was already written down on main, but only inside a `.. TODO` comment, which does not render, so the reader who needs it never sees it.

This moves the fact into the prose and leaves the TODO holding just the action it proposes (rename the profile, or add a `webxr` alias in the runtime).

No behavior change; main's code and default are already correct as of 53a1d7a0. The 1.4 docs are wrong in substance and are fixed separately in #935.

Not fixed here: `scripts/setup_cloudxr_env.sh:115` writes the same `~/.cloudxr/run/cloudxr.env` with `${NV_DEVICE_PROFILE:-auto-webrtc}` — a second writer of that file with a different default. Aligning it is a behavior change on the build-from-source path, so it wants its own PR.

## Type of change

- [x] Documentation update

## Testing

Prose and one comment block; no build or runtime surface touched.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)