### PR TITLE
Rwiltz/fix siginit cxr 1.4.x

### DIFF
--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -17,6 +17,7 @@ import contextlib
 import logging
 import os
 import signal
+import socket
 import subprocess
 import sys
 import threading
@@ -44,6 +45,17 @@ sys.path = [p for p in sys.path if p]
 from {runtime_mod}.runtime import run
 run()
 """
+
+
+def _set_pdeathsig() -> None:
+    """Ask the kernel to send SIGTERM to this process when its parent dies.
+
+    Called as subprocess preexec_fn so the runtime is cleaned up even if the
+    parent Python process is killed with SIGKILL or crashes.  Linux-only.
+    """
+    import ctypes  # noqa: PLC0415
+
+    ctypes.CDLL(None).prctl(1, signal.SIGTERM, 0, 0, 0)  # PR_SET_PDEATHSIG = 1
 
 
 class CloudXRLauncher:
@@ -148,6 +160,7 @@ class CloudXRLauncher:
             require_web_client_static_dir()
 
         self._runtime_proc: subprocess.Popen | None = None
+        self._worker_stderr_log: Path | None = None
         self._wss_thread: threading.Thread | None = None
         self._wss_loop: asyncio.AbstractEventLoop | None = None
         self._wss_stop_future: asyncio.Future | None = None
@@ -191,16 +204,20 @@ class CloudXRLauncher:
             prev = worker_env.get("LD_PRELOAD")
             worker_env["LD_PRELOAD"] = f"{preload} {prev}" if prev else preload
 
-        self._runtime_proc = subprocess.Popen(
-            [
-                sys.executable,
-                "-c",
-                _RUNTIME_WORKER_CODE.format(runtime_mod=runtime_mod),
-            ],
-            env=worker_env,
-            stderr=subprocess.PIPE,
-            start_new_session=True,
-        )
+        worker_stderr_log = logs_dir_path / "runtime_worker_stderr.log"
+        self._worker_stderr_log = worker_stderr_log
+        with open(worker_stderr_log, "w", encoding="utf-8") as _stderr_file:
+            self._runtime_proc = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-c",
+                    _RUNTIME_WORKER_CODE.format(runtime_mod=runtime_mod),
+                ],
+                env=worker_env,
+                stderr=_stderr_file,
+                start_new_session=True,
+                preexec_fn=_set_pdeathsig if sys.platform != "win32" else None,
+            )
         logger.info("CloudXR runtime process started (pid=%s)", self._runtime_proc.pid)
 
         if not self._atexit_registered:
@@ -571,39 +588,50 @@ class CloudXRLauncher:
 
     @staticmethod
     def _cleanup_stale_runtime(env_cfg: EnvConfig) -> None:
-        """Remove stale sentinel files from a previous runtime that wasn't cleaned up.
+        """Kill a stale runtime if one is running, then clear sentinel files.
 
-        If the ``ipc_cloudxr`` socket still exists in the run directory, a
-        previous Monado/CloudXR process is likely still alive.  We send
-        SIGTERM to the process group that owns the socket, giving it a
-        chance to exit cleanly before we start a fresh runtime.
+        Uses a connection probe for liveness (more reliable than file existence)
+        and kills via pidfiles so it works inside containers where fuser or
+        cross-namespace kill would fail.
         """
         run_dir = env_cfg.openxr_run_dir()
         ipc_socket = os.path.join(run_dir, "ipc_cloudxr")
 
-        if os.path.exists(ipc_socket):
+        if not os.path.exists(ipc_socket):
+            return
+
+        is_live = False
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+                sock.settimeout(0.5)
+                sock.connect(ipc_socket)
+            is_live = True
+        except (ConnectionRefusedError, FileNotFoundError, socket.timeout, OSError):
+            pass
+
+        if is_live:
             logger.warning(
-                "Stale CloudXR IPC socket found at %s; attempting cleanup of previous runtime",
-                ipc_socket,
+                "Stale CloudXR runtime detected at %s; terminating it", run_dir
             )
