### PR TITLE
ROS: make MCAP replay fixtures geometrically valid

### DIFF
--- a/examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp
+++ b/examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp
@@ -11,6 +11,8 @@
 #include <schema/pedals_generated.h>
 #include <schema/timestamp_generated.h>
 
+#include <array>
+#include <cstddef>
 #include <cstdint>
 #include <exception>
 #include <filesystem>
@@ -41,7 +43,76 @@ constexpr float kDriftRatePerFrameM = 0.0005f;
 constexpr float kHeadHeightM = 1.60f;
 constexpr float kControllerGripHeightM = 1.10f;
 constexpr float kControllerAimHeightM = 1.20f;
-constexpr float kFullBodyBaseHeightM = 0.80f;
+constexpr float kHandHeightM = 1.10f;
+constexpr float kFullBodyPelvisHeightM = 0.88f;
+
+struct PositionOffset
+{
+    float x;
+    float y;
+    float z;
+};
+
+// OpenXR hand-joint offsets from the wrist in Y-up, -Z-forward coordinates.
+// The table follows core::HandJoint order and describes an open left hand;
+// make_hand_sample mirrors X for the right hand.
+constexpr std::array<PositionOffset, static_cast<std::size_t>(core::HandJoint_NUM_JOINTS)> kHandJointOffsets = {
+    PositionOffset{ 0.000f, 0.015f, -0.035f }, // PALM
+    PositionOffset{ 0.000f, 0.000f, 0.000f }, // WRIST
+    PositionOffset{ 0.025f, 0.005f, -0.015f }, // THUMB_METACARPAL
+    PositionOffset{ 0.035f, 0.010f, -0.030f }, // THUMB_PROXIMAL
+    PositionOffset{ 0.040f, 0.012f, -0.050f }, // THUMB_DISTAL
+    PositionOffset{ 0.042f, 0.013f, -0.062f }, // THUMB_TIP
+    PositionOffset{ 0.018f, 0.003f, -0.055f }, // INDEX_METACARPAL
+    PositionOffset{ 0.020f, 0.000f, -0.095f }, // INDEX_PROXIMAL
+    PositionOffset{ 0.020f, 0.000f, -0.125f }, // INDEX_INTERMEDIATE
+    PositionOffset{ 0.019f, 0.000f, -0.145f }, // INDEX_DISTAL
+    PositionOffset{ 0.019f, 0.000f, -0.155f }, // INDEX_TIP
+    PositionOffset{ 0.005f, 0.002f, -0.055f }, // MIDDLE_METACARPAL
+    PositionOffset{ 0.005f, 0.000f, -0.100f }, // MIDDLE_PROXIMAL
+    PositionOffset{ 0.005f, 0.000f, -0.135f }, // MIDDLE_INTERMEDIATE
+    PositionOffset{ 0.005f, 0.000f, -0.160f }, // MIDDLE_DISTAL
+    PositionOffset{ 0.005f, 0.000f, -0.175f }, // MIDDLE_TIP
+    PositionOffset{ -0.008f, 0.003f, -0.055f }, // RING_METACARPAL
+    PositionOffset{ -0.010f, 0.000f, -0.095f }, // RING_PROXIMAL
+    PositionOffset{ -0.012f, 0.000f, -0.128f }, // RING_INTERMEDIATE
+    PositionOffset{ -0.013f, 0.000f, -0.150f }, // RING_DISTAL
+    PositionOffset{ -0.014f, 0.000f, -0.163f }, // RING_TIP
+    PositionOffset{ -0.022f, 0.005f, -0.050f }, // LITTLE_METACARPAL
+    PositionOffset{ -0.025f, 0.000f, -0.080f }, // LITTLE_PROXIMAL
+    PositionOffset{ -0.027f, 0.000f, -0.103f }, // LITTLE_INTERMEDIATE
+    PositionOffset{ -0.029f, 0.000f, -0.120f }, // LITTLE_DISTAL
+    PositionOffset{ -0.030f, 0.000f, -0.130f }, // LITTLE_TIP
+};
+
+// Standing body-joint offsets from the pelvis in Y-up, -Z-forward coordinates.
+// The table follows core::BodyJoint order.
+constexpr std::array<PositionOffset, static_cast<std::size_t>(core::BodyJoint_NUM_JOINTS)> kBodyJointOffsets = {
+    PositionOffset{ 0.00f, 0.00f, 0.00f }, // PELVIS
+    PositionOffset{ -0.10f, -0.05f, 0.00f }, // LEFT_HIP
+    PositionOffset{ 0.10f, -0.05f, 0.00f }, // RIGHT_HIP
+    PositionOffset{ 0.00f, 0.12f, 0.00f }, // SPINE1
+    PositionOffset{ -0.10f, -0.45f, 0.02f }, // LEFT_KNEE
+    PositionOffset{ 0.10f, -0.45f, 0.02f }, // RIGHT_KNEE
+    PositionOffset{ 0.00f, 0.28f, 0.00f }, // SPINE2
+    PositionOffset{ -0.10f, -0.78f, 0.01f }, // LEFT_ANKLE
+    PositionOffset{ 0.10f, -0.78f, 0.01f }, // RIGHT_ANKLE
+    PositionOffset{ 0.00f, 0.45f, 0.00f }, // SPINE3
+    PositionOffset{ -0.10f, -0.82f, -0.15f }, // LEFT_FOOT
+    PositionOffset{ 0.10f, -0.82f, -0.15f }, // RIGHT_FOOT
+    PositionOffset{ 0.00f, 0.62f, 0.00f }, // NECK
+    PositionOffset{ -0.08f, 0.60f, 0.00f }, // LEFT_COLLAR
+    PositionOffset{ 0.08f, 0.60f, 0.00f }, // RIGHT_COLLAR
+    PositionOffset{ 0.00f, 0.82f, 0.00f }, // HEAD
+    PositionOffset{ -0.20f, 0.57f, 0.00f }, // LEFT_SHOULDER
+    PositionOffset{ 0.20f, 0.57f, 0.00f }, // RIGHT_SHOULDER
+    PositionOffset{ -0.42f, 0.38f, -0.02f }, // LEFT_ELBOW
+    PositionOffset{ 0.42f, 0.38f, -0.02f }, // RIGHT_ELBOW
+    PositionOffset{ -0.60f, 0.20f, -0.04f }, // LEFT_WRIST
+    PositionOffset{ 0.60f, 0.20f, -0.04f }, // RIGHT_WRIST
+    PositionOffset{ -0.67f, 0.18f, -0.08f }, // LEFT_HAND
+    PositionOffset{ 0.67f, 0.18f, -0.08f }, // RIGHT_HAND
+};
 
 // Identity orientation shared by every sample pose.
 core::Quaternion identity_quaternion()
