### PR TITLE
🍒 docs(camera_viz): document Orin televiz compositor workaround

### DIFF
--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -241,7 +241,9 @@ pose shift (no effect on the equirect sphere at its default infinite radius).
 Surfaces are composited by the OpenXR runtime, which keeps them sharp under head motion and lets
 CloudXR stream them efficiently (see
 :ref:`OpenXR composition layers <openxr-composition-layers>`). For flat planes only,
-``compositor: televiz`` opts a camera back into Televiz's built-in compositor.
+``compositor: televiz`` opts a camera back into Televiz's built-in compositor. On Jetson Orin
+(CloudXR experimental runtime), set ``compositor: televiz`` so the plane is not left black; see
+Troubleshooting below.
 
 CloudXR runtime flags
 ---------------------
@@ -361,6 +363,18 @@ Troubleshooting
   directory (``configs/``), not the directory you launched from.
 - **A source fails asking for CuPy / CUDA** — check ``nvidia-smi`` works and setup completed;
   all sources allocate their frame buffers on the GPU.
+- **Black camera plane on Orin** — with the CloudXR experimental runtime on Orin, the default
+  OpenXR compositor shows the camera plane but leaves its contents black. Under the camera's
+  ``display.placements`` entry, set ``compositor: televiz`` (quads only). The same feed displays
+  correctly with this workaround:
+
+  .. code-block:: yaml
+
+     display:
+       placements:
+         cam:
+           compositor: televiz
+
 - **Split mode renders nothing** — check the sender is up (``./camera_viz.sh service-status``),
   ``$STREAMING_HOST`` was the workstation's IP at deploy time, and UDP ports (default 5000+)
   aren't firewalled.

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -132,11 +132,25 @@ display:                      # camera_viz only
       # shape: quad            # quad (default) | cylinder | equirect — XR only for
                                # the curved shapes
       # compositor: openxr     # openxr (default) | televiz — quads only
+                               # Orin: use televiz (see Known issues)
       # cylinder_radius_m: 2.0 # cylinder: viewing distance to the arc
       # cylinder_angle_deg: 90 # cylinder: visible arc width
 ```
 
 Multiple cameras → multiple `cameras:` entries; each gets its own `rtp.port` (plus `port_right` if stereo) and renders as its own plane.
+
+## Known issues
+
+### Black camera plane on Orin
+
+With the CloudXR experimental runtime on Orin, the default OpenXR compositor displays the camera plane but its contents remain black. Set `compositor: televiz` under the camera's `display.placements` entry. The same feed displays correctly with this workaround.
+
+```yaml
+display:
+  placements:
+    cam:
+      compositor: televiz
+```
 
 ## Lock modes (XR)
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Backport [ff52e4124534](https://github.com/NVIDIA/IsaacTeleop/commit/ff52e41245347195ed50f60e528461b625efd82f) from main into release/1.4.x.

On Jetson Orin with the CloudXR experimental runtime, the default OpenXR compositor can show the camera plane with black contents. Document the workaround: set `compositor: televiz` under the camera's `display.placements` entry in the `camera_viz` YAML.

Updates:
- `docs/source/references/camera_streaming.rst` (compositor note + Troubleshooting entry)
- `examples/camera_viz/README.md` (Known issues + config comment)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Docs-only. Reviewed the Sphinx and example README wording for Orin-only scope and YAML placement under `display.placements`.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)
