### PR TITLE
ctest: sync each Python test suite's uv environment once, up front

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,6 +137,7 @@ add_subdirectory(deps)
 if(BUILD_TESTING)
     # Make sure to call this after `deps` is added so that Catch2 is available
     enable_testing()
+    include(cmake/PythonTestVenv.cmake)
 endif()
 
 # Build interfaces (headers)

--- a/cmake/PythonTestVenv.cmake
+++ b/cmake/PythonTestVenv.cmake
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ==============================================================================
+# PythonTestVenv.cmake
+# ==============================================================================
+# Prepares the uv environment a directory's Python tests share.
+#
+# Each test_*.py is its own CTest entry running `uv run` in that directory, so
+# they all drive one `.venv`. `uv run` syncs before it executes, and concurrent
+# syncs of one environment are not safe, so a setup fixture syncs it once and
+# the tests then run in parallel over a complete environment.
+#
+# `uv sync` is exact where `uv run` is not: the setup installs the union of
+# every extra the directory's tests request, and a test that asks for a subset
+# leaves the environment alone.
+#
+# Usage, from the directory that owns the environment:
+#   isaac_teleop_python_test_venv_setup(<fixture> [<uv sync args>...])
+#   isaac_teleop_python_test_venv_require(<fixture> <test> [<test>...])
+# ==============================================================================
+
+# Register the one-time `uv sync` for <fixture>. Trailing arguments go to
+# `uv sync` (e.g. --extra dev --extra gpu).
+function(isaac_teleop_python_test_venv_setup fixture)
+    add_test(
+        NAME "${fixture}_venv_setup"
+        COMMAND uv sync --python ${ISAAC_TELEOP_PYTHON_VERSION} ${ARGN}
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+    set_tests_properties("${fixture}_venv_setup" PROPERTIES FIXTURES_SETUP "${fixture}_venv")
+endfunction()
+
+# Make the named tests wait for <fixture>. CTest schedules the setup even when
+# only a dependent is selected, so `ctest -R <one-test>` still prepares it.
+function(isaac_teleop_python_test_venv_require fixture)
+    set_property(TEST ${ARGN} APPEND PROPERTY FIXTURES_REQUIRED "${fixture}_venv")
+endfunction()

--- a/examples/camera_viz/tests/CMakeLists.txt
+++ b/examples/camera_viz/tests/CMakeLists.txt
@@ -11,6 +11,8 @@ file(GLOB TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/test_*.py"
 )
 
+isaac_teleop_python_test_venv_setup(camera_viz --extra dev --extra gpu)
+
 foreach(test_file ${TEST_FILES})
     get_filename_component(test_name "${test_file}" NAME_WE)
     add_test(
@@ -23,4 +25,5 @@ foreach(test_file ${TEST_FILES})
         ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
         LABELS "camera_viz"
     )
+    isaac_teleop_python_test_venv_require(camera_viz "camera_viz_${test_name}")
 endforeach()

--- a/examples/mujoco_xr/tests/CMakeLists.txt
+++ b/examples/mujoco_xr/tests/CMakeLists.txt
@@ -16,6 +16,8 @@ file(GLOB TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/test_*.py"
 )
 
+isaac_teleop_python_test_venv_setup(mujoco_xr --extra dev)
+
 foreach(test_file ${TEST_FILES})
     get_filename_component(test_name "${test_file}" NAME_WE)
     add_test(
@@ -35,4 +37,5 @@ foreach(test_file ${TEST_FILES})
         ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
         LABELS "mujoco_xr"
     )
+    isaac_teleop_python_test_venv_require(mujoco_xr "mujoco_xr_${test_name}")
 endforeach()

--- a/src/core/cloudxr_tests/python/CMakeLists.txt
+++ b/src/core/cloudxr_tests/python/CMakeLists.txt
@@ -14,6 +14,8 @@ file(GLOB TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/test_*.py"
 )
 
+isaac_teleop_python_test_venv_setup(cloudxr --extra dev)
+
 # Add each test file as a separate CTest test
 foreach(test_file ${TEST_FILES})
     # Get test name from filename (remove .py and path)
@@ -30,4 +32,6 @@ foreach(test_file ${TEST_FILES})
     set_tests_properties("cloudxr_${test_name}" PROPERTIES
         ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
     )
+
+    isaac_teleop_python_test_venv_require(cloudxr "cloudxr_${test_name}")
 endforeach()

--- a/src/core/retargeting_engine_tests/python/CMakeLists.txt
+++ b/src/core/retargeting_engine_tests/python/CMakeLists.txt
@@ -34,6 +34,8 @@ if(TEST_WUJI_RETARGETER)
     set(WUJI_EXTRA_ARGS --extra wuji)
 endif()
 
+isaac_teleop_python_test_venv_setup(retargeting --extra dev ${GROUNDING_EXTRA_ARGS} ${WUJI_EXTRA_ARGS})
+
 # Add each test file as a separate CTest test
 foreach(test_file ${TEST_FILES})
     # Get test name from filename (remove .py and path)
@@ -58,6 +60,8 @@ foreach(test_file ${TEST_FILES})
     set_tests_properties("retargeting_${test_name}" PROPERTIES
         ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
     )
+
+    isaac_teleop_python_test_venv_require(retargeting "retargeting_${test_name}")
 endforeach()
 
 # Add mypy type checking test
@@ -73,3 +77,5 @@ add_test(
 set_tests_properties("retargeting_mypy_type_check" PROPERTIES
     ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
 )
+
+isaac_teleop_python_test_venv_require(retargeting "retargeting_mypy_type_check")

--- a/src/core/rig_tests/python/CMakeLists.txt
+++ b/src/core/rig_tests/python/CMakeLists.txt
@@ -17,6 +17,8 @@ file(GLOB TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/test_*.py"
 )
 
+isaac_teleop_python_test_venv_setup(rig --extra dev)
+
 # Add each test file as a separate CTest test
 foreach(test_file ${TEST_FILES})
     # Get test name from filename (remove .py and path)
@@ -29,4 +31,6 @@ foreach(test_file ${TEST_FILES})
         COMMAND uv run --python ${ISAAC_TELEOP_PYTHON_VERSION} --extra dev pytest -v --tb=short "${test_file}"
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
+
+    isaac_teleop_python_test_venv_require(rig "rig_${test_name}")
 endforeach()

--- a/src/core/schema_tests/python/CMakeLists.txt
+++ b/src/core/schema_tests/python/CMakeLists.txt
@@ -14,6 +14,8 @@ file(GLOB TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/test_*.py"
 )
 
+isaac_teleop_python_test_venv_setup(schema --extra dev)
+
 # Add each test file as a separate CTest test
 foreach(test_file ${TEST_FILES})
     # Get test name from filename (remove .py and path)
@@ -30,4 +32,6 @@ foreach(test_file ${TEST_FILES})
     set_tests_properties("schema_${test_name}" PROPERTIES
         ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
     )
+
+    isaac_teleop_python_test_venv_require(schema "schema_${test_name}")
 endforeach()

--- a/src/core/teleop_session_manager_tests/python/CMakeLists.txt
+++ b/src/core/teleop_session_manager_tests/python/CMakeLists.txt
@@ -14,6 +14,8 @@ file(GLOB TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/test_*.py"
 )
 
+isaac_teleop_python_test_venv_setup(teleop_session_manager --extra dev)
+
 # Add each test file as a separate CTest test
 foreach(test_file ${TEST_FILES})
     # Get test name from filename (remove .py and path)
@@ -30,4 +32,6 @@ foreach(test_file ${TEST_FILES})
     set_tests_properties("teleop_session_manager_${test_name}" PROPERTIES
         ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
     )
+
+    isaac_teleop_python_test_venv_require(teleop_session_manager "teleop_session_manager_${test_name}")
 endforeach()

--- a/src/viz/python_tests/CMakeLists.txt
+++ b/src/viz/python_tests/CMakeLists.txt
@@ -13,6 +13,8 @@ file(GLOB TEST_FILES
     "${CMAKE_CURRENT_SOURCE_DIR}/test_*.py"
 )
 
+isaac_teleop_python_test_venv_setup(viz_python --extra dev)
+
 foreach(test_file ${TEST_FILES})
     get_filename_component(test_name "${test_file}" NAME_WE)
     add_test(
@@ -25,4 +27,5 @@ foreach(test_file ${TEST_FILES})
         ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>"
         LABELS "viz_python"
     )
+    isaac_teleop_python_test_venv_require(viz_python "viz_python_${test_name}")
 endforeach()


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Each `test_*.py` under a Python test directory is its own CTest entry that
runs `uv run` in that directory, so every entry shares one `.venv`. Under
`ctest --parallel`, concurrent syncs of that environment are not safe.

Add `cmake/PythonTestVenv.cmake` and wire a CTest `FIXTURES_SETUP` into each
Python test suite so one `uv sync` runs first. The suite's tests then run in
parallel over a complete environment. The setup installs the union of extras
the directory's tests can request; a test that asks for a subset leaves the
environment alone.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- Configured a mini project that includes all eight Python test directories and
  confirmed each registers a `*_venv_setup` fixture, every suite entry
  (including `retargeting_mypy_type_check`) requires it, and no
  `RESOURCE_LOCK` remains.
- Confirmed `ctest -R '^cloudxr_test_background$'` and
  `ctest -R '^retargeting_mypy_type_check$'` each auto-include only their
  suite's setup.
- Verified on uv 0.9.28 that a union `uv sync` followed by concurrent subset
  `uv run` calls neither installs nor removes packages.
- `SKIP=check-copyright-year pre-commit run --files` on the touched paths.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)