### PR TITLE
ROS: add CloudXR.js OOB client route parameter

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
+++ b/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
@@ -92,7 +92,7 @@ export const TELEOP_PROJECTS: TeleopProjectRegistry = {
     label: 'Real Robot',
     settings: { panelHiddenAtStart: true, headless: false },
     children: {
-      ros: { label: 'ROS' },
+      ros2: { label: 'ROS2' },
       isaacros: { label: 'IsaacROS' },
       gear: {
         label: 'GEAR',

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -125,7 +125,7 @@ docker run --rm --gpus all --net=host --ipc=host \
   -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -14,6 +14,7 @@ assembles a frozen ``NodeParameters`` snapshot.
 
 import itertools
 import math
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -23,6 +24,7 @@ from rclpy.node import Node
 from rclpy.parameter import Parameter
 from scipy.spatial.transform import Rotation
 
+from isaacteleop.cloudxr.oob_teleop_env import TELEOP_CLIENT_ROUTE_ENV
 from isaacteleop.deviceio import McapReplayConfig
 from isaacteleop.retargeting_engine.deviceio_source_nodes.pedals_source import (
     DEFAULT_PEDAL_COLLECTION_ID,
@@ -49,6 +51,7 @@ class CloudXRParams:
 
     install_dir: str
     env_config: str | None
+    client_route: str
     accept_eula: bool
     setup_oob: bool
     usb_local: bool
@@ -99,6 +102,18 @@ def _load_cloudxr(node: Node) -> CloudXRParams:
                 "Optional CloudXR env file (KEY=value per line) passed to "
                 "CloudXRLauncher to override default CloudXR env vars. Empty "
                 "uses the built-in defaults."
+            ),
+        ),
+    )
+    node.declare_parameter(
+        "cloudxr_client_route",
+        os.environ.get(TELEOP_CLIENT_ROUTE_ENV, "/real/ros2"),
+        ParameterDescriptor(
+            type=ParameterType.PARAMETER_STRING,
+            description=(
+                "WebXR client route exported as TELEOP_CLIENT_ROUTE before CloudXR "
+                "launch. Defaults to the inherited environment value when set, "
+                "otherwise /real/ros2. Empty suppresses the URL route."
             ),
         ),
     )
@@ -160,6 +175,11 @@ def _load_cloudxr(node: Node) -> CloudXRParams:
             )
         env_config = str(env_config_path)
 
+    client_route = (
+        node.get_parameter("cloudxr_client_route")
+        .get_parameter_value()
+        .string_value.strip()
+    )
     accept_eula = (
         node.get_parameter("cloudxr_accept_eula").get_parameter_value().bool_value
     )
@@ -171,7 +191,14 @@ def _load_cloudxr(node: Node) -> CloudXRParams:
         raise ValueError(
             "Parameter 'cloudxr_usb_local' requires 'cloudxr_setup_oob' to be true"
         )
-    return CloudXRParams(install_dir, env_config, accept_eula, setup_oob, usb_local)
+    return CloudXRParams(
+        install_dir=install_dir,
+        env_config=env_config,
+        client_route=client_route,
+        accept_eula=accept_eula,
+        setup_oob=setup_oob,
+        usb_local=usb_local,
+    )
 
 
 def _load_config_asset_root(node: Node) -> Path:

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -38,6 +38,7 @@ TF frames published in hand_teleop and controller_teleop modes (configurable via
   - world_frame -> head_frame
 """
 
+import os
 import time
 
 import rclpy
@@ -52,6 +53,7 @@ from teleop_ros2_interfaces.msg import NamedPoseArray
 from tf2_ros import TransformBroadcaster
 
 from isaacteleop.cloudxr import CloudXRLauncher
+from isaacteleop.cloudxr.oob_teleop_env import TELEOP_CLIENT_ROUTE_ENV
 from isaacteleop.teleop_session_manager import SessionMode, TeleopSession
 from messages import (
     build_controller_msg,
@@ -292,6 +294,7 @@ class TeleopRos2Node(Node):
         if self._params.session_mode != SessionMode.LIVE:
             return self._run_session_loop()
 
+        os.environ[TELEOP_CLIENT_ROUTE_ENV] = self._params.cloudxr_params.client_route
         with CloudXRLauncher(
             install_dir=self._params.cloudxr_params.install_dir,
             env_config=self._params.cloudxr_params.env_config,


### PR DESCRIPTION
Expose the WebXR route as a ROS parameter so the reference node lands on the ROS2 profile in OOB mode by default while preserving explicit environment overrides.

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Expose the CloudXR.js client route as the `cloudxr_client_route` ROS parameter. The teleop ROS 2 node now prefers an explicit ROS parameter, then an inherited `TELEOP_CLIENT_ROUTE`, and otherwise defaults to `/real/ros2` before launching CloudXR.

Rename the WebXR `/real/ros` profile and label to `/real/ros2` and `ROS2` so the route matches the integration it represents.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable CloudXR client routing for the ROS 2 teleoperation example.
  * The route can be set through a ROS parameter or environment variable, with `/real/ros2` used by default.
  * The configured route is applied automatically when starting a live CloudXR session.
  * Updated the teleoperation project registry to use the ROS 2 route while retaining the existing ROS display label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->