### PR TITLE
cloudxr: bump CXR_RUNTIME_SDK_VERSION to 6.3.0-rc4

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.3.0-rc3
+CXR_RUNTIME_SDK_VERSION=6.3.0-rc4
 CXR_WEB_SDK_VERSION=6.3.0-rc4
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 

--- a/scripts/download_cloudxr_runtime_sdk.sh
+++ b/scripts/download_cloudxr_runtime_sdk.sh
@@ -56,6 +56,19 @@ esac
 SDK_FILE="CloudXR-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
 EXP_SDK_FILE="CloudXR-exp-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
 
+# Remote names on NGC, newest convention first. 6.3.0-rc4 renamed the published
+# tarballs to a "-external" infix; the payload is unchanged. Downloads are always
+# saved as $SDK_FILE / $EXP_SDK_FILE, which is what CMake and Dockerfile.runtime-ngc
+# expect on disk.
+SDK_REMOTE_FILES=(
+    "CloudXR-external-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
+    "$SDK_FILE"
+)
+EXP_SDK_REMOTE_FILES=(
+    "CloudXR-exp-external-${CXR_RUNTIME_SDK_VERSION}-Linux-${ARCH}-sdk.tar.gz"
+    "$EXP_SDK_FILE"
+)
+
 is_valid_sdk_bundle() {
     local dir="$1"
     [[ -f "$dir/$SDK_FILE" ]] || return 1
@@ -87,14 +100,10 @@ download_ngc_file() {
     local out_path="$2"
     local label="$3"
 
-    [[ -s "$out_path" ]] && return 0
-
-    echo -e "${YELLOW}Downloading ${label}...${NC}"
     local -a curl_args=(--fail --location --output "$out_path"
         --connect-timeout 10 --max-time 120
         --retry 3 --retry-delay 5)
     if ! curl "${curl_args[@]}" "$url"; then
-        echo -e "${RED}Error: Failed to download ${label}${NC}"
         rm -f "$out_path"
         return 1
     fi
@@ -103,6 +112,29 @@ download_ngc_file() {
         rm -f "$out_path"
         return 1
     fi
+}
+
+# Try each remote name in turn; the first that resolves wins.
+download_ngc_first_match() {
+    local base="$1"
+    local out_path="$2"
+    local label="$3"
+    shift 3
+    local -a remote_files=("$@")
+
+    [[ -s "$out_path" ]] && return 0
+
+    local remote
+    for remote in "${remote_files[@]}"; do
+        echo -e "${YELLOW}Downloading ${label} (${remote})...${NC}"
+        if download_ngc_file "${base}${remote}" "$out_path" "$label"; then
+            return 0
+        fi
+    done
+
+    echo -e "${RED}Error: Failed to download ${label}${NC}"
+    echo -e "${RED}Tried: ${remote_files[*]}${NC}"
+    return 1
 }
 
 # -----------------------------------------------------------------------------
@@ -127,15 +159,17 @@ install_from_public_ngc() {
     mkdir -p "$CXR_DEPLOYMENT_DIR"
 
     local base="https://api.ngc.nvidia.com/v2/resources/org/nvidia/${resource}/${CXR_RUNTIME_SDK_VERSION}/files?redirect=true&path="
-    download_ngc_file \
-        "${base}${SDK_FILE}" \
+    download_ngc_first_match \
+        "$base" \
         "$CXR_DEPLOYMENT_DIR/$SDK_FILE" \
-        "CloudXR Runtime SDK" || return 1
+        "CloudXR Runtime SDK" \
+        "${SDK_REMOTE_FILES[@]}" || return 1
     if [[ "${CXR_DOWNLOAD_EXP:-0}" == "1" ]]; then
-        download_ngc_file \
-            "${base}${EXP_SDK_FILE}" \
+        download_ngc_first_match \
+            "$base" \
             "$CXR_DEPLOYMENT_DIR/$EXP_SDK_FILE" \
-            "CloudXR Experimental Runtime SDK" || return 1
+            "CloudXR Experimental Runtime SDK" \
+            "${EXP_SDK_REMOTE_FILES[@]}" || return 1
     fi
 
     echo -e "${GREEN}✓ CloudXR Runtime SDK installed successfully${NC}"


### PR DESCRIPTION
## Description

Bumps the CloudXR Runtime SDK pin in `deps/cloudxr/.env.default` from `6.3.0-rc3` to `6.3.0-rc4`.

The bump alone 404s: rc4 renamed the published tarballs to a `-external` infix (`CloudXR-external-6.3.0-rc4-Linux-amd64-sdk.tar.gz`, `CloudXR-exp-external-...`), while `scripts/download_cloudxr_runtime_sdk.sh` only knew the old `CloudXR-<ver>-Linux-<arch>-sdk.tar.gz` name. The second commit makes the downloader try the new name first and fall back to the old one, so rc3 and rc4 both resolve. Downloads are still saved under the canonical local filename, so `src/core/cloudxr/python/CMakeLists.txt`, `deps/cloudxr/Dockerfile.runtime-ngc` and the "drop a local tarball in `deps/cloudxr/`" path are untouched.

The rename looks like a packaging change rather than a payload change: rc3 and rc4 amd64 tarballs have identical version-normalized layouts (21 entries each, same `libcloudxr.so` / `include/openxr/` / `plugins/`), and rc4's internal `VERSION` reads `6.3.0-rc4`. Worth confirming with the CloudXR release team whether `-external` is the permanent convention going forward.

`CXR_WEB_SDK_VERSION` was already at rc4 and is unaffected: the `cloudxr-js-prerelease` resource kept its filename.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Ran the download script against live NGC on x86_64:

- rc4 with `CXR_DOWNLOAD_EXP=1`: both tarballs fetched via the `-external` names and saved under the canonical local names; sha256 matches a manual NGC fetch.
- rc3 with `CXR_DOWNLOAD_EXP=1`: first candidate 404s, falls back to the legacy name and succeeds (backward compatible).
- Re-run with the tarball already present: short-circuits on the local-tarball path.
- Bogus version: fails with exit 1 and lists both attempted names.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
