### PR TITLE
fix(cloudxr): Add NoopContext and restore --no-launch-cloudxr-runtime

### DIFF
--- a/docs/source/references/cloudxr.rst
+++ b/docs/source/references/cloudxr.rst
@@ -192,6 +192,21 @@ whatever runtime is serving, so with a service running they use it:
 The example leaves the service running when it exits, so the headset stays
 connected and the next run reattaches to the same session.
 
+Use a system OpenXR runtime (no CloudXR attach)
+-----------------------------------------------
+
+Examples that call :meth:`~isaacteleop.cloudxr.CloudXRLauncher.add_launcher_arguments`
+accept ``--no-launch-cloudxr-runtime``. That returns a :class:`~isaacteleop.cloudxr.NoopContext`:
+the process does not start or attach to CloudXR and leaves ``XR_RUNTIME_JSON`` and
+related environment variables unchanged. Use this when another runtime is already
+configured (for example Monado) or when a host singleton must not be duplicated
+(see ``examples/mujoco_xr/README.md`` and ``--no-launch-cloudxr-runtime`` there).
+
+.. code-block:: bash
+
+   export XR_RUNTIME_JSON=/path/to/your/openxr.json
+   python examples/latency_probe/python/latency_probe_example.py --no-launch-cloudxr-runtime
+
 Run the service in a container or CI
 ------------------------------------
 

--- a/examples/deviceio_live_view/python/live_deviceio.py
+++ b/examples/deviceio_live_view/python/live_deviceio.py
@@ -54,7 +54,8 @@ def main(argv: list[str]) -> int:
     )
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+        if launcher.owns_runtime:
+            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/live_controller.py
+++ b/examples/mcap_record_replay/python/live_controller.py
@@ -56,7 +56,8 @@ def main(argv: list[str]) -> int:
     )
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+        if launcher.owns_runtime:
+            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/live_full_body.py
+++ b/examples/mcap_record_replay/python/live_full_body.py
@@ -52,7 +52,8 @@ def main(argv: list[str]) -> int:
     )
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+        if launcher.owns_runtime:
+            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/live_hand.py
+++ b/examples/mcap_record_replay/python/live_hand.py
@@ -50,7 +50,8 @@ def main(argv: list[str]) -> int:
     )
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+        if launcher.owns_runtime:
+            print(f"[live] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
         print("[live] waiting for headset connection… (Ctrl+C to stop)")
 
         with TeleopSession(config) as session:

--- a/examples/mcap_record_replay/python/record_controller.py
+++ b/examples/mcap_record_replay/python/record_controller.py
@@ -59,7 +59,10 @@ def main(argv: list[str]) -> int:
     )
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        print(f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+        if launcher.owns_runtime:
+            print(
+                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
+            )
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:

--- a/examples/mcap_record_replay/python/record_full_body.py
+++ b/examples/mcap_record_replay/python/record_full_body.py
@@ -61,7 +61,10 @@ def main(argv: list[str]) -> int:
     )
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        print(f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+        if launcher.owns_runtime:
+            print(
+                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
+            )
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:

--- a/examples/mcap_record_replay/python/record_hand.py
+++ b/examples/mcap_record_replay/python/record_hand.py
@@ -58,7 +58,10 @@ def main(argv: list[str]) -> int:
     )
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        print(f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+        if launcher.owns_runtime:
+            print(
+                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
+            )
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < duration_s:

--- a/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/app.py
+++ b/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/app.py
@@ -575,7 +575,7 @@ def main(argv: list[str]) -> int:
         )
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        if launcher is not None:
+        if launcher.owns_runtime:
             LOG.info("CloudXR runtime started (WSS log: %s)", launcher.wss_log_path)
         try:
             return run()

--- a/examples/noitom/record_noitom_full_body.py
+++ b/examples/noitom/record_noitom_full_body.py
@@ -124,7 +124,10 @@ def main(argv: list[str]) -> int:
     print(f"[record] collection_id={args.collection_id}")
 
     with CloudXRLauncher.launch_context(args) as launcher:
-        print(f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})")
+        if launcher.owns_runtime:
+            print(
+                f"[record] CloudXR runtime started (WSS log: {launcher.wss_log_path})"
+            )
         with TeleopSession(config) as session:
             start = time.time()
             while time.time() - start < args.duration:

--- a/src/core/cloudxr_tests/python/test_launcher.py
+++ b/src/core/cloudxr_tests/python/test_launcher.py
@@ -13,7 +13,11 @@ from unittest.mock import patch
 import pytest
 
 from conftest import mock_service_deps
