### PR TITLE
chore(cloudxr): use rc4 SDK from public NGC

### DIFF
--- a/.github/actions/build-cloudxr-web-client/action.yml
+++ b/.github/actions/build-cloudxr-web-client/action.yml
@@ -28,8 +28,8 @@ runs:
         version=$(grep -E '^CXR_WEB_SDK_VERSION=.+' deps/cloudxr/.env.default | cut -d= -f2)
         echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-    # download_cloudxr_sdk.sh tries a local tarball, then listed and unlisted
-    # public NGC resources. Only the tarball is needed here.
+    # download_cloudxr_sdk.sh tries a local tarball, then selects its public NGC
+    # route from the version. Only the tarball is needed here.
     - name: Download CloudXR Web SDK from NGC
       shell: bash
       env:

--- a/.github/actions/build-cloudxr-web-client/action.yml
+++ b/.github/actions/build-cloudxr-web-client/action.yml
@@ -2,18 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Reads CXR_WEB_SDK_VERSION from deps/cloudxr/.env.default, downloads the SDK
-# from NGC (private if `ngc-api-key` is provided, public otherwise), and runs
-# `npm install` + `npm run build`. Output is written to
+# anonymously from NGC, and runs `npm install` + `npm run build`. Output is written to
 # deps/cloudxr/webxr_client/build/.
 
 name: Build CloudXR Web Client
 description: Download the CloudXR Web SDK from NGC and build the web client.
 
 inputs:
-  ngc-api-key:
-    description: NGC API key for the private SDK; leave empty to use the public SDK.
-    required: false
-    default: ''
   node-version:
     description: Node.js version for the web client build.
     required: false
@@ -33,14 +28,12 @@ runs:
         version=$(grep -E '^CXR_WEB_SDK_VERSION=.+' deps/cloudxr/.env.default | cut -d= -f2)
         echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-    # download_cloudxr_sdk.sh tries local tarball, public NGC, then private NGC
-    # (the latter requires NGC_API_KEY). Only the tarball is needed here; the
-    # script's full bundle layout check is irrelevant for this action.
+    # download_cloudxr_sdk.sh tries a local tarball, then listed and unlisted
+    # public NGC resources. Only the tarball is needed here.
     - name: Download CloudXR Web SDK from NGC
       shell: bash
       env:
         CXR_WEB_SDK_VERSION: ${{ steps.sdk-version.outputs.version }}
-        NGC_API_KEY: ${{ inputs.ngc-api-key }}
       run: |
         ./scripts/download_cloudxr_sdk.sh
 

--- a/.github/actions/setup-cloudxr-sdk/action.yml
+++ b/.github/actions/setup-cloudxr-sdk/action.yml
@@ -4,11 +4,6 @@
 name: Setup CloudXR SDK
 description: Parse CloudXR versions from .env.default and download the CloudXR Runtime and Web SDKs.
 
-inputs:
-  ngc-api-key:
-    description: NGC API key for downloading CloudXR SDKs from private NGC.
-    required: true
-
 outputs:
   runtime_version:
     description: CloudXR Runtime SDK version from .env.default.
@@ -39,9 +34,7 @@ runs:
       shell: bash
       env:
         CXR_RUNTIME_SDK_VERSION: ${{ steps.parse.outputs.runtime_version }}
-        # Staged here because the configure step re-runs this script without a key.
         CXR_DOWNLOAD_EXP: '1'
-        NGC_API_KEY: ${{ inputs.ngc-api-key }}
       run: |
         ./scripts/download_cloudxr_runtime_sdk.sh
 
@@ -49,6 +42,5 @@ runs:
       shell: bash
       env:
         CXR_WEB_SDK_VERSION: ${{ steps.parse.outputs.web_version }}
-        NGC_API_KEY: ${{ inputs.ngc-api-key }}
       run: |
         ./scripts/download_cloudxr_sdk.sh

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -82,8 +82,6 @@ jobs:
     - name: Setup CloudXR SDK
       id: cloudxr-sdk
       uses: ./.github/actions/setup-cloudxr-sdk
