### PR TITLE
docs: document live_full_body.py in the PICO full-body workflow

### DIFF
--- a/docs/source/device/body_tracking.rst
+++ b/docs/source/device/body_tracking.rst
@@ -225,10 +225,11 @@ Troubleshooting
 Recording and Replay
 --------------------
 
-Full body sessions can be captured to MCAP and replayed offline through the
-same retargeting pipeline — no headset required during replay. See
-:doc:`../references/mcap_record_replay` for the recording / replay API and
-the ``record_full_body.py`` / ``replay_full_body.py`` example.
+Full body sessions can be previewed live, captured to MCAP, and replayed
+offline through the same retargeting pipeline — no headset required during
+replay. See :doc:`../references/mcap_record_replay` for the API and the
+``live_full_body.py`` / ``record_full_body.py`` / ``replay_full_body.py``
+example.
 
 Recording is also available directly from C++: pass a ``McapRecordingConfig``
 to ``DeviceIOSession::run()`` with the tracker mapped to the ``full_body``

--- a/docs/source/device/trackers.rst
+++ b/docs/source/device/trackers.rst
@@ -209,6 +209,7 @@ reads the PICO ``XR_BD_body_tracking`` extension directly.
 
   - :code-file:`examples/schemaio/full_body_printer.cpp`
   - :code-file:`examples/mcap_record_replay/cpp/record_full_body.cpp`
+  - :code-file:`examples/mcap_record_replay/python/live_full_body.py`
   - :code-file:`examples/mcap_record_replay/python/record_full_body.py`
   - :code-file:`examples/mcap_record_replay/python/replay_full_body.py`
 

--- a/docs/source/references/mcap_record_replay.rst
+++ b/docs/source/references/mcap_record_replay.rst
@@ -121,6 +121,8 @@ A complete record / replay example lives at
 - ``record_controller.py`` / ``replay_controller.py`` — records the
   ``controllers`` channel and replays it in viser, including a per-controller
   HUD (thumbstick, trigger, squeeze, button states).
+- ``live_full_body.py`` — live viser preview of the full-body skeleton from
+  an active OpenXR session.
 - ``record_full_body.py`` / ``replay_full_body.py`` — records the
   ``full_body`` + ``controllers`` channels and replays the body skeleton in
   viser.
@@ -142,6 +144,20 @@ A C++ recorder lives at ``examples/mcap_record_replay/cpp/``:
   same channel base name as ``FullBodySource``, so the resulting file replays
   with ``replay_full_body.py``. ``python -m isaacteleop.rig rigs/full_body.yaml``
   runs it together with the full-body printer (see :ref:`rig-launcher`).
+
+Live preview
+^^^^^^^^^^^^
+
+From the example directory:
+
+.. code-block:: bash
+
+   cd examples/mcap_record_replay/python
+   uv sync
+   uv run python live_full_body.py --accept-eula
+   uv run python live_full_body.py --port 8090 --accept-eula  # change viser port
+
+Open the printed URL (default ``http://localhost:8080``) in a browser.
 
 Recording
 ^^^^^^^^^
@@ -189,6 +205,8 @@ left (green) and right (blue) hand skeletons update each frame.
 The ``record_controller.py`` / ``replay_controller.py`` and
 ``record_full_body.py`` / ``replay_full_body.py`` pairs use the same CLI
 (positional MCAP path, ``--host``, ``--port``, ``--loop``).
+``live_full_body.py`` accepts ``--host``, ``--port``, and the CloudXR launcher
+flags (including ``--accept-eula``).
 
 API Reference
 -------------


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Document ``live_full_body.py`` in the PICO full-body workflow so the Body
Tracking and MCAP guides cover live preview, then record, then replay.

- Body Tracking: name ``live_full_body.py`` alongside record/replay.
- MCAP Recording and Replay: list the script, add a Live preview section
  before Recording, and note its CLI flags.
- Trackers: add the script to the FullBodyTracker examples list.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- Checked the edits against the existing record/replay doc style and the
  ``live_full_body.py`` docstring / CLI.
- `SKIP=check-copyright-year pre-commit run --files` on the three touched
  rst files.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated recording and replay guidance to include live full-body session previews.
  * Added the live full-body tracking example to the relevant example lists.
  * Documented browser preview usage, the default URL, configurable port, and supported command-line options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->