-from isaacteleop.cloudxr.launcher import DEFAULT_DEVICE_PROFILE, CloudXRLauncher
+from isaacteleop.cloudxr.launcher import (
+    DEFAULT_DEVICE_PROFILE,
+    CloudXRLauncher,
+    NoopContext,
+)
 
 _windows_skip = pytest.mark.skipif(
     sys.platform == "win32",
@@ -358,7 +362,7 @@ class TestLaunchArgumentHelpers:
         args = parser.parse_args([])
         assert args.cloudxr_env_config is None
         assert args.accept_eula is False
-        assert args.launch_cloudxr_runtime is None
+        assert args.launch_cloudxr_runtime is True
         assert args.launch_wss_proxy is None
 
     def test_add_cloudxr_device_profile_argument_default(self) -> None:
@@ -373,12 +377,11 @@ class TestLaunchArgumentHelpers:
         args = parser.parse_args(["--cloudxr-device-profile", "AppleVisionPro"])
         assert args.cloudxr_device_profile == "AppleVisionPro"
 
-    def test_add_launch_cloudxr_runtime_argument_defaults_to_unset(self) -> None:
-        """None distinguishes "not passed" from "passed", so only the latter warns."""
+    def test_add_launch_cloudxr_runtime_argument_defaults_to_true(self) -> None:
         parser = argparse.ArgumentParser()
         CloudXRLauncher.add_launch_cloudxr_runtime_argument(parser)
         args = parser.parse_args([])
-        assert args.launch_cloudxr_runtime is None
+        assert args.launch_cloudxr_runtime is True
 
     def test_add_launch_cloudxr_runtime_argument_no_launch(self) -> None:
         parser = argparse.ArgumentParser()
@@ -386,19 +389,50 @@ class TestLaunchArgumentHelpers:
         args = parser.parse_args(["--no-launch-cloudxr-runtime"])
         assert args.launch_cloudxr_runtime is False
 
-    def test_no_launch_cloudxr_runtime_is_a_deprecated_noop(self, tmp_path) -> None:
-        """It used to skip the runtime entirely; a live one is now always used."""
-        install = _env_file(tmp_path, XR_RUNTIME_JSON="/x/openxr.json")
+    def test_no_launch_cloudxr_runtime_returns_noop_context(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        install = _env_file(tmp_path, XR_RUNTIME_JSON="/cloudxr/openxr.json")
+        monkeypatch.setenv("XR_RUNTIME_JSON", "/system/openxr.json")
         args = argparse.Namespace(
             launch_cloudxr_runtime=False,
             cloudxr_install_dir=install,
             cloudxr_device_profile="Quest3",
         )
         with _live():
-            with pytest.warns(DeprecationWarning, match="no-launch-cloudxr-runtime"):
-                with CloudXRLauncher.launch_context(args) as launcher:
-                    assert launcher is not None
-                    assert launcher.owns_runtime is False
+            with CloudXRLauncher.launch_context(args) as launcher:
+                assert isinstance(launcher, NoopContext)
+                assert not isinstance(launcher, CloudXRLauncher)
+                assert launcher.owns_runtime is False
+                assert launcher.wss_log_path is None
+                launcher.stop()
+                launcher.health_check()
+        assert os.environ["XR_RUNTIME_JSON"] == "/system/openxr.json"
+
+    def test_no_launch_warns_when_launcher_options_ignored(
+        self, tmp_path, caplog
+    ) -> None:
+        install = _env_file(tmp_path, XR_RUNTIME_JSON="/cloudxr/openxr.json")
+        args = argparse.Namespace(
+            launch_cloudxr_runtime=False,
+            cloudxr_install_dir=install,
+            cloudxr_device_profile="Quest3",
+        )
+        with caplog.at_level(logging.WARNING, logger="isaacteleop.cloudxr.launcher"):
+            with CloudXRLauncher.launch_context(
+                args,
+                run_embedded=True,
+                setup_oob=True,
+                usb_local=True,
+                host_client=True,
+            ) as launcher:
+                assert isinstance(launcher, NoopContext)
+
+        assert "ignoring CloudXR launcher options" in caplog.text
+        assert "run_embedded" in caplog.text
+        assert "setup_oob" in caplog.text
+        assert "usb_local" in caplog.text
+        assert "host_client" in caplog.text
 
     @_windows_skip
     def test_launch_context_attaches_to_a_running_service(self, tmp_path) -> None:

--- a/src/python/isaacteleop/cloudxr/__init__.py
+++ b/src/python/isaacteleop/cloudxr/__init__.py
@@ -3,7 +3,7 @@
 
 """CloudXR integration for isaacteleop."""
 
-from .launcher import CloudXRLauncher
+from .launcher import CloudXRLauncher, NoopContext
 from .service import CloudXRService
 
-__all__ = ["CloudXRLauncher", "CloudXRService"]
+__all__ = ["CloudXRLauncher", "CloudXRService", "NoopContext"]

--- a/src/python/isaacteleop/cloudxr/launcher.py
+++ b/src/python/isaacteleop/cloudxr/launcher.py
@@ -95,6 +95,34 @@ def _countdown(remaining: float, *, dots: int, redraw: bool = False) -> None:
     print(f"\r\033[K{line}" if redraw else line, end="", file=sys.stderr, flush=True)
 
 
+class NoopContext:
+    """Skip CloudXR start/attach; leave the process OpenXR environment alone.
+
+    Duck-typed subset of :class:`CloudXRLauncher` for ``with`` blocks:
+    ``owns_runtime``, ``wss_log_path``, ``stop``, ``health_check``.
+    """
+
+    @property
+    def owns_runtime(self) -> bool:
+        return False
+
+    @property
+    def wss_log_path(self) -> Path | None:
+        return None
+
+    def stop(self) -> None:
+        pass
+
+    def health_check(self) -> None:
+        pass
+
+    def __enter__(self) -> NoopContext:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        pass
+
+
 class CloudXRLauncher:
     """Attaches to the CloudXR runtime and WSS proxy a service is running.
 
@@ -418,36 +446,25 @@ class CloudXRLauncher:
             help="CloudXR install directory (default: ~/.cloudxr)",
         )
 
-    # TODO(1.7): drop --launch-cloudxr-runtime and this helper.
     @staticmethod
     def add_launch_cloudxr_runtime_argument(parser: argparse.ArgumentParser) -> None:
-        """Register the deprecated no-op ``--launch-cloudxr-runtime`` on ``parser``.
+        """Register ``--launch-cloudxr-runtime`` on ``parser``.
 
-        Defaults to ``None`` so an explicit flag is distinguishable from an
-        absent one and only the former warns.
+        Uses :class:`argparse.BooleanOptionalAction`, so callers may pass
+        ``--no-launch-cloudxr-runtime`` to use an already-configured OpenXR
+        runtime (system or sourced env) without attaching to or starting CloudXR.
         """
         parser.add_argument(
             "--launch-cloudxr-runtime",
             action=argparse.BooleanOptionalAction,
-            default=None,
+            default=True,
             help=(
-                "Deprecated no-op, removed in 1.7: a running runtime is always "
-                "attached to, and one is started only when none is serving the "
-                "install dir."
+                "Attach to or start the CloudXR runtime before running "
+                "(default: true). Pass --no-launch-cloudxr-runtime to use the "
+                "OpenXR runtime already configured in this process "
+                "(e.g. XR_RUNTIME_JSON for a system runtime)."
             ),
         )
-
-    # TODO(1.7): drop this helper with the flag.
-    @staticmethod
-    def _warn_launch_runtime_deprecated() -> None:
-        """Announce that the ``--launch-cloudxr-runtime`` no-op is on its way out."""
-        message = (
-            "--no-launch-cloudxr-runtime is deprecated and does nothing; a "
-            "running runtime is attached to automatically.  It is removed in "
-            "Isaac Teleop 1.7."
-        )
-        warnings.warn(message, DeprecationWarning, stacklevel=3)
-        logger.warning(message)
 
     @staticmethod
     def add_cloudxr_device_profile_argument(parser: argparse.ArgumentParser) -> None:
@@ -585,8 +602,11 @@ class CloudXRLauncher:
         host_client: bool = False,
         run_embedded: bool = False,
         start_wss_proxy: bool | None = None,
-    ) -> CloudXRLauncher:
-        """Build a :class:`CloudXRLauncher` from parsed arguments.
+    ) -> CloudXRLauncher | NoopContext:
+        """Build a launcher context from parsed arguments.
+
+        Returns :class:`NoopContext` when ``args.launch_cloudxr_runtime`` is
+        false so callers can always ``with CloudXRLauncher.launch_context(args):``.
 
         ``install_dir``, ``env_config``, ``device_profile``, and ``accept_eula``
         default to the values registered by :meth:`add_launcher_arguments`
@@ -601,8 +621,23 @@ class CloudXRLauncher:
             or getattr(args, "launch_wss_proxy", None) is not None
         ):
             CloudXRLauncher._warn_start_wss_proxy_deprecated()