-      with:
-        ngc-api-key: ${{ secrets.NGC_TELEOP_CORE_GITHUB_SERVICE_KEY }}
 
     # robotic_grounding source bundle for the [grounding] extra (Sharpa retargeter).
     # Disabled on release branches (and PRs targeting them) to keep release
@@ -675,8 +673,6 @@ jobs:
 
     - name: Setup CloudXR SDK
       uses: ./.github/actions/setup-cloudxr-sdk
-      with:
-        ngc-api-key: ${{ secrets.NGC_TELEOP_CORE_GITHUB_SERVICE_KEY }}
 
     - name: Build teleop_ros2 image
       run: |

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -11,9 +11,7 @@
 # Builds are gated on changed paths by the `changes` job; gh-pages
 # `keep_files: true` preserves whichever artifact was skipped.
 #
-# Web client uses the private CloudXR SDK for pushes and for PRs whose
-# author is in ALLOWED_CLOUDXR_JS_PR_AUTHORS (Repo Settings → Variables);
-# all other PRs fall back to the public SDK.
+# The web client downloads its CloudXR SDK anonymously from public NGC resources.
 
 name: Build & deploy docs
 
@@ -45,7 +43,6 @@ jobs:
     outputs:
       is-canonical-repo: ${{ steps.is-canonical-repo.outputs.defined }}
       is-deploy-branch: ${{ steps.is-deploy-branch.outputs.defined }}
-      use_ngc_key: ${{ steps.ngc-allowlist.outputs.use_ngc_key }}
     steps:
     - id: is-canonical-repo
       if: github.repository == 'NVIDIA/IsaacTeleop'
@@ -56,22 +53,6 @@ jobs:
         || startsWith(github.ref, 'refs/heads/release/')
         || startsWith(github.ref, 'refs/tags/v')
       run: echo "defined=true" >> "$GITHUB_OUTPUT"
-    - id: ngc-allowlist
-      run: |
-        if [ "${{ github.event_name }}" != 'pull_request' ]; then
-          echo "use_ngc_key=true" >> "$GITHUB_OUTPUT"
-        elif [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]; then
-          echo "use_ngc_key=false" >> "$GITHUB_OUTPUT"
-        else
-          ACTOR="${{ github.actor }}"
-          ALLOWED="${{ vars.ALLOWED_CLOUDXR_JS_PR_AUTHORS }}"
-          # Normalize: remove spaces so "alice, bob" matches like "alice,bob"
-          ALLOWED="${ALLOWED// /}"
-          case ",${ALLOWED}," in
-            *",${ACTOR},"*) echo "use_ngc_key=true" >> "$GITHUB_OUTPUT" ;;
-            *) echo "use_ngc_key=false" >> "$GITHUB_OUTPUT" ;;
-          esac
-        fi
 
   # gh-pages keep_files preserves whichever artifact isn't rebuilt this run.
   changes:
@@ -171,11 +152,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # Allowlist no → public only. Allowlist yes + NGC_API_KEY → private only.
       - name: Build CloudXR web client
         uses: ./.github/actions/build-cloudxr-web-client
-        with:
-          ngc-api-key: ${{ needs.check-repo.outputs.use_ngc_key == 'true' && secrets.NGC_TELEOP_CORE_GITHUB_SERVICE_KEY || '' }}
 
       - name: Upload web app artifact
         uses: actions/upload-artifact@v6

--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -6,7 +6,7 @@
 # CloudXR Docker Images and Configs
 ###########################################################
 CXR_RUNTIME_SDK_VERSION=6.3.0-rc3
-CXR_WEB_SDK_VERSION=6.3.0-rc2
+CXR_WEB_SDK_VERSION=6.3.0-rc4
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 
 ###########################################################

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudxr-isaac-lab-teleop",
-  "version": "6.3.0-rc2",
+  "version": "6.3.0-rc4",
   "private": true,
   "description": "NVIDIA Isaac Teleop Web Client",
   "author": "NVIDIA Corporation",
