### PR TITLE
Rwiltz/fix siginit cxr

### DIFF
--- a/src/core/cloudxr_tests/python/test_service.py
+++ b/src/core/cloudxr_tests/python/test_service.py
@@ -370,3 +370,92 @@ class TestWssProxyStartup:
 
         # The thread outlives the timeout; stop() is what reaps it.
         service._stop_wss_proxy()
+
+
+# ============================================================================
+# TestSignalHandlers
+# ============================================================================
+
+
+class TestSignalHandlers:
+    """Signal handlers must propagate first so with-block teardown runs in order.
+
+    The key invariant: the handler must NOT call stop() directly.  Instead it
+    propagates to the previous handler (e.g. raising KeyboardInterrupt for
+    SIGINT), so that inner context managers (like an OpenXR session) can clean
+    up before the outer CloudXRService terminates the runtime process.
+    stop() is reached via __exit__ and atexit.
+    """
+
+    def test_sigint_handler_raises_keyboard_interrupt_not_stop(self, tmp_path):
+        """SIGINT handler raises KeyboardInterrupt via prev; does not call stop()."""
+        with mock_service_deps(tmp_path, ready=True):
+            service = CloudXRService()
+
+        stop_called = []
+        service._original_stop = service.stop
+        service.stop = lambda: stop_called.append(True)
+
+        handler = signal.getsignal(signal.SIGINT)
+        try:
+            with pytest.raises(KeyboardInterrupt):
+                handler(signal.SIGINT, None)
+        finally:
+            service.stop = service._original_stop
+            service.stop()
+
+        assert not stop_called, "signal handler must not call stop() directly"
+
+    def test_sigterm_with_sig_dfl_prev_raises_system_exit(self, tmp_path):
+        """SIGTERM handler raises SystemExit when prev was SIG_DFL."""
+        orig_sigterm = signal.getsignal(signal.SIGTERM)
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        try:
+            with mock_service_deps(tmp_path, ready=True):
+                service = CloudXRService()
+
+            stop_called = []
+            service._original_stop = service.stop
+            service.stop = lambda: stop_called.append(True)
+
+            handler = signal.getsignal(signal.SIGTERM)
+            try:
+                with pytest.raises(SystemExit) as exc_info:
+                    handler(signal.SIGTERM, None)
+                assert exc_info.value.code == 0
+            finally:
+                service.stop = service._original_stop
+                service.stop()
+        finally:
+            signal.signal(signal.SIGTERM, orig_sigterm)
+
+        assert not stop_called, "signal handler must not call stop() directly"
+
+    def test_sigint_handler_with_callable_prev_calls_prev(self, tmp_path):
+        """SIGINT handler with a custom callable prev calls it instead of stop()."""
+        prev_called = []
+
+        def custom_prev(signum, frame):
+            prev_called.append(signum)
+
+        orig_sigint = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, custom_prev)
+        try:
+            with mock_service_deps(tmp_path, ready=True):
+                service = CloudXRService()
+
+            stop_called = []
+            service._original_stop = service.stop
+            service.stop = lambda: stop_called.append(True)
+
+            handler = signal.getsignal(signal.SIGINT)
+            try:
+                handler(signal.SIGINT, None)
+            finally:
+                service.stop = service._original_stop
+                service.stop()
+        finally:
+            signal.signal(signal.SIGINT, orig_sigint)
+
+        assert prev_called == [signal.SIGINT]
+        assert not stop_called, "signal handler must not call stop() directly"

--- a/src/core/cloudxr_tests/python/test_service.py
+++ b/src/core/cloudxr_tests/python/test_service.py
@@ -459,3 +459,26 @@ class TestSignalHandlers:
 
         assert prev_called == [signal.SIGINT]
         assert not stop_called, "signal handler must not call stop() directly"