-            try:
-                result = subprocess.run(
-                    ["fuser", "-k", "-TERM", ipc_socket],
-                    capture_output=True,
-                    timeout=5,
-                )
-                if result.returncode == 0:
-                    time.sleep(1)
-                    logger.info("Sent SIGTERM to processes holding stale IPC socket")
-            except (FileNotFoundError, subprocess.TimeoutExpired):
-                pass
+            for pidfile in ("cloudxr.pid", "monado.pid"):
+                pid_path = os.path.join(run_dir, pidfile)
+                try:
+                    pid = int(Path(pid_path).read_text().strip())
+                    os.kill(pid, signal.SIGTERM)
+                    logger.info(
+                        "Sent SIGTERM to stale runtime pid %d (%s)", pid, pidfile
+                    )
+                except (
+                    FileNotFoundError,
+                    ValueError,
+                    ProcessLookupError,
+                    PermissionError,
+                    OSError,
+                ):
+                    pass
+            time.sleep(2.0)
 
-            try:
-                os.remove(ipc_socket)
-            except FileNotFoundError:
-                pass
-
-        for name in ("runtime_started", "monado.pid", "cloudxr.pid"):
+        for name in ("ipc_cloudxr", "runtime_started", "monado.pid", "cloudxr.pid"):
             try:
                 os.remove(os.path.join(run_dir, name))
             except FileNotFoundError:
@@ -623,13 +651,14 @@ class CloudXRLauncher:
             exit_code = proc.poll()
             if exit_code is not None:
                 parts.append(f"Process exited with code {exit_code}.")
-                stderr_pipe = getattr(proc, "stderr", None)
-                if stderr_pipe is not None:
+                if self._worker_stderr_log and self._worker_stderr_log.is_file():
                     try:
-                        stderr_tail = stderr_pipe.read(_MAX_LOG_BYTES)
-                        if stderr_tail:
+                        content = self._worker_stderr_log.read_text(
+                            errors="replace"
+                        ).strip()
+                        if content:
                             parts.append(
-                                f"stderr: {stderr_tail.decode(errors='replace').strip()}"
+                                f"runtime_worker_stderr.log:\n{content[-_MAX_LOG_BYTES:]}"
                             )
                     except Exception:
                         pass
@@ -658,6 +687,10 @@ class CloudXRLauncher:
         stderr_log = logs_dir / "runtime_stderr.log"
         if stderr_log.is_file():
             result.append(stderr_log)
+
+        worker_stderr_log = logs_dir / "runtime_worker_stderr.log"
+        if worker_stderr_log.is_file():
+            result.append(worker_stderr_log)
 
         cxr_logs = sorted(logs_dir.glob("cxr_server.*.log"))
         if cxr_logs:

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -21,7 +21,6 @@ import socket
 import subprocess
 import sys
 import threading
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -588,11 +587,13 @@ class CloudXRLauncher:
 
     @staticmethod
     def _cleanup_stale_runtime(env_cfg: EnvConfig) -> None:
-        """Kill a stale runtime if one is running, then clear sentinel files.
+        """Refuse to start over a live runtime; clear stale sentinels otherwise.
 
