### PR TITLE
chore(scripts): Add helper script to run with local version of IsaacTeleop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,15 @@ only point here — edit the rules in the doc, not the shims.
   must keep `[ ... ]`. Check the shebang (and, for sourced files, who sources
   them) first.
 
+## Examples / `run_example.sh`
+
+- `scripts/run_example.sh` syncs against the **install-tree** example
+  (`install/examples/...`), not `examples/`. Dependency extras such as
+  `isaacteleop[cloudxr]` only take effect once `install_python_example`
+  regenerates that pyproject (configure-time; see
+  `cmake/InstallPythonExample.cmake`). Editing the source pyproject alone is
+  not enough until cmake reconfigures and reinstalls.
+
 ## Comments and docstrings — say it once, briefly
 
 Comments earn their place by recording what the code cannot: a constraint, a

--- a/scripts/run_example.sh
+++ b/scripts/run_example.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Developer helper for people changing Isaac Teleop — not for end users.
+#
+# When you edit the tree and re-run an install-tree example, uv often keeps a
+# cached isaacteleop==X.Y+local wheel, so you silently exercise yesterday's
+# build. This script always rebuilds, installs, force-reinstalls that package
+# into the example venv, then runs the script so you get the right bits.
+#
+# End users should follow the docs / released wheels, not this script.
+#
+# Usage:
+#   ./scripts/run_example.sh <example_dir> <script.py> [script args...]
+#
+# <example_dir> may be under install/ or examples/ (the latter is mapped to
+# install/examples/... so uv uses the installed pyproject + find-links wheels).
+#
+# Examples:
+#   ./scripts/run_example.sh examples/retargeting/python \
+#       example_retargeters.py --accept-eula
+#   ./scripts/run_example.sh examples/deviceio_live_view/python \
+#       live_deviceio.py
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-${REPO_ROOT}/build}"
+
+usage() {
+    cat <<'EOF' >&2
+Developer helper for people changing Isaac Teleop — not for end users.
+
+When you edit the tree and re-run an install-tree example, uv often keeps a
+cached isaacteleop==X.Y+local wheel, so you silently exercise yesterday's
+build. This script always rebuilds, installs, force-reinstalls that package
+into the example venv, then runs the script so you get the right bits.
+
+End users should follow the docs / released wheels, not this script.
+
+Usage:
+  ./scripts/run_example.sh <example_dir> <script.py> [script args...]
+
+<example_dir> may be under install/ or examples/ (the latter is mapped to
+install/examples/... so uv uses the installed pyproject + find-links wheels).
+
+Examples:
+  ./scripts/run_example.sh install/examples/latency_probe/python \
+      latency_probe_example.py --accept-eula
+  ./scripts/run_example.sh examples/latency_probe/python \
+      latency_probe_example.py --no-launch-cloudxr-runtime
+EOF
+    exit "${1:-0}"
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+    usage 0
+fi
+if [[ $# -lt 2 ]]; then
+    usage 1
+fi
+
+EXAMPLE_ARG="$1"
+SCRIPT_NAME="$2"
+shift 2
+
+if [[ "${EXAMPLE_ARG}" != /* ]]; then
+    EXAMPLE_ARG="${REPO_ROOT}/${EXAMPLE_ARG}"
+fi
+# Canonicalize only when the path already exists (source-tree or prior install).
+# install/examples/... may be absent until cmake --install below.
+if [[ -d "${EXAMPLE_ARG}" ]]; then
+    EXAMPLE_ARG="$(cd "${EXAMPLE_ARG}" && pwd)"
+fi
+
+# Prefer the install-tree copy so find-links points at install/wheels.
+if [[ "${EXAMPLE_ARG}" == "${REPO_ROOT}/examples/"* ]]; then
+    REL_FROM_EXAMPLES="${EXAMPLE_ARG#"${REPO_ROOT}/examples/"}"
+    EXAMPLE_DIR="${REPO_ROOT}/install/examples/${REL_FROM_EXAMPLES}"
+elif [[ "${EXAMPLE_ARG}" == "${REPO_ROOT}/install/examples/"* ]]; then
+    EXAMPLE_DIR="${EXAMPLE_ARG}"
+else
+    EXAMPLE_DIR="${EXAMPLE_ARG}"
+fi
+
+if [[ ! -d "${BUILD_DIR}" ]]; then
+    echo "error: build dir not found: ${BUILD_DIR}" >&2
+    echo "Configure first, e.g. cmake -B build ..." >&2
+    exit 1
+fi
+
+cd "${REPO_ROOT}"
+
+echo "==> cmake --build ${BUILD_DIR}"
+cmake --build "${BUILD_DIR}"
+
+echo "==> cmake --install ${BUILD_DIR}"
+cmake --install "${BUILD_DIR}"
+
+EXAMPLE_DIR="$(cd "${EXAMPLE_DIR}" && pwd)"
+
+if [[ ! -f "${EXAMPLE_DIR}/pyproject.toml" ]]; then
+    echo "error: no pyproject.toml in example dir: ${EXAMPLE_DIR}" >&2
+    exit 1
+fi
+if [[ ! -f "${EXAMPLE_DIR}/${SCRIPT_NAME}" ]]; then
+    echo "error: script not found: ${EXAMPLE_DIR}/${SCRIPT_NAME}" >&2
+    exit 1
+fi
+
+echo "==> uv sync --reinstall-package isaacteleop (${EXAMPLE_DIR})"
+uv sync --directory "${EXAMPLE_DIR}" --reinstall-package isaacteleop
+
+echo "==> uv run ${SCRIPT_NAME} $*"
+exec uv run --directory "${EXAMPLE_DIR}" "${SCRIPT_NAME}" "$@"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

I kept running the wrong version, of IsaacTeleop and things keeps changing so I would like to have definitive way to run a local version of IsaacTeleop.

Fixes #(issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

Ran the script and it worked.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a helper script for building, installing, and running Isaac Teleop examples in their associated environments.
  * Supports usage guidance, example path mapping, validation of required files and directories, argument forwarding, and clear failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->