### PR TITLE
fix(cmake): reconfigure when example pyproject.toml changes

### DIFF
--- a/cmake/InstallPythonExample.cmake
+++ b/cmake/InstallPythonExample.cmake
@@ -8,8 +8,12 @@
 #
 # Reads the source pyproject.toml and appends a [tool.uv] block only to the
 # installed copy so that `uv run` works out of the box in the install tree. On the
-# way it pins isaacteleop to the version this build produced and drops any
-# [tool.uv.sources], so the installed example resolves the wheel next to it.
+# way it pins isaacteleop to the version this build produced (preserving extras
+# like [cloudxr]) and drops any [tool.uv.sources], so the installed example
+# resolves the wheel next to it. Generation runs at configure time; the
+# CMAKE_CONFIGURE_DEPENDS below re-runs configure when the source pyproject
+# changes so `cmake --build && cmake --install` (e.g. scripts/run_example.sh)
+# picks up dependency edits.
 #
 # Usage:
 #   install_python_example(DESTINATION examples/oxr/python)
@@ -30,6 +34,10 @@ macro(install_python_example)
     else()
         set(_IPE_PLATFORM_MACHINE "x86_64")
     endif()
+
+    # Reconfigure when the source pyproject changes (file(READ) is configure-time).
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+        "${CMAKE_CURRENT_SOURCE_DIR}/python/pyproject.toml")
 
     # Read the bare pyproject.toml and append uv configuration for the
     # installed environment.


### PR DESCRIPTION

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

install_python_example snapshots the source pyproject at configure time, so edits to extras (e.g. isaacteleop[cloudxr]) were ignored by build/install until a manual reconfigure. Depend on the source file so cmake --build picks them up.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

Tested with #954 and changing the project file.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build configuration updates when Python project dependency metadata changes.
  * Preserved additional project configuration during installation and regeneration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->