### PR TITLE
Fixed camera_viz head lock mode bug

### DIFF
--- a/examples/camera_viz/placements/lock_modes.py
+++ b/examples/camera_viz/placements/lock_modes.py
@@ -142,7 +142,7 @@ class HeadLocked(PlacementStrategy):
             head_pos[1] + forward[1] * d + right[1] * ox + up[1] * oy,
             head_pos[2] + forward[2] * d + right[2] * ox + up[2] * oy,
         )
-        orientation = quat_mul(head_orientation, _ROT_Y_180)
+        orientation = head_orientation
         # Anchor = the head itself (plus the configured offsets, already
         # baked into ``position``): pull the plane back by ``distance``.
         # Orientation is the UNflipped head pose so the anchor's local −z


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

The orientation of head locked displays is reversed, causing them not to be visible. This PR addresses this by removing the 180 degree rotation that is applied to the display's orientation.

Fixes #952

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing
Tested with `config/synthetic_xr_3up.yaml` on a Jetson Thor with a Pico 4U.

## Checklist

- [X] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [X] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [X] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

Note: `ruff check` did give errors but these are not related to my changes, so I am leaving them untouched. I don't feel this small changes justifies the need for tests or documentation update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the orientation of head-locked camera visuals to align directly with the viewer’s head orientation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->