### PR TITLE
release/1.4.x: docs(cloudxr): correct the device-profile default to Quest3

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -108,10 +108,13 @@ The first launch downloads the CloudXR Web Client SDK and asks you to review and
 accept the EULA on the terminal; answer the prompt once and the acceptance is
 remembered for subsequent runs.
 
-The CloudXR runtime uses the ``auto-webrtc`` device profile by default
-(Pico & Quest). For Apple Vision Pro it defaults to ``auto-native``. To
-override settings, write a ``KEY=value`` env file and pass it to the example
-with ``--cloudxr-env-config``:
+The CloudXR runtime uses the ``Quest3`` device profile by default. The name is
+narrower than the profile: ``Quest3`` serves every WebXR client — Quest, PICO,
+and the desktop-browser IWER emulator — so PICO users should keep it. Apple
+Vision Pro connects natively and needs ``auto-native`` instead — the default is
+not derived from the connected headset, so set it yourself. To override the
+profile, or any other setting, write a ``KEY=value`` env file and pass it to the
+example with ``--cloudxr-env-config``:
 
 .. code-block:: bash
 
@@ -145,7 +148,7 @@ To inspect the resolved settings after startup:
      - Description
      - Values
    * - ``NV_DEVICE_PROFILE``
-     - ``auto-webrtc``
+     - ``Quest3``
      - Device profile
      - ``auto-webrtc``, ``auto-native``, ``Quest3``, ``AppleVisionPro``
    * - ``NV_CXR_ENABLE_PUSH_DEVICES``


### PR DESCRIPTION
## Description

Fixes NVBug 6582650 on the 1.4 branch. The quick start documents `NV_DEVICE_PROFILE` as defaulting to `auto-webrtc` "(Pico & Quest)", and claims Apple Vision Pro "defaults to `auto-native`". Neither is true on 1.4: every path that resolves the variable goes through `CloudXRLauncher`, which always injects `launcher_defaults={"NV_DEVICE_PROFILE": "Quest3"}`, so `env_config.py:53`'s `auto-webrtc` is unreachable and no default is derived from the connected headset. Verified against `__main__.py`, `runtime.py`, `wss.py`, `rig/launcher.py`, and the ROS 2 node. The reporter's root-cause analysis was correct; their conclusion that PICO is mis-served was not, since `Quest3` is the profile for every WebXR client.

Docs only, deliberately. main consolidated the launcher/env_config split in 53a1d7a0, but that commit is ten files including an unrelated runtime behavior change and sits on the post-`src/python` layout 1.4 does not have, so this is hand-authored rather than cherry-picked — no 🍒 marker and no code change on a release branch. (main needs no docs change; it has been correct since 53a1d7a0.) 1.4's `camera_streaming.rst:253` already said `Quest3`; the docs now agree with each other and with `--help`.

Also on 1.4: `scripts/setup_cloudxr_env.sh:115` still defaults to `auto-webrtc`, so it writes the same `~/.cloudxr/run/cloudxr.env` with a different default than the launcher. Present on main too, and left alone on both — aligning it is a behavior change on the build-from-source path and wants its own PR.

## Type of change

- [x] Documentation update

## Testing

Prose and one table cell; no code or build surface touched.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)