-        Uses a connection probe for liveness (more reliable than file existence)
-        and kills via pidfiles so it works inside containers where fuser or
-        cross-namespace kill would fail.
+        Uses a connection probe for liveness so dead-process socket files are
+        cleaned up without affecting an intentionally running runtime.
+
+        Raises:
+            RuntimeError: If a runtime is already serving the run directory.
         """
         run_dir = env_cfg.openxr_run_dir()
         ipc_socket = os.path.join(run_dir, "ipc_cloudxr")
@@ -610,26 +611,10 @@ class CloudXRLauncher:
             pass
 
         if is_live:
-            logger.warning(
-                "Stale CloudXR runtime detected at %s; terminating it", run_dir
+            raise RuntimeError(
+                f"A CloudXR runtime is already serving {run_dir}. "
+                "Stop it before starting a new one."
             )
-            for pidfile in ("cloudxr.pid", "monado.pid"):
-                pid_path = os.path.join(run_dir, pidfile)
-                try:
-                    pid = int(Path(pid_path).read_text().strip())
-                    os.kill(pid, signal.SIGTERM)
-                    logger.info(
-                        "Sent SIGTERM to stale runtime pid %d (%s)", pid, pidfile
-                    )
-                except (
-                    FileNotFoundError,
-                    ValueError,
-                    ProcessLookupError,
-                    PermissionError,
-                    OSError,
-                ):
-                    pass
-            time.sleep(2.0)
 
         for name in ("ipc_cloudxr", "runtime_started", "monado.pid", "cloudxr.pid"):
             try:

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -539,10 +539,11 @@ class CloudXRLauncher:
                     # e.g. default_int_handler raises KeyboardInterrupt, which
                     # unwinds with-blocks in order before atexit calls stop().
                     prev(signum, frame)
-                else:
+                elif prev == signal.SIG_DFL:
                     # SIG_DFL would terminate the process without running atexit
                     # or __exit__ handlers.  SystemExit triggers both.
                     raise SystemExit(0)
+                # SIG_IGN: signal was previously ignored — preserve that (no-op).
 
             return _handler
 

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -523,10 +523,9 @@ class CloudXRLauncher:
     def _install_signal_handlers(self) -> None:
         """Install SIGTERM/SIGINT handlers that propagate to the prior handler.
 