@@ -66,9 +137,9 @@ std::shared_ptr<core::ControllerSnapshotT> make_controller_sample(bool left, int
     const float delta = kDriftRatePerFrameM * static_cast<float>(frame);
     auto sample = std::make_shared<core::ControllerSnapshotT>();
     sample->grip_pose = std::make_shared<core::ControllerPose>(
-        core::Pose(core::Point(0.15f * side, 0.10f + delta, kControllerGripHeightM), identity_quaternion()), true);
+        core::Pose(core::Point(0.15f * side, kControllerGripHeightM, -0.10f - delta), identity_quaternion()), true);
     sample->aim_pose = std::make_shared<core::ControllerPose>(
-        core::Pose(core::Point(0.20f * side, 0.15f + delta, kControllerAimHeightM), identity_quaternion()), true);
+        core::Pose(core::Point(0.20f * side, kControllerAimHeightM, -0.15f - delta), identity_quaternion()), true);
     sample->inputs = std::make_shared<core::ControllerInputState>(
         true, !left, false, left, 0.25f * side, left ? 0.40f : -0.40f, 0.55f, 0.70f);
     return sample;
@@ -76,17 +147,17 @@ std::shared_ptr<core::ControllerSnapshotT> make_controller_sample(bool left, int
 
 std::shared_ptr<core::HandPoseT> make_hand_sample(bool left, int frame)
 {
-    const float side = left ? -1.0f : 1.0f;
+    const float anchor_x = left ? -0.25f : 0.25f;
+    const float mirror_x = left ? 1.0f : -1.0f;
     const float delta = kDriftRatePerFrameM * static_cast<float>(frame);
     auto sample = std::make_shared<core::HandPoseT>();
     sample->joints = std::make_unique<core::HandJoints>();
     for (int joint = 0; joint < core::HandJoint_NUM_JOINTS; ++joint)
     {
-        // Per-joint offsets fan the joints out into a plausible-looking hand layout.
-        const float joint_f = static_cast<float>(joint);
-        const float x = 0.05f * side + 0.003f * side * joint_f;
-        const float y = 0.03f + 0.006f * joint_f + delta;
-        const float z = 1.00f + 0.004f * joint_f;
+        const auto& offset = kHandJointOffsets[static_cast<std::size_t>(joint)];
+        const float x = anchor_x + mirror_x * offset.x;
+        const float y = kHandHeightM + offset.y;
+        const float z = offset.z - delta;
         const core::Point position(x, y, z);
         const core::Pose pose(position, identity_quaternion());
         sample->joints->mutable_poses()->Mutate(joint, core::HandJointPose(pose, true, 0.010f));
@@ -99,7 +170,7 @@ std::shared_ptr<core::HeadPoseT> make_head_sample(int frame)
     // Deterministic, slowly drifting head pose at standing height.
     const float delta = kDriftRatePerFrameM * static_cast<float>(frame);
     auto sample = std::make_shared<core::HeadPoseT>();
-    sample->pose = std::make_shared<core::Pose>(core::Point(0.0f, 0.10f + delta, kHeadHeightM), identity_quaternion());
+    sample->pose = std::make_shared<core::Pose>(core::Point(0.0f, kHeadHeightM, -0.10f - delta), identity_quaternion());
     sample->is_valid = true;
     return sample;
 }
@@ -118,13 +189,13 @@ std::shared_ptr<core::FullBodyPoseT> make_full_body_sample(int frame)
     const float delta = kDriftRatePerFrameM * static_cast<float>(frame);
     auto sample = std::make_shared<core::FullBodyPoseT>();
     sample->joints = std::make_unique<core::BodyJoints>();
+    sample->all_joint_poses_tracked = true;
     for (int joint = 0; joint < core::BodyJoint_NUM_JOINTS; ++joint)
     {
-        // Per-joint offsets spread the joints into a plausible-looking body layout.
-        const float joint_f = static_cast<float>(joint);
-        const float x = 0.01f * joint_f;
-        const float y = -0.02f + 0.002f * joint_f + delta;
-        const float z = kFullBodyBaseHeightM + 0.01f * joint_f;
+        const auto& offset = kBodyJointOffsets[static_cast<std::size_t>(joint)];
+        const float x = offset.x;
+        const float y = kFullBodyPelvisHeightM + offset.y;
+        const float z = offset.z - delta;
         const core::Point position(x, y, z);
         const core::Pose pose(position, identity_quaternion());
         sample->joints->mutable_joints()->Mutate(joint, core::BodyJointPose(pose, true));

--- a/examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp
+++ b/examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp
@@ -151,7 +151,7 @@ std::shared_ptr<core::HandPoseT> make_hand_sample(bool left, int frame)
     const float mirror_x = left ? 1.0f : -1.0f;
     const float delta = kDriftRatePerFrameM * static_cast<float>(frame);
     auto sample = std::make_shared<core::HandPoseT>();
-    sample->joints = std::make_unique<core::HandJoints>();
+    sample->joints = std::make_shared<core::HandJoints>();
     for (int joint = 0; joint < core::HandJoint_NUM_JOINTS; ++joint)
     {
         const auto& offset = kHandJointOffsets[static_cast<std::size_t>(joint)];
@@ -188,7 +188,7 @@ std::shared_ptr<core::FullBodyPoseT> make_full_body_sample(int frame)
 {
     const float delta = kDriftRatePerFrameM * static_cast<float>(frame);
     auto sample = std::make_shared<core::FullBodyPoseT>();
-    sample->joints = std::make_unique<core::BodyJoints>();
+    sample->joints = std::make_shared<core::BodyJoints>();
     sample->all_joint_poses_tracked = true;
     for (int joint = 0; joint < core::BodyJoint_NUM_JOINTS; ++joint)
     {

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -11,21 +11,24 @@ import argparse
 import math
 import sys
 import time
-from typing import Callable
+from collections.abc import Callable
 
 import msgpack
 import rclpy
 from constants import TELEOP_MODES
 from geometry_msgs.msg import PoseStamped, TwistStamped
-from isaacteleop.retargeting_engine.tensor_types.indices import HandJointIndex
+from isaacteleop.retargeting_engine.tensor_types.indices import (
+    BodyJointIndex,
+    HandJointIndex,
+)
 from rclpy.node import Node
 from sensor_msgs.msg import JointState
 from std_msgs.msg import ByteMultiArray
 from teleop_ros2_interfaces.msg import NamedPoseArray
 from tf2_msgs.msg import TFMessage
 
-
 _EXPECTED_TF_FRAMES = {"right_wrist", "left_wrist", "head"}
+_EXPECTED_BODY_JOINT_NAMES = [joint.name for joint in BodyJointIndex]
 _HAND_POSE_NAMES = [
     HandJointIndex(i).name
     for i in range(HandJointIndex.WRIST, HandJointIndex.LITTLE_TIP + 1)
@@ -89,6 +92,40 @@ def _assert_nonzero_pose_positions(msg: NamedPoseArray, label: str) -> None:
         raise ValueError(f"{label} positions are all zero")
 
 
+def _assert_noncollinear_positions(
+    positions: list[tuple[float, float, float]], label: str
+) -> None:
+    if len(positions) < 3:
+        raise ValueError(f"{label} needs at least three valid positions")
+
+    anchor = positions[0]
+    vectors = [
+        (
+            position[0] - anchor[0],
+            position[1] - anchor[1],
+            position[2] - anchor[2],
+        )
+        for position in positions[1:]
+    ]
+    for index, left in enumerate(vectors):
+        left_norm_sq = sum(value * value for value in left)
+        for right in vectors[index + 1 :]:
+            right_norm_sq = sum(value * value for value in right)
+            norm_product = left_norm_sq * right_norm_sq
+            if norm_product <= 1e-12:
+                continue
+            cross = (
+                left[1] * right[2] - left[2] * right[1],
+                left[2] * right[0] - left[0] * right[2],
+                left[0] * right[1] - left[1] * right[0],
+            )
+            cross_norm_sq = sum(value * value for value in cross)
+            if cross_norm_sq > norm_product * 1e-8:
+                return
+
+    raise ValueError(f"{label} positions are collinear")
+
+
 def _assert_ee_poses_array(msg: NamedPoseArray) -> None:
     _assert_named_pose_array(msg, ["left", "right"])
     if not all(bool(is_valid) for is_valid in msg.is_valid):
@@ -101,6 +138,18 @@ def _assert_hand_pose_array(msg: NamedPoseArray) -> None:
     if not any(bool(is_valid) for is_valid in msg.is_valid):
         raise ValueError("all hand joint poses are invalid")
     _assert_nonzero_pose_positions(msg, "hand joint pose")
+    poses_per_hand = len(_HAND_POSE_NAMES)
+    for side_index, side in enumerate(("left", "right")):
+        start = side_index * poses_per_hand
+        stop = start + poses_per_hand
+        positions = [
+            (pose.position.x, pose.position.y, pose.position.z)
+            for pose, is_valid in zip(
+                msg.pose[start:stop], msg.is_valid[start:stop], strict=True
+            )
+            if bool(is_valid)
+        ]
+        _assert_noncollinear_positions(positions, f"{side} hand joint")
 
 
 def _assert_pose_stamped(
@@ -181,8 +230,8 @@ def _assert_controller_payload(msg: ByteMultiArray) -> None:
 
 def _assert_full_body_payload(msg: ByteMultiArray) -> None:
     payload = _unpack_msgpack(msg)
-    if len(payload["joint_names"]) != 24:
-        raise ValueError("expected 24 full-body joint names")
+    if payload["joint_names"] != _EXPECTED_BODY_JOINT_NAMES:
+        raise ValueError("full-body joint names do not match the expected order")
     if len(payload["joint_positions"]) != 24:
         raise ValueError("expected 24 full-body joint positions")
     if len(payload["joint_orientations"]) != 24:
@@ -201,6 +250,14 @@ def _assert_full_body_payload(msg: ByteMultiArray) -> None:
             raise ValueError("full-body joint orientation must have 4 values")
         if not _is_finite_sequence(values):
             raise ValueError("full-body joint orientation contains non-finite values")
+    valid_positions = [
+        tuple(float(value) for value in position)
+        for position, is_valid in zip(
+            payload["joint_positions"], payload["joint_valid"], strict=True
+        )
+        if bool(is_valid)
+    ]
+    _assert_noncollinear_positions(valid_positions, "full-body joint")
 
 
 class TopicVerifier(Node):


### PR DESCRIPTION
## Description

Addresses b/6591500, Part B.

- Replace index-linear hand and full-body fixture coordinates with explicit OpenXR Y-up layouts.
- Mark generated full-body samples fully tracked and keep all replay poses in the same coordinate convention.
- Verify full-body joint ordering and reject collinear hand or body geometry during ROS replay validation.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- `SKIP=check-copyright-year pre-commit run --all-files`
- `clang-format-14 --dry-run --Werror examples/teleop_ros2/cpp/integration_tests/mcap_generator.cpp`
- Built `teleop_ros2_mcap_generator` in an isolated CMake build.
- Built `examples/teleop_ros2/Dockerfile`, generated a full-length MCAP, and verified `controller_teleop`, `hand_teleop`, `controller_raw`, and `full_body` replay modes.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation (not applicable; this changes internal integration fixtures only)
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved teleoperation integration test data with more realistic body, hand, controller, and head movements.
  * Added validation for tracked full-body joints, expected joint ordering, and anatomically consistent hand data.
  * Enhanced pose checks to detect invalid or non-varying position samples.
  * Updated spatial movement scenarios to use consistent coordinate conventions and simulated frame drift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->