### PR TITLE
Expose interface to take in manus calibration files

### DIFF
--- a/src/plugins/manus/app/main.cpp
+++ b/src/plugins/manus/app/main.cpp
@@ -66,6 +66,14 @@ ManusPluginConfig parse_args(int argc, char** argv)
         {
             datasets_arg = arg.substr(std::string("--datasets=").size());
         }
+        else if (starts_with(arg, "--left-calibration="))
+        {
+            config.left_calibration_file = arg.substr(std::string("--left-calibration=").size());
+        }
+        else if (starts_with(arg, "--right-calibration="))
+        {
+            config.right_calibration_file = arg.substr(std::string("--right-calibration=").size());
+        }
         else if (starts_with(arg, "--plugin-root-id="))
         {
             // Injected by the PluginManager; not used by this plugin.

--- a/src/plugins/manus/core/inc/manus/manus_hand_tracking_plugin.hpp
+++ b/src/plugins/manus/core/inc/manus/manus_hand_tracking_plugin.hpp
@@ -124,8 +124,8 @@ private:
     mutable std::mutex landscape_mutex;
     std::optional<uint32_t> left_glove_id;
     std::optional<uint32_t> right_glove_id;
-    std::vector<unsigned char> m_left_calibration;
-    std::vector<unsigned char> m_right_calibration;
+    std::vector<unsigned char> m_left_calibration_file;
+    std::vector<unsigned char> m_right_calibration_file;
     bool is_connected = false;
 
     // Haptic state — the per-side log-once flags use std::atomic to stay

--- a/src/plugins/manus/core/inc/manus/manus_hand_tracking_plugin.hpp
+++ b/src/plugins/manus/core/inc/manus/manus_hand_tracking_plugin.hpp
@@ -44,6 +44,8 @@ inline constexpr std::size_t kManusFingerCount = 5;
 struct ManusPluginConfig
 {
     std::string app_name = "ManusHandPlugin";
+    std::string left_calibration_file;
+    std::string right_calibration_file;
     bool human = true; // OpenXR HandInjector
     bool sensors = true; // RawDeviceData -> SchemaPusher
     bool haptic = true; // inbound HapticCommandReaderTracker
@@ -91,6 +93,7 @@ private:
     void RegisterCallbacks();
     void ConnectToGloves() noexcept(false);
     void DisconnectFromGloves();
+    bool apply_glove_calibration(uint32_t glove_id, bool is_left);
     static void OnSkeletonStream(const SkeletonStreamInfo* skeleton_stream_info);
     static void OnLandscapeStream(const Landscape* landscape);
     static void OnRawDeviceDataStream(const RawDeviceDataInfo* raw_device_data_info);
@@ -121,6 +124,10 @@ private:
     mutable std::mutex landscape_mutex;
     std::optional<uint32_t> left_glove_id;
     std::optional<uint32_t> right_glove_id;
+    std::optional<uint32_t> m_left_calibrated_glove_id;
+    std::optional<uint32_t> m_right_calibrated_glove_id;
+    std::vector<unsigned char> m_left_calibration;
+    std::vector<unsigned char> m_right_calibration;
     bool is_connected = false;
 
     // Haptic state — the per-side log-once flags use std::atomic to stay

--- a/src/plugins/manus/core/inc/manus/manus_hand_tracking_plugin.hpp
+++ b/src/plugins/manus/core/inc/manus/manus_hand_tracking_plugin.hpp
@@ -124,8 +124,6 @@ private:
     mutable std::mutex landscape_mutex;
     std::optional<uint32_t> left_glove_id;
     std::optional<uint32_t> right_glove_id;
-    std::optional<uint32_t> m_left_calibrated_glove_id;
-    std::optional<uint32_t> m_right_calibrated_glove_id;
     std::vector<unsigned char> m_left_calibration;
     std::vector<unsigned char> m_right_calibration;
     bool is_connected = false;

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -21,7 +21,9 @@
 #include <array>
 #include <chrono>
 #include <cmath>
+#include <fstream>
 #include <iostream>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -69,6 +71,29 @@ SDKReturnCode get_raw_skeleton_node_count(uint32_t glove_id, uint32_t& node_coun
 
 // Must agree with JointStateTracker::DEFAULT_MAX_FLATBUFFER_SIZE on the consumer side.
 constexpr size_t kSensorFlatbufferSize = 4096;
+
+std::vector<unsigned char> read_calibration_file(const std::string& path)
+{
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file)
+    {
+        throw std::runtime_error("Failed to open Manus calibration file: " + path);
+    }
+
+    const std::streamsize size = file.tellg();
+    if (size <= 0 || static_cast<uint64_t>(size) > std::numeric_limits<uint32_t>::max())
+    {
+        throw std::runtime_error("Invalid Manus calibration file size: " + path);
+    }
+
+    std::vector<unsigned char> data(static_cast<size_t>(size));
+    file.seekg(0, std::ios::beg);
+    if (!file.read(reinterpret_cast<char*>(data.data()), size))
+    {
+        throw std::runtime_error("Failed to read Manus calibration file: " + path);
+    }
+    return data;
+}
 
 } // anonymous namespace
 