-        Propagation happens first so that with-block __exit__ teardown runs in
-        the correct order: inner contexts (e.g. an OpenXR session) close before
-        the outer launcher terminates the runtime process.  stop() is reached
-        via __exit__ (context manager) and atexit (standalone use).
+        Propagating first lets with-block __exit__ teardown run in order so
+        inner contexts (e.g. an OpenXR session) close before stop() kills the
+        runtime.  stop() is reached via __exit__ and atexit.
         """
         if threading.current_thread() is not threading.main_thread():
             return
@@ -536,14 +535,11 @@ class CloudXRLauncher:
         def _make_handler(prev):
             def _handler(signum, frame):
                 if callable(prev):
-                    # e.g. default_int_handler raises KeyboardInterrupt, which
-                    # unwinds with-blocks in order before atexit calls stop().
                     prev(signum, frame)
                 elif prev == signal.SIG_DFL:
-                    # SIG_DFL would terminate the process without running atexit
-                    # or __exit__ handlers.  SystemExit triggers both.
+                    # Raise SystemExit so __exit__ and atexit handlers run.
                     raise SystemExit(0)
-                # SIG_IGN: signal was previously ignored — preserve that (no-op).
+                # SIG_IGN: preserve the "ignore" disposition — no-op.
 
             return _handler
 

--- a/src/core/cloudxr/python/launcher.py
+++ b/src/core/cloudxr/python/launcher.py
@@ -521,7 +521,13 @@ class CloudXRLauncher:
     # ------------------------------------------------------------------
 
     def _install_signal_handlers(self) -> None:
-        """Install SIGTERM/SIGINT handlers that call :meth:`stop`, then the prior handler."""
+        """Install SIGTERM/SIGINT handlers that propagate to the prior handler.
+
+        Propagation happens first so that with-block __exit__ teardown runs in
+        the correct order: inner contexts (e.g. an OpenXR session) close before
+        the outer launcher terminates the runtime process.  stop() is reached
+        via __exit__ (context manager) and atexit (standalone use).
+        """
         if threading.current_thread() is not threading.main_thread():
             return
 
@@ -529,15 +535,14 @@ class CloudXRLauncher:
 
         def _make_handler(prev):
             def _handler(signum, frame):
-                try:
-                    self.stop()
-                finally:
-                    if callable(prev):
-                        prev(signum, frame)
-                    else:
-                        signal.signal(signum, prev)
-                        if prev == signal.SIG_DFL:
-                            os.kill(os.getpid(), signum)
+                if callable(prev):
+                    # e.g. default_int_handler raises KeyboardInterrupt, which
+                    # unwinds with-blocks in order before atexit calls stop().
+                    prev(signum, frame)
+                else:
+                    # SIG_DFL would terminate the process without running atexit
+                    # or __exit__ handlers.  SystemExit triggers both.
+                    raise SystemExit(0)
 
             return _handler
 

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -292,6 +292,12 @@ void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
         if (shutdown_fn_)
         {
             XrResult result = shutdown_fn_(channel_);
+            if (result == XR_ERROR_INSTANCE_LOST || result == XR_ERROR_RUNTIME_FAILURE)
+            {
+                instance_lost_ = true;
+                channel_ = XR_NULL_HANDLE;
+                return;
+            }
             if (result != XR_SUCCESS)
                 std::cerr << "[LiveMessageChannelTrackerImpl] xrShutdownOpaqueDataChannelNV failed, result=" << result
                           << std::endl;
@@ -299,7 +305,9 @@ void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
         if (destroy_channel_fn_)
         {
             XrResult result = destroy_channel_fn_(channel_);
-            if (result != XR_SUCCESS)
+            if (result == XR_ERROR_INSTANCE_LOST || result == XR_ERROR_RUNTIME_FAILURE)
+                instance_lost_ = true;
+            else if (result != XR_SUCCESS)
                 std::cerr << "[LiveMessageChannelTrackerImpl] xrDestroyOpaqueDataChannelNV failed, result=" << result
                           << std::endl;
         }
@@ -335,9 +343,10 @@ MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
     XrResult state_result = get_state_fn_(channel_, &channel_state);
     if (state_result != XR_SUCCESS)
     {
-        // Return DISCONNECTED rather than throwing so callers don't treat
-        // instance loss as a recoverable pipeline error.
-        instance_lost_ = true;
+        // Only permanently disable the channel on fatal runtime-loss errors;
+        // transient failures return DISCONNECTED to allow a reopen attempt.
+        if (state_result == XR_ERROR_INSTANCE_LOST || state_result == XR_ERROR_RUNTIME_FAILURE)
+            instance_lost_ = true;
         channel_ = XR_NULL_HANDLE;
         return MessageChannelStatus::DISCONNECTED;
     }

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -265,26 +265,26 @@ void LiveMessageChannelTrackerImpl::create_channel()
 void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
 {
     if (channel_ == XR_NULL_HANDLE)
-    {
         return;
-    }
 
-    if (shutdown_fn_)
+    // Skip NV extension calls when the instance is already lost: the IPC
+    // socket is closed so every call would fail with XRT_ERROR_IPC_FAILURE
+    // and generate noisy "Broken pipe" log spam against a dead runtime.
+    if (!instance_lost_)
     {
-        XrResult result = shutdown_fn_(channel_);
-        if (result != XR_SUCCESS)
+        if (shutdown_fn_)
         {
-            std::cerr << "[LiveMessageChannelTrackerImpl] xrShutdownOpaqueDataChannelNV failed, result=" << result
-                      << std::endl;
+            XrResult result = shutdown_fn_(channel_);
+            if (result != XR_SUCCESS)
+                std::cerr << "[LiveMessageChannelTrackerImpl] xrShutdownOpaqueDataChannelNV failed, result=" << result
+                          << std::endl;
         }
-    }
-    if (destroy_channel_fn_)
-    {
-        XrResult result = destroy_channel_fn_(channel_);
-        if (result != XR_SUCCESS)
+        if (destroy_channel_fn_)
         {
-            std::cerr << "[LiveMessageChannelTrackerImpl] xrDestroyOpaqueDataChannelNV failed, result=" << result
-                      << std::endl;
+            XrResult result = destroy_channel_fn_(channel_);
+            if (result != XR_SUCCESS)
+                std::cerr << "[LiveMessageChannelTrackerImpl] xrDestroyOpaqueDataChannelNV failed, result=" << result
+                          << std::endl;
         }
     }
     channel_ = XR_NULL_HANDLE;
@@ -307,12 +307,13 @@ bool LiveMessageChannelTrackerImpl::try_reopen_channel()
     }
 }
 
-MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
+MessageChannelStatus LiveMessageChannelTrackerImpl::query_status()
 {
-    if (channel_ == XR_NULL_HANDLE)
+    if (instance_lost_ || channel_ == XR_NULL_HANDLE)
     {
-        // Channel was destroyed (e.g. failed reopen); report DISCONNECTED so
-        // update() will schedule a reopen attempt on the next frame.
+        // Channel was destroyed (e.g. failed reopen, or instance lost); report
+        // DISCONNECTED so update() will schedule a reopen attempt next frame
+        // (try_reopen_channel guards against retrying after instance loss).
         return MessageChannelStatus::DISCONNECTED;
     }
 
@@ -320,8 +321,14 @@ MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
     XrResult state_result = get_state_fn_(channel_, &channel_state);
     if (state_result != XR_SUCCESS)
     {
-        throw std::runtime_error("LiveMessageChannelTrackerImpl: xrGetOpaqueDataChannelStateNV failed, result=" +
-                                 std::to_string(state_result));
+        // Any failure here means the runtime connection is gone.  Mark the
+        // instance lost and return DISCONNECTED rather than throwing: a thrown
+        // exception would propagate to the embedding app (e.g. Isaac Lab) and
+        // be misread as a recoverable pipeline error, triggering a needless
+        // session restart against a dead runtime.
+        instance_lost_ = true;
+        channel_ = XR_NULL_HANDLE;
+        return MessageChannelStatus::DISCONNECTED;
     }
 
     switch (channel_state.state)

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -111,7 +111,11 @@ void LiveMessageChannelTrackerImpl::drain_messages()
         if (query_result != XR_SUCCESS)
         {
             if (query_result == XR_ERROR_CHANNEL_NOT_CONNECTED_NV)
+                return;
+            if (query_result == XR_ERROR_INSTANCE_LOST)
             {
+                instance_lost_ = true;
+                channel_ = XR_NULL_HANDLE;
                 return;
             }
             throw std::runtime_error("LiveMessageChannelTrackerImpl: xrReceiveOpaqueDataChannelNV (query) failed, result=" +
@@ -156,7 +160,11 @@ void LiveMessageChannelTrackerImpl::drain_messages()
         if (recv_result != XR_SUCCESS)
         {
             if (recv_result == XR_ERROR_CHANNEL_NOT_CONNECTED_NV)
+                return;
+            if (recv_result == XR_ERROR_INSTANCE_LOST)
             {
+                instance_lost_ = true;
+                channel_ = XR_NULL_HANDLE;
                 return;
             }
             throw std::runtime_error("LiveMessageChannelTrackerImpl: xrReceiveOpaqueDataChannelNV (read) failed, result=" +
@@ -197,6 +205,11 @@ void LiveMessageChannelTrackerImpl::send_message(const std::vector<uint8_t>& pay
     XrResult state_result = get_state_fn_(channel_, &channel_state);
     if (state_result != XR_SUCCESS)
     {
+        if (state_result == XR_ERROR_INSTANCE_LOST)
+        {
+            instance_lost_ = true;
+            channel_ = XR_NULL_HANDLE;
+        }
         throw std::runtime_error("LiveMessageChannelTrackerImpl: xrGetOpaqueDataChannelStateNV failed, result=" +
                                  std::to_string(state_result));
     }
@@ -209,6 +222,11 @@ void LiveMessageChannelTrackerImpl::send_message(const std::vector<uint8_t>& pay
     XrResult send_result = send_fn_(channel_, static_cast<uint32_t>(payload.size()), payload_ptr);
     if (send_result != XR_SUCCESS)
     {
+        if (send_result == XR_ERROR_INSTANCE_LOST)
+        {
+            instance_lost_ = true;
+            channel_ = XR_NULL_HANDLE;
+        }
         throw std::runtime_error("LiveMessageChannelTrackerImpl: xrSendOpaqueDataChannelNV failed, result=" +
                                  std::to_string(send_result));
     }
@@ -307,7 +325,7 @@ bool LiveMessageChannelTrackerImpl::try_reopen_channel()
     }
 }
 
-MessageChannelStatus LiveMessageChannelTrackerImpl::query_status()
+MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
 {
     if (instance_lost_ || channel_ == XR_NULL_HANDLE)
     {

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -273,7 +273,9 @@ void LiveMessageChannelTrackerImpl::create_channel()
     XrResult result = create_channel_fn_(handles_.instance, &create_info, &channel_);
     if (result != XR_SUCCESS)
     {
-        if (result == XR_ERROR_INSTANCE_LOST)
+        // INSTANCE_LOST and RUNTIME_FAILURE both indicate the IPC connection
+        // to the runtime is gone; suppress further reopen attempts.
+        if (result == XR_ERROR_INSTANCE_LOST || result == XR_ERROR_RUNTIME_FAILURE)
             instance_lost_ = true;
         throw std::runtime_error("LiveMessageChannelTrackerImpl: xrCreateOpaqueDataChannelNV failed, result=" +
                                  std::to_string(result));
@@ -285,9 +287,6 @@ void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
     if (channel_ == XR_NULL_HANDLE)
         return;
 
-    // Skip NV extension calls when the instance is already lost: the IPC
-    // socket is closed so every call would fail with XRT_ERROR_IPC_FAILURE
-    // and generate noisy "Broken pipe" log spam against a dead runtime.
     if (!instance_lost_)
     {
         if (shutdown_fn_)
@@ -329,9 +328,6 @@ MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
 {
     if (instance_lost_ || channel_ == XR_NULL_HANDLE)
     {
-        // Channel was destroyed (e.g. failed reopen, or instance lost); report
-        // DISCONNECTED so update() will schedule a reopen attempt next frame
-        // (try_reopen_channel guards against retrying after instance loss).
         return MessageChannelStatus::DISCONNECTED;
     }
 
@@ -339,11 +335,8 @@ MessageChannelStatus LiveMessageChannelTrackerImpl::query_status() const
     XrResult state_result = get_state_fn_(channel_, &channel_state);
     if (state_result != XR_SUCCESS)
     {
-        // Any failure here means the runtime connection is gone.  Mark the
-        // instance lost and return DISCONNECTED rather than throwing: a thrown
-        // exception would propagate to the embedding app (e.g. Isaac Lab) and
-        // be misread as a recoverable pipeline error, triggering a needless
-        // session restart against a dead runtime.
+        // Return DISCONNECTED rather than throwing so callers don't treat
+        // instance loss as a recoverable pipeline error.
         instance_lost_ = true;
         channel_ = XR_NULL_HANDLE;
         return MessageChannelStatus::DISCONNECTED;

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.cpp
@@ -255,6 +255,8 @@ void LiveMessageChannelTrackerImpl::create_channel()
     XrResult result = create_channel_fn_(handles_.instance, &create_info, &channel_);
     if (result != XR_SUCCESS)
     {
+        if (result == XR_ERROR_INSTANCE_LOST)
+            instance_lost_ = true;
         throw std::runtime_error("LiveMessageChannelTrackerImpl: xrCreateOpaqueDataChannelNV failed, result=" +
                                  std::to_string(result));
     }
@@ -290,6 +292,8 @@ void LiveMessageChannelTrackerImpl::destroy_channel() noexcept
 
 bool LiveMessageChannelTrackerImpl::try_reopen_channel()
 {
+    if (instance_lost_)
+        return false;
     try
     {
         destroy_channel();

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
@@ -50,7 +50,7 @@ public:
 private:
     void initialize_functions();
     XrSystemId resolve_system_id() const;
-    MessageChannelStatus query_status() const;
+    MessageChannelStatus query_status();
     void create_channel();
     void destroy_channel() noexcept;
     bool try_reopen_channel();

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
@@ -73,6 +73,7 @@ private:
 
     XrTimeConverter time_converter_;
     int64_t last_update_time_ = 0;
+    bool instance_lost_ = false;
     MessageChannelMessagesTrackedT messages_;
     std::vector<uint8_t> receive_buffer_;
     std::unique_ptr<MessageChannelMcapChannels> mcap_channels_;

--- a/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
+++ b/src/core/live_trackers/cpp/live_message_channel_tracker_impl.hpp
@@ -50,7 +50,7 @@ public:
 private:
     void initialize_functions();
     XrSystemId resolve_system_id() const;
-    MessageChannelStatus query_status();
+    MessageChannelStatus query_status() const;
     void create_channel();
     void destroy_channel() noexcept;
     bool try_reopen_channel();
@@ -61,7 +61,7 @@ private:
     const MessageChannelTracker* tracker_{ nullptr };
     XrSystemId system_id_{ XR_NULL_SYSTEM_ID };
     XrUuidEXT channel_uuid_{};
-    XrOpaqueDataChannelNV channel_{ XR_NULL_HANDLE };
+    mutable XrOpaqueDataChannelNV channel_{ XR_NULL_HANDLE };
 
     PFN_xrCreateOpaqueDataChannelNV create_channel_fn_{ nullptr };
     PFN_xrDestroyOpaqueDataChannelNV destroy_channel_fn_{ nullptr };
@@ -73,7 +73,7 @@ private:
 
     XrTimeConverter time_converter_;
     int64_t last_update_time_ = 0;
-    bool instance_lost_ = false;
+    mutable bool instance_lost_ = false;
     MessageChannelMessagesTrackedT messages_;
     std::vector<uint8_t> receive_buffer_;
     std::unique_ptr<MessageChannelMcapChannels> mcap_channels_;


### PR DESCRIPTION
## Description
  Problem
 
  1. Error flood on Ctrl+C: The signal handler called stop() (killing the runtime) before propagating KeyboardInterrupt, so inner with-block teardown — OpenXR channel cleanup, session teardown — ran
  against a dead IPC socket, producing a cascade of broken-pipe errors and an infinite per-frame retry loop in the container.
  2. Ports held after unexpected exit: If the Python process was killed (SIGKILL, OOM, crash), the runtime subprocess was orphaned with no kernel-level death notification, leaving ports occupied. On the
  next launch, the stale cleanup used fuser -k -TERM, which fails silently in containers (PID namespace isolation, seccomp, missing psmisc).

  Changes

  Signal handling (_service.py / launcher.py)

  - Handler propagates to the prior handler first (raising KeyboardInterrupt for SIGINT, SystemExit for SIG_DFL, no-op for SIG_IGN), so with-block __exit__ teardown unwinds in order before stop() kills
  the runtime.

  Channel tracker (live_message_channel_tracker_impl)

  - create_channel(): sets instance_lost_ on INSTANCE_LOST or RUNTIME_FAILURE; try_reopen_channel() short-circuits immediately, stopping the per-frame retry loop.
  - query_status(): returns DISCONNECTED on failure instead of throwing, preventing Isaac Lab from misreading it as a recoverable error and restarting the session.
  - destroy_channel(): skips NV extension calls when instance_lost_, eliminating the broken-pipe log flood on teardown.
  - drain_messages() / send_message(): propagate INSTANCE_LOST to instance_lost_ flag.

  Stale runtime cleanup (_service.py / launcher.py)

  - PR_SET_PDEATHSIG via preexec_fn: kernel sends SIGTERM to the runtime if the Python parent dies unexpectedly.
  - Stale cleanup: replaced fuser with a connect() liveness probe + os.kill(pid) from cloudxr.pid/monado.pid — no external binary, works inside containers.
  - 1.4.x only: stderr=subprocess.PIPE → log file, eliminating the 64 KB pipe-buffer deadlock on long-running sessions.


Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved shutdown behavior so cleanup completes correctly when termination signals are received.
- Default termination signals now exit cleanly, while intentionally ignored signals remain unaffected.
- Improved resilience when live communication instances are lost during sending, receiving, or status checks.
- Lost connections now report as disconnected instead of producing errors, and unsafe channel operations are skipped.
- Improved stale runtime cleanup and startup diagnostics using persistent worker logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->