### PR TITLE
CloudXR.js: use Generic profile as the default route

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
+++ b/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
@@ -39,7 +39,7 @@ export interface TeleopProjectNode {
 export type TeleopProjectRegistry = Record<string, TeleopProjectNode>;
 
 /** Default teleop path when nothing is resolvable from URL hash or localStorage. */
-export const DEFAULT_TELEOP_PATH = 'sim';
+export const DEFAULT_TELEOP_PATH = 'generic';
 
 /** localStorage key that remembers the last-used teleop path across reloads. */
 const PATH_STORAGE_KEY = 'cxr.isaac.teleopPath';
@@ -76,6 +76,10 @@ export function saveStoredTeleopPath(path: string): void {
  * layer and take priority over any registry defaults.
  */
 export const TELEOP_PROJECTS: TeleopProjectRegistry = {
+  generic: {
+    label: 'Generic',
+    settings: { panelHiddenAtStart: false, headless: false },
+  },
   sim: {
     label: 'Simulation',
     settings: { panelHiddenAtStart: false, headless: false },


### PR DESCRIPTION
## Description

Add a neutral Generic teleop profile and use it when neither the URL hash nor the last saved route resolves. This prevents fresh clients with no specified use case from being switched to Simulation while preserving explicit-route and saved-route precedence.