@@ -213,6 +238,15 @@ ManusTracker::~ManusTracker()
 
 void ManusTracker::initialize() noexcept(false)
 {
+    if (!m_config.left_calibration_file.empty())
+    {
+        m_left_calibration = read_calibration_file(m_config.left_calibration_file);
+    }
+    if (!m_config.right_calibration_file.empty())
+    {
+        m_right_calibration = read_calibration_file(m_config.right_calibration_file);
+    }
+
     std::cout << "[Manus] Initializing SDK..." << std::endl;
     const SDKReturnCode t_InitializeResult = CoreSdk_InitializeIntegrated();
     if (t_InitializeResult != SDKReturnCode::SDKReturnCode_Success)
@@ -529,6 +563,30 @@ void ManusTracker::DisconnectFromGloves()
     }
 }
 
+bool ManusTracker::apply_glove_calibration(uint32_t glove_id, bool is_left)
+{
+    auto& calibration = is_left ? m_left_calibration : m_right_calibration;
+    if (calibration.empty())
+    {
+        return true;
+    }
+
+    SetGloveCalibrationReturnCode result = SetGloveCalibrationReturnCode_Error;
+    const SDKReturnCode rc =
+        CoreSdk_SetGloveCalibration(glove_id, calibration.data(), static_cast<uint32_t>(calibration.size()), &result);
+    if (rc != SDKReturnCode::SDKReturnCode_Success || result != SetGloveCalibrationReturnCode_Success)
+    {
+        std::cerr << "[Manus] Failed to apply " << (is_left ? "left" : "right")
+                  << " glove calibration (glove id=" << glove_id << ", SDK code=" << static_cast<int>(rc)
+                  << ", result=" << static_cast<int>(result) << ")" << std::endl;
+        return false;
+    }
+
+    std::cout << "[Manus] Applied " << (is_left ? "left" : "right") << " glove calibration to glove id=" << glove_id
+              << std::endl;
+    return true;
+}
+
 void ManusTracker::OnSkeletonStream(const SkeletonStreamInfo* skeleton_stream_info)
 {
     auto& tracker = instance();
@@ -610,6 +668,10 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         {
             tracker.left_glove_id = glove.id;
             left_present = true;
+            if (tracker.m_left_calibrated_glove_id != glove.id && tracker.apply_glove_calibration(glove.id, true))
+            {
+                tracker.m_left_calibrated_glove_id = glove.id;
+            }
             // Fetch bone topology once on connect
             uint32_t nc = 0;
             if (get_raw_skeleton_node_count(glove.id, nc) == SDKReturnCode::SDKReturnCode_Success && nc > 0)
@@ -625,6 +687,10 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         {
             tracker.right_glove_id = glove.id;
             right_present = true;
+            if (tracker.m_right_calibrated_glove_id != glove.id && tracker.apply_glove_calibration(glove.id, false))
+            {
+                tracker.m_right_calibrated_glove_id = glove.id;
+            }
             uint32_t nc = 0;
             if (get_raw_skeleton_node_count(glove.id, nc) == SDKReturnCode::SDKReturnCode_Success && nc > 0)
             {
@@ -647,6 +713,7 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         {
             std::cout << "[Manus] Left glove disconnected (ID " << *tracker.left_glove_id << ")" << std::endl;
             tracker.left_glove_id.reset();
+            tracker.m_left_calibrated_glove_id.reset();
             tracker.m_left_hand_nodes.clear();
             tracker.m_left_node_info.clear();
             {
@@ -658,6 +725,7 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         {
             std::cout << "[Manus] Right glove disconnected (ID " << *tracker.right_glove_id << ")" << std::endl;
             tracker.right_glove_id.reset();
+            tracker.m_right_calibrated_glove_id.reset();
             tracker.m_right_hand_nodes.clear();
             tracker.m_right_node_info.clear();
             {

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -572,8 +572,8 @@ bool ManusTracker::apply_glove_calibration(uint32_t glove_id, bool is_left)
     }
 
     SetGloveCalibrationReturnCode result = SetGloveCalibrationReturnCode_Error;
-    const SDKReturnCode rc =
-        CoreSdk_SetGloveCalibration(glove_id, calibration_file.data(), static_cast<uint32_t>(calibration_file.size()), &result);
+    const SDKReturnCode rc = CoreSdk_SetGloveCalibration(
+        glove_id, calibration_file.data(), static_cast<uint32_t>(calibration_file.size()), &result);
     if (rc != SDKReturnCode::SDKReturnCode_Success || result != SetGloveCalibrationReturnCode_Success)
     {
         std::cerr << "[Manus] Failed to apply " << (is_left ? "left" : "right")
@@ -582,8 +582,8 @@ bool ManusTracker::apply_glove_calibration(uint32_t glove_id, bool is_left)
         return false;
     }
 
-    std::cout << "[Manus] Applied " << (is_left ? "left" : "right") << " glove calibration file to glove id=" << glove_id
-              << std::endl;
+    std::cout << "[Manus] Applied " << (is_left ? "left" : "right")
+              << " glove calibration file to glove id=" << glove_id << std::endl;
     return true;
 }
 

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -240,11 +240,11 @@ void ManusTracker::initialize() noexcept(false)
 {
     if (!m_config.left_calibration_file.empty())
     {
-        m_left_calibration = read_calibration_file(m_config.left_calibration_file);
+        m_left_calibration_file = read_calibration_file(m_config.left_calibration_file);
     }
     if (!m_config.right_calibration_file.empty())
     {
-        m_right_calibration = read_calibration_file(m_config.right_calibration_file);
+        m_right_calibration_file = read_calibration_file(m_config.right_calibration_file);
     }
 
     std::cout << "[Manus] Initializing SDK..." << std::endl;
@@ -565,24 +565,24 @@ void ManusTracker::DisconnectFromGloves()
 
 bool ManusTracker::apply_glove_calibration(uint32_t glove_id, bool is_left)
 {
-    auto& calibration = is_left ? m_left_calibration : m_right_calibration;
-    if (calibration.empty())
+    auto& calibration_file = is_left ? m_left_calibration_file : m_right_calibration_file;
+    if (calibration_file.empty())
     {
         return true;
     }
 
     SetGloveCalibrationReturnCode result = SetGloveCalibrationReturnCode_Error;
     const SDKReturnCode rc =
-        CoreSdk_SetGloveCalibration(glove_id, calibration.data(), static_cast<uint32_t>(calibration.size()), &result);
+        CoreSdk_SetGloveCalibration(glove_id, calibration_file.data(), static_cast<uint32_t>(calibration_file.size()), &result);
     if (rc != SDKReturnCode::SDKReturnCode_Success || result != SetGloveCalibrationReturnCode_Success)
     {
         std::cerr << "[Manus] Failed to apply " << (is_left ? "left" : "right")
-                  << " glove calibration (glove id=" << glove_id << ", SDK code=" << static_cast<int>(rc)
+                  << " glove calibration file (glove id=" << glove_id << ", SDK code=" << static_cast<int>(rc)
                   << ", result=" << static_cast<int>(result) << ")" << std::endl;
         return false;
     }
 
-    std::cout << "[Manus] Applied " << (is_left ? "left" : "right") << " glove calibration to glove id=" << glove_id
+    std::cout << "[Manus] Applied " << (is_left ? "left" : "right") << " glove calibration file to glove id=" << glove_id
               << std::endl;
     return true;
 }

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -666,11 +666,11 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         const GloveLandscapeData& glove = gloves.gloves[i];
         if (glove.side == Side::Side_Left)
         {
-            tracker.left_glove_id = glove.id;
             left_present = true;
-            if (tracker.m_left_calibrated_glove_id != glove.id && tracker.apply_glove_calibration(glove.id, true))
+            if (tracker.left_glove_id != glove.id)
             {
-                tracker.m_left_calibrated_glove_id = glove.id;
+                tracker.left_glove_id = glove.id;
+                tracker.apply_glove_calibration(glove.id, true);
             }
             // Fetch bone topology once on connect
             uint32_t nc = 0;
@@ -685,11 +685,11 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         }
         else if (glove.side == Side::Side_Right)
         {
-            tracker.right_glove_id = glove.id;
             right_present = true;
-            if (tracker.m_right_calibrated_glove_id != glove.id && tracker.apply_glove_calibration(glove.id, false))
+            if (tracker.right_glove_id != glove.id)
             {
-                tracker.m_right_calibrated_glove_id = glove.id;
+                tracker.right_glove_id = glove.id;
+                tracker.apply_glove_calibration(glove.id, false);
             }
             uint32_t nc = 0;
             if (get_raw_skeleton_node_count(glove.id, nc) == SDKReturnCode::SDKReturnCode_Success && nc > 0)
@@ -713,7 +713,6 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         {
             std::cout << "[Manus] Left glove disconnected (ID " << *tracker.left_glove_id << ")" << std::endl;
             tracker.left_glove_id.reset();
-            tracker.m_left_calibrated_glove_id.reset();
             tracker.m_left_hand_nodes.clear();
             tracker.m_left_node_info.clear();
             {
@@ -725,7 +724,6 @@ void ManusTracker::OnLandscapeStream(const Landscape* landscape)
         {
             std::cout << "[Manus] Right glove disconnected (ID " << *tracker.right_glove_id << ")" << std::endl;
             tracker.right_glove_id.reset();
-            tracker.m_right_calibrated_glove_id.reset();
             tracker.m_right_hand_nodes.clear();
             tracker.m_right_node_info.clear();
             {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<!-- Describe the motivation and the changes. Link related issues, e.g. "Fixes #123". -->

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [ ] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring separate left- and right-hand glove calibration files.
  * Calibration files are loaded and applied automatically when hand tracking starts.
  * Calibration is reapplied when gloves reconnect.

* **Bug Fixes**
  * Added validation for missing, empty, oversized, or unreadable calibration files.
  * Improved calibration handling for individually detected gloves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->