@@ -38,7 +38,7 @@
     ]
   },
   "dependencies": {
-    "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.3.0-rc2.tgz",
+    "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.3.0-rc4.tgz",
     "@preact/signals-react": "^3.10.0",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.0",

--- a/scripts/download_cloudxr_runtime_sdk.sh
+++ b/scripts/download_cloudxr_runtime_sdk.sh
@@ -7,10 +7,10 @@
 # The SDK tarball (CloudXR-<VERSION>-Linux-<ARCH>-sdk.tar.gz) is placed in deps/cloudxr/
 # for use by Dockerfile.runtime.
 #
-# Three ways to obtain the SDK (tried in order):
+# Two ways to obtain the SDK:
 # 1) Local tarball: place CloudXR-<VERSION>-Linux-<ARCH>-sdk.tar.gz in deps/cloudxr/.
-# 2) Listed public NGC: nvidia/cloudxr-runtime.
-# 3) Unlisted public NGC: nvidia/cloudxr-runtime-for-isaac-teleop.
+# 2) Public NGC: RC versions use nvidia/cloudxr-runtime-for-isaac-teleop directly.
+#    Other versions try nvidia/cloudxr-runtime first and fall back to the unlisted resource.
 # Optional: set CXR_DOWNLOAD_EXP=1 to also download CloudXR-exp-<VERSION>-....
 
 set -Eeuo pipefail
@@ -106,8 +106,8 @@ download_ngc_file() {
 }
 
 # -----------------------------------------------------------------------------
-# Public NGC: try the listed resource before the unlisted Isaac Teleop resource.
-# Both sources are anonymous and must not require NGC credentials.
+# Public NGC is anonymous. RC versions go directly to the unlisted Isaac Teleop resource;
+# non-RC versions try listed first and fall back to unlisted without credentials.
 # -----------------------------------------------------------------------------
 install_from_public_ngc() {
     local resource="$1"
@@ -151,15 +151,27 @@ if install_from_local_tarball; then
     exit 0
 fi
 
-echo "Cannot install from local tarball, trying listed public NGC..."
-if install_from_public_ngc "cloudxr-runtime" "listed"; then
+if [[ "$CXR_RUNTIME_SDK_VERSION" == *-rc* ]]; then
+    NGC_RESOURCE="cloudxr-runtime-for-isaac-teleop"
+    NGC_VISIBILITY="unlisted"
+else
+    NGC_RESOURCE="cloudxr-runtime"
+    NGC_VISIBILITY="listed"
+fi
+
+echo "Cannot install from local tarball, trying ${NGC_VISIBILITY} public NGC..."
+if install_from_public_ngc "$NGC_RESOURCE" "$NGC_VISIBILITY"; then
     exit 0
 fi
 
-echo "Cannot install from listed public NGC, trying unlisted public NGC..."
-if install_from_public_ngc "cloudxr-runtime-for-isaac-teleop" "unlisted"; then
-    exit 0
+if [[ "$NGC_VISIBILITY" == "listed" ]]; then
+    NGC_RESOURCE="cloudxr-runtime-for-isaac-teleop"
+    NGC_VISIBILITY="unlisted"
+    echo "Cannot install from listed public NGC, trying unlisted public NGC..."
+    if install_from_public_ngc "$NGC_RESOURCE" "$NGC_VISIBILITY"; then
+        exit 0
+    fi
 fi
 
-echo "Cannot install from unlisted public NGC, exiting..."
+echo "Cannot install from ${NGC_VISIBILITY} public NGC, exiting..."
 exit 1

--- a/scripts/download_cloudxr_runtime_sdk.sh
+++ b/scripts/download_cloudxr_runtime_sdk.sh
@@ -168,6 +168,8 @@ if [[ "$NGC_VISIBILITY" == "listed" ]]; then
     NGC_RESOURCE="cloudxr-runtime-for-isaac-teleop"
     NGC_VISIBILITY="unlisted"
     echo "Cannot install from listed public NGC, trying unlisted public NGC..."
+    # Do not combine a partial listed download with the unlisted SDK bundle.
+    rm -f "$CXR_DEPLOYMENT_DIR/$SDK_FILE" "$CXR_DEPLOYMENT_DIR/$EXP_SDK_FILE"
     if install_from_public_ngc "$NGC_RESOURCE" "$NGC_VISIBILITY"; then
         exit 0
     fi

--- a/scripts/download_cloudxr_runtime_sdk.sh
+++ b/scripts/download_cloudxr_runtime_sdk.sh
@@ -9,8 +9,8 @@
 #
 # Three ways to obtain the SDK (tried in order):
 # 1) Local tarball: place CloudXR-<VERSION>-Linux-<ARCH>-sdk.tar.gz in deps/cloudxr/.
-# 2) Public NGC: downloads via curl from the public NGC resource API.
-# 3) Private NGC: downloads via curl from the private NGC resource API; requires NGC_API_KEY.
+# 2) Listed public NGC: nvidia/cloudxr-runtime.
+# 3) Unlisted public NGC: nvidia/cloudxr-runtime-for-isaac-teleop.
 # Optional: set CXR_DOWNLOAD_EXP=1 to also download CloudXR-exp-<VERSION>-....
 
 set -Eeuo pipefail
@@ -86,7 +86,6 @@ download_ngc_file() {
     local url="$1"
     local out_path="$2"
     local label="$3"
-    local auth_bearer="${4:-}"
 
     [[ -s "$out_path" ]] && return 0
 
@@ -94,9 +93,6 @@ download_ngc_file() {
     local -a curl_args=(--fail --location --output "$out_path"
         --connect-timeout 10 --max-time 120
         --retry 3 --retry-delay 5)
-    if [[ -n "$auth_bearer" ]]; then
-        curl_args+=(-H "Authorization: Bearer ${auth_bearer}" -H "Content-Type: application/json")
-    fi
     if ! curl "${curl_args[@]}" "$url"; then
         echo -e "${RED}Error: Failed to download ${label}${NC}"
         rm -f "$out_path"
@@ -110,10 +106,13 @@ download_ngc_file() {
 }
 
 # -----------------------------------------------------------------------------
-# Public NGC: download via curl from the public NGC resource API
-# Resource: nvidia/cloudxr-runtime-for-isaac-teleop/${CXR_RUNTIME_SDK_VERSION}
+# Public NGC: try the listed resource before the unlisted Isaac Teleop resource.
+# Both sources are anonymous and must not require NGC credentials.
 # -----------------------------------------------------------------------------
 install_from_public_ngc() {
+    local resource="$1"
+    local visibility="$2"
+
     if ! command -v curl &> /dev/null; then
         echo -e "${RED}Error: curl not found. Please install it first.${NC}"
         echo -e "To use a local SDK instead, place $SDK_FILE in deps/cloudxr/"
@@ -121,13 +120,13 @@ install_from_public_ngc() {
     fi
 
     echo -e "${GREEN}========================================${NC}"
-    echo -e "${GREEN}Downloading CloudXR Runtime SDK${NC}"
+    echo -e "${GREEN}Downloading CloudXR Runtime SDK from ${visibility} NGC resource${NC}"
     echo -e "${GREEN}========================================${NC}"
     echo ""
 
     mkdir -p "$CXR_DEPLOYMENT_DIR"
 
-    local base="https://api.ngc.nvidia.com/v2/resources/org/nvidia/cloudxr-runtime-for-isaac-teleop/${CXR_RUNTIME_SDK_VERSION}/files?redirect=true&path="
+    local base="https://api.ngc.nvidia.com/v2/resources/org/nvidia/${resource}/${CXR_RUNTIME_SDK_VERSION}/files?redirect=true&path="
     download_ngc_file \
         "${base}${SDK_FILE}" \
         "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
@@ -144,56 +143,6 @@ install_from_public_ngc() {
 }
 
 # -----------------------------------------------------------------------------
-# Private NGC: download via curl from the private NGC resource API
-# Resource: 0566138804516934/cloudxr-dev/cloudxr-runtime-binary:${VERSION}-public
-# Requires NGC_API_KEY for Bearer-token auth.
-# Optional: CXR_RUNTIME_NGC_SUFFIX is appended to CXR_RUNTIME_SDK_VERSION (default: -public).
-# -----------------------------------------------------------------------------
-install_from_private_ngc() {
-    local NGC_ORG="0566138804516934"
-    local NGC_TEAM="cloudxr-dev"
-    local NGC_RESOURCE="cloudxr-runtime-binary"
-    local NGC_VERSION="${CXR_RUNTIME_SDK_VERSION}${CXR_RUNTIME_NGC_SUFFIX:--public}"
-    local NGC_SDK_FILE="CloudXR-external-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
-    local NGC_EXP_SDK_FILE="CloudXR-exp-external-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
-    local base="https://api.ngc.nvidia.com/v2/org/${NGC_ORG}/team/${NGC_TEAM}/resources/${NGC_RESOURCE}/versions/${NGC_VERSION}/files"
-
-    if [[ -z "${NGC_API_KEY:-}" ]]; then
-        echo -e "${RED}Error: NGC_API_KEY is not set; cannot download from private NGC${NC}"
-        return 1
-    fi
-
-    if ! command -v curl &> /dev/null; then
-        echo -e "${RED}Error: curl not found. Please install it first.${NC}"
-        return 1
-    fi
-
-    echo -e "${GREEN}=================================================${NC}"
-    echo -e "${GREEN}Downloading CloudXR Runtime SDK from private NGC${NC}"
-    echo -e "${GREEN}=================================================${NC}"
-    echo ""
-
-    mkdir -p "$CXR_DEPLOYMENT_DIR"
-
-    download_ngc_file \
-        "${base}/${NGC_SDK_FILE}" \
-        "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
-        "CloudXR Runtime SDK" \
-        "$NGC_API_KEY" || return 1
-    if [[ "${CXR_DOWNLOAD_EXP:-0}" == "1" ]]; then
-        download_ngc_file \
-            "${base}/${NGC_EXP_SDK_FILE}" \
-            "$CXR_DEPLOYMENT_DIR/$EXP_SDK_FILE" \
-            "CloudXR Experimental Runtime SDK" \
-            "$NGC_API_KEY" || return 1
-    fi
-
-    echo -e "${GREEN}✓ CloudXR Runtime SDK installed successfully${NC}"
-    echo ""
-    return 0
-}
-
-# -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
 
@@ -202,15 +151,15 @@ if install_from_local_tarball; then
     exit 0
 fi
 
-echo "Cannot install from local tarball, trying public NGC..."
-if install_from_public_ngc; then
+echo "Cannot install from local tarball, trying listed public NGC..."
+if install_from_public_ngc "cloudxr-runtime" "listed"; then
     exit 0
 fi
 
-echo "Cannot install from public NGC, trying private NGC..."
-if install_from_private_ngc; then
+echo "Cannot install from listed public NGC, trying unlisted public NGC..."
+if install_from_public_ngc "cloudxr-runtime-for-isaac-teleop" "unlisted"; then
     exit 0
 fi
 
-echo "Cannot install from private NGC, exiting..."
+echo "Cannot install from unlisted public NGC, exiting..."
 exit 1

--- a/scripts/download_cloudxr_sdk.sh
+++ b/scripts/download_cloudxr_sdk.sh
@@ -6,12 +6,12 @@
 # Downloads the CloudXR Web Client SDK if not already present using NGC.
 # The SDK is extracted to deps/cloudxr/cloudxr-web-sdk-${CXR_WEB_SDK_VERSION}/ for use by Dockerfile.web-app.
 #
-# Three ways to obtain the SDK (tried in order):
+# Two ways to obtain the SDK:
 # 1) Local tarball: place cloudxr-web-sdk-${CXR_WEB_SDK_VERSION}.tar.gz in deps/cloudxr/.
 #    The tarball must extract to the same layout as the NGC release: root must contain
 #    nvidia-cloudxr-${CXR_WEB_SDK_VERSION}.tgz (optionally inside a single top-level directory).
-# 2) Listed public NGC: nvidia/cloudxr-js.
-# 3) Unlisted public NGC: nvidia/cloudxr-js-prerelease.
+# 2) Public NGC: RC versions use nvidia/cloudxr-js-prerelease directly. Other versions
+#    try nvidia/cloudxr-js first and fall back to nvidia/cloudxr-js-prerelease.
 
 set -Eeuo pipefail
 
@@ -94,8 +94,8 @@ install_from_local_tarball() {
 }
 
 # -----------------------------------------------------------------------------
-# Public NGC: try the listed resource before the unlisted prerelease resource.
-# Both sources are anonymous and must not require NGC credentials.
+# Public NGC is anonymous. RC versions go directly to the unlisted prerelease resource;
+# non-RC versions try listed first and fall back to unlisted without credentials.
 # -----------------------------------------------------------------------------
 install_from_public_ngc() {
     local resource="$1"
@@ -155,15 +155,27 @@ if install_from_local_tarball; then
     exit 0
 fi
 
-echo "Cannot install from local tarball, trying listed public NGC..."
-if install_from_public_ngc "cloudxr-js" "listed"; then
+if [[ "$CXR_WEB_SDK_VERSION" == *-rc* ]]; then
+    NGC_RESOURCE="cloudxr-js-prerelease"
+    NGC_VISIBILITY="unlisted"
+else
+    NGC_RESOURCE="cloudxr-js"
+    NGC_VISIBILITY="listed"
+fi
+
+echo "Cannot install from local tarball, trying ${NGC_VISIBILITY} public NGC..."
+if install_from_public_ngc "$NGC_RESOURCE" "$NGC_VISIBILITY"; then
     exit 0
 fi
 
-echo "Cannot install from listed public NGC, trying unlisted public NGC..."
-if install_from_public_ngc "cloudxr-js-prerelease" "unlisted"; then
-    exit 0
+if [[ "$NGC_VISIBILITY" == "listed" ]]; then
+    NGC_RESOURCE="cloudxr-js-prerelease"
+    NGC_VISIBILITY="unlisted"
+    echo "Cannot install from listed public NGC, trying unlisted public NGC..."
+    if install_from_public_ngc "$NGC_RESOURCE" "$NGC_VISIBILITY"; then
+        exit 0
+    fi
 fi
 
-echo "Cannot install from unlisted public NGC, exiting..."
+echo "Cannot install from ${NGC_VISIBILITY} public NGC, exiting..."
 exit 1

--- a/scripts/download_cloudxr_sdk.sh
+++ b/scripts/download_cloudxr_sdk.sh
@@ -10,8 +10,8 @@
 # 1) Local tarball: place cloudxr-web-sdk-${CXR_WEB_SDK_VERSION}.tar.gz in deps/cloudxr/.
 #    The tarball must extract to the same layout as the NGC release: root must contain
 #    nvidia-cloudxr-${CXR_WEB_SDK_VERSION}.tgz (optionally inside a single top-level directory).
-# 2) Public NGC: downloads via curl from the public NGC resource API.
-# 3) Private NGC: downloads via curl from the private NGC resource API; requires NGC_API_KEY.
+# 2) Listed public NGC: nvidia/cloudxr-js.
+# 3) Unlisted public NGC: nvidia/cloudxr-js-prerelease.
 
 set -Eeuo pipefail
 
@@ -94,11 +94,13 @@ install_from_local_tarball() {
 }
 
 # -----------------------------------------------------------------------------
-# Public NGC: download via curl from the public NGC resource API
-# Resource: nvidia/cloudxr-js/${CXR_WEB_SDK_VERSION}
+# Public NGC: try the listed resource before the unlisted prerelease resource.
+# Both sources are anonymous and must not require NGC credentials.
 # -----------------------------------------------------------------------------
 install_from_public_ngc() {
-    local NGC_URL="https://api.ngc.nvidia.com/v2/resources/org/nvidia/cloudxr-js/${CXR_WEB_SDK_VERSION}/files?redirect=true&path=${SDK_FILE}"
+    local resource="$1"
+    local visibility="$2"
+    local NGC_URL="https://api.ngc.nvidia.com/v2/resources/org/nvidia/${resource}/${CXR_WEB_SDK_VERSION}/files?redirect=true&path=${SDK_FILE}"
 
     if ! command -v curl &> /dev/null; then
         echo -e "${RED}Error: curl not found. Please install it first.${NC}"
@@ -113,7 +115,7 @@ install_from_public_ngc() {
 
     mkdir -p "$CXR_DEPLOYMENT_DIR"
 
-    echo -e "${YELLOW}Downloading CloudXR Web SDK from NGC...${NC}"
+    echo -e "${YELLOW}Downloading CloudXR Web SDK from ${visibility} NGC resource...${NC}"
     if ! curl --fail --location \
         --connect-timeout 10 --max-time 120 \
         --retry 3 --retry-delay 5 \
@@ -126,52 +128,6 @@ install_from_public_ngc() {
 
     echo -e "${GREEN}✓ CloudXR Web SDK installed successfully${NC}"
     echo ""
-}
-
-# -----------------------------------------------------------------------------
-# Private NGC: download via curl from the private NGC resource API
-# Resource: 0566138804516934/cloudxr-dev/cloudxr-js:${CXR_WEB_SDK_VERSION}
-# Requires NGC_API_KEY for Bearer-token auth.
-# -----------------------------------------------------------------------------
-install_from_private_ngc() {
-    local NGC_ORG="0566138804516934"
-    local NGC_TEAM="cloudxr-dev"
-    local NGC_RESOURCE="cloudxr-js"
-    local NGC_URL="https://api.ngc.nvidia.com/v2/org/${NGC_ORG}/team/${NGC_TEAM}/resources/${NGC_RESOURCE}/versions/${CXR_WEB_SDK_VERSION}/files/${SDK_FILE}"
-
-    if [[ -z "${NGC_API_KEY:-}" ]]; then
-        echo -e "${RED}Error: NGC_API_KEY is not set; cannot download from private NGC${NC}"
-        return 1
-    fi
-
-    if ! command -v curl &> /dev/null; then
-        echo -e "${RED}Error: curl not found. Please install it first.${NC}"
-        return 1
-    fi
-
-    echo -e "${GREEN}=================================================${NC}"
-    echo -e "${GREEN}Downloading CloudXR Web SDK from private NGC${NC}"
-    echo -e "${GREEN}=================================================${NC}"
-    echo ""
-
-    mkdir -p "$CXR_DEPLOYMENT_DIR"
-
-    echo -e "${YELLOW}Downloading CloudXR Web SDK from private NGC...${NC}"
-    if ! curl --fail --location \
-        --connect-timeout 10 --max-time 120 \
-        --retry 3 --retry-delay 5 \
-        -H "Authorization: Bearer $NGC_API_KEY" \
-        -H "Content-Type: application/json" \
-        --output "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
-        "$NGC_URL"; then
-        echo -e "${RED}Error: Failed to download CloudXR Web SDK from private NGC${NC}"
-        rm -f "$CXR_DEPLOYMENT_DIR/$SDK_FILE"
-        return 1
-    fi
-
-    echo -e "${GREEN}✓ CloudXR Web SDK installed successfully${NC}"
-    echo ""
-    return 0
 }
 
 # -----------------------------------------------------------------------------
@@ -199,15 +155,15 @@ if install_from_local_tarball; then
     exit 0
 fi
 
-echo "Cannot install from local tarball, trying public NGC..."
-if install_from_public_ngc; then
+echo "Cannot install from local tarball, trying listed public NGC..."
+if install_from_public_ngc "cloudxr-js" "listed"; then
     exit 0
 fi
 
-echo "Cannot install from public NGC, trying private NGC..."
-if install_from_private_ngc; then
+echo "Cannot install from listed public NGC, trying unlisted public NGC..."
+if install_from_public_ngc "cloudxr-js-prerelease" "unlisted"; then
     exit 0
 fi
 
-echo "Cannot install from private NGC, exiting..."
+echo "Cannot install from unlisted public NGC, exiting..."
 exit 1

--- a/src/core/cloudxr/python/CMakeLists.txt
+++ b/src/core/cloudxr/python/CMakeLists.txt
@@ -52,9 +52,7 @@ if(NOT EXISTS "${CLOUDXR_SDK_PATH}" OR
     execute_process(
         COMMAND ${CMAKE_COMMAND} -E env
             "CXR_RUNTIME_SDK_VERSION=${CXR_RUNTIME_SDK_VERSION}"
-            "CXR_RUNTIME_NGC_SUFFIX=$ENV{CXR_RUNTIME_NGC_SUFFIX}"
             "CXR_DOWNLOAD_EXP=${_cloudxr_download_exp}"
-            "NGC_API_KEY=$ENV{NGC_API_KEY}"
             /bin/bash "${DOWNLOAD_SCRIPT}"
         WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
         RESULT_VARIABLE DOWNLOAD_EXIT_CODE
@@ -131,7 +129,7 @@ if(ENABLE_CLOUDXR_EXP_BUNDLE)
     if(NOT EXISTS "${CLOUDXR_SDK_EXP_PATH}")
         set(exp_error_message
             "CloudXR Experimental Runtime SDK tarball is required. Place ${CLOUDXR_SDK_EXP_FILE} in "
-            "deps/cloudxr/, or set NGC_API_KEY and update CXR_RUNTIME_SDK_VERSION to a version that publishes it.")
+            "deps/cloudxr/ or update CXR_RUNTIME_SDK_VERSION to a version that publishes it.")
         if(ENABLE_CLOUDXR_BUNDLE_CHECK)
             message(FATAL_ERROR "${exp_error_message}")
         else()


### PR DESCRIPTION
## Description

- bump the CloudXR.js SDK and client pin from `6.3.0-rc2` to `6.3.0-rc4`
- select anonymous NGC resources by version for both SDKs:
  - RC versions go directly to unlisted `nvidia/cloudxr-js-prerelease` and `nvidia/cloudxr-runtime-for-isaac-teleop`
  - non-RC versions try listed `nvidia/cloudxr-js` and `nvidia/cloudxr-runtime` first, then fall back to their unlisted resources if unavailable
- use the published standard and experimental runtime filenames for `6.3.0-rc3`
- remove the private NGC download fallback and all `NGC_API_KEY` action, workflow, and CMake plumbing

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- `SKIP=check-copyright-year pre-commit run --all-files`
- `bash -n scripts/download_cloudxr_sdk.sh scripts/download_cloudxr_runtime_sdk.sh`
- live CloudXR.js NGC smoke test: `6.3.0-rc4` went directly to the unlisted resource, downloaded `nvidia-cloudxr-6.3.0-rc4.tgz`, and the archive contains `package/build/cloudxr.js`
- verified the unlisted runtime `6.3.0-rc3` manifest contains correctly formatted standard and experimental SDK tarballs for amd64 and arm64

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding workflow and inline documentation changes
- [x] I have tested the routing behavior against NGC; no separate test fixture was added
- [x] I have signed off all commits with DCO