### PR TITLE
fix(cloudxr): generate WSS certificate in-process using cryptography package

### DIFF
--- a/src/core/cloudxr/python/wss.py
+++ b/src/core/cloudxr/python/wss.py
@@ -96,6 +96,8 @@ def cert_paths_from_dir(cert_dir: Path) -> CertPaths:
 def _generate_self_signed_cert(cert_paths: CertPaths) -> None:
     """Generate a self-signed RSA certificate and private key using the cryptography package."""
     import datetime
+    import ipaddress
+    import stat
 
     from cryptography import x509
     from cryptography.hazmat.primitives import hashes, serialization
@@ -114,16 +116,31 @@ def _generate_self_signed_cert(cert_paths: CertPaths) -> None:
         .not_valid_after(
             datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365)
         )
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [
+                    x509.DNSName("localhost"),
+                    x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+                ]
+            ),
+            critical=False,
+        )
         .sign(key, hashes.SHA256())
     )
-    cert_paths.key_file.write_bytes(
-        key.private_bytes(
-            serialization.Encoding.PEM,
-            serialization.PrivateFormat.TraditionalOpenSSL,
-            serialization.NoEncryption(),
-        )
+    key_pem = key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.TraditionalOpenSSL,
+        serialization.NoEncryption(),
     )
-    cert_paths.key_file.chmod(0o600)
+    # Write the private key with mode 0o600 from the start to avoid a world-readable
+    # window between write_bytes() and a subsequent chmod().
+    key_fd = os.open(
+        cert_paths.key_file,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        stat.S_IRUSR | stat.S_IWUSR,
+    )
+    with os.fdopen(key_fd, "wb") as f:
+        f.write(key_pem)
     cert_paths.cert_file.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
 
 
@@ -144,12 +161,18 @@ def ensure_certificate(cert_paths: CertPaths) -> None:
 
     log.info("Generating self-signed SSL certificate ...")
     cert_paths.cert_dir.mkdir(parents=True, exist_ok=True)
-    if not os.access(cert_paths.cert_dir, os.W_OK):
+    if not os.access(cert_paths.cert_dir, os.W_OK | os.X_OK):
         raise RuntimeError(
             f"Certificate directory {cert_paths.cert_dir} is not writable. "
             f"Create it manually and retry: mkdir -p {cert_paths.cert_dir}"
         )
-    _generate_self_signed_cert(cert_paths)
+    try:
+        _generate_self_signed_cert(cert_paths)
+    except PermissionError as exc:
+        raise RuntimeError(
+            f"Permission denied writing TLS certificate to {cert_paths.cert_dir}. "
+            f"Create it manually and retry: mkdir -p {cert_paths.cert_dir}"
+        ) from exc
     log.info("SSL certificate generated at %s", cert_paths.cert_file)
 
 

--- a/src/core/cloudxr/python/wss.py
+++ b/src/core/cloudxr/python/wss.py
@@ -9,7 +9,6 @@ import json
 import logging
 import os
 from urllib.parse import unquote, urlparse
-import shutil
 import ssl
 import subprocess
 import sys
@@ -94,6 +93,40 @@ def cert_paths_from_dir(cert_dir: Path) -> CertPaths:
     )
 
 
+def _generate_self_signed_cert(cert_paths: CertPaths) -> None:
+    """Generate a self-signed RSA certificate and private key using the cryptography package."""
+    import datetime
+
+    from cryptography import x509
+    from cryptography.hazmat.primitives import hashes, serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+    from cryptography.x509.oid import NameOID
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    subject = issuer = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.now(datetime.timezone.utc))
+        .not_valid_after(
+            datetime.datetime.now(datetime.timezone.utc) + datetime.timedelta(days=365)
+        )
+        .sign(key, hashes.SHA256())
+    )
+    cert_paths.key_file.write_bytes(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    cert_paths.key_file.chmod(0o600)
+    cert_paths.cert_file.write_bytes(cert.public_bytes(serialization.Encoding.PEM))
+
+
 def ensure_certificate(cert_paths: CertPaths) -> None:
     """Generate a self-signed certificate if one does not already exist."""
     cert_exists = cert_paths.cert_file.exists()
@@ -111,34 +144,12 @@ def ensure_certificate(cert_paths: CertPaths) -> None:
 
     log.info("Generating self-signed SSL certificate ...")
     cert_paths.cert_dir.mkdir(parents=True, exist_ok=True)
-    openssl_bin = shutil.which("openssl")
-    if not openssl_bin:
+    if not os.access(cert_paths.cert_dir, os.W_OK):
         raise RuntimeError(
-            "OpenSSL executable not found on PATH; cannot generate TLS certificates."
+            f"Certificate directory {cert_paths.cert_dir} is not writable. "
+            f"Create it manually and retry: mkdir -p {cert_paths.cert_dir}"
         )
-
-    subprocess.run(
-        [
-            openssl_bin,
-            "req",
-            "-x509",
-            "-newkey",
-            "rsa:2048",
-            "-keyout",
-            str(cert_paths.key_file),
-            "-out",
-            str(cert_paths.cert_file),
-            "-days",
-            "365",
-            "-nodes",
-            "-subj",
-            "/CN=localhost",
-        ],
-        check=True,
-        capture_output=True,
-    )
-
-    cert_paths.key_file.chmod(0o600)
+    _generate_self_signed_cert(cert_paths)
     log.info("SSL certificate generated at %s", cert_paths.cert_file)
 
 

--- a/src/core/python/requirements-cloudxr.txt
+++ b/src/core/python/requirements-cloudxr.txt
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+cryptography>=3.0
 websockets>=14.0


### PR DESCRIPTION
## Description

  ## Problem

  `ensure_certificate` generated the self-signed TLS certificate by shelling
  out to the system `openssl` binary. In environments where `LD_LIBRARY_PATH`
  is set by the caller (e.g. Isaac Sim, Isaac ROS, conda), the injected shared
  libraries can conflict with the system `openssl`'s own `libcrypto`, causing
  the subprocess to fail with a cryptic error that was also hidden by
  `capture_output=True + check=True`.

  Additionally, `mkdir(exist_ok=True)` silently succeeded even when the
  resulting directory wasn't writable, causing a confusing "No such file or
  directory" from openssl rather than a clear permission error.
   
  ## Fix
  
  - Replace the `openssl` subprocess with in-process cert generation using the
    `cryptography` package (added to `requirements-cloudxr.txt`). No subprocess
    means no `LD_LIBRARY_PATH` sensitivity — works identically in Docker,
    `uv run`, Isaac ROS, conda, etc. 
  - Add a writability check after `mkdir` so permission failures surface with a
    clear error message and a manual workaround command.


Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