-        if getattr(args, "launch_cloudxr_runtime", None) is not None:
-            CloudXRLauncher._warn_launch_runtime_deprecated()
+        if not getattr(args, "launch_cloudxr_runtime", True):
+            ignored: list[str] = []
+            if run_embedded:
+                ignored.append("run_embedded")
+            if setup_oob:
+                ignored.append("setup_oob")
+            if usb_local:
+                ignored.append("usb_local")
+            if host_client:
+                ignored.append("host_client")
+            if ignored:
+                logger.warning(
+                    "--no-launch-cloudxr-runtime: ignoring CloudXR launcher "
+                    "options %s (no runtime is started or attached).",
+                    ", ".join(ignored),
+                )
+            return NoopContext()
         return CloudXRLauncher(
             install_dir=CloudXRLauncher._resolve_install_dir(args, install_dir),
             env_config=CloudXRLauncher._resolve_env_config(args, env_config),


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->
I need to have a way to run a development version of the runtime easily, add back `--no-launch-cloudxr-runtime`.

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running examples with an existing OpenXR runtime without launching CloudXR.
  - Added the `--no-launch-cloudxr-runtime` option, preserving existing runtime settings.
  - Added a no-op context for externally managed runtimes.

- **Bug Fixes**
  - Startup messages now appear only when CloudXR launches the runtime.
  - Warnings clarify when runtime-specific options are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->