### PR TITLE
docs: link GR00T-WholeBodyControl SONIC from body tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See the [Ecosystem](https://nvidia.github.io/IsaacTeleop/main/overview/ecosystem
   - Use XR headsets for gripper / tri-finger hand manipulation
   - Use XR headsets with gloves for dex-hand manipulation
   - Seated full body loco-manipulation (Homie)
-  - Tracking based full body loco-manipulation (Sonic)
+  - Tracking based full body loco-manipulation with GR00T-WholeBodyControl (SONIC)
   - Egocentric data collection (aka “no-robot”)
 - Upcoming use cases
   - Teleoperate using only non-XR devices (e.g. gamepad, Gello, haply, etc.)

--- a/docs/source/device/body_tracking.rst
+++ b/docs/source/device/body_tracking.rst
@@ -32,6 +32,13 @@ and the BD skeleton format used on the server.
    and accuracy is lower since there are no physical trackers. See
    `Quest Body Tracking (Limited Support)`_ for details.
 
+.. seealso::
+
+   `GR00T-WholeBodyControl (SONIC)`_ can consume this CloudXR skeleton on a G1 robot as well.
+   See that project's setup guide for additional details.
+
+.. _`GR00T-WholeBodyControl (SONIC)`: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/isaac_teleop_publisher_setup.html
+
 .. contents:: On this page
    :local:
    :depth: 2

--- a/docs/source/overview/ecosystem.rst
+++ b/docs/source/overview/ecosystem.rst
@@ -145,8 +145,7 @@ Targeted Robotics Embodiments
   including popular embodiments such as Unitree G1.
 - :code-dir:`Retargeter tuning UI <src/python/isaacteleop/retargeting_engine_ui>` to facilitate
   live retargeter tuning.
-- GR00T-WholeBodyControl SONIC whole-body control on Unitree G1 (Thor backpack); see
-  `GR00T-WholeBodyControl: Isaac Teleop Publisher Setup`_ to get started.
+- `GR00T-WholeBodyControl (SONIC)`_ for whole-body control on Unitree G1.
 
 Device Acquisition
 ------------------
@@ -267,4 +266,4 @@ WeChat app** (Discover → Scan) to join. Scanning with your phone's built-in ca
 .. _`Generic 3-axis Pedal Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/generic_3axis_pedal
 .. _`OAK-D Camera Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/oak
 .. _`Haptikos Plugin`: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/haptikos
-.. _`GR00T-WholeBodyControl: Isaac Teleop Publisher Setup`: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/isaac_teleop_publisher_setup.html
+.. _`GR00T-WholeBodyControl (SONIC)`: https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/isaac_teleop_publisher_setup.html


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Link GR00T-WholeBodyControl (SONIC) from body tracking, the ecosystem page, and the README. Point the CloudXR skeleton at that project's Isaac Teleop setup page. Keep install and host notes in GR00T-WBC.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Docs-only. Ran `SKIP=check-copyright-year pre-commit run --all-files`.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated teleoperation documentation to identify GR00T-WholeBodyControl (SONIC).
  * Added a setup-guide reference explaining that SONIC can consume the CloudXR skeleton on a G1 robot.
  * Improved ecosystem documentation with a direct link to the GR00T-WholeBodyControl (SONIC) reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->