+
+    def test_sigint_handler_with_sig_ign_prev_is_noop(self, tmp_path):
+        """SIGINT handler is a no-op when prev was SIG_IGN."""
+        orig_sigint = signal.getsignal(signal.SIGINT)
+        signal.signal(signal.SIGINT, signal.SIG_IGN)
+        try:
+            with mock_service_deps(tmp_path, ready=True):
+                service = CloudXRService()
+
+            stop_called = []
+            service._original_stop = service.stop
+            service.stop = lambda: stop_called.append(True)
+
+            handler = signal.getsignal(signal.SIGINT)
+            try:
+                handler(signal.SIGINT, None)  # must not raise
+            finally:
+                service.stop = service._original_stop
+                service.stop()
+        finally:
+            signal.signal(signal.SIGINT, orig_sigint)
+
+        assert not stop_called, "signal handler must not call stop() directly"

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -292,6 +292,12 @@ void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
         if (shutdown_fn_)
         {
             XrResult result = shutdown_fn_(channel_);
+            if (result == XR_ERROR_INSTANCE_LOST || result == XR_ERROR_RUNTIME_FAILURE)
+            {
+                instance_lost_ = true;
+                channel_ = XR_NULL_HANDLE;
+                return;
+            }
             if (result != XR_SUCCESS)
                 std::cerr << "[LiveMessageChannelTrackerImpl] xrShutdownOpaqueDataChannelNV failed, result=" << result
                           << std::endl;
@@ -299,7 +305,9 @@ void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
         if (destroy_channel_fn_)
         {
             XrResult result = destroy_channel_fn_(channel_);
-            if (result != XR_SUCCESS)
+            if (result == XR_ERROR_INSTANCE_LOST || result == XR_ERROR_RUNTIME_FAILURE)
+                instance_lost_ = true;
+            else if (result != XR_SUCCESS)
                 std::cerr << "[LiveMessageChannelTrackerImpl] xrDestroyOpaqueDataChannelNV failed, result=" << result
                           << std::endl;
         }
@@ -335,9 +343,10 @@ MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
     XrResult state_result = get_state_fn_(channel_, &channel_state);
     if (state_result != XR_SUCCESS)
     {
-        // Return DISCONNECTED rather than throwing so callers don't treat
-        // instance loss as a recoverable pipeline error.
-        instance_lost_ = true;
+        // Only permanently disable the channel on fatal runtime-loss errors;
+        // transient failures return DISCONNECTED to allow a reopen attempt.
+        if (state_result == XR_ERROR_INSTANCE_LOST || state_result == XR_ERROR_RUNTIME_FAILURE)
+            instance_lost_ = true;
         channel_ = XR_NULL_HANDLE;
         return MessageChannelStatus::DISCONNECTED;
     }

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -265,26 +265,26 @@ void LiveMessageChannelTrackerImpl::create_channel()
 void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
 {
     if (channel_ == XR_NULL_HANDLE)
-    {
         return;
-    }
 
-    if (shutdown_fn_)
+    // Skip NV extension calls when the instance is already lost: the IPC
+    // socket is closed so every call would fail with XRT_ERROR_IPC_FAILURE
+    // and generate noisy "Broken pipe" log spam against a dead runtime.
+    if (!instance_lost_)
     {
-        XrResult result = shutdown_fn_(channel_);
-        if (result != XR_SUCCESS)
+        if (shutdown_fn_)
         {
-            std::cerr << "[LiveMessageChannelTrackerImpl] xrShutdownOpaqueDataChannelNV failed, result=" << result
-                      << std::endl;
+            XrResult result = shutdown_fn_(channel_);
+            if (result != XR_SUCCESS)
+                std::cerr << "[LiveMessageChannelTrackerImpl] xrShutdownOpaqueDataChannelNV failed, result=" << result
+                          << std::endl;
         }
-    }
-    if (destroy_channel_fn_)
-    {
-        XrResult result = destroy_channel_fn_(channel_);
-        if (result != XR_SUCCESS)
+        if (destroy_channel_fn_)
         {
-            std::cerr << "[LiveMessageChannelTrackerImpl] xrDestroyOpaqueDataChannelNV failed, result=" << result
-                      << std::endl;
+            XrResult result = destroy_channel_fn_(channel_);
+            if (result != XR_SUCCESS)
+                std::cerr << "[LiveMessageChannelTrackerImpl] xrDestroyOpaqueDataChannelNV failed, result=" << result
+                          << std::endl;
         }
     }
     channel_ = XR_NULL_HANDLE;
@@ -307,12 +307,13 @@ bool LiveMessageChannelTrackerImpl::try_reopen_channel()
     }
 }
 
-MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
+MessageChannelStatus LiveMessageChannelTrackerImpl::query_status()
 {
-    if (channel_ == XR_NULL_HANDLE)
+    if (instance_lost_ || channel_ == XR_NULL_HANDLE)
     {
-        // Channel was destroyed (e.g. failed reopen); report DISCONNECTED so
-        // update() will schedule a reopen attempt on the next frame.
+        // Channel was destroyed (e.g. failed reopen, or instance lost); report
+        // DISCONNECTED so update() will schedule a reopen attempt next frame
+        // (try_reopen_channel guards against retrying after instance loss).
         return MessageChannelStatus::DISCONNECTED;
     }
 
@@ -320,8 +321,14 @@ MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
     XrResult state_result = get_state_fn_(channel_, &channel_state);
     if (state_result != XR_SUCCESS)
     {
-        throw std::runtime_error("LiveMessageChannelTrackerImpl: xrGetOpaqueDataChannelStateNV failed, result=" +
-                                 std::to_string(state_result));
+        // Any failure here means the runtime connection is gone.  Mark the
+        // instance lost and return DISCONNECTED rather than throwing: a thrown
+        // exception would propagate to the embedding app (e.g. Isaac Lab) and
+        // be misread as a recoverable pipeline error, triggering a needless
+        // session restart against a dead runtime.
+        instance_lost_ = true;
+        channel_ = XR_NULL_HANDLE;
+        return MessageChannelStatus::DISCONNECTED;
     }
 
     switch (channel_state.state)

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -111,7 +111,11 @@ void LiveMessageChannelTrackerImpl::drain_messages()
         if (query_result != XR_SUCCESS)
         {
             if (query_result == XR_ERROR_CHANNEL_NOT_CONNECTED_NV)
+                return;
+            if (query_result == XR_ERROR_INSTANCE_LOST)
             {
+                instance_lost_ = true;
+                channel_ = XR_NULL_HANDLE;
                 return;
             }
             throw std::runtime_error("LiveMessageChannelTrackerImpl: xrReceiveOpaqueDataChannelNV (query) failed, result=" +
@@ -156,7 +160,11 @@ void LiveMessageChannelTrackerImpl::drain_messages()
         if (recv_result != XR_SUCCESS)
         {
             if (recv_result == XR_ERROR_CHANNEL_NOT_CONNECTED_NV)
+                return;
+            if (recv_result == XR_ERROR_INSTANCE_LOST)
             {
+                instance_lost_ = true;
+                channel_ = XR_NULL_HANDLE;
                 return;
             }
             throw std::runtime_error("LiveMessageChannelTrackerImpl: xrReceiveOpaqueDataChannelNV (read) failed, result=" +
@@ -197,6 +205,11 @@ void LiveMessageChannelTrackerImpl::send_message(const std::vector<uint8_t>& pay
     XrResult state_result = get_state_fn_(channel_, &channel_state);
     if (state_result != XR_SUCCESS)
     {
+        if (state_result == XR_ERROR_INSTANCE_LOST)
+        {
+            instance_lost_ = true;
+            channel_ = XR_NULL_HANDLE;
+        }
         throw std::runtime_error("LiveMessageChannelTrackerImpl: xrGetOpaqueDataChannelStateNV failed, result=" +
                                  std::to_string(state_result));
     }
@@ -209,6 +222,11 @@ void LiveMessageChannelTrackerImpl::send_message(const std::vector<uint8_t>& pay
     XrResult send_result = send_fn_(channel_, static_cast<uint32_t>(payload.size()), payload_ptr);
     if (send_result != XR_SUCCESS)
     {
+        if (send_result == XR_ERROR_INSTANCE_LOST)
+        {
+            instance_lost_ = true;
+            channel_ = XR_NULL_HANDLE;
+        }
         throw std::runtime_error("LiveMessageChannelTrackerImpl: xrSendOpaqueDataChannelNV failed, result=" +
                                  std::to_string(send_result));
     }
@@ -307,7 +325,7 @@ bool LiveMessageChannelTrackerImpl::try_reopen_channel()
     }
 }
 
-MessageChannelStatus LiveMessageChannelTrackerImpl::query_status()
+MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
 {
     if (instance_lost_ || channel_ == XR_NULL_HANDLE)
     {

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -273,7 +273,9 @@ void LiveMessageChannelTrackerImpl::create_channel()
     XrResult result = create_channel_fn_(handles_.instance, &create_info, &channel_);
     if (result != XR_SUCCESS)
     {
-        if (result == XR_ERROR_INSTANCE_LOST)
+        // INSTANCE_LOST and RUNTIME_FAILURE both indicate the IPC connection
+        // to the runtime is gone; suppress further reopen attempts.
+        if (result == XR_ERROR_INSTANCE_LOST || result == XR_ERROR_RUNTIME_FAILURE)
             instance_lost_ = true;
         throw std::runtime_error("LiveMessageChannelTrackerImpl: xrCreateOpaqueDataChannelNV failed, result=" +
                                  std::to_string(result));
@@ -285,9 +287,6 @@ void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
     if (channel_ == XR_NULL_HANDLE)
         return;
 
-    // Skip NV extension calls when the instance is already lost: the IPC
-    // socket is closed so every call would fail with XRT_ERROR_IPC_FAILURE
-    // and generate noisy "Broken pipe" log spam against a dead runtime.
     if (!instance_lost_)
     {
         if (shutdown_fn_)
@@ -329,9 +328,6 @@ MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
 {
     if (instance_lost_ || channel_ == XR_NULL_HANDLE)
     {
-        // Channel was destroyed (e.g. failed reopen, or instance lost); report
-        // DISCONNECTED so update() will schedule a reopen attempt next frame
-        // (try_reopen_channel guards against retrying after instance loss).
         return MessageChannelStatus::DISCONNECTED;
     }
 
@@ -339,11 +335,8 @@ MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
     XrResult state_result = get_state_fn_(channel_, &channel_state);
     if (state_result != XR_SUCCESS)
     {
-        // Any failure here means the runtime connection is gone.  Mark the
-        // instance lost and return DISCONNECTED rather than throwing: a thrown
-        // exception would propagate to the embedding app (e.g. Isaac Lab) and
-        // be misread as a recoverable pipeline error, triggering a needless
-        // session restart against a dead runtime.
+        // Return DISCONNECTED rather than throwing so callers don't treat
+        // instance loss as a recoverable pipeline error.
         instance_lost_ = true;
         channel_ = XR_NULL_HANDLE;
         return MessageChannelStatus::DISCONNECTED;

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -255,6 +255,8 @@ void LiveMessageChannelTrackerImpl::create_channel()
     XrResult result = create_channel_fn_(handles_.instance, &create_info, &channel_);
     if (result != XR_SUCCESS)
     {
+        if (result == XR_ERROR_INSTANCE_LOST)
+            instance_lost_ = true;
         throw std::runtime_error("LiveMessageChannelTrackerImpl: xrCreateOpaqueDataChannelNV failed, result=" +
                                  std::to_string(result));
     }
@@ -290,6 +292,8 @@ void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
 
 bool LiveMessageChannelTrackerImpl::try_reopen_channel()
 {
+    if (instance_lost_)
+        return false;
     try
     {
         destroy_channel();

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
@@ -50,7 +50,7 @@ public:
 private:
     void initialize_functions();
     XrSystemId resolve_system_id() const;
-    MessageChannelStatus query_status() const;
+    MessageChannelStatus query_status();
     void create_channel();
     void destroy_channel() noexcept;
     bool try_reopen_channel();

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
@@ -73,6 +73,7 @@ private:
 
     XrTimeConverter time_converter_;
     int64_t last_update_time_ = 0;
+    bool instance_lost_ = false;
     MessageChannelMessagesTrackedT messages_;
     std::vector<uint8_t> receive_buffer_;
     std::unique_ptr<MessageChannelMcapChannels> mcap_channels_;

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
@@ -50,7 +50,7 @@ public:
 private:
     void initialize_functions();
     XrSystemId resolve_system_id() const;
-    MessageChannelStatus query_status();
+    MessageChannelStatus query_status() const;
     void create_channel();
     void destroy_channel() noexcept;
     bool try_reopen_channel();
@@ -61,7 +61,7 @@ private:
     const MessageChannelTracker* tracker_{ nullptr };
     XrSystemId system_id_{ XR_NULL_SYSTEM_ID };
     XrUuidEXT channel_uuid_{};
-    XrOpaqueDataChannelNV channel_{ XR_NULL_HANDLE };
+    mutable XrOpaqueDataChannelNV channel_{ XR_NULL_HANDLE };
 
     PFN_xrCreateOpaqueDataChannelNV create_channel_fn_{ nullptr };
     PFN_xrDestroyOpaqueDataChannelNV destroy_channel_fn_{ nullptr };
@@ -73,7 +73,7 @@ private:
 
     XrTimeConverter time_converter_;
     int64_t last_update_time_ = 0;
-    bool instance_lost_ = false;
+    mutable bool instance_lost_ = false;
     MessageChannelMessagesTrackedT messages_;
     std::vector<uint8_t> receive_buffer_;
     std::unique_ptr<MessageChannelMcapChannels> mcap_channels_;

--- a/src/python/isaacteleop/cloudxr/service/_service.py
+++ b/src/python/isaacteleop/cloudxr/service/_service.py
@@ -310,7 +310,13 @@ class CloudXRService:
     # ------------------------------------------------------------------
 
     def _install_signal_handlers(self) -> None:
-        """Install SIGTERM/SIGINT handlers that call :meth:`stop`, then the prior handler."""
+        """Install SIGTERM/SIGINT handlers that propagate to the prior handler.
+
+        Propagation happens first so that with-block __exit__ teardown runs in
+        the correct order: inner contexts (e.g. an OpenXR session) close before
+        the outer launcher terminates the runtime process.  stop() is reached
+        via __exit__ (context manager) and atexit (standalone use).
+        """
         if threading.current_thread() is not threading.main_thread():
             return
 
@@ -318,15 +324,14 @@ class CloudXRService:
 
         def _make_handler(prev):
             def _handler(signum, frame):
-                try:
-                    self.stop()
-                finally:
-                    if callable(prev):
-                        prev(signum, frame)
-                    else:
-                        signal.signal(signum, prev)
-                        if prev == signal.SIG_DFL:
-                            os.kill(os.getpid(), signum)
+                if callable(prev):
+                    # e.g. default_int_handler raises KeyboardInterrupt, which
+                    # unwinds with-blocks in order before atexit calls stop().
+                    prev(signum, frame)
+                else:
+                    # SIG_DFL would terminate the process without running atexit
+                    # or __exit__ handlers.  SystemExit triggers both.
+                    raise SystemExit(0)
 
             return _handler
 

--- a/src/python/isaacteleop/cloudxr/service/_service.py
+++ b/src/python/isaacteleop/cloudxr/service/_service.py
@@ -21,7 +21,6 @@ import signal
 import subprocess
 import sys
 import threading
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -374,45 +373,22 @@ class CloudXRService:
 
     @staticmethod
     def _cleanup_stale_runtime(run_dir: str) -> None:
-        """Kill a stale runtime if one is running, then clear sentinel files.
+        """Refuse to start over a live runtime; clear stale sentinels otherwise.
 
-        Uses a connection probe to distinguish a live runtime from stale files,
-        and kills via pidfiles rather than external tools so it works inside
-        containers where fuser or cross-namespace kill would fail.
+        A run directory holds one runtime.  Liveness is decided by connecting
+        to the IPC socket, not by its existence — the file routinely outlives
+        the process that made it.
 
         Raises:
-            RuntimeError: If a live runtime is detected and cannot be stopped.
+            RuntimeError: If a runtime is already serving the run directory.
         """
         if is_runtime_live(run_dir):
-            logger.warning(
-                "Stale CloudXR runtime detected at %s; terminating it", run_dir
-            )
-            for pidfile in ("cloudxr.pid", "monado.pid"):
-                pid_path = os.path.join(run_dir, pidfile)
-                try:
-                    pid = int(Path(pid_path).read_text().strip())
-                    os.kill(pid, signal.SIGTERM)
-                    logger.info(
-                        "Sent SIGTERM to stale runtime pid %d (%s)", pid, pidfile
-                    )
-                except (
-                    FileNotFoundError,
-                    ValueError,
-                    ProcessLookupError,
-                    PermissionError,
-                    OSError,
-                ):
-                    pass
-
-            time.sleep(2.0)
-
-            if is_runtime_live(run_dir):
-                raise RuntimeError(
-                    _RUNTIME_ALREADY_SERVING.format(
-                        run_dir=run_dir,
-                        env_file=os.path.join(run_dir, ENV_FILE_NAME),
-                    )
+            raise RuntimeError(
+                _RUNTIME_ALREADY_SERVING.format(
+                    run_dir=run_dir,
+                    env_file=os.path.join(run_dir, ENV_FILE_NAME),
                 )
+            )
 
         for name in ("ipc_cloudxr", "runtime_started", "monado.pid", "cloudxr.pid"):
             path = os.path.join(run_dir, name)

--- a/src/python/isaacteleop/cloudxr/service/_service.py
+++ b/src/python/isaacteleop/cloudxr/service/_service.py
@@ -21,6 +21,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -53,6 +54,18 @@ drop the live session.
 #: Runtime worker stderr, kept apart from runtime_stderr.log so the worker and
 #: :func:`~.runtime.run` never append to one file from two processes.
 _WORKER_STDERR_LOG = "runtime_worker_stderr.log"
+
+
+def _set_pdeathsig() -> None:
+    """Ask the kernel to send SIGTERM to this process when its parent dies.
+
+    Called as subprocess preexec_fn so the runtime is cleaned up even if the
+    parent Python process is killed with SIGKILL or crashes.  Linux-only.
+    """
+    import ctypes  # noqa: PLC0415
+
+    ctypes.CDLL(None).prctl(1, signal.SIGTERM, 0, 0, 0)  # PR_SET_PDEATHSIG = 1
+
 
 _RUNTIME_WORKER_CODE = """\
 import sys, os
@@ -201,6 +214,7 @@ class CloudXRService:
                 env=worker_env,
                 stderr=stderr_file,
                 start_new_session=True,
+                preexec_fn=_set_pdeathsig if sys.platform != "win32" else None,
             )
         logger.info("CloudXR runtime process started (pid=%s)", self._runtime_proc.pid)
 
@@ -360,26 +374,45 @@ class CloudXRService:
 
     @staticmethod
     def _cleanup_stale_runtime(run_dir: str) -> None:
-        """Refuse to start over a live runtime; otherwise clear stale sentinels.
+        """Kill a stale runtime if one is running, then clear sentinel files.
 
-        A run directory holds one runtime.  Liveness is decided by
-        connecting to the IPC socket, not by its existence — the file
-        routinely outlives the process that made it.
-
-        Runs before :class:`EnvConfig` resolves anything: resolving rewrites
-        ``cloudxr.env`` in place, so a refused start would otherwise have
-        already replaced the live runtime's environment with its own.
+        Uses a connection probe to distinguish a live runtime from stale files,
+        and kills via pidfiles rather than external tools so it works inside
+        containers where fuser or cross-namespace kill would fail.
 
         Raises:
-            RuntimeError: If a runtime is already serving the run directory.
+            RuntimeError: If a live runtime is detected and cannot be stopped.
         """
         if is_runtime_live(run_dir):
-            raise RuntimeError(
-                _RUNTIME_ALREADY_SERVING.format(
-                    run_dir=run_dir,
-                    env_file=os.path.join(run_dir, ENV_FILE_NAME),
-                )
+            logger.warning(
+                "Stale CloudXR runtime detected at %s; terminating it", run_dir
             )
+            for pidfile in ("cloudxr.pid", "monado.pid"):
+                pid_path = os.path.join(run_dir, pidfile)
+                try:
+                    pid = int(Path(pid_path).read_text().strip())
+                    os.kill(pid, signal.SIGTERM)
+                    logger.info(
+                        "Sent SIGTERM to stale runtime pid %d (%s)", pid, pidfile
+                    )
+                except (
+                    FileNotFoundError,
+                    ValueError,
+                    ProcessLookupError,
+                    PermissionError,
+                    OSError,
+                ):
+                    pass
+
+            time.sleep(2.0)
+
+            if is_runtime_live(run_dir):
+                raise RuntimeError(
+                    _RUNTIME_ALREADY_SERVING.format(
+                        run_dir=run_dir,
+                        env_file=os.path.join(run_dir, ENV_FILE_NAME),
+                    )
+                )
 
         for name in ("ipc_cloudxr", "runtime_started", "monado.pid", "cloudxr.pid"):
             path = os.path.join(run_dir, name)

--- a/src/python/isaacteleop/cloudxr/service/_service.py
+++ b/src/python/isaacteleop/cloudxr/service/_service.py
@@ -328,10 +328,11 @@ class CloudXRService:
                     # e.g. default_int_handler raises KeyboardInterrupt, which
                     # unwinds with-blocks in order before atexit calls stop().
                     prev(signum, frame)
-                else:
+                elif prev == signal.SIG_DFL:
                     # SIG_DFL would terminate the process without running atexit
                     # or __exit__ handlers.  SystemExit triggers both.
                     raise SystemExit(0)
+                # SIG_IGN: signal was previously ignored — preserve that (no-op).
 
             return _handler
 

--- a/src/python/isaacteleop/cloudxr/service/_service.py
+++ b/src/python/isaacteleop/cloudxr/service/_service.py
@@ -312,10 +312,9 @@ class CloudXRService:
     def _install_signal_handlers(self) -> None:
         """Install SIGTERM/SIGINT handlers that propagate to the prior handler.
 
-        Propagation happens first so that with-block __exit__ teardown runs in
-        the correct order: inner contexts (e.g. an OpenXR session) close before
-        the outer launcher terminates the runtime process.  stop() is reached
-        via __exit__ (context manager) and atexit (standalone use).
+        Propagating first lets with-block __exit__ teardown run in order so
+        inner contexts (e.g. an OpenXR session) close before stop() kills the
+        runtime.  stop() is reached via __exit__ and atexit.
         """
         if threading.current_thread() is not threading.main_thread():
             return
@@ -325,14 +324,11 @@ class CloudXRService:
         def _make_handler(prev):
             def _handler(signum, frame):
                 if callable(prev):
-                    # e.g. default_int_handler raises KeyboardInterrupt, which
-                    # unwinds with-blocks in order before atexit calls stop().
                     prev(signum, frame)
                 elif prev == signal.SIG_DFL:
-                    # SIG_DFL would terminate the process without running atexit
-                    # or __exit__ handlers.  SystemExit triggers both.
+                    # Raise SystemExit so __exit__ and atexit handlers run.
                     raise SystemExit(0)
-                # SIG_IGN: signal was previously ignored — preserve that (no-op).
+                # SIG_IGN: preserve the "ignore" disposition — no-op.
 
             return _handler
 


### PR DESCRIPTION
## Description

Problem

  1. Error flood on Ctrl+C: The signal handler called stop() (killing the runtime) before propagating KeyboardInterrupt, so inner with-block teardown — OpenXR channel cleanup, session teardown — ran
  against a dead IPC socket, producing a cascade of broken-pipe errors and an infinite per-frame retry loop in the container.
  2. Ports held after unexpected exit: If the Python process was killed (SIGKILL, OOM, crash), the runtime subprocess was orphaned with no kernel-level death notification, leaving ports occupied. On the
  next launch, the stale cleanup used fuser -k -TERM, which fails silently in containers (PID namespace isolation, seccomp, missing psmisc).

  Changes

  Signal handling (_service.py / launcher.py)

  - Handler propagates to the prior handler first (raising KeyboardInterrupt for SIGINT, SystemExit for SIG_DFL, no-op for SIG_IGN), so with-block __exit__ teardown unwinds in order before stop() kills
  the runtime.

  Channel tracker (live_message_channel_tracker_impl)

  - create_channel(): sets instance_lost_ on INSTANCE_LOST or RUNTIME_FAILURE; try_reopen_channel() short-circuits immediately, stopping the per-frame retry loop.
  - query_status(): returns DISCONNECTED on failure instead of throwing, preventing Isaac Lab from misreading it as a recoverable error and restarting the session.
  - destroy_channel(): skips NV extension calls when instance_lost_, eliminating the broken-pipe log flood on teardown.
  - drain_messages() / send_message(): propagate INSTANCE_LOST to instance_lost_ flag.

  Stale runtime cleanup (_service.py / launcher.py)

  - PR_SET_PDEATHSIG via preexec_fn: kernel sends SIGTERM to the runtime if the Python parent dies unexpectedly.
  - Stale cleanup: replaced fuser with a connect() liveness probe + os.kill(pid) from cloudxr.pid/monado.pid — no external binary, works inside containers.
  - 1.4.x only: stderr=subprocess.PIPE → log file, eliminating the 64 KB pipe-buffer deadlock on long-running sessions.


Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal handling so interrupts and termination signals propagate correctly while allowing normal cleanup to complete.
  * Improved connection status reporting after an XR instance is lost.
  * Prevented invalid shutdown, destruction, or channel reopening attempts after instance loss.
  * State-query failures now report a disconnected status instead of raising an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->