### PR TITLE
🍒 build(cloudxr): enable experimental runtime bundle by default

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -148,7 +148,6 @@ jobs:
           -DBUILD_PLUGIN_OAK_CAMERA=ON \
           -DBUILD_VIZ=ON \
           -DENABLE_CLOUDXR_BUNDLE_CHECK=ON \
-          -DENABLE_CLOUDXR_EXP_BUNDLE=ON \
           -DBUNDLE_ROBOTIC_GROUNDING=${{ steps.setup-v2d-src.outputs.bundled || 'false' }} \
           -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake \
           "${coverage_args[@]}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ option(ENABLE_EXPERIMENTAL_WINDOWS_BUILD "Enable experimental Windows build supp
 option(ENABLE_CLOUDXR_BUNDLE_CHECK "Enable CloudXR bundle check" OFF)
 
 # When ON, also package CloudXR Experimental Runtime SDK as isaacteleop.cloudxr_exp.
-option(ENABLE_CLOUDXR_EXP_BUNDLE "Also package CloudXR Experimental Runtime SDK as isaacteleop.cloudxr_exp" OFF)
+option(ENABLE_CLOUDXR_EXP_BUNDLE "Also package CloudXR Experimental Runtime SDK as isaacteleop.cloudxr_exp" ON)
 
 ## Enforce clang-format on Linux builds by default
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -94,9 +94,10 @@ Sometimes NVIDIA might share early access CloudXR SDKs with you. In that case, y
 tarballs such as:
 
 - ``CloudXR-<version-for-runtime-sdk>-Linux-<arch>-sdk.tar.gz`` (CloudXR Runtime SDK)
-- ``CloudXR-exp-<version-for-runtime-sdk>-Linux-<arch>-sdk.tar.gz`` (optional experimental
-  runtime). Needed for Jetson Orin support (for example :doc:`/getting_started/televiz`)
-  until the default runtime covers those platforms.
+- ``CloudXR-exp-<version-for-runtime-sdk>-Linux-<arch>-sdk.tar.gz`` (experimental
+  runtime). Packaged by default as ``isaacteleop.cloudxr_exp``; needed for Jetson Orin
+  support (for example :doc:`/getting_started/televiz`) until the default runtime covers
+  those platforms.
 - ``nvidia-cloudxr-<version-for-web-sdk>.tgz`` (CloudXR Web SDK)
 
 You can place them in the :code-file:`deps/cloudxr/` directory and update the ``deps/cloudxr/.env``
@@ -108,8 +109,9 @@ like this:
    CXR_RUNTIME_SDK_VERSION=<version-for-runtime-sdk>
    CXR_WEB_SDK_VERSION=<version-for-web-sdk>
 
-To package the experimental runtime into the wheel as ``isaacteleop.cloudxr_exp``, configure with
-``-DENABLE_CLOUDXR_EXP_BUNDLE=ON``. Select it at runtime with ``ISAAC_TELEOP_CLOUDXR_EXP``.
+The experimental runtime is packaged into the wheel as ``isaacteleop.cloudxr_exp`` by default
+(``ENABLE_CLOUDXR_EXP_BUNDLE=ON``). Pass ``-DENABLE_CLOUDXR_EXP_BUNDLE=OFF`` to skip it.
+Select it at runtime with ``ISAAC_TELEOP_CLOUDXR_EXP``.
 See :ref:`dedicated-cloudxr-runtime`.
 
 2. CMake: Configure and build


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Backport [d3f45254184e](https://github.com/NVIDIA/IsaacTeleop/commit/d3f45254184ea672cba0437d94fcc20c8b91b432) from main into release/1.4.x.

Default `ENABLE_CLOUDXR_EXP_BUNDLE` to `ON` so Linux builds package the experimental CloudXR Runtime SDK as `isaacteleop.cloudxr_exp` without an extra CMake flag. Jetson Orin (and anyone forcing `ISAAC_TELEOP_CLOUDXR_EXP=1`) get the experimental package from a normal configure.

Cleanup:
- Drop the redundant `-DENABLE_CLOUDXR_EXP_BUNDLE=ON` from `build-ubuntu` CI (the default covers it).
- Update build-from-source docs for the new default and `-DENABLE_CLOUDXR_EXP_BUNDLE=OFF` to skip.
- Align the `pyproject.toml.in` comment with the default.

Pass `-DENABLE_CLOUDXR_EXP_BUNDLE=OFF` to keep the previous “stable-only” packaging behavior.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- `SKIP=check-copyright-year pre-commit run --files CMakeLists.txt .github/workflows/build-ubuntu.yml docs/source/getting_started/build_from_source/index.rst src/core/python/pyproject.toml.in`
- No new unit tests: this is a CMake default flip plus docs/CI cleanup. Existing `cloudxr_exp` selection tests are unchanged. CI `build-ubuntu` will exercise packaging via the new default (no explicit `-DENABLE_CLOUDXR_EXP_BUNDLE=ON`).

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
