### PR TITLE
chore: Refactor out starting plugins into it's own function

### DIFF
--- a/src/python/isaacteleop/teleop_session_manager/teleop_session.py
+++ b/src/python/isaacteleop/teleop_session_manager/teleop_session.py
@@ -1055,33 +1055,7 @@ class TeleopSession:
             )
 
         # Initialize plugins (if any)
-        if self.config.plugins:
-            for plugin_config in self.config.plugins:
-                if not plugin_config.enabled:
-                    continue
-
-                # Validate search paths
-                valid_paths = [p for p in plugin_config.search_paths if p.exists()]
-                if not valid_paths:
-                    continue
-
-                # Create plugin manager
-                manager = pm.PluginManager([str(p) for p in valid_paths])
-                self.plugin_managers.append(manager)
-
-                # Check if plugin exists
-                plugins = manager.get_plugin_names()
-                if plugin_config.plugin_name not in plugins:
-                    continue
-
-                # Start plugin and add to exit stack
-                context = manager.start(
-                    plugin_config.plugin_name,
-                    plugin_config.plugin_root_id,
-                    plugin_config.plugin_args,
-                )
-                stack.enter_context(context)
-                self.plugin_contexts.append(context)
+        self._start_configured_plugins(stack)
 
         # Initialize runtime state
         self.frame_count = 0
@@ -1091,6 +1065,34 @@ class TeleopSession:
         self._last_execution_state = None
         self._async_runner = None
         self._active_retargeting_execution_mode = self.config.retargeting_execution.mode
+
+    def _start_configured_plugins(self, stack: ExitStack) -> None:
+        """Start ``config.plugins`` and register them on ``stack`` for cleanup."""
+        if not self.config.plugins:
+            return
+
+        for plugin_config in self.config.plugins:
+            if not plugin_config.enabled:
+                continue
+
+            valid_paths = [p for p in plugin_config.search_paths if p.exists()]
+            if not valid_paths:
+                continue
+
+            manager = pm.PluginManager([str(p) for p in valid_paths])
+            self.plugin_managers.append(manager)
+
+            plugins = manager.get_plugin_names()
+            if plugin_config.plugin_name not in plugins:
+                continue
+
+            context = manager.start(
+                plugin_config.plugin_name,
+                plugin_config.plugin_root_id,
+                plugin_config.plugin_args,
+            )
+            stack.enter_context(context)
+            self.plugin_contexts.append(context)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         """Exit the context - cleanup resources."""


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Did this when trying to debug other things, thought it be a small improvement.

Fixes #(issue)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal plugin initialization flow without changing user-visible behavior.
  * Plugin discovery, startup, registration, and cleanup continue to work as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->