### PR TITLE
docs(camera_viz): document Orin H.264 client setting

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -285,6 +285,12 @@ running the CloudXR runtime and wss proxy in containerized environment; or using
       - Click the **Click https://<ip>:48322/ to accept cert** link that appears on the page.
       - In the new tab, you will see a **"Your connection is not private"** warning. Click **Advanced**, then **Proceed to <ip> (unsafe)**.
       - Once accepted, the page will show **Certificate Accepted**. Navigate back to the CloudXR.js client page.
+
+   .. important::
+
+      **Jetson Orin:** when the CloudXR runtime runs on Orin, set **Video Codec** to
+      **H.264** in the CloudXR web client.
+
    3. Click **Connect** to begin teleoperation.
 
    .. note::

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -362,6 +362,9 @@ Troubleshooting
   directory (``configs/``), not the directory you launched from.
 - **A source fails asking for CuPy / CUDA** — check ``nvidia-smi`` works and setup completed;
   all sources allocate their frame buffers on the GPU.
+- **No video on Orin.** When the CloudXR runtime runs on Jetson Orin, set
+  **Video Codec** to **H.264** in the CloudXR web client. See
+  :ref:`connect-xr-headset`.
 - **Black camera plane on Orin** — with the CloudXR experimental runtime on Orin, the default
   OpenXR compositor shows the camera plane but leaves its contents black. Under the camera's
   ``display.placements`` entry, set ``compositor: televiz`` (quads only). The same feed displays

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -58,6 +58,8 @@ Flags: `--no-{v4l2,oakd}`, `--with-rtp` (split mode / `loopback`; implied by `--
 
 Set `source: local`. Swap config for `oakd.yaml`, `zed.yaml`, `realsense.yaml`, `synthetic.yaml`, `synthetic_stereo.yaml`, `synthetic_xr_3up.yaml`, `multi_camera.yaml`, `replay.yaml` (file replay — point `path:` at any recording).
 
+> **Jetson Orin:** when the CloudXR runtime runs on Orin, set **Video Codec** to **H.264** in the CloudXR web client.
+
 ## Mode 2 — Split (robot → workstation, RTP)
 
 > ⚠ **Wired only.** No retransmit / FEC; one lost packet = one corrupted frame until the next IDR (default 5 s).
@@ -140,6 +142,10 @@ display:                      # camera_viz only
 Multiple cameras → multiple `cameras:` entries; each gets its own `rtp.port` (plus `port_right` if stereo) and renders as its own plane.
 
 ## Known issues
+
+### No video on Orin
+
+When the CloudXR runtime runs on Jetson Orin, set **Video Codec** to **H.264** in the CloudXR web client.
 
 ### Black camera plane on Orin
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Document the CloudXR web client setting required for the tested `camera_viz` workflow when the CloudXR runtime runs on Jetson Orin.

The guidance now appears in the quick-start connection flow, the camera streaming troubleshooting guide, and the `camera_viz` README.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- Validated the H.264 client selection with `camera_viz` on Jetson AGX Orin.
- Built the documentation with warnings treated as errors: `make -C docs current-docs`
- Ran the full pre-commit suite: `SKIP=check-copyright-year pre-commit run --all-files`
- No code tests were added because this change only updates documentation.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Jetson Orin setup guidance to select the H.264 video codec in the CloudXR web client.
  - Included H.264 troubleshooting instructions for camera streaming and XR headset connections.
  - Clarified codec configuration for Direct mode and documented it under known issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->