### PR TITLE
cloudxr: redirect /client to /client/ so the bundle resolves

### DIFF
--- a/src/core/cloudxr_tests/python/pyproject.toml
+++ b/src/core/cloudxr_tests/python/pyproject.toml
@@ -12,11 +12,13 @@ dev = [
     "pytest",
     "pytest-asyncio>=1.3.0",
     "numpy",
+    "websockets>=14",
 ]
 test = [
     "pytest",
     "pytest-asyncio>=1.3.0",
     "numpy",
+    "websockets>=14",
 ]
 
 [tool.pytest.ini_options]

--- a/src/core/cloudxr_tests/python/test_service.py
+++ b/src/core/cloudxr_tests/python/test_service.py
@@ -301,8 +301,7 @@ class TestRefusalLeavesTheLiveRuntimeAlone:
 
 @contextlib.contextmanager
 def _stub_wss(run):
-    """Stand in for isaacteleop.cloudxr.wss, whose websockets dependency the
-    unit suite deliberately does not install."""
+    """Stand in for isaacteleop.cloudxr.wss so no real proxy is started."""
     name = "isaacteleop.cloudxr.wss"
     module = types.ModuleType(name)
     module.run = run

--- a/src/core/cloudxr_tests/python/test_wss_static_client.py
+++ b/src/core/cloudxr_tests/python/test_wss_static_client.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the ``--host-client`` static routes in ``wss``.
+
+Run from this directory (after ``pip install pytest``)::
+
+    pytest -q
+
+No CloudXR runtime, TLS, or ``isaacteleop`` install required — ``conftest.py`` adds
+``src/core/cloudxr/python`` to ``sys.path``.
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+from pathlib import Path
+
+import pytest
+
+from cloudxr_py_test_ns.wss import _make_http_handler
+
+
+class FakeRequest:
+    """Minimal stand-in for the websockets request passed to the HTTP handler."""
+
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.headers: dict[str, str] = {}
+
+
+@pytest.fixture
+def static_dir(tmp_path: Path) -> Path:
+    (tmp_path / "index.html").write_text('<script src="bundle.js"></script>')
+    (tmp_path / "bundle.js").write_text("// bundle")
+    return tmp_path
+
+
+async def _get(static_dir: Path, path: str):
+    handler = _make_http_handler("localhost", 49100, static_dir=static_dir)
+    return await handler(None, FakeRequest(path))
+
+
+@pytest.mark.asyncio
+async def test_client_without_trailing_slash_redirects(static_dir: Path) -> None:
+    response = await _get(static_dir, "/client")
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.headers["Location"] == "/client/"
+
+
+@pytest.mark.asyncio
+async def test_client_redirect_preserves_query(static_dir: Path) -> None:
+    response = await _get(static_dir, "/client?showVersion=1")
+    assert response.status_code == HTTPStatus.FOUND
+    assert response.headers["Location"] == "/client/?showVersion=1"
+
+
+@pytest.mark.asyncio
+async def test_client_directory_serves_index(static_dir: Path) -> None:
+    response = await _get(static_dir, "/client/")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "text/html; charset=utf-8"
+    assert b"bundle.js" in response.body
+
+
+@pytest.mark.asyncio
+async def test_bundle_resolves_under_client_prefix(static_dir: Path) -> None:
+    response = await _get(static_dir, "/client/bundle.js")
+    assert response.status_code == 200
+    assert response.headers["Content-Type"] == "application/javascript; charset=utf-8"
+
+
+@pytest.mark.asyncio
+async def test_unknown_client_asset_is_404(static_dir: Path) -> None:
+    response = await _get(static_dir, "/client/secrets.env")
+    assert response.status_code == 404

--- a/src/python/isaacteleop/cloudxr/wss.py
+++ b/src/python/isaacteleop/cloudxr/wss.py
@@ -8,6 +8,7 @@ import errno
 import json
 import logging
 import os
+from http import HTTPStatus
 from urllib.parse import unquote, urlparse
 import shutil
 import ssl
@@ -335,6 +336,18 @@ def _make_http_handler(backend_host, backend_port, hub=None, static_dir=None):
         if static_dir is not None and (
             path == "/client" or path.startswith("/client/")
         ):
+            # index.html asks for ``bundle.js`` relatively, which the browser
+            # resolves against ``/`` unless the directory URL ends in a slash.
+            # ``path`` is normalized, so the raw target decides slash presence.
+            target, _, query = raw_path.partition("?")
+            if path == "/client" and not target.endswith("/"):
+                location = "/client/" + (f"?{query}" if query else "")
+                return Response(
+                    HTTPStatus.FOUND,
+                    HTTPStatus.FOUND.phrase,
+                    Headers({"Location": location, **CORS_HEADERS}),
+                    b"",
+                )
             _MIME = {
                 "index.html": "text/html; charset=utf-8",
                 "bundle.js": "application/javascript; charset=utf-8",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Currently `https://<host>:48322/client` (no trailing slash) served `index.html`, but relative `bundle.js` then resolved to `/bundle.js` instead of `/client/bundle.js`. Redirect `/client` to `/client/` with HTTP 302 so the assets load.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- `pytest src/core/cloudxr_tests/python/test_wss_static_client.py` (5 passed)
- Manual: open `https://<host>:48322/client` and confirm redirect to `/client/` and that `bundle.js` loads

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a redirect from `/client` to `/client/`, preserving query parameters.
  * Improved static client asset handling, including index pages and prefixed bundles.
  * Unknown client assets now return a clear 404 response.

* **Tests**
  * Added coverage for redirects, query preservation, asset serving, content types, and missing assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->