### PR TITLE
docs: read the built ref name from the command line, not the environment

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,6 +5,7 @@
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
 
 import os
+import sys
 from datetime import datetime, timezone
 
 # -- Project information -----------------------------------------------------
@@ -15,20 +16,45 @@ copyright = f"2025-{build_time.year}, NVIDIA CORPORATION & AFFILIATES"
 copyright += f", last updated on {build_time.strftime('%B %d, %Y')}"
 author = "NVIDIA"
 
+
+def _smv_ref_name():
+    """Git ref name sphinx-multiversion is building, or "" outside it.
+
+    sphinx-multiversion builds every ref with ``-c`` pointing at the checkout it
+    was invoked from, so this conf.py is always the deploy branch's and anything
+    read from the tree describes that branch, not the ref. It passes the ref name
+    as ``-D smv_current_version=``, which Sphinx applies to the config only after
+    conf.py has run, so read it off the command line.
+    """
+    prefix = "smv_current_version="
+    return next((a[len(prefix) :] for a in sys.argv if a.startswith(prefix)), "")
+
+
 _version_file = os.path.join(os.path.dirname(__file__), "..", "..", "VERSION")
 # ``VERSION`` is ``MAJOR.MINOR.x`` on main and on every release branch and tag, so its
 # first two components name the release series a given build of the docs describes.
-# ``_pip_version_pin`` turns that into a specifier (``1.5.x`` -> ``~=1.5.0``, i.e.
-# >=1.5.0 <1.6.0) so each versioned docs build shows how to install its own series.
 if os.path.exists(_version_file):
     with open(_version_file) as f:
-        full_version = f.read().strip()
-    version = full_version
-    release = full_version
-    _pip_version_pin = "~={}.0".format(".".join(full_version.split(".")[:2]))
+        version = release = f.read().strip()
 else:
     version = release = "0.0.0"
-    _pip_version_pin = "~=1.0"
+
+
+def _pip_pin(ref_name, fallback):
+    """Install specifier for the series a build describes: ``1.5.x`` -> ``~=1.5.0``.
+
+    Release refs name their own series (``release/1.4.x``, ``v1.4.7``); ``main``
+    and plain ``sphinx-build`` fall back to the checked-out ``VERSION``.
+    """
+    tail = ref_name.rsplit("/", 1)[-1].removeprefix("v")
+    major, _, rest = (tail if tail[:1].isdigit() else fallback).partition(".")
+    minor = rest.partition(".")[0]
+    if not (major.isdigit() and minor.isdigit()) or major == "0":
+        return "~=1.0"
+    return f"~={major}.{minor}.0"
+
+
+_pip_version_pin = _pip_pin(_smv_ref_name(), version)
 
 # -- General configuration -----------------------------------------------------
 
@@ -65,9 +91,9 @@ html_static_path = ["_static"]
 html_css_files = ["css/custom.css"]
 
 # Per-version icon link overrides.  Keyed by the git ref name that
-# sphinx-multiversion builds (SPHINX_MULTIVERSION_NAME env var).  Unmatched
-# refs (including plain ``sphinx-build`` without multiversion) use _DEFAULT_ICONS.
-_smv_name = os.environ.get("SPHINX_MULTIVERSION_NAME", "")
+# sphinx-multiversion builds.  Unmatched refs (including plain ``sphinx-build``
+# without multiversion) use _DEFAULT_ICONS.
+_smv_name = _smv_ref_name()
 
 _DEFAULT_ICONS = {
     "teleop_version": "main",


### PR DESCRIPTION
## Description

The published 1.4 quick start tells you to install `~=1.5.0`. Found alongside NVBug 6582650.

<img width="796" height="153" alt="Screenshot 2026-08-10 at 12 20 30 PM" src="https://github.com/user-attachments/assets/69afb70a-f050-40e3-9511-036b3e36e77c" />

**Why `|version|` is right on the same page and the pin is not.** Sphinx resolves `|version|` in the `DefaultSubstitutions` transform, which reads `config.version` at doctree time; sphinx-multiversion restores `version`/`release`/`today` per ref in its `config-inited` handler, so that lands correctly. Anything baked into `rst_epilog` when `conf.py` *executes* misses that entirely — and it executes from the wrong tree, because sphinx-multiversion builds every ref with `-c` pointing at the checkout it was invoked from. Only the sources come from the ref. (So fixing `release/1.4.x`'s own `conf.py` would change nothing.)

Two stale values, one line each:

- `_smv_name` read `SPHINX_MULTIVERSION_NAME`, which sphinx-multiversion 0.2.4 **never sets** — verified in its source. Always `""`, so `_VERSION_ICON_MAP` has never applied, every version linked to `client/main`, and every "Edit this page" pointed at main. The ref name does reach the build as `-D smv_current_version=`; Sphinx applies it just after `conf.py` runs, so read it off `sys.argv`.
- The install pin came from the deploy branch's `VERSION`. Take the series from the ref name instead, falling back to `VERSION` for `main` and for a plain `sphinx-build`.

Trade-off worth a look: the pin now comes from the ref *name* rather than the ref's `VERSION` file. Those agree by the convention this file already documents (`release/1.4.x` -> `1.4.x`), and `smv_branch_whitelist` only admits `main`, `release/*` and `v*` tags.

Out of scope: `release/1.0.x` emits pre-existing duplicate-target errors — its own `.rst` redefines a link target the epilog provides. Predates this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

`sphinx-build -W --keep-going` (what `make current-docs` runs) succeeds with no warnings; a plain build is unchanged.

Multiversion builds, reading the generated HTML:

| | `release/1.4.x` | `main` |
|---|---|---|
| pip pin | `~=1.4.0` | `~=1.5.0` |
| `\|version\|` | `1.4.x` | `1.5.x` |
| web client | `client/release-1.4.x` | `client/main` |
| GitHub ref | `tree/release/1.4.x` | `tree/main` |

A separate `release/1.0.x` build renders its `_VERSION_ICON_MAP` entry (CloudXR 6.1 badge, IsaacLab `develop`) for the first time.

Note for anyone re-running this locally: sphinx-multiversion prefers local refs, so a stale local `release/1.4.x` silently shadows the remote. Pass `-D smv_prefer_remote_refs=1`. CI checks out only `main` locally, so it is unaffected.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved multi-version documentation builds by accepting the selected version through a command-line option.
  * Added clearer package-version compatibility handling, including validation and fallback behavior for invalid or missing version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->