### PR TITLE
SO-101 follower visualization and placement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,11 +70,14 @@ deps/v2d/wheels/
 # Runtime device files injected by MCP server infrastructure
 .mcp.json
 
-# SO-101 leader-gripper assets, fetched by scripts/fetch-so-arm.sh into the
-# package's assets directory, so only the authored wrapper XML is tracked.
+# SO-101 leader-gripper and follower-arm assets, fetched by
+# scripts/fetch-so-arm.sh into the package's assets directory, so only the
+# authored wrapper XML is tracked.
 #
 # Keep this rule HERE, not in examples/mujoco_xr/.gitignore: scikit-build-core
 # resolves .gitignore against the project root, so a rule there would strip the
 # meshes out of the wheel too.
 /examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/assets/leader/*
 !/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/assets/leader/leader_gripper.xml
+/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/assets/follower/*
+!/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/assets/follower/follower_arm.xml

--- a/docs/source/references/retargeting/so101.rst
+++ b/docs/source/references/retargeting/so101.rst
@@ -36,7 +36,8 @@ At a glance
      - Same output contract as ``Se3AbsRetargeter``, but clutches the **full pose**: re-latches
        both the home position and the home orientation on every engage, composing the orientation
        delta on the **left** (base frame) with no fixed offset. Engages on
-       ``RUNNING`` **and** ``squeeze > squeeze_threshold``.
+       ``RUNNING`` **and** ``squeeze > squeeze_threshold``, and only latches on a frame the owner
+       permits.
    * - ``SO101GripperRetargeter``
      - 1 float ``gripper_command`` ``c`` in ``[0, 1]``
      - Trigger -> jaw closedness (``0`` = open, ``1`` = closed), with a released-end deadzone.
@@ -82,7 +83,9 @@ conjuncts are different things and both are load-bearing: ``squeeze`` is *operat
 should hold ``STOPPED`` so a squeeze cannot latch a home the arm has not reached yet -- which also
 makes it safe to supply the real home late, via
 :meth:`~isaacteleop.retargeters.SO101ClutchRetargeter.set_home_base_T_ee`, when the retargeting
-graph must be built before the arm is homed.
+graph must be built before the arm is homed. Calling that method on every disengaged frame of a
+``RUNNING`` session is equally sound, and is what an owner whose arm moves while disengaged wants;
+see its own documentation, where the constraint is the engaged state rather than the cadence.
 
 Latching uses a **pending-latch sentinel**: the latch is *owed* until a frame arrives that can be
 trusted, and it is re-armed on every disengaged, dropped, invalid or degenerate frame. Both halves
@@ -113,6 +116,14 @@ an arm that sagged while disengaged is not snapped back to a stale command), whi
 softly, so latching the measured orientation would inject that tracking offset into the command on
 every re-clutch.
 
+.. warning::
+   The consequence is that ``MEASURED_BASE_T_EE_INPUT`` **cannot deliver rotation**. An owner
+   whose arm has rotated away from the configured home engages at the measured position and the
+   *stale* orientation -- see the attribute's own documentation for the measured figure. When the
+   arm's achieved rotation is what must be engaged against,
+   :meth:`~isaacteleop.retargeters.SO101ClutchRetargeter.set_home_base_T_ee` is not the preferred
+   route, it is the only one: it reads both blocks.
+
 ``MEASURED_BASE_T_EE_INPUT`` is declared ``OptionalType`` and a consumer **may omit it entirely**
 from ``connect()`` -- optional inputs are exempt from the missing-input check. A consumer whose
 owning task slews the arm to a known configured home (Isaac Lab) legitimately leaves it unwired
@@ -124,6 +135,26 @@ is connected to a ``ValueInput`` leaf, that leaf is an external graph input, and
 validates every external leaf name is present in ``external_inputs`` on **every** step,
 independently of ``OptionalType``. Such a producer must send the key unconditionally, carrying an
 absent ``OptionalTensorGroup`` on frames with no pose.
+
+Latch permission
+^^^^^^^^^^^^^^^^
+
+:data:`~isaacteleop.retargeters.SO101ClutchRetargeter.ENGAGE_PERMITTED_INPUT` is an optional
+boolean the owner sets when a jump-free engage is possible *right now*. It is read **only** on a
+frame where a latch is owed, so it gates the **latch** and never the engagement: revoking it
+mid-engagement does nothing, and :attr:`~isaacteleop.retargeters.SO101ClutchRetargeter.is_engaged`
+remains exactly ``_origin is not None``. Absent, unwired, or ``True`` all mean permitted, so an
+existing consumer is unaffected.
+
+It is an **enable precondition, not a safety-rated stop**. Denial does not disengage and does not
+re-arm anything; it holds the pending latch until a permitted frame arrives, and the latch then
+fires against *that* frame's controller pose, not the one it was first squeezed at. The same
+``ValueInput``-leaf rule as ``MEASURED_BASE_T_EE_INPUT`` applies: a producer that wires it must
+send the key on every step.
+
+The motivating consumer is ``examples/mujoco_xr``, whose owner shows the operator an SO-101
+follower before engaging and withholds permission until the operator's wrist is turned the way
+that arm is -- see that example's README.
 
 Reset
 ^^^^^

--- a/examples/mujoco_xr/README.md
+++ b/examples/mujoco_xr/README.md
@@ -6,14 +6,15 @@ SPDX-License-Identifier: Apache-2.0
 # MuJoCo XR
 
 A MuJoCo scene rendered stereoscopically into an Isaac Teleop Televiz XR
-session, with an SO-101 leader gripper locked to the operator's right hand.
+session: an SO-101 **follower arm** the operator drags around by hand, and an
+SO-101 **leader gripper** that replaces it once the clutch engages.
 
 Single process, single thread, **one** OpenXR session:
 
 ```
 VizSession(kXr)  ──get_oxr_handles()──▶  TeleopSession
      │                                        │
-     │ recommended resolution                 │ controller grip poses
+     │ recommended resolution                 │ EePoseRateLimiter output
      ▼                                        ▼
 mjr_render ─blit─▶ flip + depth-invert ─glReadPixels─▶ PBO ═CUDA═▶ submit()
 ```
@@ -66,9 +67,9 @@ extension and asserts both report the same version.
 
 | | |
 |---|---|
-| **Covered by tests** | [`ctest -L mujoco_xr`](#tests) — the frame conventions, the frustum, the clock, the ghost overlay and its jaw channel, all pure CPU; **plus `test_readback.py`, which drives the real GPU path** (mjr_render → blit → flip/invert → PBO → CUDA). That one needs CUDA-OpenGL interop, so it wants a discrete NVIDIA GPU; it skips loudly elsewhere. **Measured on Jetson/Tegra it skips**, because `cudaGLGetDevices` reports the EGL context on no CUDA device — so a green `ctest` there does *not* mean the GPU path ran. |
+| **Covered by tests** | [`ctest -L mujoco_xr`](#tests) — the frame conventions, the frustum, the clock, the ghost overlay and its jaw channel, the safety harness the ghost renders, the follower's head anchoring and rigid drag, and the whole clutch handoff driven at frame rate through the real pipeline, all pure CPU; **plus `test_readback.py`, which drives the real GPU path** (mjr_render → blit → flip/invert → PBO → CUDA). That one needs CUDA-OpenGL interop, so it wants a discrete NVIDIA GPU; it skips loudly elsewhere. **Measured on Jetson/Tegra it skips**, because `cudaGLGetDevices` reports the EGL context on no CUDA device — so a green `ctest` there does *not* mean the GPU path ran. |
 | **Never executed anywhere** | **The XR half** — everything downstream of the readback. See [Not verified anywhere](#not-verified-anywhere-in-ci-or-on-a-developer-desktop). |
-| **Wrong by construction until calibrated** | The workspace translation, for any scene that adds static content — see [Frames](#frames-cppframeshpp). The shipped ghost-only scene does not show it. |
+| **Wrong by construction until calibrated** | Nothing, now. The follower is placed against the **measured head pose** rather than the reference-space origin, and its offset is authored in the **XR** frame and pushed through `mj_from_xr`, so `kTransMjFromXr` appears once with each sign and cancels — see [Frames](#frames-cppframeshpp). |
 
 Nothing in `.github/workflows/` installs `mujoco`, so the example is never
 configured and **not one of its tests has ever run in CI**. Green means one
@@ -78,9 +79,9 @@ developer ran it locally. Wiring examples into CI is
 ## Scope
 
 Renderer + MuJoCo + rig, and one scene: `assets/scene.xml` — an **SO-101
-leader gripper ghost** locked to the right controller's grip pose, and nothing
-else. No table, no blocks, no ground plane: this is an AR scene and passthrough
-is the background.
+follower arm** and an **SO-101 leader gripper ghost**, exactly one of which is
+drawn at a time. No table, no blocks, no ground plane: this is an AR scene and
+passthrough is the background.
 
 The ghost is not decoration. It is a real mesh assembly (4 fetched STLs, so it
 exercises the `mjGEOM_MESH` path), and locking it to the hand makes the *grip*
@@ -97,9 +98,14 @@ therefore the screen. There is no robot in the scene, so the jaw it drives is
 the operator's own trigger; that is enough to show the edge is live, and the
 SO-101 that will read the same output arrives with the scene catalogue.
 
+**And its pose is the safety harness's output, not the controller's** — see
+[The harness the ghost renders](#the-harness-the-ghost-renders). What that
+harness governs is the **clutch's** output; see
+[The clutch and the follower preview](#the-clutch-and-the-follower-preview).
+
 Two calibrations, and they are different in kind. `cpp/frames.hpp` is a
 *convention* fixed by two specs and cannot be wrong at runtime.
-`_QUAT_GRIP_FROM_GHOST` / `_POS_GRIP_FROM_GHOST` in `app.py` are a *measurement*
+`_QUAT_HAND_FROM_GHOST` / `_POS_HAND_FROM_GHOST` in `app.py` are a *measurement*
 of how a hand holds a tool, taken on a headset and checkable nowhere else. See
 [Frames](#frames-cppframeshpp).
 
@@ -237,6 +243,387 @@ beside the module, and editing it is how you load something else. There is no
 desktop or headless display mode; without a headset the verification path is
 [`ctest -L mujoco_xr`](#tests).
 
+## The harness the ghost renders
+
+The ghost's pose comes from an `EePoseRateLimiter` (`harness.py`,
+`_build_pipeline()`), so what the operator sees is **the command a follower
+would execute**, not where their hand is. That is the point:
+[#738](https://github.com/NVIDIA/IsaacTeleop/issues/738) reports operators
+losing minutes to harness interventions they could not perceive — the arm "stops
+following", and the instinct that produces (push harder, move faster) is exactly
+wrong.
+
+The limiter is a three-band governor: motion under the limits passes through
+untouched, motion over them is clamped to the limit, and a frame whose input
+velocity breaks the reject envelope is refused outright. Two things report which
+band is live:
+
+- **The ghost lags the hand.** Proprioceptive, and free — you feel where your
+  hand is and see the tool is not there.
+- **The ghost changes colour.** Amber while clamping, red while rejecting,
+  authored blue while passing through. Categorical, which the lag alone is not:
+  a clamp and a refusal both read as "behind my hand".
+
+Colour is written to the shared `leader_ghost` **material**, so one write
+recolours the whole tool. Do not switch it to `geom_rgba`: that silently wins
+over the material, and the four geoms would then have to be kept in step by
+hand. Alpha stays 1.0 in every band —
+`assets/leader/leader_gripper.xml` explains what opacity buys, and a translucent
+"intervening" state would quietly take those risks back.
+
+`InterventionMonitor` recovers the band by comparing what the limiter was handed
+against what it emitted, rather than by asking the limiter. That keeps the
+shipped node unmodified and works for any governor with the same contract; the
+cost is one extra `OutputCombiner` key (`COMMANDED_POSE_KEY`) carrying the
+limiter's own input, which nothing draws.
+
+**The limits are chosen for this demo, not measured against an SO-101.** 0.5 m/s
+and 2.5 rad/s clamp, 2.0 m/s and 10 rad/s reject — set so ordinary reaching is
+pass-through and a deliberate flick trips both bands on demand.
+`RateLimiterConfig` itself defaults to 0.25 m/s, which is the more conservative
+bring-up value and would clamp during ordinary reaching. **Nothing tests these
+numbers**, so retuning `_HARNESS` past what a hand can reach silently produces a
+demo that never intervenes.
+
+**The jaw is ungoverned** — a `JointRateLimiter` would bound it, but the trigger
+is one scalar the operator drives directly, not a solved output that can diverge.
+
+While the clutch is disengaged the limiter is still running, on a commanded pose
+that tracks the follower. That is not idling: the gate below refuses to go green
+unless the limiter is in its pass-through band, so this is where that conjunct
+gets its evidence.
+
+`rate_limiter.py` is
+[#727](https://github.com/NVIDIA/IsaacTeleop/pull/727) rehomed from
+`src/retargeters/` to `src/python/isaacteleop/retargeters/`, which is where that
+package now lives.
+
+## The clutch and the follower preview
+
+Disengaged, the operator drives the **follower's** gripper, and two things move
+it independently:
+
+- **Position** is the controller's, all three axes — `follower.py` slides the
+  whole arm so its **jaw** tracks the hand every frame, the grip offset off it
+  *exactly*.
+- **Yaw** is the controller's own yaw, every frame, with no button held. The base
+  turns onto it and the arm swings around the jaw.
+
+**The joints are locked.** `qpos` is written once, to `Q_HOME`, and the arm is
+moved as a rigid body — `Follower._place` is the one writer of `body_quat`,
+`Follower._move_base` the one writer of `body_pos` — so the gripper's orientation
+*in the base's frame* is a constant, and the jaw lands at its offset from the hand
+with no residual and no point it cannot reach. The offset starts at
+`GRIP_FROM_CONTROLLER_XR`: level with the hand laterally, 0.25 m ahead and 0.10 m
+below it, so they can see an arm they are not standing inside.
+
+**Both channels land on `GRIPPER_SITE`, and that is what makes the yaw pivot
+right.** Upstream declares a `gripperframe` site on the `gripper` body 98.4 mm out
+from its origin, 3.8 mm off the closed jaw surface — where a grasped object would
+be. The arm is placed *by* that point, so it is also the axis the yaw turns about:
+the jaw holds still and the base swings around it, 273 mm across ±90° of yaw.
+Place by the gripper **body** instead and the pinned point sits 98.4 mm short of
+the jaw, which then orbits it — a 15.8 mm arc over that same sweep, on the one
+point the operator is actually aiming. The body frame is still the **orientation**
+carrier, and `Follower.gripper_pose_mj()` returns it for exactly that; do not read
+its position as the tool point.
+
+**That offset is tunable from the headset, and only while disengaged.** The right
+thumbstick walks its two horizontal terms — stick X left/right, stick Y
+forward/back, forward sending the arm further out — at 0.20 m/s of full
+deflection, past a 0.15 deadzone and clamped to ±0.60 m on each. Deflection is a
+*rate*, so the offset holds where the stick left it; the drop below the hand is
+not on the stick. Both terms are carried on the **controller's own facing**, so
+forward sends the arm further along the pointing ray and right sends it to the
+controller's right — and yawing the controller carries the arm around with it at a
+fixed relative position, rather than leaving it behind in the world. Note this is
+the *facing*, not the base yaw, which leads it by the measured bias and would send
+"forward" off by exactly that much. Let go and the app prints what it settled on,
+in the constant's own form:
+
+```
+follower:   offset tuned to GRIP_FROM_CONTROLLER_XR = np.array([-0.31, -0.10, -0.22])
+```
+
+**Paste that back into `follower.py` as the new default.** It is a headset
+judgement and no headless test can make it, so this is how a session becomes a
+constant rather than a note-to-self. B (`SECONDARY_CLICK`) puts it back to the
+authored value on its rising edge, for an offset walked out to its clamp or a
+drifting stick that got there on its own. `ENGAGED` neither the stick nor the
+button does anything visible: the arm is hidden and frozen there, and an offset
+moving under it would apply the whole excursion on the release frame.
+
+Squeeze while the arm is **green** and the follower vanishes, the leader appears
+**in the hand** at the follower's rotation, and the harness colouring above takes
+over. **The offset is the preview's alone.** The leader is the tool the operator
+teleoperates, so it is mapped 1:1 onto the controller and an engagement does not
+inherit it — tuned or not. The visible cost is that the engage frame swaps one
+tool for another a whole offset away — a handoff between two objects, not one
+object jumping.
+
+Release and the follower comes back **immediately**: the arm is drawn again on
+the release frame itself and the drag resumes on that same frame, so the
+controller is driving it again with nothing in between.
+
+**Do not put a smoothstep back to the home pose on the release.** The drag runs on
+every disengaged frame, so a ramp has nothing to do: the arm would reach home and
+be dragged straight back onto the hand on the next frame. The visible cost of not
+having one is real and accepted — the arm teleports from where it froze onto the
+hand's position and yaw, by however far the operator moved and turned during the
+engagement.
+
+**The dwell is therefore the whole post-release debounce.** The gate's phase
+conjunct holds it shut for the entire engagement, so `_dwell_s` restarts at the
+release and no squeeze can re-latch for ~8 frames. Nothing else gates it: the
+limiter's reset pulse absorbs the teleport in one frame, so `still catching up`
+does not fire.
+
+**The app drives from the `aim` pose, and `HAND_POSE` is the single constant that
+says so.** OpenXR publishes two controller poses for two different jobs.
+`grip` is the palm centroid, published so an application can render an object the
+user is *holding*; its `-Z` runs little finger to thumb, **up through the fist**,
+and is not a pointing direction at all. `aim` is published so an application can
+*point*: its `-Z` is the ray. Reading a facing off `grip` therefore turns 1:1 with
+the hand but has an arbitrary zero — a fixed yaw offset the operator sees and
+cannot tune away — which is why this app moved to `aim`.
+
+`HAND_POSE` reaches everything: the follower's drive, the engage gate's operand,
+the clutch's latched home and the ghost's placement, because they all consume the
+one `HAND_POSE_KEY` channel. `SO101ClutchRetargeter` reads the controller group
+directly rather than that channel, so it takes a matching `controller_pose=`
+argument; its *orientation* delta is provably invariant to the choice — for a fixed
+body-frame `T`, `(R·T)(R₀·T)⁻¹ == R·R₀⁻¹` — so that argument changes the
+translation pivot only.
+
+**The cost is real and is the thing to watch in a headset.** `aim`'s *origin* is a
+device-specific ray origin rather than the palm centroid, so the arm's position
+gains a lever arm that swings as the wrist turns. Flip `HAND_POSE` back to
+`HandPose.GRIP` to compare — but re-tune `_EULER_HAND_FROM_GHOST_DEG` when you do,
+because the ghost calibration is relative to whichever frame that constant names.
+
+**Which axis you read was a leakage budget on `grip`; on `aim` there is nothing to
+choose**, since `-Z` is the ray by definition. The measurement is kept because it
+is what rules `grip` out and what to re-run if `aim` disappoints. Every candidate
+turns 1:1 with a rotation about the world vertical — an axis' azimuth does that by
+construction — so what separated them is only how much wrist **roll and pitch bleed
+into the arm's yaw**. Each axis is blind to rotation about *itself* and sensitive to
+the rest. Worst leak over ±45° at the posture the gate demands, measured on `grip`:
+
+| motion | `-Z` thumb | tool/barrel | flattened | best-fit |
+|---|---|---|---|---|
+| roll about the thumb axis | **0.00** | 12.89 | 21.09 | 23.40 |
+| roll about the barrel | 11.75 | **0.00** | 29.60 | 31.94 |
+| pitch about grip `+X` | **0.00** | 27.88 | 0.41 | **0.00** |
+| pitch about horizontal-perp | 2.30 | **0.00** | **0.00** | **0.00** |
+
+On `grip` the thumb axis won that table — best worst case, exact on two of four.
+`aim`'s `-Z` is the **tool/barrel** column, whose leak is dominated by how far the
+axis sits from horizontal at the posture held; the 27.88° there is a near-vertical
+singularity reached only because that stand-in axis starts 43.7° up, and a real aim
+ray held level does not go near it. **That is an expectation, not a measurement** —
+the grip-to-aim transform is per-device and no headless test here can supply it, so
+re-measure the leak on a headset. `follower.yaw_of_axis` takes the axis as a
+**required** argument for exactly this reason; `follower.yaw_of` keeps `-Z` and is
+for the **head** alone, whose `-Z` genuinely is its view direction.
+
+**`_YAW_TRIM_DEG` should now be zero, and a session that needs a large one is
+evidence, not a knob.** Removing the offset is the whole reason for reading `aim`,
+so if a trim is still needed the switch did not do its job. It is kept only to
+absorb a runtime whose aim convention differs from the operator's expectation.
+**Hold A and push the right thumbstick** left or right at 20°/s; A owns the stick
+while held, so a trim cannot also walk the grip offset. Let go and the app prints
+it in the constant's own form, to paste back:
+
+```
+follower:   yaw trim -> _YAW_TRIM_DEG = -10.0
+```
+
+It is applied as a **constant** on top of the reading, so it cannot introduce
+leakage of its own.
+
+**The ghost calibration's two halves are now sourced differently, and that is the
+point.**
+
+Its **rotation**, `_EULER_HAND_FROM_GHOST_DEG`, is **solved, not measured**. Nothing
+in it is a free choice once you decide what posture the engage gate should ask for,
+and *that* is the thing worth choosing. On `aim` a pose's `-Z` is the pointing ray,
+so demanding "level and unrolled" means "hold the controller the way you would
+naturally point it". `(270, 0, 90)` produces exactly that — **0.00° of pitch and
+0.00° of roll** against `Q_HOME`. It is a consequence of `Q_HOME`, so re-solve when
+that moves: it is the gripper's `xquat` at `Q_HOME` and base yaw 0, carried into XR by
+`_xr_from_mj_quat`, as intrinsic-XYZ Euler.
+
+Getting it wrong is quiet, and porting a `grip`-measured value is how it went wrong
+before: ported from that frame, it
+demanded **30° of upward pitch** — invisible on `grip`, where `-Z` is the thumb axis
+and points up anyway, and immediately obvious on `aim`, where it means aiming at the
+ceiling. Bearing is deliberately unpinned, hence the rounding to whole degrees: the
+base tracks the hand's yaw, so the gate's yaw cancels and `base_yaw_bias` absorbs the
+2.8° that is left.
+
+Its **translation**, `_POS_HAND_FROM_GHOST`, stays a headset measurement — no posture
+pins it — and the shipped value was measured on `grip`. That port *is* per-device, so
+`_log_hand_frames` computes it from one frame with both poses valid and prints it:
+
+```
+hand frames: this device's aim pose sits 50 deg and 40 mm off its grip pose. HAND_POSE is AIM, so for the ghost to sit where it did on GRIP, its POSITION wants:
+hand frames:   _POS_HAND_FROM_GHOST = np.array((-0.000, 0.020, 0.015))
+```
+
+Both terms of that port are needed — the origins' separation *and* the old offset
+turned by the same rotation; dropping the second leaves the ghost centimetres out
+while its orientation looks perfect.
+
+**The base leads the hand by a measured bias so the JAW faces it.**
+`Follower.jaw_yaw_xr` reads `GRIPPER_SITE`'s `+Z` — which way the gripper is turned
+— and `base_yaw_bias()` measures the lead at startup rather than authoring it,
+because how far the jaw sits off its own base yaw follows from `Q_HOME` and
+upstream's chain. With `J5 = -90` it comes out at **92.79°**. The jaw then faces the
+controller to **0.000° at every world yaw**, with **0.00° of leak from wrist roll
+and 0.00° from pitch**.
+
+The jaw and the arm's *reach* are different axes, parting company by exactly J5's
+roll: J5 turns the gripper about its tool axis without moving the links, so aiming
+one leaves the other off by that much. Aiming the jaw is the choice here, and the
+cost is the arm's body sitting **92.79°** to the side of where you point. The two
+are coupled through the calibration — moving the bias moves the demanded posture
+with it — so `_EULER_HAND_FROM_GHOST_DEG` must be re-solved whenever the aimed axis
+or `Q_HOME` changes.
+
+**The arm's yaw cancels the hand's, and that is why no button locks one.** The
+gate compares the controller against the rotation the clutch would latch, and
+because the base carries the wrist's own yaw that rotation is `wrist_yaw ∘ C` for
+a session constant `C`. The geodesic angle between them is therefore the angle
+between the wrist's *pitch and roll* and `C` — the same number whichever way the
+operator faces and whichever way they point. One posture to learn rather than one
+per reach, and `Q_HOME` earns its derivation from exactly that: the gripper
+orientation it produces is what the gate asks for. Correcting the yaw drive also
+drained `C` of nearly all its own yaw — from 2.79° to 0.73° — so the posture the
+gate demands no longer asks the operator to hold their wrist turned off the
+direction they are pointing.
+
+### Where the arm goes
+
+**Against the measured head pose, not the reference-space origin.** On the first
+frame carrying a usable `info.views[0].pose`, the home grip is placed
+`HOME_GRIP_FROM_HEAD_XR` — 0.30 m below and 0.60 m in front — of the head,
+**yaw-projected** onto the head's facing so "in front" means in front of the
+operator and not along the reference space's `-Z`. Yaw only: a bowed or tilted
+head must not tip the arm toward the floor.
+
+**The anchor is a starting pose and nothing more.** Its *position* is only where
+the arm waits out the window between the first head pose and the first controller
+frame; its *yaw* only turns the arm to face the operator for that same window.
+From the first driven frame the controller owns everything — position, base yaw,
+and the frame the thumbstick offset is carried on. `Follower.base_yaw_xr` reports
+whichever yaw is actually on the base.
+
+The app does not get to choose its reference origin. viz asks for no
+floor-origin space, so a runtime that hands back a stage-origin one puts
+everything authored against that origin a standing height out — which is what a
+headset run showed. The head pose is the only datum the app can trust.
+
+The anchor does not follow the head afterwards either: the pose the clutch is
+about to latch must not move out from under the operator as they look around.
+
+Placement is therefore runtime-derived, and so **neither tool is drawn until the
+anchor exists**. `Follower.__init__` starts the arm hidden, `_Preview.__init__`
+starts the ghost hidden, and `_Preview.after_step` returns early while
+`arm.anchored` is false — with the gate held shut, so the clutch cannot latch
+onto a pose the arm never held either.
+
+Two phases — `DISENGAGED` and `ENGAGED` — and the enum never answers "is the
+clutch latched?". `SO101ClutchRetargeter.is_engaged` is the sole authority for
+that; the phase takes it as an input every frame and never copies it into a
+field.
+
+**Green means all three of these hold**, and `follower.py`'s gate returns every
+one that does not, which `app.py` logs on each transition:
+
+- the hand's rotation is within the enter band of the rotation the clutch would
+  latch,
+- the rate limiter is passing through, not clamping,
+- and all of that has held for a dwell.
+
+**There is no reach conjunct, and no reach envelope.** The rigid drag puts the
+gripper exactly at its offset from the hand every frame, so a position residual
+is identically zero and a limit on it would forbid nothing — the arm goes
+wherever the hand goes, including places no articulated SO-101 could reach.
+`EngageGate.evaluate` says so where the conjunct used to be; do not add one back
+believing it keeps the operator inside a workspace this preview does not have.
+
+The rotation conjunct is the whole point. The leader is rebased onto the
+follower's rotation at engage, so if the operator's wrist is 40° from where the
+follower's gripper is pointing, that 40° does not go away — the clutch composes
+orientation as a **delta**, so it persists for the entire engagement. Hysteresis
+and the
+dwell are not polish either: the angle is recomputed every frame from a noisy
+controller, and a colour strobing at 72 Hz in a headset is worse than a wrong
+colour.
+
+**The pass-through conjunct is not optional.** The leader renders the *limiter's*
+output. The grip calibration converts hand rotation into ~4°/cm of tool motion,
+so 0.5 m/s of hand speed is 3.49 rad/s against a 2.5 rad/s clamp: clamping starts
+around 0.36 m/s, which is ordinary dragging. Without this conjunct the arm goes
+green while the tool about to be revealed is tens of degrees and hundreds of
+milliseconds behind.
+
+**The handoff is exact, and that is measurable.** `app.py` pushes
+`clutch.set_home_base_T_ee(pose_from_ghost_body(...))` on every non-`ENGAGED`
+frame, built from **two different sources**: the position from the last usable
+hand pose — latched in `after_step`, because `before_step` runs a frame ahead of
+it — and the rotation from the follower's gripper. So the clutch's home is the
+hand's position at the follower's rotation, and on the latch frame it emits that
+home exactly. Neither half is interchangeable: latching the gripper's *position*
+would carry the preview's offset into an engagement the clutch composes as a
+delta, and taking the *rotation* from the hand would leave the gate's rotation
+conjunct demanding nothing. `MEASURED_BASE_T_EE_INPUT` is deliberately left unwired — `_latch`
+reads it for **position only** and always takes the rotation from the last
+commanded rotation, so it cannot deliver this.
+
+Which is also the trap. Because the grip calibration **cancels exactly** through
+the handoff, the leader lands in the hand at the follower's rotation for *any*
+value of it and every geometric test passes. Its one surviving effect is which
+wrist posture the gate demands, so `app.py` logs two readable directions at
+startup — where the tool points and where the gate wants the operator's thumb —
+and **warns** past 45° on the thumb. It does not refuse to start: this app is the
+only place the calibration can be judged, so aborting would prevent the
+inspection the log exists for.
+
+Read the **hand-axis** direction when judging `_EULER_HAND_FROM_GHOST_DEG` — the log names it `pointing` on `aim` and `thumb` on `grip`. The tool
+direction does not contain the calibration at all — it is a guard on `Q_HOME` and
+a mesh refresh, and it reads the same 15° for a calibration that is right and one
+that is 118° wrong. Both are reported in the **arm's own frame** — XR axes
+un-yawed by `base_yaw_xr` — so they read the same whichever way the operator was
+facing and however they hold their wrist, which is also why the log can run
+*before* the arm is anchored.
+Against the reference space's `-Z` they would just report where the operator
+happened to stand.
+
+**Nothing integrates.** `mj_step` is never called: the follower is slid by its
+base and read back through `mj_forward`, and the ghost is two mocap bodies.
+Upstream's six `position` actuators are therefore inert — with `ctrl = 0` and
+`mj_step` they would drag the arm back to `qpos0` at about 1 rad per 0.4 s. There
+are deliberately no `gravity="0 0 0"` or `<flag actuation="disable"/>` attributes
+in `scene.xml`: flags that suppress dynamics nobody runs tell the next reader
+that dynamics run. The invariant that replaces them is simply *`qpos` is written
+once, by `follower.py`, and `body_pos` only by `Follower._move_base`*.
+
+With no `mj_step` there is also nothing left to refresh derived state, so the
+second invariant is the pass `mj_step` used to supply for free: **one
+`mj_forward` after every `qpos`, `body_pos` *or* `mocap_*` write, before every
+`xpos` / `xquat` / `geom_xpos` read — including the read inside
+`mjv_updateScene`.** `mocap_pos`/`mocap_quat` are *inputs to* forward kinematics
+and the renderer draws `geom_xpos`, so a correct mocap row is not a drawn pose.
+`follower.py` owns that call for the arm and `_Preview.after_step` for the ghost;
+nothing while `ENGAGED` moves the arm, which is why the ghost cannot borrow the
+drag's.
+
+`SO101ClutchRetargeter` gains one input for this, `ENGAGE_PERMITTED_INPUT`: an
+`OptionalType` boolean checked **only** where a latch is owed, so it gates the
+latch and never the engagement, and absent or unwired means permitted. It is an
+enable precondition, not a safety-rated stop.
+
 ## Conventions you can break
 
 ### Frames (`cpp/frames.hpp`)
@@ -273,8 +660,8 @@ disambiguate.
 
 ### Where the ghost sits on the hand (`app.py`)
 
-A *second* calibration, and a different kind: `_EULER_GRIP_FROM_GHOST_DEG` and
-`_POS_GRIP_FROM_GHOST` place the leader gripper on the operator's hand. Without
+A *second* calibration, and a different kind: `_EULER_HAND_FROM_GHOST_DEG` and
+`_POS_HAND_FROM_GHOST` place the leader gripper on the operator's hand. Without
 them the gripper's body origin — the follower's `gripper` datum, up at the wrist
 — lands on the grip pose, so the tool hangs off the hand at an arbitrary angle.
 
@@ -302,7 +689,7 @@ convention as a MuJoCo `euler=` attribute, pinned by a test against a compiled
 model rather than asserted here. Change one angle, `uv pip install
 --reinstall-package isaacteleop-examples-mujoco-xr ./examples/mujoco_xr`,
 relaunch: `Rz` spins the gripper about its own long axis, `Rx` / `Ry` tilt it in
-the hand, and `_POS_GRIP_FROM_GHOST` slides it along the grip axes if the angle
+the hand, and `_POS_HAND_FROM_GHOST` slides it along the hand-pose axes if the angle
 is right but the placement is not. **No test asserts a posture**, deliberately —
 they cover the machinery, so re-tuning cannot turn them red. The one that
 matters asserts the ghost is *rigidly attached* to the grip frame, which is
@@ -368,10 +755,10 @@ reads the array as you leave it, and `dir` is the camera's `forward`, un-negated
 or give the scene its own `<light>` elements, which `mjv_updateScene` does place
 correctly.
 
-The ghost's four STLs are **fetched, not vendored** — 2.3 MB of binary in a
-source tree is a poor trade when upstream publishes them at a stable commit, and
-Git LFS made every clone pay for them. Run it once, then reinstall, because they
-are package data:
+The 17 STLs are **fetched, not vendored** — 18 MB of binary in a source tree is
+a poor trade when upstream publishes them at a stable commit, and Git LFS made
+every clone pay for them. Run it once, then reinstall, because they are package
+data:
 
 ```bash
 examples/mujoco_xr/scripts/fetch-so-arm.sh          # from the repository root
@@ -384,30 +771,51 @@ the network, so the app fails at startup naming the script and `test_ghost.py`
 commit — a silently substituted mesh renders as a broken gripper rather than an
 error, which has already cost a debugging session.
 
+Each entry names its own destination: the two tools are separate MJCF fragments
+in separate directories, and each resolves meshes against its own, so
+`sts3215_03a_v1.stl` is fetched **twice** rather than aliased across. Both sets
+land **flat** beside their fragment — MuJoCo drops an included file's own
+`meshdir`, so upstream's `meshdir="assets"` is inert once included.
+
+The follower's MJCF is upstream's own `so101_new_calib.xml`, fetched verbatim and
+never edited; `assets/follower/follower_arm.xml` is a tracked wrapper — one
+material and an `<include>`, under a provenance comment. (`joints_properties.xml` is
+deliberately not fetched: upstream inlines its `<default>` block rather than
+`<include>`ing it, so the file is never read.)
+
 The script also pulls `so101_new_calib.urdf`, which is where the trigger's hinge
-and its 0..100° travel come from, so it is on disk to check them against. Three of the four
-meshes are leader-specific print parts; the fourth is the **STS3215 servo**,
-shared with the follower. It is not decoration — `wrist_roll` is a C-shaped
+and its 0..100° travel come from, so it is on disk to check them against. Three of
+the leader's four meshes are leader-specific print parts; the fourth is the
+**STS3215 servo**, shared with the follower. It is not decoration — `wrist_roll` is a C-shaped
 bracket that wraps the servo, so without it the assembly has an open notch where
 the motor belongs and reads as a broken asset.
 
 It declares **two** mocap bodies — the gripper and its trigger — because the
-trigger articulates; a jointed child of a mocap body would be a dynamic joint
-that `mj_step` integrates gravity into, and a mocap body is kinematic by
-construction.
+trigger articulates. A mocap body must be a jointless child of the world, so the
+trigger cannot be a hinged child of the gripper: its angle would live in `qpos`,
+which nothing here writes — this app never calls `mj_step` and drives the ghost
+through `mocap_*` alone — so the jaw would never swing.
 
 The ghost is **opaque**, and `test_ghost.py` asserts it. That removes the
 draw-order constraint (at alpha 1.0 the depth test decides everything) and the
-ghost-writes-depth-into-the-reprojection-buffer concern. A scene that puts a
-robot under the ghost and drops the alpha back takes both on again: `mjv_updateScene`
-emits in geom-id order, so the `<include>` must come **last**. Nothing asserts
-that ordering today — it only matters below alpha 1.0, so the test belongs with
-the scene that needs it.
+ghost-writes-depth-into-the-reprojection-buffer concern. This scene **does** now
+put a robot under the ghost — the follower — so opacity is the only thing still
+holding both off. `scene.xml` already `<include>`s the leader **last**, which is
+the order the draw would need (`mjv_updateScene` emits in geom-id order), but
+nothing asserts it: the assertion belongs with the first scene that drops the
+alpha back.
 
 **Pass MuJoCo an absolute scene path.** Measured on mujoco 3.11.0, a *relative*
-model path mis-composes the mesh paths of an `<include>`d file in a
-subdirectory and fails with `Error opening file '<a path that exists>'`.
+model path mis-composes an `<include>`d file's paths and fails with
+`Error opening file '<a path that exists>'` — with the follower's nested include
+it composes the directory onto itself and opens `<dir>/<dir>/so101_new_calib.xml`.
 `DEFAULT_SCENE` in `app.py` is absolute for this reason.
+
+**Visibility is `model.geom_group`, from Python.** Group 2 draws and group 3 does
+not (`mjv_defaultOption`), so hiding a tool is one write to a slice of
+`geom_group`. A hidden geom never becomes an `mjvGeom`, so it never reaches the
+draw loop and never writes depth — which is why this is a group switch and not an
+alpha. No C++ renderer change is needed or wanted for it.
 
 ## Tests
 

--- a/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/app.py
+++ b/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/app.py
@@ -9,19 +9,21 @@ ProjectionLayer.submit() by CUDA pointer, never through host memory.
 
     VizSession(kXr)  ──get_oxr_handles()──▶  TeleopSession
          │                                        │
-         │ recommended resolution                 │ controller grip poses
+         │ recommended resolution                 │ EePoseRateLimiter output
          ▼                                        ▼                      │
     _mujoco_xr.Renderer  ──__cuda_array_interface__──▶  ProjectionLayer  │
          ▲                                                               │
          └──────────────── mjData.mocap_pos/_quat ◀─────────────────────┘
 
-The renderer needs an OpenGL context current on this thread, made below and torn
-down after it; viz and the renderer meet through CUDA alone, on VizSession's GPU.
+The renderer needs an OpenGL context current on this thread; viz and the renderer
+meet through CUDA alone, on VizSession's GPU. C++ owns
+mjvScene/mjvOption/mjvCamera/mjrContext, Python owns mjModel/mjData.
 
-C++ owns mjvScene/mjvOption/mjvCamera/mjrContext; Python owns
-mjModel/mjData/mj_step, so everything reading a controller and writing mjData is
-testable without a GPU. Frame order is load-bearing: input is sampled before the
-physics it feeds, on every frame that will step or draw.
+Nothing is integrated -- mj_step is never called -- which makes one invariant
+load-bearing: **one mj_forward after every `qpos`, `body_pos` or `mocap_*` write,
+before every `xpos` / `xquat` / `geom_xpos` read, including the read inside
+mjv_updateScene.** `mocap_*` is an INPUT to forward kinematics; the renderer draws
+`geom_xpos`. See README.md for the rest of the design.
 """
 
 from __future__ import annotations
@@ -41,8 +43,24 @@ from isaacteleop import viz
 from isaacteleop.cloudxr import CloudXRLauncher
 from isaacteleop.oxr import OpenXRSessionHandles
 from isaacteleop.retargeting_engine.deviceio_source_nodes import ControllersSource
-from isaacteleop.retargeting_engine.interface import OutputCombiner
-from isaacteleop.retargeting_engine.tensor_types import ControllerInputIndex
+from isaacteleop.retargeting_engine.interface import (
+    ExecutionEvents,
+    ExecutionState,
+    OutputCombiner,
+    TensorGroup,
+    ValueInput,
+)
+from isaacteleop.retargeting_engine.interface.tensor_group_type import (
+    OptionalType,
+    TensorGroupType,
+)
+from isaacteleop.retargeting_engine.tensor_types import BoolType, ControllerInputIndex
+from isaacteleop.retargeters.rate_limiter import (
+    EE_POSE_KEY,
+    EePoseRateLimiter,
+    RateLimiterConfig,
+)
+from isaacteleop.retargeters.SO101.clutch_retargeter import SO101ClutchRetargeter
 from isaacteleop.retargeters.SO101.gripper_retargeter import (
     GRIPPER_COMMAND_KEY,
     SO101GripperRetargeter,
@@ -53,17 +71,18 @@ from isaacteleop.teleop_session_manager import (
     get_required_oxr_extensions_from_pipeline,
 )
 
-from . import _mujoco_xr
+from . import _mujoco_xr, follower
+from .harness import ControllerPoseSource, HandPose, HarnessBand, InterventionMonitor
 
 LOG = logging.getLogger("mujoco_xr")
 
-# The app's only clip planes. VizSessionConfig, the projection and the submitted
-# depth must all agree, or world-locked geometry swims under head motion -- and
-# only a headset shows it. There is no near/far literal in cpp/, by construction.
+# The app's only clip planes. VizSessionConfig, the projection and the submitted depth
+# must all agree, or world-locked geometry swims under head motion, and only a headset
+# shows it. There is no near/far literal in cpp/, by construction.
 NEAR_Z = 0.05
 FAR_Z = 50.0
 
-# Wall-clock ceiling for one simulation advance. See _clamp_dt.
+# Wall-clock ceiling for one advance of the app's own clock. See _clamp_dt.
 MAX_DT_S = 0.1
 
 # The only mode: this needs a headset and a CloudXR runtime. A headless fallback
@@ -79,27 +98,47 @@ _CLOCK_SOURCE = (
     "not sampled as 0"
 )
 
-# Package data, so it resolves the same from the wheel and the source tree. Keep
-# it ABSOLUTE: on mujoco 3.11.0 a relative model path mis-composes the mesh paths
-# of an <include>d fragment and fails naming a file that is right there on disk.
+# Package data, so it resolves the same from the wheel and the source tree. Keep it
+# ABSOLUTE: on mujoco 3.11.0 a relative model path composes scene.xml's nested
+# <include> path onto itself and opens `<dir>/<dir>/so101_new_calib.xml`.
 DEFAULT_SCENE = Path(__file__).parent / "assets" / "scene.xml"
 
 # Checked by name before MuJoCo sees the scene: its failure for a missing
 # <include> target is a bare "Error opening file <mesh>.stl", naming a file
 # nobody asked for.
 FETCH_SCRIPT = "examples/mujoco_xr/scripts/fetch-so-arm.sh"
-_LEADER_ASSETS = Path(__file__).parent / "assets" / "leader"
-_LEADER_MESHES = (
-    "Wrist_Roll_SO101.stl",
-    "Trigger_SO101.stl",
-    "Handle_SO101.stl",
-    "STS3215_03a.stl",
+_ASSETS = Path(__file__).parent / "assets"
+_LEADER_ASSETS = _ASSETS / "leader"
+_FETCHED = (
+    "leader/Wrist_Roll_SO101.stl",
+    "leader/Trigger_SO101.stl",
+    "leader/Handle_SO101.stl",
+    "leader/STS3215_03a.stl",
+    "follower/so101_new_calib.xml",
+    "follower/base_motor_holder_so101_v1.stl",
+    "follower/base_so101_v2.stl",
+    "follower/motor_holder_so101_base_v1.stl",
+    "follower/motor_holder_so101_wrist_v1.stl",
+    "follower/moving_jaw_so101_v1.stl",
+    "follower/rotation_pitch_so101_v1.stl",
+    "follower/sts3215_03a_no_horn_v1.stl",
+    "follower/sts3215_03a_v1.stl",
+    "follower/under_arm_so101_v1.stl",
+    "follower/upper_arm_so101_v1.stl",
+    "follower/waveshare_mounting_plate_so101_v2.stl",
+    "follower/wrist_roll_follower_so101_v1.stl",
+    "follower/wrist_roll_pitch_so101_v2.stl",
 )
 
 
-def _missing_leader_assets() -> list[str]:
-    """Names of the fetched meshes that are not on disk. Empty when fetched."""
-    return [n for n in _LEADER_MESHES if not (_LEADER_ASSETS / n).is_file()]
+def _missing_assets() -> list[str]:
+    """The fetched files that are not on disk. Empty when fetched.
+
+    Both tools, because one scene includes both. Hand-kept in step with the ``ASSETS``
+    list in ``scripts/fetch-so-arm.sh``: a destination renamed in one and not the other
+    makes this demand a file nothing fetches, or miss one the scene needs.
+    """
+    return [n for n in _FETCHED if not (_ASSETS / n).is_file()]
 
 
 # One hand and no flag: the ghost is a right-handed gripper.
@@ -109,13 +148,61 @@ GHOST_HAND = ControllersSource.RIGHT
 GHOST_BODY = "leader_ghost"
 GHOST_JAW_BODY = "leader_ghost_jaw"
 
-# ── Where the ghost sits on the hand ───────────────────────────────────────
-# Measured on a headset, not derived: this is a claim about a hand holding a
-# CONTROLLER, so do not re-derive it from the mesh. Euler degrees, intrinsic
-# XYZ, i.e. MuJoCo's `euler=`. Re-tuning procedure and the mesh trap:
-# README.md#where-the-ghost-sits-on-the-hand-apppy.
-_EULER_GRIP_FROM_GHOST_DEG = (60, 180, 270)
-_POS_GRIP_FROM_GHOST = np.array((0, 0.02, -0.025))
+# The four ghost geoms, hidden as a set whenever the follower is the tool on
+# show. Named here rather than discovered, so a renamed geom is an error.
+GHOST_GEOMS = (
+    "leader_ghost_wrist_roll",
+    "leader_ghost_motor",
+    "leader_ghost_handle",
+    "leader_ghost_trigger",
+)
+
+# Three pose channels, three jobs, and none substitutes for another. HAND_POSE_KEY is
+# Optional and is the app's ONLY tracking-loss oracle; it is what drives the follower
+# and the gate's rotation operand. COMMANDED_POSE_KEY is what the limiter was handed,
+# the reference its band is measured against; it is required, so it can never signal
+# loss. EE_POSE_KEY is the limiter's output and the only channel anything draws.
+HAND_POSE_KEY = "hand_pose"
+COMMANDED_POSE_KEY = "commanded_ee_pose"
+
+# The one hand frame, reaching the follower's drive, the gate's operand, the clutch's
+# home and the ghost. Aim because only aim's -Z is a pointing ray; grip's runs little
+# finger to thumb, whose azimuth turns 1:1 with the hand but has an arbitrary zero. The
+# cost is aim's device-specific ray origin, which gives the arm's position a lever arm
+# as the wrist turns. Everything relative to this frame must be re-derived when it
+# changes. See README.md.
+HAND_POSE = HandPose.AIM
+
+# The B button. ControllerInput carries no field of that name: the OpenXR bindings put
+# `/user/hand/right/input/b/click` on SECONDARY_CLICK
+# (live_controller_tracker_impl.cpp:292). GHOST_HAND is the right controller.
+_RESET_OFFSET_BUTTON = ControllerInputIndex.SECONDARY_CLICK
+
+# The A button, held to put the right thumbstick on the yaw trim instead of the grip
+# offset. Modal rather than a second stick because only one controller is wired.
+_YAW_TRIM_BUTTON = ControllerInputIndex.PRIMARY_CLICK
+
+# The external graph leaf carrying the engage gate's verdict. TeleopSession validates
+# every external leaf name is present in external_inputs on EVERY step, independently
+# of OptionalType, so this key is sent unconditionally.
+ENGAGE_PERMISSION_LEAF = "engage_permission"
+
+# The clutch's own degenerate-quaternion threshold (clutch_retargeter.py:109),
+# restated so `after_step`'s usable-pose test covers its whole disarm set. Reused
+# for the head pose, which has no such consumer but is just as unusable at zero.
+_MIN_QUAT_NORM = 1e-6
+
+# ── Where the ghost sits on the hand ───────────────────────────────────
+# Euler degrees, intrinsic XYZ, i.e. MuJoCo's `euler=`. Solve this rotation from Q_HOME;
+# do not port a grip-measured value, which demands a wrist pitch nobody chose. It fixes
+# the posture the gate asks for, and this value makes that posture level and unrolled.
+# Re-solve when Q_HOME moves: it is the gripper's xquat at Q_HOME and base yaw 0, carried
+# into XR by _xr_from_mj_quat, as intrinsic-XYZ Euler.
+_EULER_HAND_FROM_GHOST_DEG = (270, 0, 90)
+# Measured on a headset: a claim about a hand holding a CONTROLLER, so do not re-derive
+# it from the mesh. Relative to HAND_POSE; `_log_hand_frames` prints the replacement
+# when that changes.
+_POS_HAND_FROM_GHOST = np.array((0, 0, 0))
 
 # ── The trigger hinge ──────────────────────────────────────────────────────
 # The follower's `gripper` revolute joint, from SO-ARM100's
@@ -137,8 +224,8 @@ _TRIGGER_SQUEEZED_RAD = 0.0  # closedness 1, tucked to the authored pose
 def _quat_from_euler_deg(angles_deg) -> np.ndarray:
     """Intrinsic X-then-Y-then-Z degrees -> a wxyz quaternion, MuJoCo's `euler=`.
 
-    Right-multiplication is what makes it intrinsic. Spelled out rather than
-    calling mju_euler2Quat so the sequence is visible where it is used.
+    Right-multiplication is what makes it intrinsic. Spelled out rather than calling
+    mju_euler2Quat so the sequence is visible where it is used.
     """
     quat = np.array((1.0, 0.0, 0.0, 0.0))
     for axis, angle in zip(np.eye(3), angles_deg):
@@ -151,37 +238,116 @@ def _quat_from_euler_deg(angles_deg) -> np.ndarray:
 
 
 # ── Derived below; nothing from here on is authored ────────────────────────
-_QUAT_GRIP_FROM_GHOST = _quat_from_euler_deg(_EULER_GRIP_FROM_GHOST_DEG)
+_QUAT_HAND_FROM_GHOST = _quat_from_euler_deg(_EULER_HAND_FROM_GHOST_DEG)
 
 
 def _clamp_dt(dt: float) -> float:
     """NaN-safe clamp into [0, MAX_DT_S].
 
-    Comparisons, not min/max: max(nan, 0) is nan, so the obvious form passes
-    NaN through both limits and into mj_step.
+    Comparisons, not min/max: max(nan, 0) is nan, so the obvious form passes NaN
+    through both limits and into whatever accumulates it.
     """
     if dt > 0:
         return MAX_DT_S if dt > MAX_DT_S else dt
     return 0.0
 
 
-def _build_pipeline() -> OutputCombiner:
-    """Controllers, plus the shipped SO-101 jaw retargeter as a graph edge.
+# ── What the harness lets through ──────────────────────────────────────────
+# Chosen for this demo, not measured against a follower: ordinary reaching passes
+# through and a deliberate flick trips the clamp and then the reject band. An
+# SO-101's own envelope is lower -- RateLimiterConfig defaults to 0.25 m/s.
+_HARNESS = RateLimiterConfig(
+    max_linear_velocity=0.5,  # m/s
+    max_angular_velocity=2.5,  # rad/s, ~143 deg/s
+    reject_linear_velocity=2.0,  # m/s
+    reject_angular_velocity=10.0,  # rad/s
+)
 
-    A BaseRetargeter node in the pipeline, not a library call beside it. With no
-    robot in the scene the jaw it drives is the operator's own trigger.
+
+_PERMISSION_TYPE = TensorGroupType(
+    SO101ClutchRetargeter.ENGAGE_PERMITTED_INPUT, [BoolType("permitted")]
+)
+
+
+def _permission(permitted: bool) -> TensorGroup:
+    """One frame of the permission leaf's payload. BoolType wants a real Python bool."""
+    group = TensorGroup(_PERMISSION_TYPE)
+    group[SO101ClutchRetargeter.PERMITTED_INDEX] = bool(permitted)
+    return group
+
+
+def _build_pipeline(  # noqa: N803
+    home_base_T_ee: np.ndarray,
+) -> tuple[OutputCombiner, SO101ClutchRetargeter]:
+    """Controllers, the SO-101 jaw and clutch retargeters, and the pose harness.
+
+    ControllerPoseSource is a parallel branch rather than a link in the clutch's chain: its
+    Optional output is the app's only tracking-validity oracle. The jaw is ungoverned.
+    Returns the clutch too, because the app reads `is_engaged` off it.
     """
     controllers = ControllersSource(name="controllers")
     jaw = SO101GripperRetargeter(name="ghost_jaw", input_device=GHOST_HAND).connect(
         {GHOST_HAND: controllers.output(GHOST_HAND)}
     )
-    return OutputCombiner(
+    hand = ControllerPoseSource(
+        name="hand_pose", pose=HAND_POSE, input_device=GHOST_HAND
+    ).connect({GHOST_HAND: controllers.output(GHOST_HAND)})
+    permission = ValueInput(ENGAGE_PERMISSION_LEAF, OptionalType(_PERMISSION_TYPE))
+    clutch = SO101ClutchRetargeter(
+        name="ee_pose",
+        home_base_T_ee=home_base_T_ee,
+        input_device=GHOST_HAND,
+        # The same frame the rest of the app drives from. Its orientation delta is
+        # invariant to the choice, so this is here for the translation pivot alone.
+        controller_pose=HAND_POSE.value,
+    )
+    # MEASURED_BASE_T_EE_INPUT is left unwired on purpose: it is position-only
+    # (its own docstring carries the measurement), so it cannot put the leader on
+    # the follower's orientation.
+    commanded = clutch.connect(
         {
-            ControllersSource.LEFT: controllers.output(ControllersSource.LEFT),
-            ControllersSource.RIGHT: controllers.output(ControllersSource.RIGHT),
-            GRIPPER_COMMAND_KEY: jaw.output(GRIPPER_COMMAND_KEY),
+            GHOST_HAND: controllers.output(GHOST_HAND),
+            SO101ClutchRetargeter.ENGAGE_PERMITTED_INPUT: permission.output(
+                ValueInput.VALUE
+            ),
         }
     )
+    governed = EePoseRateLimiter(name="ghost_harness", config=_HARNESS).connect(
+        {EE_POSE_KEY: commanded.output(EE_POSE_KEY)}
+    )
+    return (
+        OutputCombiner(
+            {
+                ControllersSource.LEFT: controllers.output(ControllersSource.LEFT),
+                ControllersSource.RIGHT: controllers.output(ControllersSource.RIGHT),
+                GRIPPER_COMMAND_KEY: jaw.output(GRIPPER_COMMAND_KEY),
+                HAND_POSE_KEY: hand.output(EE_POSE_KEY),
+                COMMANDED_POSE_KEY: commanded.output(EE_POSE_KEY),
+                EE_POSE_KEY: governed.output(EE_POSE_KEY),
+            }
+        ),
+        clutch,
+    )
+
+
+def _head_pose(info) -> np.ndarray | None:
+    """FrameInfo.views[0] as a 7-D XR pose (position, xyzw), or None if unusable.
+
+    The left eye rather than a head centre, which the runtime does not report; the
+    ~32 mm between them is well inside what HOME_GRIP_FROM_HEAD_XR is authored to.
+    """
+    if len(info.views) == 0:
+        return None
+    view = info.views[0]
+    px, py, pz = view.pose.position
+    qw, qx, qy, qz = view.pose.orientation
+    pose = np.array([px, py, pz, qx, qy, qz, qw], dtype=float)
+    if (
+        not np.all(np.isfinite(pose))
+        or float(np.linalg.norm(pose[3:7])) < _MIN_QUAT_NORM
+    ):
+        return None
+    return pose
 
 
 def _flatten_xr_views(info) -> tuple[list[float], list[float]]:
@@ -311,46 +477,126 @@ def _resolve_ghost(model) -> _GhostChannels:
     return _GhostChannels(int(model.body_mocapid[body]), int(model.body_mocapid[jaw]))
 
 
-def _update_ghost(data, ghost: _GhostChannels, result) -> None:
-    """Lock the leader gripper to the GHOST_HAND grip pose; swing its trigger.
+def _pose(result, key: str) -> np.ndarray | None:
+    """One of the pipeline's three 7-D pose channels, or None when it carries nothing.
 
-    Keep the validity gate: an untracked controller reports (0, 0, 0), which is
-    the scene origin and a place a legitimate pose could put it, so freezing is
-    the honest rendering of "tracking lost" and there is no else branch.
-    _QUAT_GRIP_FROM_GHOST right-multiplies because it is fixed in the gripper's
+    Carrying nothing has two spellings and `is_none` is only one: for the two REQUIRED
+    channels it is hardcoded False, and the limiter keeps a path that returns without
+    writing (rate_limiter.py:424-427). Reading an unset tensor raises, and there is no
+    "has it been set" predicate, so that raise is the other spelling.
+    """
+    pose = result[key]
+    if pose.is_none:
+        return None
+    try:
+        tensor = pose[0]
+    except ValueError:
+        return None
+    return np.asarray(np.from_dlpack(tensor), dtype=float)
+
+
+def _xr_from_mj_pos(p_mj: np.ndarray) -> np.ndarray:
+    """MuJoCo world point -> XR reference-space point.
+
+    The inverse of `_mujoco_xr.mj_from_xr_pos`, derived from the same two exported
+    constants so there is still only one definition of the frame.
+    """
+    out = np.empty(3)
+    inverse = np.empty(4)
+    mujoco.mju_negQuat(inverse, np.array(_mujoco_xr.QUAT_MJ_FROM_XR, dtype=float))
+    mujoco.mju_rotVecQuat(
+        out,
+        np.asarray(p_mj, dtype=float) - np.array(_mujoco_xr.TRANS_MJ_FROM_XR),
+        inverse,
+    )
+    return out
+
+
+def _xr_from_mj_quat(q_wxyz: np.ndarray) -> np.ndarray:
+    """MuJoCo world orientation (wxyz) -> XR orientation as xyzw."""
+    inverse = np.empty(4)
+    mujoco.mju_negQuat(inverse, np.array(_mujoco_xr.QUAT_MJ_FROM_XR, dtype=float))
+    q_xr = np.empty(4)
+    mujoco.mju_mulQuat(q_xr, inverse, np.asarray(q_wxyz, dtype=float))
+    return np.array([q_xr[1], q_xr[2], q_xr[3], q_xr[0]])
+
+
+def ghost_body_from_pose(pose: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """A 7-D XR hand pose -> where the leader ghost BODY goes in MuJoCo world.
+
+    The grip calibration lives on this side of the boundary, so follower.py never owns
+    it. _QUAT_HAND_FROM_GHOST right-multiplies because it is fixed in the gripper's
     frame; left-multiplying swings the ghost around the room as the operator turns.
     """
-    controller = result[GHOST_HAND]
-    if controller.is_none:
-        return
-    if not bool(controller[ControllerInputIndex.GRIP_IS_VALID]):
-        return
-    position = controller[ControllerInputIndex.GRIP_POSITION]
-    orientation = controller[ControllerInputIndex.GRIP_ORIENTATION]
-    p_xr = [float(position[0]), float(position[1]), float(position[2])]
-    q_xyzw = [
-        float(orientation[0]),
-        float(orientation[1]),
-        float(orientation[2]),
-        float(orientation[3]),
-    ]
+    p_xr = [float(pose[0]), float(pose[1]), float(pose[2])]
+    q_xyzw = [float(pose[3]), float(pose[4]), float(pose[5]), float(pose[6])]
 
     q_grip = np.array(_mujoco_xr.mj_from_xr_quat(q_xyzw), dtype=float)
     p_grip = np.array(_mujoco_xr.mj_from_xr_pos(p_xr), dtype=float)
 
     q_body = np.empty(4)
-    mujoco.mju_mulQuat(q_body, q_grip, _QUAT_GRIP_FROM_GHOST)
+    mujoco.mju_mulQuat(q_body, q_grip, _QUAT_HAND_FROM_GHOST)
     p_offset = np.empty(3)
-    mujoco.mju_rotVecQuat(p_offset, _POS_GRIP_FROM_GHOST, q_grip)
-    p_body = p_grip + p_offset
+    mujoco.mju_rotVecQuat(p_offset, _POS_HAND_FROM_GHOST, q_grip)
+    return p_grip + p_offset, q_body
+
+
+def _grip_quat_mj(q_body: np.ndarray) -> np.ndarray:
+    """The MuJoCo grip orientation (wxyz) whose ghost body lands at ``q_body``."""
+    inverse = np.empty(4)
+    mujoco.mju_negQuat(inverse, _QUAT_HAND_FROM_GHOST)
+    q_grip = np.empty(4)
+    mujoco.mju_mulQuat(q_grip, np.asarray(q_body, dtype=float), inverse)
+    return q_grip
+
+
+def grip_quat_from_ghost_body(q_body: np.ndarray) -> np.ndarray:
+    """The XR hand orientation (xyzw) that would put the ghost body at ``q_body``.
+
+    The engage gate's second operand: it is what the clutch will latch, so the gate
+    compares the hand against this rather than the tool's own orientation. Both
+    operands are xyzw in XR, which is what makes a geodesic angle meaningful.
+    """
+    return _xr_from_mj_quat(_grip_quat_mj(q_body))
+
+
+def pose_from_ghost_body(p_body: np.ndarray, q_body: np.ndarray) -> np.ndarray:
+    """The exact inverse of :func:`ghost_body_from_pose`, as a 4x4 in the XR frame.
+
+    4x4 because its one consumer is ``SO101ClutchRetargeter.set_home_base_T_ee``, and
+    XR because that is the frame the clutch's controller stream is already in -- the
+    app does no rebase, so "base" is the XR anchor.
+    """
+    q_grip = _grip_quat_mj(q_body)
+    p_offset = np.empty(3)
+    mujoco.mju_rotVecQuat(p_offset, _POS_HAND_FROM_GHOST, q_grip)
+
+    transform = np.eye(4)
+    transform[:3, 3] = _xr_from_mj_pos(np.asarray(p_body, dtype=float) - p_offset)
+    rot = np.empty(9)
+    q_xyzw = _xr_from_mj_quat(q_grip)
+    mujoco.mju_quat2Mat(rot, np.array([q_xyzw[3], q_xyzw[0], q_xyzw[1], q_xyzw[2]]))
+    transform[:3, :3] = rot.reshape(3, 3)
+    return transform
+
+
+def _update_ghost(
+    data, ghost: _GhostChannels, pose: np.ndarray, closedness: float
+) -> None:
+    """Lock the leader gripper to the governed pose; swing its trigger.
+
+    `pose` is the harness output, not the controller. Both arguments must be held
+    frozen by the caller on an untracked frame -- (0, 0, 0) is the scene origin, and a
+    jaw articulating on a frozen body reads as an actuated gripper. Writes `mocap_*`
+    only; the caller owns the mj_forward.
+    """
+    p_body, q_body = ghost_body_from_pose(pose)
 
     data.mocap_pos[ghost.body] = p_body
     data.mocap_quat[ghost.body] = q_body
 
-    # The deadzone and clamp are the retargeter's contract, not this app's.
-    # Rotated ABOUT the hinge, not placed at it: the jaw's XML rest pose equals
-    # the ghost's, so the pivot lives in exactly one place.
-    closedness = float(result[GRIPPER_COMMAND_KEY][0])
+    # Rotated ABOUT the hinge, not placed at it: the jaw's XML rest pose equals the
+    # ghost's, so the pivot lives in exactly one place.
     angle = _TRIGGER_RELEASED_RAD + closedness * (
         _TRIGGER_SQUEEZED_RAD - _TRIGGER_RELEASED_RAD
     )
@@ -369,12 +615,191 @@ def _update_ghost(data, ghost: _GhostChannels, result) -> None:
     data.mocap_quat[ghost.jaw] = q_jaw
 
 
+# ── The wrist posture the gate will demand ─────────────────────────────────
+# _QUAT_HAND_FROM_GHOST cancels EXACTLY through the engage handoff, so no geometric
+# test can discriminate it; its one surviving effect is the wrist posture the operator
+# must adopt, which is what this reports. Only the THUMB direction carries it -- the
+# tool direction reads 15.2 deg for every calibration swept, so it is a guard on
+# Q_HOME. Both are in the OPERATOR'S frame. See README.md.
+_OPERATOR_FORWARD = np.array((0.0, 0.0, -1.0))
+# Handle centroid to wrist-roll centroid in the ghost body frame, measured on the
+# fetched meshes: (-56.9, -0.5, -63.2) mm -> (-4.3, -1.4, -13.2) mm. Rotated below by
+# the FOLLOWER `gripper` quaternion, because the handoff puts the ghost body on its
+# orientation exactly even though the position comes from the hand.
+_GHOST_POINTING_AXIS = np.array((0.7228, -0.0124, 0.6910))
+# The -Z of whatever HAND_POSE names, reported so the demanded posture is legible. What
+# it MEANS depends on that constant: on GRIP it is the thumb axis, up through the fist;
+# on AIM it is the pointing ray. The angle is only "comfortable to hold" on the reading
+# that matches, so read the log's wording and not just the number.
+_HAND_REPORT_AXIS = np.array((0.0, 0.0, -1.0))
+# Warned on, never asserted: test-bounding the posture angle would pin it and
+# make _EULER_HAND_FROM_GHOST_DEG untunable on a headset, which is the one place it
+# can be tuned.
+_POSTURE_LIMIT_DEG = 45.0
+
+# Which axis of HAND_POSE the yaw drive reads: aim's -Z, the pointing ray. Every axis
+# tracks a world-vertical turn 1:1 and is blind to rotation about itself, so the choice
+# only decides how much wrist roll and pitch leak into the arm's yaw. README.md
+# tabulates the leak per candidate, measured on grip; aim's is unmeasured here because
+# the grip-to-aim transform is per-device. Re-measure on a headset before trusting it.
+_HAND_FORWARD_AXIS = np.array((0.0, 0.0, -1.0))
+
+# Whatever azimuth is left between where the operator means to point and what the app
+# reads. On AIM this SHOULD be zero -- that is the entire reason for reading aim -- so a
+# session that has to dial in a large value is evidence the switch did not do its job,
+# not a knob to lean on. Kept because it is the only thing that can absorb a runtime
+# whose aim convention differs from the operator's expectation. Tuned on a headset: hold
+# A and push the right thumbstick, then paste back what the app prints. Degrees, positive
+# turning the arm the way a positive XR yaw does, applied as a constant on top of the
+# reading so it cannot introduce leakage of its own.
+_YAW_TRIM_DEG = 0.0
+_YAW_TRIM_RATE_DEG_S = 20.0
+
+
+def hand_facing_xr(q_hand_xyzw: np.ndarray) -> np.ndarray:
+    """The XR yaw (wxyz) the operator's hand is facing, for the follower's base."""
+    return follower.yaw_of_axis(q_hand_xyzw, _HAND_FORWARD_AXIS)
+
+
+def _log_hand_frames(result) -> bool:
+    """Measure the device's grip-to-aim transform and print the calibration it implies.
+
+    The grip-to-aim transform is per-device, so no constant can carry
+    :data:`_POS_HAND_FROM_GHOST` across a :data:`HAND_POSE` change -- but the runtime
+    publishes both poses on one controller, so one frame with both valid yields the
+    replacement. Position only: porting the rotation would hand back the wrist pitch that
+    solving it from Q_HOME removes. Returns whether it got a reading. Never raises.
+    """
+    try:
+        controller = result[GHOST_HAND]
+        if controller.is_none or not (
+            bool(controller[ControllerInputIndex.GRIP_IS_VALID])
+            and bool(controller[ControllerInputIndex.AIM_IS_VALID])
+        ):
+            return False
+        grip = np.asarray(
+            controller[ControllerInputIndex.GRIP_ORIENTATION], dtype=float
+        )
+        aim = np.asarray(controller[ControllerInputIndex.AIM_ORIENTATION], dtype=float)
+        grip_pos = np.asarray(
+            controller[ControllerInputIndex.GRIP_POSITION], dtype=float
+        )
+        aim_pos = np.asarray(controller[ControllerInputIndex.AIM_POSITION], dtype=float)
+        if min(np.linalg.norm(aim), np.linalg.norm(grip)) < _MIN_QUAT_NORM:
+            return False
+    except (ValueError, IndexError, TypeError):
+        return False
+
+    # aim^-1 . grip, wxyz: what carries a direction from the GRIP frame into AIM's.
+    inverse = np.empty(4)
+    mujoco.mju_negQuat(inverse, aim[[3, 0, 1, 2]])
+    aim_from_grip = np.empty(4)
+    mujoco.mju_mulQuat(aim_from_grip, inverse, grip[[3, 0, 1, 2]])
+    # The ghost offset is applied in the hand's frame, so carrying it across costs both
+    # terms: the origins' separation pulled back into the new frame, and the old offset
+    # turned by the same rotation the orientation above is. Dropping the second leaves
+    # the ghost centimetres out while its orientation looks perfect.
+    separation = np.empty(3)
+    mujoco.mju_rotVecQuat(separation, grip_pos - aim_pos, inverse)
+    turned = np.empty(3)
+    mujoco.mju_rotVecQuat(
+        turned, np.asarray(_POS_HAND_FROM_GHOST, dtype=float), aim_from_grip
+    )
+    offset = separation + turned
+
+    LOG.info(
+        "hand frames: this device's aim pose sits %.0f deg and %.0f mm off its grip "
+        "pose. HAND_POSE is %s, so for the ghost to sit where it did on GRIP, its "
+        "position wants:",
+        math.degrees(2.0 * math.acos(min(1.0, abs(float(aim_from_grip[0]))))),
+        1000.0 * float(np.linalg.norm(grip_pos - aim_pos)),
+        HAND_POSE.value.upper(),
+    )
+    LOG.info(
+        "hand frames:   _POS_HAND_FROM_GHOST = np.array((%.3f, %.3f, %.3f))", *offset
+    )
+    return True
+
+
+def base_yaw_bias(arm) -> np.ndarray:
+    """How far the base yaw must LEAD the hand for the JAW to face it (wxyz).
+
+    Measured off the arm at startup rather than authored: how far the jaw sits off its
+    base yaw follows from Q_HOME and upstream's chain, J5 above all. Both operands are
+    yaws about +Y, so the order is free.
+    """
+    inverse = np.empty(4)
+    mujoco.mju_negQuat(inverse, arm.jaw_yaw_xr)
+    bias = np.empty(4)
+    mujoco.mju_mulQuat(bias, arm.base_yaw_xr, inverse)
+    return bias
+
+
+def _log_grip_posture(arm) -> tuple[float, float]:
+    """Invert the chain at Q_HOME and report the posture the gate will ask for.
+
+    Both angles are un-yawed into the operator's own frame, so they read the same
+    whichever way they face -- which is also what lets this run before the anchor. Warns
+    rather than raises: this app is the only place the calibration can be judged.
+    """
+    p_body, q_body = arm.gripper_pose_mj()
+    ghost_axis = np.empty(3)
+    mujoco.mju_rotVecQuat(ghost_axis, _GHOST_POINTING_AXIS, q_body)
+    # The OPERATOR's frame is the HAND's yaw, which the base leads by base_yaw_bias.
+    # Un-yawing by the base instead reports the demand a whole bias out, which is
+    # invisible while that bias is small and wrong by 93 degrees once it is not.
+    inverse_bias, hand_yaw, unyaw = np.empty(4), np.empty(4), np.empty(4)
+    mujoco.mju_negQuat(inverse_bias, base_yaw_bias(arm))
+    mujoco.mju_mulQuat(hand_yaw, arm.base_yaw_xr, inverse_bias)
+    mujoco.mju_negQuat(unyaw, hand_yaw)
+
+    def in_operator_frame(direction_xr):
+        out = np.empty(3)
+        mujoco.mju_rotVecQuat(out, np.asarray(direction_xr, dtype=float), unyaw)
+        return out
+
+    tool = in_operator_frame(
+        _xr_from_mj_pos(p_body + ghost_axis) - _xr_from_mj_pos(p_body)
+    )
+    hand_axis = in_operator_frame(
+        pose_from_ghost_body(p_body, q_body)[:3, :3] @ _HAND_REPORT_AXIS
+    )
+
+    def ahead(direction):
+        return math.degrees(
+            math.acos(min(1.0, max(-1.0, float(direction @ _OPERATOR_FORWARD))))
+        )
+
+    LOG.info(
+        "grip calib: at Q_HOME the tool points (%+.2f, %+.2f, %+.2f), %.0f deg off the "
+        "operator's forward, and the gate will demand a hand whose %s axis is "
+        "(%+.2f, %+.2f, %+.2f), %.0f deg off. XR axes, in the operator's frame. Only the "
+        "SECOND depends on _EULER_HAND_FROM_GHOST_DEG.",
+        *tool,
+        ahead(tool),
+        "pointing" if HAND_POSE is HandPose.AIM else "thumb",
+        *hand_axis,
+        ahead(hand_axis),
+    )
+    # The hand axis only: the tool angle does not depend on the calibration at all, so a
+    # warning on it would report a Q_HOME or mesh change under a misleading name.
+    if ahead(hand_axis) > _POSTURE_LIMIT_DEG:
+        LOG.warning(
+            "grip calib: the gate will demand a hand held %.0f deg off neutral, past the "
+            "%.0f deg that reads as a comfortable hold. Check _EULER_HAND_FROM_GHOST_DEG "
+            "-- it is the only constant this angle depends on.",
+            ahead(hand_axis),
+            _POSTURE_LIMIT_DEG,
+        )
+    return ahead(tool), ahead(hand_axis)
+
+
 def _frame_clock(info) -> float | None:
-    """The simulation clock, or None if this frame carries no time.
+    """The app's clock, or None if this frame carries no time.
 
     viz zeroes predicted_display_time with should_render on every frame before
-    kRunning; sampling it makes the next real frame compute dt from 0 and step
-    50 times in one display frame. The caller must skip it entirely.
+    kRunning. The caller must skip the sample rather than record a zero, or the next
+    real frame computes dt from 0 and _clamp_dt reports a full MAX_DT_S stall.
     """
     if info.predicted_display_time == 0:
         return None
@@ -384,11 +809,17 @@ def _frame_clock(info) -> float | None:
 def run() -> int:
     model = mujoco.MjModel.from_xml_path(str(DEFAULT_SCENE))
     data = mujoco.MjData(model)
+    # Before the Renderer, which uploads geometry once from the model address: the
+    # follower repoints geom materials and poses its joints here. Not placed yet --
+    # that waits for the first head pose, in _Preview.before_step.
+    arm = follower.Follower(model, data)
 
     # Order is load-bearing: VizSession calls xrCreateInstance, so an extension
-    # discovered after it cannot be added -- and a controller tracker missing
-    # XR_NVX1_action_context is silently dead rather than an error.
-    pipeline = _build_pipeline()
+    # discovered after it cannot be added, and a controller tracker missing
+    # XR_NVX1_action_context is silently dead rather than an error. The clutch's home
+    # is pushed every non-ENGAGED frame, so this constructor value only has to be
+    # well-formed -- nothing can latch before the anchor exists.
+    pipeline, clutch = _build_pipeline(pose_from_ghost_body(*arm.gripper_pose_mj()))
     required_extensions = get_required_oxr_extensions_from_pipeline(pipeline)
 
     config = viz.VizSessionConfig()
@@ -448,6 +879,22 @@ def run() -> int:
             math.degrees(_TRIGGER_SQUEEZED_RAD),
         )
 
+        arm.log_placement()
+        # Before the anchor, and correct there: both angles are reported in the
+        # operator's own frame, which the anchor's yaw is exactly what defines.
+        _log_grip_posture(arm)
+
+        monitor = InterventionMonitor(model)
+        LOG.info(
+            "harness:    the ghost renders the EePoseRateLimiter output, clamped at "
+            "%.2f m/s / %.0f deg/s and rejecting above %.2f m/s / %.0f deg/s. Amber "
+            "while clamping, red while rejecting, authored blue passing through.",
+            _HARNESS.max_linear_velocity,
+            math.degrees(_HARNESS.max_angular_velocity),
+            _HARNESS.reject_linear_velocity,
+            math.degrees(_HARNESS.reject_angular_velocity),
+        )
+
         oxr = viz_session.get_oxr_handles()
         if oxr is None:
             raise RuntimeError(
@@ -461,7 +908,21 @@ def run() -> int:
             oxr_handles=OpenXRSessionHandles(*oxr),
         )
         with TeleopSession(teleop_config) as teleop_session:
-            _loop(viz_session, layer, renderer, model, data, teleop_session, ghost)
+            try:
+                _loop(
+                    viz_session,
+                    layer,
+                    renderer,
+                    model,
+                    data,
+                    teleop_session,
+                    ghost,
+                    monitor,
+                    arm,
+                    clutch,
+                )
+            finally:
+                LOG.info(monitor.summary())
     finally:
         # Innermost first: the renderer's GL objects need a current context.
         if renderer is not None:
@@ -472,43 +933,353 @@ def run() -> int:
     return 0
 
 
-def _loop(viz_session, layer, renderer, model, data, teleop_session, ghost) -> None:
+# ── The per-frame protocol ─────────────────────────────────────────────────
+# It spans four files, so it is stated once, here. Each frame, in order:
+#
+#   1. before_step()  -- anchor the arm to the head if it is not anchored yet,
+#                        push the hand's position at the follower's rotation as
+#                        the clutch home (every non-ENGAGED frame), and emit the
+#                        permission leaf.
+#   2. step()         -- the retargeting graph runs: jaw, grip source, clutch,
+#                        limiter. The clutch reads permission on THIS frame.
+#   3. after_step()   -- advance the phase, drive the arm, write the ghost's
+#                        mocap rows, mj_forward, re-evaluate the gate.
+#   4. render         -- mjv_updateScene reads geom_xpos, then submit.
+#
+# Permission is one frame stale, deliberately: step N's leaf carries the verdict
+# after_step produced on frame N-1, because the gate needs a limiter band step N has
+# not computed yet. Squeezing inside that 14 ms costs nothing -- a denied latch stays
+# OWED and fires on the first permitted frame.
+class _Preview:
+    """The follower/leader handoff: one call before ``step()``, one after.
+
+    Everything in ``_loop`` that is not rendering. Split out so the whole engage
+    sequence can be driven headlessly at frame rate, which is the only way to exercise
+    the gate's pass-through conjunct -- a quasi-static drive passes it by luck.
+    """
+
+    def __init__(self, model, data, ghost, monitor, arm, clutch) -> None:
+        """Bind to one scene, one pair of tools and one clutch.
+
+        Measures the arm's yaw bias here, while the base still stands on the yaw
+        ``Follower.__init__`` left it on -- ``anchor`` has not run, so the reading is the
+        arm's own and not a head's.
+        """
+        self._model = model
+        self._data = data
+        self._ghost = ghost
+        self._monitor = monitor
+        self._arm = arm
+        self._clutch = clutch
+        self._ghost_geoms = np.array(
+            [mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_GEOM, n) for n in GHOST_GEOMS]
+        )
+        self.phases = follower.PhaseMachine()
+        self._gate = follower.EngageGate()
+        # Its own key, not the un-anchored one: they share a frame in practice, and
+        # merging them would suppress the first verdict of the session.
+        self.verdict = follower.GateResult((("startup", "starting up"),))
+        # Neither tool is drawn until the arm is anchored, so start both hidden rather
+        # than relying on the first after_step to arrive.
+        follower.set_geoms_visible(model, self._ghost_geoms, False)
+        # SO101GripperRetargeter's own released end, held until the first frame with a
+        # usable hand pose refreshes it.
+        self._closedness = 0.0
+        # B is edge-triggered, so a held button resets the offset once.
+        self._reset_held = False
+        # The ghost body of the last usable hand pose, latched by after_step because
+        # before_step runs a frame ahead of it. None until one arrives, and no latch can
+        # be permitted before then: the gate reports `controller not tracked`.
+        self._hand_body_mj: np.ndarray | None = None
+        self._yaw_bias = base_yaw_bias(arm)
+        self._yaw_trim_deg = _YAW_TRIM_DEG
+        self._trimming = False
+        # One reading is all it takes, and it needs a tracked controller, so it cannot
+        # happen at construction.
+        self._frames_logged = False
+        LOG.info(
+            "follower:   the base leads the hand by %+.2f deg of yaw, measured off "
+            "Q_HOME so the JAW faces where the controller does.",
+            math.degrees(2.0 * math.atan2(self._yaw_bias[2], self._yaw_bias[0])),
+        )
+
+    def before_step(self, head: np.ndarray | None) -> tuple[dict, ExecutionEvents]:
+        """Anchor the arm if it is not anchored, then build this frame's step() kwargs.
+
+        Two rules on the home push. Key it off the app's phase, never
+        ``clutch.is_engaged``, which drops on four paths of which one is a real disengage;
+        and take the position from the hand and the rotation from the gripper, so the
+        leader appears in the operator's hand at the rotation they aimed. The gripper's
+        own position would carry the preview's offset into the clutch's delta.
+        """
+        if head is not None and not self._arm.anchored:
+            self._arm.anchor(head)
+        if (
+            self.phases.phase is not follower.ClutchPhase.ENGAGED
+            and self._hand_body_mj is not None
+        ):
+            self._clutch.set_home_base_T_ee(
+                pose_from_ghost_body(self._hand_body_mj, self._arm.gripper_pose_mj()[1])
+            )
+        # The reset pulse re-seeds the limiter's baseline onto the first frame after a
+        # disengage, where the commanded pose jumps from the leader back to the
+        # follower. Without it the limiter rejects for ~30 frames (0.92 s).
+        # execution_state is spelled out because ExecutionEvents defaults to UNKNOWN,
+        # which would make the clutch silently never engage.
+        reset = self.phases.reset_requested
+        self.phases.reset_requested = False
+        permitted = self.phases.permits_engagement or self.verdict.ok
+        return (
+            {ENGAGE_PERMISSION_LEAF: {ValueInput.VALUE: _permission(permitted)}},
+            ExecutionEvents(reset=reset, execution_state=ExecutionState.RUNNING),
+        )
+
+    def after_step(self, result, dt: float) -> follower.ClutchPhase:
+        """Advance the phase, drive both tools, and re-evaluate the gate."""
+        if not self._arm.anchored:
+            # Nowhere to put the arm yet. Draw neither tool and hold the gate shut:
+            # with `permits_engagement` false too, `before_step` cannot permit a latch.
+            # Returns before the phase machine, so a frame with no placement is a frame
+            # that did not happen.
+            self._show(follower_visible=False, ghost_visible=False)
+            self._blocked(follower.GateResult((("unanchored", "no head pose yet"),)))
+            return self.phases.phase
+
+        # HAND_POSE_KEY is the only channel that can report tracking loss.
+        hand = _pose(result, HAND_POSE_KEY)
+        commanded = _pose(result, COMMANDED_POSE_KEY)
+        governed = _pose(result, EE_POSE_KEY)
+
+        # ControllerPoseSource drops on the pose's IS_VALID; the clutch ALSO disarms on a
+        # non-finite pose and on a finite but degenerate quaternion. Both folded in, so
+        # `hand` covers the clutch's whole disarm set -- otherwise a bad frame leaves
+        # hand_present True while is_engaged has just gone False, and the phase machine
+        # reads that as a real disengage.
+        if hand is not None and (
+            not np.all(np.isfinite(hand))
+            or float(np.linalg.norm(hand[3:7])) < _MIN_QUAT_NORM
+        ):
+            hand = None
+
+        # Latched, and refreshed only on a usable frame. SO101GripperRetargeter tests
+        # `inp.is_none` alone, so it keeps articulating the trigger while GRIP_IS_VALID
+        # is false, and a jaw swinging on a frozen body reads as "the gripper actuated".
+        if hand is not None:
+            self._closedness = float(result[GRIPPER_COMMAND_KEY][0])
+            # Latched for the same reason and one of its own: `before_step` pushes the
+            # clutch's home a frame before this one exists. Taken from the hand rather
+            # than read back off the arm, so the grip offset -- tuned or not -- cannot
+            # leak into an engagement the clutch composes as a delta.
+            self._hand_body_mj = ghost_body_from_pose(hand)[0]
+
+        if not self._frames_logged:
+            self._frames_logged = _log_hand_frames(result)
+
+        # Before the phase advance, so a press takes effect on this frame rather
+        # than the next.
+        self._reset_offset(result)
+
+        phase = self.phases.advance(
+            is_engaged=self._clutch.is_engaged, hand_present=hand is not None, dt=dt
+        )
+
+        # Nothing moves the arm while ENGAGED -- it is hidden and frozen where it stood
+        # on the engage frame. The disengage edge lands DISENGAGED, so the drag resumes
+        # on that very frame with no ramp in between.
+        if phase is follower.ClutchPhase.DISENGAGED and hand is not None:
+            # The hand, not the governed pose: the limiter governs only what the leader
+            # renders. Raw XR, not the ghost body -- follower.py is free of the grip
+            # calibration and must stay that way.
+            stick_x, stick_y = self._stick(result)
+            if self._trim_yaw(result, stick_x, dt):
+                # A owns the stick while held, so a trim cannot also walk the offset.
+                stick_x = stick_y = 0.0
+            facing, base_yaw = self._yaws(hand[3:7])
+            self._arm.drive(hand[:3], facing, base_yaw, stick_x, stick_y, dt)
+
+        engaged = phase is follower.ClutchPhase.ENGAGED
+        self._show(follower_visible=not engaged, ghost_visible=engaged)
+
+        limiter_passing = False
+        if commanded is not None and governed is not None:
+            # The body needs no tracking-loss gate: the clutch emits its held pose on
+            # every disarm path, so the pipeline freezes it. The JAW does, hence the
+            # latch above.
+            _update_ghost(self._data, self._ghost, governed, self._closedness)
+            # Classified on every governed frame, painted only while the ghost is the
+            # tool on show: the band needs an unbroken baseline to tell a refused frame
+            # from a clamped one.
+            band = self._monitor.update(self._model, commanded, governed, paint=engaged)
+            limiter_passing = band is HarnessBand.PASS_THROUGH
+
+        # The module docstring's invariant, at the one place that writes mocap_*.
+        # Unconditional, and here rather than in _loop so the tests drive it: without
+        # it the gate's xpos read below and mjv_updateScene both see the ghost's XML
+        # rest pose, and the leader appears in the right place and never moves again.
+        mujoco.mj_forward(self._model, self._data)
+
+        self._blocked(
+            self._gate.evaluate(
+                phase=phase,
+                hand_quat_xyzw=None if hand is None else hand[3:7],
+                home_quat_xyzw=grip_quat_from_ghost_body(
+                    self._arm.gripper_pose_mj()[1]
+                ),
+                limiter_passing=limiter_passing,
+                dt=dt,
+            )
+        )
+        return phase
+
+    def _yaws(self, q_hand_xyzw: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        """``(where the controller points, what to turn the base onto)``, both wxyz.
+
+        The app's half of the yaw drive, and the whole of it: which axis of a pose is its
+        facing is a fact about the calibration, so follower.py is handed the answer. The
+        second leads the first by the measured bias and the operator's trim, all yaws
+        about +Y, so their order is free. The follower needs both -- the base takes the
+        second, the grip offset is carried on the first.
+        """
+        facing = hand_facing_xr(q_hand_xyzw)
+        trim = np.empty(4)
+        mujoco.mju_axisAngle2Quat(
+            trim, np.array([0.0, 1.0, 0.0]), math.radians(self._yaw_trim_deg)
+        )
+        biased = np.empty(4)
+        mujoco.mju_mulQuat(biased, facing, self._yaw_bias)
+        base_yaw = np.empty(4)
+        mujoco.mju_mulQuat(base_yaw, biased, trim)
+        return facing, base_yaw
+
+    def _trim_yaw(self, result, stick_x: float, dt: float) -> bool:
+        """A + the right thumbstick: walk the yaw trim. True while it owns the stick.
+
+        A rate, like the grip offset, so the trim holds where the stick left it. Logs
+        once on the release in the constant's own form, with what the AIM pose would
+        have said beside it.
+        """
+        controller = result[GHOST_HAND]
+        held = not controller.is_none and bool(controller[_YAW_TRIM_BUTTON])
+        if not held:
+            if self._trimming:
+                self._trimming = False
+                LOG.info(
+                    "follower:   yaw trim -> _YAW_TRIM_DEG = %.1f", self._yaw_trim_deg
+                )
+            return False
+        step = follower.deflection(stick_x) * _YAW_TRIM_RATE_DEG_S * float(dt)
+        self._yaw_trim_deg += step
+        # Only a stick that actually moved arms the log, so holding A to keep the trim
+        # off the grip offset does not print a line every time it is released.
+        self._trimming = self._trimming or step != 0.0
+        return True
+
+    def _stick(self, result) -> tuple[float, float]:
+        """The right thumbstick's two raw axes, or a stick at rest.
+
+        ``Follower.drive`` owns which way each one points: the horizontal drive has one
+        definition and it is not here.
+        """
+        controller = result[GHOST_HAND]
+        if controller.is_none:
+            # Absent before the tracker has a controller, and reading the group there
+            # raises rather than reporting a stick at rest -- see `_reset_offset`.
+            return 0.0, 0.0
+        return (
+            float(controller[ControllerInputIndex.THUMBSTICK_X]),
+            float(controller[ControllerInputIndex.THUMBSTICK_Y]),
+        )
+
+    def _reset_offset(self, result) -> None:
+        """B, on its rising edge: put the grip offset back to its authored value.
+
+        The operator's escape hatch, so deliberately phase-free. Needs no pose: the
+        offset is a constant in the anchor's frame, not a point in the world.
+        """
+        # The controller group is Optional and absent before the tracker has one;
+        # reading it there raises rather than returning a falsy button, which took the
+        # whole session down at startup. Absent is "not pressed", so a press spanning a
+        # dropout re-arms and the first tracked frame is a fresh rising edge.
+        controller = result[GHOST_HAND]
+        pressed = not controller.is_none and bool(controller[_RESET_OFFSET_BUTTON])
+        rising = pressed and not self._reset_held
+        self._reset_held = pressed
+        if not rising:
+            return
+        self._arm.reset_offset()
+        LOG.info(
+            "follower:   grip offset reset to XR (%.2f, %.2f, %.2f).",
+            *self._arm.grip_from_controller_xr,
+        )
+
+    def _show(self, *, follower_visible: bool, ghost_visible: bool) -> None:
+        """The only place either tool's visibility is set. At most one is drawn."""
+        self._arm.set_visible(follower_visible)
+        follower.set_geoms_visible(self._model, self._ghost_geoms, ghost_visible)
+
+    def _blocked(self, verdict: follower.GateResult) -> None:
+        """Publish the gate's verdict: the arm's colour, and a log on transitions.
+
+        Keyed on `verdict.keys`, never on the text it renders. The verdict is stored
+        even on frames nothing is logged, so the first frame after a release is
+        compared against the last engaged one and the release is always heard.
+        """
+        previous_keys = self.verdict.keys
+        self.verdict = verdict
+        self._arm.set_engageable(verdict.ok)
+        if verdict.keys == previous_keys or follower.GATE_KEY_ENGAGED in verdict.keys:
+            return
+        LOG.info(
+            "clutch: %s",
+            "engageable"
+            if verdict.ok
+            else "blocked (" + "; ".join(verdict.blocked) + ")",
+        )
+
+
+def _loop(
+    viz_session,
+    layer,
+    renderer,
+    model,
+    data,
+    teleop_session,
+    ghost,
+    monitor,
+    arm,
+    clutch,
+) -> None:
     view_count = renderer.view_count
-    previous_clock: float | None = None
-    # NOT reset or drained on a non-render frame: the simulation owes that time
-    # whether or not anything was displayed.
-    accumulator = 0.0
     checked_frustum = False
+    preview = _Preview(model, data, ghost, monitor, arm, clutch)
+    previous_clock: float | None = None
 
     while not viz_session.should_close():
         info = viz_session.begin_frame()
         try:
-            # None means no usable timestamp -- skip the sample, never record 0.
-            now = _frame_clock(info)
-            if now is not None:
-                if previous_clock is not None:
-                    accumulator += _clamp_dt(now - previous_clock)
-                previous_clock = now
-
-            # Above both the should_render gate and the step loop, so it
-            # precedes the physics it feeds. Gated rather than every frame: an
-            # ungated step() calls xrSyncActions on the unthrottled
-            # pre-kRunning burst, hundreds of frames in milliseconds.
-            result = None
-            will_step = accumulator >= model.opt.timestep
-            if will_step or info.should_render:
-                result = teleop_session.step()
-                _update_ghost(data, ghost, result)
-
-            steps = 0
-            while accumulator >= model.opt.timestep and steps < 64:
-                mujoco.mj_step(model, data)
-                accumulator -= model.opt.timestep
-                steps += 1
-
+            # Nothing integrates, so there is no fixed-step accumulator and the whole
+            # frame hangs off should_render. That is also what keeps
+            # teleop_session.step() from calling xrSyncActions on the unthrottled
+            # pre-kRunning burst. The cost is that retargeter compute follows render
+            # cadence; a resumed session sees one large dt, bounded by max_dt.
             if not info.should_render:
-                # Deliberately does NOT touch the accumulator.
                 continue
+
+            now = _frame_clock(info)
+            dt = (
+                0.0
+                if now is None or previous_clock is None
+                else _clamp_dt(now - previous_clock)
+            )
+            previous_clock = previous_clock if now is None else now
+
+            # Input first, so it precedes everything it feeds. The head pose comes
+            # from this frame's views, which viz only fills past should_render.
+            external_inputs, events = preview.before_step(_head_pose(info))
+            result = teleop_session.step(
+                external_inputs=external_inputs, execution_events=events
+            )
+            preview.after_step(result, dt)
 
             renderer.update_scene(model._address, data._address)
             # mjv_updateScene truncates on overflow and returns normally, with
@@ -564,11 +1335,11 @@ def main(argv: list[str]) -> int:
     )
 
     # Before launch_context starts the runtime, so an unfetched checkout says so
-    # plainly instead of buried in the runtime's own startup logging.
-    missing = _missing_leader_assets()
+    # plainly rather than buried in the runtime's startup logging.
+    missing = _missing_assets()
     if missing:
         raise SystemExit(
-            f"mujoco_xr: the leader gripper meshes are not fetched ({', '.join(missing)}).\n"
+            f"mujoco_xr: the SO-101 assets are not fetched ({', '.join(missing)}).\n"
             f"  Run {FETCH_SCRIPT} from the repository root, then reinstall:\n"
             "  uv pip install --reinstall-package isaacteleop-examples-mujoco-xr "
             "./examples/mujoco_xr"

--- a/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/assets/follower/follower_arm.xml
+++ b/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/assets/follower/follower_arm.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+The SO-101 follower arm: what the operator drags before the clutch engages.
+A wrapper around upstream's own MJCF, which is fetched verbatim and NEVER
+edited -- scripts/fetch-so-arm.sh checksums it, so an edit here is a fetch
+failure on the next clone.
+
+Provenance: TheRobotStudio/SO-ARM100 at commit
+fda892cba81032c46c40976a48c9ceadbf40a9ca, Apache-2.0. The 13 meshes land FLAT
+beside this file, not under assets/: MuJoCo drops an included file's own
+`meshdir`, so upstream's `meshdir="assets"` is inert here and the paths resolve
+against this directory.
+
+follower.py repoints EVERY follower geom's `geom_matid` at this material at
+startup -- collision geoms included, so the rule has no exception to remember --
+replacing upstream's thirteen. One material is what lets the whole arm change
+colour in one write, the same way the leader ghost's does.
+
+The authored colour is the BLOCKED one, which is also where the arm starts;
+follower.py owns the engageable colour and restores this one from mat_rgba,
+alpha included -- it writes rgba[:3] only, so translucency survives both states.
+
+Translucent, unlike the leader ghost: this arm is a preview the operator looks
+PAST, so it must not hide what it is being aimed at. The cost is the draw-order
+and blending risk assets/leader/leader_gripper.xml avoids by staying opaque, over
+~30 overlapping geoms, and only a headset shows it.
+-->
+<mujoco model="so101 follower arm">
+  <asset>
+    <material name="follower_arm" rgba="0.45 0.45 0.45 0.6"/>
+  </asset>
+
+  <include file="so101_new_calib.xml"/>
+</mujoco>

--- a/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/assets/scene.xml
+++ b/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/assets/scene.xml
@@ -3,18 +3,17 @@
 SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
-The shipped scene: the SO-101 leader gripper ghost, and nothing else. No ground
-plane and no static furniture -- this is an AR scene and passthrough is the
+The shipped scene: the SO-101 follower arm and the leader gripper ghost. No
+ground plane and no furniture -- this is an AR scene and passthrough is the
 background.
 
-What a ghost-only scene cannot show: cpp/frames.hpp's constants place the ghost
-and the eye pose alike, so they cancel and it lands on the hand whatever they
-are. Only static content is placed by them, so adding any here puts
-kTransMjFromXr under test.
+cpp/frames.hpp's constants place the ghost and the eye pose alike, so they
+cancel and it lands on the hand whatever they are. The follower's base is static
+content and does not get that for free: follower.py authors its placement in the
+XR reference frame and pushes it through mj_from_xr at startup, so the constants
+cancel there too and kTransMjFromXr stays untuned.
 -->
 <mujoco model="mujoco_xr_scene">
-  <option timestep="0.002"/>
-
   <!-- A high ambient FLOOR, not a brighter light. Ambient is
        direction-independent, so it bounds how dark a surface can get (measured:
        0.40 of albedo, exactly the ambient term) while diffuse carries the shape.
@@ -26,5 +25,6 @@ kTransMjFromXr under test.
     <headlight ambient="0.4 0.4 0.4" diffuse="0.4 0.4 0.4" specular="0.3 0.3 0.3"/>
   </visual>
 
+  <include file="follower/follower_arm.xml"/>
   <include file="leader/leader_gripper.xml"/>
 </mujoco>

--- a/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/follower.py
+++ b/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/follower.py
@@ -1,0 +1,731 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The SO-101 follower preview: the arm, the phase it is in, and whether the clutch may latch.
+
+The joints are locked: ``qpos`` is written once, to :data:`Q_HOME`, and the arm is moved
+as a rigid body. ``Follower._place`` is the one writer of ``body_quat`` and
+``Follower._move_base`` the one writer of ``body_pos``. This module must not learn the
+leader ghost's grip calibration, which is a claim about a hand holding a CONTROLLER;
+app.py converts between the two.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import enum
+import logging
+import math
+
+import mujoco
+import numpy as np
+from isaacteleop.retargeters.rate_limiter import _quat_geodesic_angle
+
+from . import _mujoco_xr
+
+LOG = logging.getLogger("mujoco_xr")
+
+# Declared by assets/follower/follower_arm.xml and repointed onto every follower geom
+# at startup, so the arm recolours in one write.
+FOLLOWER_MATERIAL = "follower_arm"
+
+BASE_BODY = "base"
+GRIPPER_BODY = "gripper"
+
+# Upstream's own tool frame, declared on the `gripper` body 98.4 mm out from its origin.
+# The arm is placed BY this point, so it is also the axis the yaw turns about: it sits
+# 3.8 mm off the closed jaw surface, where a grasped object would be. Placing by the
+# gripper body instead pins a point 98.4 mm short of the jaw, which then swings on a
+# 15.8 mm arc across +-90 degrees of yaw.
+GRIPPER_SITE = "gripperframe"
+
+# Upstream's joint order, which is also the qpos order Q_HOME is written in. Asserted
+# by name at startup: a reordered upstream file would put each of Q_HOME's angles on a
+# different joint and still look like an arm.
+ARM_JOINTS = (
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_roll",
+)
+GRIPPER_JOINT = "gripper"
+
+# The configuration the arm holds for the whole session, written to qpos once at
+# construction. This pose IS the wrist posture the engage gate demands, so turning
+# these re-aims the operator's hand. The arm is planar while J1 and J5 are zero, so
+# the gripper's orientation is the SUM of J2, J3 and J4, and J4 stops at +-95 degrees.
+Q_HOME_DEG = (
+    0.00,  # J1 shoulder_pan  -- base yaw
+    -45.00,  # J2 shoulder_lift -- first segment elevation
+    45.00,  # J3 elbow_flex    -- second segment elevation
+    90.00,  # J4 wrist_flex    -- wrist up/down
+    -90.00,  # J5 wrist_roll    -- spin about the tool axis
+    00.00,  # J6 gripper       -- jaw opening, 0 is the authored pose
+)
+Q_HOME = np.radians(Q_HOME_DEG)
+
+# Where the home gripper sits relative to the OPERATOR'S HEAD, in XR axes: 0.30 m
+# below eye level and 0.60 m ahead on the head's yaw-projected facing (anchor_from_head).
+# Measured from the head, not the reference-space origin: the app does not get to choose
+# that origin, and a stage-origin space puts anything authored against it a standing
+# height out. Whether it lands inside the gaze cone is a headset judgement. Only the
+# yaw of this anchor lasts the session -- it is the frame the grip offset below is
+# carried on. The position holds only until the first frame carrying a controller,
+# which owns all three axes from then on.
+HOME_GRIP_FROM_HEAD_XR = np.array([0.0, -0.30, -0.60])
+
+# Where the gripper's JAW sits relative to the CONTROLLER, in metres, XR axes: level
+# with the hand laterally, 0.25 m ahead and 0.10 m below it (XR is y-up and -z-forward,
+# cpp/frames.hpp). Only the starting value for the horizontal pair; the live one is
+# Follower.grip_from_controller_xr, which the thumbstick walks. The vertical term is
+# fixed. Carried on the anchor's yaw and never the wrist's, or turning the hand would
+# swing the arm around the operator.
+GRIP_FROM_CONTROLLER_XR = np.array([0.0, -0.10, -0.25])
+
+# What the thumbstick does to the two horizontal terms above. Deflection is a RATE, so
+# the offset holds where the stick left it. Metres per second at full deflection,
+# scaled by the frame dt -- not per frame, or its feel would track the frame rate.
+_TUNE_RATE_M_S = 0.20
+# Sticks drift and the offset is latched, so a resting controller would walk the arm
+# away over a session.
+_STICK_DEADZONE = 0.15
+# Each tuned term, absolutely: a stuck stick must not push the arm out of sight. The
+# vertical term is not tuned and so not bounded here.
+_TUNE_LIMIT_M = 0.60
+
+# mjv_defaultOption enables geom groups 0-2 and disables 3-5, so this pair is "drawn"
+# and "not drawn". A hidden geom never becomes an mjvGeom, so it never writes depth.
+DRAWN_GROUP = 2
+HIDDEN_GROUP = 3
+
+# Engageable. The blocked colour is authored in follower_arm.xml: neutral grey, and
+# darker at 0.45 against this one's 0.68 luminance. There is no HUD to fall back on, so
+# brightness carries the signal as well as hue -- and a translucent arm dilutes both
+# against whatever is behind it, so check the pair on a headset before trusting either.
+_ENGAGEABLE_RGB = (0.20, 0.85, 0.35)
+
+# ENGAGED is held while the hand channel is absent, so a one-frame tracking blip does
+# not cost a teleport back onto the hand. This bounds the hold, so a genuinely lost
+# controller cannot strand the app engaged.
+_DROPOUT_TIMEOUT_S = 0.5
+
+# The engage gate's one metric conjunct, with hysteresis. Only the RELATION is pinned
+# -- enter tighter than exit -- because no value here is defensible without a headset.
+_ROTATION_ENTER_RAD = math.radians(20.0)
+_ROTATION_EXIT_RAD = math.radians(30.0)
+# Time the gate must stay inside the enter band before it goes green.
+_DWELL_S = 0.1
+
+
+def yaw_of_direction(forward_xr: np.ndarray, fallback_xr: np.ndarray) -> np.ndarray:
+    """The horizontal bearing of an XR direction, as a wxyz quaternion about +Y.
+
+    ``fallback_xr`` covers a direction within a hair of vertical, which has no bearing to
+    report. Every yaw reading goes through here, so all of them track a world-vertical
+    turn 1:1; what differs between callers is only what leaks in from the other two
+    degrees of freedom, which is a property of the axis they pick.
+    """
+    forward = np.asarray(forward_xr, dtype=float)
+    if abs(forward[0]) < 1e-6 and abs(forward[2]) < 1e-6:
+        # Straight up or down -- a headset face-down on a desk, a controller held
+        # muzzle-up. The fallback then points along the horizon: forwards when the
+        # direction points down, backwards when up.
+        forward = -math.copysign(1.0, forward[1]) * np.asarray(fallback_xr, dtype=float)
+
+    q_yaw = np.empty(4)
+    mujoco.mju_axisAngle2Quat(
+        q_yaw, np.array([0.0, 1.0, 0.0]), math.atan2(-forward[0], -forward[2])
+    )
+    return q_yaw
+
+
+def yaw_of_axis(q_xyzw: np.ndarray, forward_local: np.ndarray) -> np.ndarray:
+    """The horizontal facing of an XR orientation, as a wxyz quaternion about +Y.
+
+    ``forward_local`` names which axis of the pose is its facing, in the pose's own
+    frame. No default: each axis is blind to rotation about itself and sensitive to the
+    rest, so it must be chosen against the motions the reading has to ignore. See
+    app.py's _HAND_FORWARD_AXIS.
+    """
+    q_wxyz = np.asarray(q_xyzw, dtype=float)[[3, 0, 1, 2]]
+    forward = np.empty(3)
+    mujoco.mju_rotVecQuat(forward, np.asarray(forward_local, dtype=float), q_wxyz)
+    up = np.empty(3)
+    mujoco.mju_rotVecQuat(up, np.array([0.0, 1.0, 0.0]), q_wxyz)
+    return yaw_of_direction(forward, up)
+
+
+def yaw_of(q_xyzw: np.ndarray) -> np.ndarray:
+    """The horizontal facing of a HEAD pose, reading its -Z as the view direction."""
+    return yaw_of_axis(q_xyzw, np.array([0.0, 0.0, -1.0]))
+
+
+def anchor_from_head(head_pose_xr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Where the home grip goes and which way the arm faces, from a 7-D head pose.
+
+    Takes ``(position, xyzw)`` in XR; returns the XR home-grip position and the head's
+    YAW as a wxyz quaternion. The same yaw does both jobs: it carries
+    :data:`HOME_GRIP_FROM_HEAD_XR` onto the head's facing, and :meth:`Follower.anchor`
+    turns the arm by it.
+    """
+    pose = np.asarray(head_pose_xr, dtype=float)
+    q_yaw = yaw_of(pose[3:7])
+    offset = np.empty(3)
+    mujoco.mju_rotVecQuat(offset, HOME_GRIP_FROM_HEAD_XR, q_yaw)
+    return pose[:3] + offset, q_yaw
+
+
+def mj_from_xr_rotation(q_xr_wxyz: np.ndarray) -> np.ndarray:
+    """An XR-frame ROTATION expressed in MuJoCo: ``Q q Q^-1``, wxyz throughout.
+
+    Not ``_mujoco_xr.mj_from_xr_quat``, which maps a body's ORIENTATION across the
+    frames and is a single left-multiply. Conjugating keeps the axis map with its one
+    definition in cpp/frames.hpp: XR +Y is MuJoCo +z, so an XR yaw of theta comes out
+    as a MuJoCo rotation of theta about +z.
+    """
+    q_frame = np.array(_mujoco_xr.QUAT_MJ_FROM_XR, dtype=float)
+    inverse = np.empty(4)
+    mujoco.mju_negQuat(inverse, q_frame)
+    rotated = np.empty(4)
+    mujoco.mju_mulQuat(rotated, q_frame, np.asarray(q_xr_wxyz, dtype=float))
+    out = np.empty(4)
+    mujoco.mju_mulQuat(out, rotated, inverse)
+    return out
+
+
+def set_geoms_visible(model, geoms: np.ndarray, visible: bool) -> None:
+    """Add or remove ``geoms`` from what ``mjv_updateScene`` emits."""
+    model.geom_group[geoms] = DRAWN_GROUP if visible else HIDDEN_GROUP
+
+
+class ClutchPhase(enum.Enum):
+    """Where the app is in the engage cycle, and so which tool it draws.
+
+    Never the authority on "is the clutch latched?" -- that is
+    ``SO101ClutchRetargeter.is_engaged``, which this is derived from.
+    """
+
+    #: The follower is drawn and dragged by the hand; the leader is hidden.
+    DISENGAGED = "disengaged"
+    #: The leader is drawn and follows the hand; the follower is hidden and frozen.
+    ENGAGED = "engaged"
+
+
+class PhaseMachine:
+    """``DISENGAGED <-> ENGAGED``, one call per frame.
+
+    Takes ``is_engaged`` as an input on every call and never copies it into a field,
+    so the two cannot drift.
+    """
+
+    def __init__(self) -> None:
+        """Start disengaged, with the arm already at Q_HOME."""
+        self.phase = ClutchPhase.DISENGAGED
+        #: Set on the disengage edge; the app clears it once it has pulsed the limiter.
+        #: Without that pulse the limiter rejects the next ~30 frames -- its per-frame
+        #: reject threshold at 72 Hz is only 27.8 mm.
+        self.reset_requested = False
+        self._dropout_s = 0.0
+
+    def advance(
+        self, *, is_engaged: bool, hand_present: bool, dt: float
+    ) -> ClutchPhase:
+        """Fold one frame in and return the new phase.
+
+        ``is_engaged`` is read, never re-derived from the squeeze: the latch can be
+        deferred by frames the app cannot observe. ``hand_present`` is what makes the
+        disengage edge trustworthy -- ``is_engaged`` drops on four paths and only one
+        of them is a real disengage.
+        """
+        if self.phase is ClutchPhase.DISENGAGED:
+            if is_engaged:
+                self.phase = ClutchPhase.ENGAGED
+                self._dropout_s = 0.0
+        elif not hand_present:
+            # Hold ENGAGED through the gap. The clutch re-arms itself and re-latches at
+            # _last_commanded_*, where the leader already is, so the resumed frame is
+            # jump-free. Past the timeout the arm simply stays where it froze.
+            self._dropout_s += dt
+            if self._dropout_s > _DROPOUT_TIMEOUT_S:
+                self._disengage()
+        else:
+            self._dropout_s = 0.0
+            if not is_engaged:
+                self._disengage()
+        return self.phase
+
+    def _disengage(self) -> None:
+        self.phase = ClutchPhase.DISENGAGED
+        self.reset_requested = True
+        self._dropout_s = 0.0
+
+    @property
+    def permits_engagement(self) -> bool:
+        """One disjunct of what the app feeds the clutch's latch gate.
+
+        The other is the engage gate's verdict; the app sends ``permits_engagement or
+        verdict.ok``. Reads the phase rather than ``is_engaged``: during a tracking
+        dropout ``is_engaged`` is False on exactly the frames this exists to cover.
+        """
+        return self.phase is ClutchPhase.ENGAGED
+
+
+#: The ``keys`` entry for the latched-clutch conjunct. While the clutch is latched
+#: there is nothing to engage, so app.py logs no verdict carrying it.
+GATE_KEY_ENGAGED = ClutchPhase.ENGAGED.value
+
+
+@dataclasses.dataclass(frozen=True)
+class GateResult:
+    """Whether the clutch may latch, and -- when it may not -- why not.
+
+    ``failed`` names **every** failing conjunct, not the first: an operator who fixes
+    their wrist angle and immediately hits an unreported second failure has been told
+    half the truth twice. Each entry is ``(key, phrase)``, kept as a pair so the
+    value-free identity and the text it identifies cannot fall out of step.
+    """
+
+    #: ``key`` is app.py's transition key -- value-free, or a rounded angle in it
+    #: would move the key every frame. ``phrase`` carries the measurement, for display.
+    failed: tuple[tuple[str, str], ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return not self.failed
+
+    @property
+    def keys(self) -> tuple[str, ...]:
+        return tuple(key for key, _ in self.failed)
+
+    @property
+    def blocked(self) -> tuple[str, ...]:
+        return tuple(phrase for _, phrase in self.failed)
+
+
+class EngageGate:
+    """The three conjuncts of requirement 3, plus hysteresis and a dwell.
+
+    Pure with respect to the app: it returns the failing conjuncts and app.py decides
+    what to log.
+    """
+
+    def __init__(self) -> None:
+        """Start closed, with no dwell credit."""
+        self._ok = False
+        self._dwell_s = 0.0
+
+    def evaluate(
+        self,
+        *,
+        phase: ClutchPhase,
+        hand_quat_xyzw: np.ndarray | None,
+        home_quat_xyzw: np.ndarray,
+        limiter_passing: bool,
+        dt: float,
+    ) -> GateResult:
+        """Fold one frame in.
+
+        ``hand_quat_xyzw`` and ``home_quat_xyzw`` must share a layout -- the geodesic
+        angle is layout-agnostic only under that condition, and both are xyzw in XR here.
+        ``home_quat_xyzw`` carries the hand's own yaw, put there by :meth:`Follower.drive`,
+        so the two cancel and what is left is the wrist's pitch and roll against a session
+        constant.
+        """
+        failed: list[tuple[str, str]] = []
+        # The whole post-release debounce: `ok` is held False for the entire
+        # engagement, so the dwell below is zeroed on every engaged frame and a release
+        # cannot re-latch for at least _DWELL_S. It is also why the app must feed the
+        # clutch `permits_engagement or verdict.ok`.
+        if phase is ClutchPhase.ENGAGED:
+            failed.append((GATE_KEY_ENGAGED, phase.value))
+        theta = math.inf
+        if hand_quat_xyzw is None:
+            failed.append(("untracked", "controller not tracked"))
+        else:
+            theta = _quat_geodesic_angle(
+                np.asarray(hand_quat_xyzw, dtype=float),
+                np.asarray(home_quat_xyzw, dtype=float),
+            )
+
+        # There is no reach conjunct and no reach envelope. The gripper is placed
+        # exactly at its offset from the hand every frame, so a position residual is
+        # zero by construction. Do not add one back believing it bounds a workspace:
+        # this preview has none.
+        rotation_tol = _ROTATION_EXIT_RAD if self._ok else _ROTATION_ENTER_RAD
+        # Only against a tracked hand: with none there is no angle, and reporting one
+        # would be a second failure derived from the first.
+        if hand_quat_xyzw is not None and not theta < rotation_tol:
+            failed.append(
+                (
+                    "rotation",
+                    f"rotation {math.degrees(theta):.0f} deg "
+                    f"> {math.degrees(rotation_tol):.0f}",
+                )
+            )
+        # The leader renders the LIMITER's output, so a gate that opens while it is
+        # still clamping reveals a tool tens of degrees and hundreds of milliseconds
+        # behind the hand. 4 deg/cm x 0.5 m/s is 3.49 rad/s against a 2.5 rad/s clamp,
+        # so this trips at about 0.36 m/s of hand speed -- ordinary dragging.
+        if not limiter_passing:
+            failed.append(("limiter", "still catching up"))
+
+        if failed:
+            self._dwell_s = 0.0
+            self._ok = False
+            return GateResult(tuple(failed))
+
+        self._dwell_s += dt
+        if self._dwell_s < _DWELL_S:
+            return GateResult((("settling", "settling"),))
+        self._ok = True
+        return GateResult()
+
+
+class Follower:
+    """The follower arm in one scene: posed once, drawn, and driven rigidly by the hand.
+
+    :meth:`drive` moves it two independent ways: position from the controller plus a
+    thumbstick-trimmed offset, yaw from the wrist. Placed by :data:`GRIPPER_SITE`,
+    upstream's tool frame at the jaw, which is therefore also the axis the yaw turns
+    about; the gripper body carries the orientation and sits 98.4 mm short of it.
+    """
+
+    def __init__(self, model, data) -> None:
+        """Resolve the arm, check its qpos layout and pose it. NOT yet placed."""
+        self._model = model
+        self._data = data
+
+        self._base = _body(model, BASE_BODY)
+        self._gripper = _body(model, GRIPPER_BODY)
+        self._jaw = _site(model, GRIPPER_SITE)
+        # Kept because the anchor composes its yaw onto it rather than replacing it,
+        # so a scene that authors a base tilt keeps it.
+        self._authored_base_quat = np.array(model.body_quat[self._base], dtype=float)
+        _check_qpos_layout(model)
+
+        self._material = mujoco.mj_name2id(
+            model, mujoco.mjtObj.mjOBJ_MATERIAL, FOLLOWER_MATERIAL
+        )
+        if self._material < 0:
+            raise RuntimeError(
+                f"mujoco_xr: the scene declares no `{FOLLOWER_MATERIAL}` material; it must "
+                "<include> assets/follower/follower_arm.xml rather than upstream's MJCF directly."
+            )
+        self._geoms = _subtree_geoms(model, self._base)
+        self._visual_geoms = self._geoms[model.geom_group[self._geoms] == DRAWN_GROUP]
+        if self._visual_geoms.size == 0:
+            # Upstream numbers its visual geoms 2 and its collision geoms 3. A
+            # renumbering has to be an error, not a silently invisible arm.
+            raise RuntimeError(
+                f"mujoco_xr: no follower geom is in group {DRAWN_GROUP}, so the arm would "
+                "never be drawn; upstream's geom groups changed."
+            )
+        # One material for thirteen upstream ones, on every follower geom rather than
+        # just the drawn ones, so the rule has no exception to remember.
+        model.geom_matid[self._geoms] = self._material
+        self._blocked_rgba = np.array(model.mat_rgba[self._material], dtype=np.float64)
+
+        # The one and only qpos write. Everything after this moves the base.
+        self._data.qpos[: len(Q_HOME)] = Q_HOME
+        self._jaw_from_base = self._measure_jaw_from_base()
+
+        # The live grip offset. This class is its only definition; app.py passes two raw
+        # stick axes and never learns which way either points.
+        self._grip_from_controller_xr = GRIP_FROM_CONTROLLER_XR.copy()
+        # Whether the stick has moved the offset since it was last at rest, so the tuned
+        # value is logged once on the release rather than at 72 Hz.
+        self._tuning = False
+
+        # The frame the offset is carried on. None until anchor() takes it off the head,
+        # which is also what `anchored` reports.
+        self._anchored = False
+        # The yaw the base is currently turned by -- the wrist's, past the first driven
+        # frame, and so not the operator's above.
+        self._base_yaw_xr = np.array([1.0, 0.0, 0.0, 0.0])
+        self.set_visible(False)
+
+    # ---------------------------------------------------------------- geometry
+
+    @property
+    def anchored(self) -> bool:
+        """Whether a head pose has placed the arm. False until then; never back."""
+        return self._anchored
+
+    @property
+    def base_yaw_xr(self) -> np.ndarray:
+        """The XR yaw (wxyz) the base is currently turned by; identity before any.
+
+        Past the first driven frame this is the wrist's yaw, not the operator's. Kept as
+        the value that was used rather than read back off ``body_quat``.
+        """
+        return self._base_yaw_xr.copy()
+
+    def anchor(self, head_pose_xr: np.ndarray) -> np.ndarray:
+        """Take the offset's frame off the first head pose, and park the arm.
+
+        Returns the XR home grip. Where the arm waits until a controller arrives, and the
+        head's yaw is only what turns it to face the operator meanwhile -- from the first
+        driven frame the controller owns both position and yaw.
+        """
+        home_xr, q_yaw_xr = anchor_from_head(head_pose_xr)
+        self._anchored = True
+        self._place(home_xr, q_yaw_xr)
+        LOG.info(
+            "follower:   anchored to a head at XR (%.2f, %.2f, %.2f) facing %.0f deg; "
+            "home grip at XR (%.2f, %.2f, %.2f), base at MuJoCo (%.3f, %.3f, %.3f). "
+            "The controller owns both from the first driven frame.",
+            *np.asarray(head_pose_xr, dtype=float)[:3],
+            math.degrees(2.0 * math.atan2(q_yaw_xr[2], q_yaw_xr[0])),
+            *home_xr,
+            *self._model.body_pos[self._base],
+        )
+        return home_xr
+
+    def reset_offset(self) -> None:
+        """Put the grip offset back to :data:`GRIP_FROM_CONTROLLER_XR`. Any phase.
+
+        The operator's escape hatch for an offset walked out to its clamp, or a drifting
+        stick that got there on its own. Nothing else to reset: the arm is already on
+        the hand and already on its yaw.
+        """
+        self._grip_from_controller_xr = GRIP_FROM_CONTROLLER_XR.copy()
+        self._tuning = False
+
+    def _place(self, grip_xr: np.ndarray, q_yaw_xr: np.ndarray) -> None:
+        """Turn the base onto a yaw and put the gripper on an XR point. Does both, always.
+
+        The order is load-bearing: turning the base swings the gripper around it, so
+        ``_jaw_from_base`` is re-measured between the ``body_quat`` and ``body_pos``
+        writes. That second ``mj_forward`` costs 202 us a frame on a Jetson AGX Orin,
+        1.5% of a 72 Hz frame -- cheap enough to keep the offset measured, not derived.
+        """
+        # Yaw on the LEFT: it turns the arm in the WORLD, where upstream's quat orients
+        # it in its own frame. Upstream authors identity, so no shipped scene can tell
+        # the two orders apart -- this comment is the only guard.
+        turned = np.empty(4)
+        mujoco.mju_mulQuat(
+            turned, mj_from_xr_rotation(q_yaw_xr), self._authored_base_quat
+        )
+        self._model.body_quat[self._base] = turned
+        self._base_yaw_xr = np.asarray(q_yaw_xr, dtype=float).copy()
+        self._jaw_from_base = self._measure_jaw_from_base()
+        self._move_base(
+            np.array(_mujoco_xr.mj_from_xr_pos(list(grip_xr)), dtype=float)
+            - self._jaw_from_base
+        )
+
+    def _measure_jaw_from_base(self) -> np.ndarray:
+        """Base origin -> the jaw tool frame in MuJoCo world. Measured, never derived.
+
+        With the base at the MuJoCo origin the site's world position is the offset. Only
+        the base's yaw can change it, so only :meth:`_place` calls this -- and it must
+        write ``body_pos`` afterwards, because this leaves the base at the origin. Goes
+        through ``_move_base``, the one writer of ``body_pos``.
+        """
+        self._move_base(np.zeros(3))
+        return np.array(self._data.site_xpos[self._jaw], dtype=float)
+
+    def _move_base(self, base_pos_mj: np.ndarray) -> None:
+        """Slide the whole arm. The one place ``body_pos`` is written.
+
+        ``base`` is a fixed child of world, so every link translates with it and no
+        joint moves. Never touches ``body_quat``: :meth:`_place` is that one writer.
+        """
+        self._model.body_pos[self._base] = base_pos_mj
+        mujoco.mj_forward(self._model, self._data)
+
+    @property
+    def jaw_yaw_xr(self) -> np.ndarray:
+        """The XR yaw (wxyz) the jaw faces along: :data:`GRIPPER_SITE`'s +Z.
+
+        Which way the gripper is turned, and what app.py aims at the controller. Not the
+        links' reach: J5 rolls the jaw about the tool axis without moving them, so the
+        two part company by exactly that roll. The site's +X is the tool axis and points
+        down at Q_HOME, which is why a roll there reads as a bearing change here.
+        """
+        facing = np.array(self._data.site_xmat[self._jaw], dtype=float).reshape(3, 3)[
+            :, 2
+        ]
+        inverse = np.empty(4)
+        mujoco.mju_negQuat(inverse, np.array(_mujoco_xr.QUAT_MJ_FROM_XR, dtype=float))
+        facing_xr = np.empty(3)
+        mujoco.mju_rotVecQuat(facing_xr, facing, inverse)
+        return yaw_of_direction(facing_xr, np.array([0.0, 0.0, -1.0]))
+
+    def gripper_pose_mj(self) -> tuple[np.ndarray, np.ndarray]:
+        """The gripper body's ``(pos, quat_wxyz)`` in MuJoCo world coordinates.
+
+        Callers want the orientation: it is what the gate demands of the wrist and what
+        the clutch latches. The position is the body's, 98.4 mm short of the jaw the arm
+        is placed by, so do not read it as the tool point.
+        """
+        return (
+            np.array(self._data.xpos[self._gripper], dtype=float),
+            np.array(self._data.xquat[self._gripper], dtype=float),
+        )
+
+    # ------------------------------------------------------------------ drives
+
+    def drive(
+        self,
+        hand_pos_xr: np.ndarray,
+        q_facing_xr: np.ndarray,
+        q_base_yaw_xr: np.ndarray,
+        stick_x: float,
+        stick_y: float,
+        dt: float,
+    ) -> None:
+        """One disengaged frame: the jaw at the live grip offset off ``hand_pos_xr``, the
+        base on ``q_base_yaw_xr``.
+
+        Both land on :data:`GRIPPER_SITE`, so the yaw turns the arm about the jaw. Both
+        yaws arrive already computed: deriving them needs the grip calibration, which this
+        module does not get to learn. ``q_facing_xr`` is where the controller points and
+        ``q_base_yaw_xr`` what to turn the base onto; they differ by app.py's measured
+        bias. Only legal once :attr:`anchored` and while DISENGAGED -- an offset moving
+        while the arm is frozen applies its excursion on the release frame.
+        """
+        self._walk(stick_x, stick_y, dt)
+        # A direction, so it crosses onto the yaw by rotation alone. The CONTROLLER'S
+        # facing, so the offset is what the operator sees: stick forward sends the arm
+        # away along the pointing ray, and yawing the controller carries the arm around
+        # with it at a fixed relative position. Not the BASE yaw, which leads the facing
+        # by the bias and would send "forward" off by that much. A yaw leaves the vertical
+        # term untouched, so this one rotate is correct for all three.
+        offset = np.empty(3)
+        mujoco.mju_rotVecQuat(offset, self._grip_from_controller_xr, q_facing_xr)
+        self._place(np.asarray(hand_pos_xr, dtype=float) + offset, q_base_yaw_xr)
+
+    @property
+    def grip_from_controller_xr(self) -> np.ndarray:
+        """The live gripper-from-controller offset in XR axes, tuning included."""
+        return self._grip_from_controller_xr.copy()
+
+    def _walk(self, stick_x: float, stick_y: float, dt: float) -> None:
+        """Walk the offset's two horizontal terms at the thumbstick's deflection.
+
+        The caller passes raw stick axes and this decides where they point: OpenXR's
+        stick is +x right and +y forward while XR is +x right and -z forward, so x follows
+        the stick and z opposes it. Both are read in the CONTROLLER's frame by
+        :meth:`drive`, so forward is further along the pointing ray. The vertical term is
+        never touched.
+        """
+        step = _TUNE_RATE_M_S * float(dt)
+        delta = np.array([deflection(stick_x) * step, 0.0, -deflection(stick_y) * step])
+        if not delta.any():
+            if self._tuning:
+                self._tuning = False
+                # In the constant's own form, so a headset session ends in a value that
+                # can be pasted back into this file.
+                LOG.info(
+                    "follower:   offset tuned to GRIP_FROM_CONTROLLER_XR = "
+                    "np.array([%.2f, %.2f, %.2f])",
+                    *self._grip_from_controller_xr,
+                )
+            return
+        tuned = self._grip_from_controller_xr + delta
+        # Indexed rather than whole-vector: the vertical term is not tuned, so it must
+        # not be bounded by a limit chosen for the horizontal ones.
+        tuned[[0, 2]] = np.clip(tuned[[0, 2]], -_TUNE_LIMIT_M, _TUNE_LIMIT_M)
+        self._grip_from_controller_xr = tuned
+        self._tuning = True
+
+    # -------------------------------------------------------------- appearance
+
+    def set_visible(self, visible: bool) -> None:
+        """Draw the arm, or not. Its collision geoms are never drawn either way.
+
+        An un-anchored arm cannot be shown at all: drawing it against the
+        reference-space origin is the bug the anchor exists to fix. Enforced here
+        rather than only at the call site.
+        """
+        set_geoms_visible(self._model, self._visual_geoms, visible and self.anchored)
+
+    def set_engageable(self, engageable: bool) -> None:
+        """Green when the clutch would latch on a squeeze, the authored colour otherwise."""
+        rgba = self._blocked_rgba.copy()
+        if engageable:
+            rgba[:3] = _ENGAGEABLE_RGB
+        self._model.mat_rgba[self._material] = rgba
+
+    def log_placement(self) -> None:
+        """One line naming the placement rule, before any head pose exists."""
+        LOG.info(
+            "follower:   SO-101 home grip %.2f m below and %.2f m in front of the HEAD, "
+            "turned onto its facing, on the first frame carrying one. Hidden until then. "
+            "After it: the JAW dragged rigidly by the controller at (%.2f, %.2f, %.2f) "
+            "off it, turning about itself on the wrist's own yaw, with the right "
+            "thumbstick trimming the horizontal pair to +-%.2f m.",
+            -HOME_GRIP_FROM_HEAD_XR[1],
+            -HOME_GRIP_FROM_HEAD_XR[2],
+            *GRIP_FROM_CONTROLLER_XR,
+            _TUNE_LIMIT_M,
+        )
+
+
+def deflection(axis: float) -> float:
+    """One stick axis past the deadzone, or zero inside it. NaN reads as inside.
+
+    Spelled ``not >=`` rather than ``<`` so a non-finite axis falls inside: everything
+    the stick drives is latched, so one bad frame would poison it for the whole session.
+    Public because app.py's yaw trim integrates the same axis under the same deadzone.
+    """
+    value = float(axis)
+    return 0.0 if not abs(value) >= _STICK_DEADZONE else value
+
+
+def _site(model, name: str) -> int:
+    site = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_SITE, name)
+    if site < 0:
+        raise RuntimeError(
+            f"mujoco_xr: the scene declares no `{name}` site; upstream's MJCF stopped "
+            "publishing its tool frame, and the arm has no point to be placed by."
+        )
+    return site
+
+
+def _body(model, name: str) -> int:
+    body = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_BODY, name)
+    if body < 0:
+        raise RuntimeError(
+            f"mujoco_xr: the scene declares no `{name}` body; it must <include> "
+            "assets/follower/follower_arm.xml."
+        )
+    return body
+
+
+def _subtree_geoms(model, root: int) -> np.ndarray:
+    """Every geom on ``root`` and its descendants, by geom id.
+
+    ``body_rootid`` is the top of the kinematic tree a body belongs to, so this holds
+    exactly while ``root`` is a direct child of world -- which the scene guarantees.
+    """
+    return np.where(model.body_rootid[model.geom_bodyid] == root)[0].astype(np.int32)
+
+
+def _check_qpos_layout(model) -> None:
+    """What licenses writing ``Q_HOME`` straight into ``qpos[:6]``.
+
+    The follower must be the scene's only jointed body, in upstream's order, so a
+    scene that gains a second one fails here rather than landing Q_HOME's angles on
+    somebody else's joints.
+    """
+    names = tuple(ARM_JOINTS) + (GRIPPER_JOINT,)
+    if not (model.nq == model.njnt == len(names)):
+        raise RuntimeError(
+            f"mujoco_xr: expected {len(names)} hinge DOFs and nothing else, got "
+            f"nq={model.nq} njnt={model.njnt}."
+        )
+    for index, expected in enumerate(names):
+        actual = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, index)
+        if actual != expected:
+            raise RuntimeError(
+                f"mujoco_xr: joint {index} is `{actual}`, expected `{expected}`; upstream's "
+                "joint order changed and Q_HOME would pose the wrong joints."
+            )
+        # Q_HOME is six angles in radians; a slide joint would read them as metres.
+        # Hinges take one qpos slot each, so this is also what makes the addresses
+        # 0..5 and lets Q_HOME be written as a slice.
+        if model.jnt_type[index] != mujoco.mjtJoint.mjJNT_HINGE:
+            raise RuntimeError(f"mujoco_xr: joint `{actual}` is not a hinge.")

--- a/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/follower.py
+++ b/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/follower.py
@@ -53,8 +53,9 @@ GRIPPER_JOINT = "gripper"
 
 # The configuration the arm holds for the whole session, written to qpos once at
 # construction. This pose IS the wrist posture the engage gate demands, so turning
-# these re-aims the operator's hand. The arm is planar while J1 and J5 are zero, so
-# the gripper's orientation is the SUM of J2, J3 and J4, and J4 stops at +-95 degrees.
+# these re-aims the operator's hand, so re-solve _EULER_HAND_FROM_GHOST_DEG with them.
+# J2+J3+J4 set the gripper's elevation and J4 stops at +-95 degrees; J5 rolls the jaw
+# about the tool axis, which is a bearing shift in the posture the gate demands.
 Q_HOME_DEG = (
     0.00,  # J1 shoulder_pan  -- base yaw
     -45.00,  # J2 shoulder_lift -- first segment elevation
@@ -69,18 +70,17 @@ Q_HOME = np.radians(Q_HOME_DEG)
 # below eye level and 0.60 m ahead on the head's yaw-projected facing (anchor_from_head).
 # Measured from the head, not the reference-space origin: the app does not get to choose
 # that origin, and a stage-origin space puts anything authored against it a standing
-# height out. Whether it lands inside the gaze cone is a headset judgement. Only the
-# yaw of this anchor lasts the session -- it is the frame the grip offset below is
-# carried on. The position holds only until the first frame carrying a controller,
-# which owns all three axes from then on.
+# height out. Whether it lands inside the gaze cone is a headset judgement. A starting
+# pose only: the position holds until the first frame carrying a controller, and the yaw
+# only turns the arm to face the operator meanwhile. The controller owns both after it.
 HOME_GRIP_FROM_HEAD_XR = np.array([0.0, -0.30, -0.60])
 
 # Where the gripper's JAW sits relative to the CONTROLLER, in metres, XR axes: level
 # with the hand laterally, 0.25 m ahead and 0.10 m below it (XR is y-up and -z-forward,
 # cpp/frames.hpp). Only the starting value for the horizontal pair; the live one is
 # Follower.grip_from_controller_xr, which the thumbstick walks. The vertical term is
-# fixed. Carried on the anchor's yaw and never the wrist's, or turning the hand would
-# swing the arm around the operator.
+# fixed. Carried on the controller's own facing, so stick forward sends the arm along
+# the pointing ray and yawing the controller carries it around at a fixed offset.
 GRIP_FROM_CONTROLLER_XR = np.array([0.0, -0.10, -0.25])
 
 # What the thumbstick does to the two horizontal terms above. Deflection is a RATE, so
@@ -339,7 +339,13 @@ class EngageGate:
         # clutch `permits_engagement or verdict.ok`.
         if phase is ClutchPhase.ENGAGED:
             failed.append((GATE_KEY_ENGAGED, phase.value))
-        theta = math.inf
+        # There is no reach conjunct and no reach envelope. The gripper is placed
+        # exactly at its offset from the hand every frame, so a position residual is
+        # zero by construction. Do not add one back believing it bounds a workspace:
+        # this preview has none.
+        #
+        # The rotation conjunct is judged inside the tracked branch: with no hand there
+        # is no angle, and reporting one would be a second failure derived from the first.
         if hand_quat_xyzw is None:
             failed.append(("untracked", "controller not tracked"))
         else:
@@ -347,22 +353,15 @@ class EngageGate:
                 np.asarray(hand_quat_xyzw, dtype=float),
                 np.asarray(home_quat_xyzw, dtype=float),
             )
-
-        # There is no reach conjunct and no reach envelope. The gripper is placed
-        # exactly at its offset from the hand every frame, so a position residual is
-        # zero by construction. Do not add one back believing it bounds a workspace:
-        # this preview has none.
-        rotation_tol = _ROTATION_EXIT_RAD if self._ok else _ROTATION_ENTER_RAD
-        # Only against a tracked hand: with none there is no angle, and reporting one
-        # would be a second failure derived from the first.
-        if hand_quat_xyzw is not None and not theta < rotation_tol:
-            failed.append(
-                (
-                    "rotation",
-                    f"rotation {math.degrees(theta):.0f} deg "
-                    f"> {math.degrees(rotation_tol):.0f}",
+            rotation_tol = _ROTATION_EXIT_RAD if self._ok else _ROTATION_ENTER_RAD
+            if not theta < rotation_tol:
+                failed.append(
+                    (
+                        "rotation",
+                        f"rotation {math.degrees(theta):.0f} deg "
+                        f"> {math.degrees(rotation_tol):.0f}",
+                    )
                 )
-            )
         # The leader renders the LIMITER's output, so a gate that opens while it is
         # still clamping reveals a tool tens of degrees and hundreds of milliseconds
         # behind the hand. 4 deg/cm x 0.5 m/s is 3.49 rad/s against a 2.5 rad/s clamp,

--- a/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/harness.py
+++ b/examples/mujoco_xr/python/isaacteleop_examples/mujoco_xr/harness.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The safety harness the ghost renders, and the signal that it intervened.
+
+``EePoseRateLimiter`` is a three-band governor -- pass-through, clamped, refused -- and
+the ghost renders its *output*, so an intervention already shows as the tool lagging
+the hand. A lag alone does not say which band, so :class:`InterventionMonitor` recovers
+it by comparing what the limiter was given against what it emitted, and recolours the
+ghost. Colour goes on the shared ``leader_ghost`` material rather than per geom.
+"""
+
+from __future__ import annotations
+
+import enum
+
+import mujoco
+import numpy as np
+from isaacteleop.retargeting_engine.deviceio_source_nodes import ControllersSource
+from isaacteleop.retargeting_engine.interface import BaseRetargeter, RetargeterIOType
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import RetargeterIO
+from isaacteleop.retargeting_engine.interface.tensor_group_type import (
+    OptionalType,
+    TensorGroupType,
+)
+from isaacteleop.retargeting_engine.tensor_types import (
+    ControllerInput,
+    ControllerInputIndex,
+    DLDataType,
+    NDArrayType,
+)
+from isaacteleop.retargeters.rate_limiter import EE_POSE_KEY
+
+# The material every ghost geom in assets/leader/leader_gripper.xml carries.
+GHOST_MATERIAL = "leader_ghost"
+
+
+class HandPose(enum.Enum):
+    """Which standard OpenXR controller pose the app drives from.
+
+    Different frames for different jobs, per the OpenXR spec. Grip is the palm centroid,
+    for rendering a held object; its -Z runs little finger to thumb, through the fist,
+    and is not a pointing direction. Aim's -Z is the pointing ray. A facing read off grip
+    therefore turns 1:1 with the hand but has an arbitrary zero.
+    """
+
+    GRIP = "grip"
+    AIM = "aim"
+
+    @property
+    def indices(self) -> tuple[int, int, int]:
+        """``(position, orientation, is_valid)`` in ``ControllerInput`` for this pose."""
+        if self is HandPose.GRIP:
+            return (
+                ControllerInputIndex.GRIP_POSITION,
+                ControllerInputIndex.GRIP_ORIENTATION,
+                ControllerInputIndex.GRIP_IS_VALID,
+            )
+        return (
+            ControllerInputIndex.AIM_POSITION,
+            ControllerInputIndex.AIM_ORIENTATION,
+            ControllerInputIndex.AIM_IS_VALID,
+        )
+
+
+def _pose_type() -> TensorGroupType:
+    """The 7-D ``[x, y, z, qx, qy, qz, qw]`` contract EePoseRateLimiter governs."""
+    return TensorGroupType(
+        EE_POSE_KEY,
+        [NDArrayType("pose", shape=(7,), dtype=DLDataType.FLOAT, dtype_bits=32)],
+    )
+
+
+class ControllerPoseSource(BaseRetargeter):
+    """One controller pose, repacked as the 7-D ``ee_pose`` the limiter takes.
+
+    Emits in the XR reference frame; ``mj_from_xr`` is rigid, so limiting here and
+    transforming afterwards bounds the same metres and radians. Goes absent on an invalid
+    pose rather than holding the last one, which is the limiter's job. Everything
+    downstream consumes this output, so :class:`HandPose` switches the whole app at once.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        pose: HandPose = HandPose.GRIP,
+        input_device: str = ControllersSource.RIGHT,
+    ) -> None:
+        """Initialize the controller-pose adapter.
+
+        Args:
+            name: Name identifier for this retargeter node.
+            pose: Which OpenXR controller pose to read.
+            input_device: Controller source key to read the pose from.
+        """
+        self._input_device = input_device
+        self._pose = pose
+        super().__init__(name=name)
+
+    @property
+    def pose(self) -> HandPose:
+        """Which OpenXR controller pose this emits."""
+        return self._pose
+
+    def input_spec(self) -> RetargeterIOType:
+        """Requires the configured controller (Optional)."""
+        return {self._input_device: OptionalType(ControllerInput())}
+
+    def output_spec(self) -> RetargeterIOType:
+        """Outputs an Optional absolute 7-D ``ee_pose``."""
+        return {EE_POSE_KEY: OptionalType(_pose_type())}
+
+    def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
+        """Repacks the pose; goes absent when the controller is untracked."""
+        out = outputs[EE_POSE_KEY]
+        inp = inputs[self._input_device]
+        position_index, orientation_index, valid_index = self._pose.indices
+        if inp.is_none or not bool(inp[valid_index]):
+            out.set_none()
+            return
+
+        position = inp[position_index]
+        orientation = inp[orientation_index]
+        # Both orientations are already (x, y, z, w), the limiter's convention.
+        out[0] = np.array(
+            [
+                float(position[0]),
+                float(position[1]),
+                float(position[2]),
+                float(orientation[0]),
+                float(orientation[1]),
+                float(orientation[2]),
+                float(orientation[3]),
+            ],
+            dtype=np.float32,
+        )
+
+
+class HarnessBand(enum.Enum):
+    """Which of the limiter's three bands produced the frame the ghost renders."""
+
+    PASS_THROUGH = "pass-through"
+    CLAMPED = "clamped"
+    REJECTED = "rejected"
+
+
+# Above the float32 round-trip and quaternion-recomposition floor (~1e-7), far below
+# anything an operator could see. A band decided by numerical noise would strobe the
+# ghost every frame.
+_POS_EPS_M = 1e-4
+_ANG_EPS_RAD = 1e-3
+
+
+def _moved(a: np.ndarray, b: np.ndarray) -> bool:
+    """True when two 7-D poses differ by more than the noise floor.
+
+    Double-cover aware on the quaternion: the two signs are the same rotation.
+    """
+    dot = min(1.0, abs(float(np.dot(a[3:7], b[3:7]))))
+    return (
+        float(np.linalg.norm(a[:3] - b[:3])) > _POS_EPS_M
+        or 2.0 * float(np.arccos(dot)) > _ANG_EPS_RAD
+    )
+
+
+def classify(
+    given: np.ndarray, emitted: np.ndarray, previous: np.ndarray | None
+) -> HarnessBand:
+    """The band, from the pose the limiter was given and the one it emitted.
+
+    Reading it off the poses keeps the limiter unmodified and works for any governor
+    with the same contract.
+
+    Args:
+        given: The 7-D pose handed to the limiter this frame.
+        emitted: The 7-D pose it produced.
+        previous: The pose it produced last frame, or None on the first.
+    """
+    if not _moved(given, emitted):
+        return HarnessBand.PASS_THROUGH
+    # Emitted nothing new while the input moved away: refused, not approached. A clamp
+    # always closes some of the gap, so it cannot land here.
+    if previous is not None and not _moved(emitted, previous):
+        return HarnessBand.REJECTED
+    return HarnessBand.CLAMPED
+
+
+# rgb only: the authored alpha is kept, because the ghost is opaque by design (see
+# assets/leader/leader_gripper.xml).
+_BAND_RGB = {
+    HarnessBand.CLAMPED: (1.00, 0.72, 0.20),
+    HarnessBand.REJECTED: (1.00, 0.25, 0.20),
+}
+
+
+class InterventionMonitor:
+    """Classifies each governed frame and recolours the ghost to match.
+
+    Holds the previous emitted pose, which is what separates a refused frame from a
+    clamped one, and counts the bands so a session can be summarised afterwards.
+    """
+
+    def __init__(self, model) -> None:
+        """Latch the authored ghost colour as the pass-through colour.
+
+        Args:
+            model: The compiled ``mjModel``; must declare :data:`GHOST_MATERIAL`.
+        """
+        self._mat = mujoco.mj_name2id(
+            model, mujoco.mjtObj.mjOBJ_MATERIAL, GHOST_MATERIAL
+        )
+        if self._mat < 0:
+            raise RuntimeError(
+                f"mujoco_xr: the scene declares no `{GHOST_MATERIAL}` material; "
+                "the ghost cannot report harness interventions."
+            )
+        self._rgba = np.array(model.mat_rgba[self._mat], dtype=np.float64)
+        self._previous: np.ndarray | None = None
+        self.counts = dict.fromkeys(HarnessBand, 0)
+
+    @property
+    def pass_through_rgba(self) -> np.ndarray:
+        """The authored ghost colour, restored whenever the harness is not acting."""
+        return self._rgba.copy()
+
+    def update(
+        self, model, given: np.ndarray, emitted: np.ndarray, *, paint: bool = True
+    ) -> HarnessBand:
+        """Classify this frame, advance the baseline, and (unless told not to) paint.
+
+        Classification runs on every governed frame even while the ghost is hidden: a
+        gap in the baseline would misclassify the frame the ghost reappears on.
+        """
+        band = classify(given, emitted, self._previous)
+        self._previous = np.array(emitted, dtype=np.float64)
+        self.counts[band] += 1
+
+        if paint:
+            rgba = self._rgba.copy()
+            if band in _BAND_RGB:
+                rgba[:3] = _BAND_RGB[band]
+            model.mat_rgba[self._mat] = rgba
+        return band
+
+    def summary(self) -> str:
+        """One line: how much of the session the harness spent intervening."""
+        total = sum(self.counts.values())
+        if total == 0:
+            return "harness: no governed frames"
+        return "harness: {} frames -- {} clamped, {} rejected".format(
+            total,
+            self.counts[HarnessBand.CLAMPED],
+            self.counts[HarnessBand.REJECTED],
+        )

--- a/examples/mujoco_xr/scripts/fetch-so-arm.sh
+++ b/examples/mujoco_xr/scripts/fetch-so-arm.sh
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Fetches the SO-101 leader-gripper assets, rather than vendoring 2.3 MB of
-# binary STL that Git LFS made every clone pay for.
+# Fetches the SO-101 assets this example draws -- the leader gripper the ghost
+# is made of, and the follower arm -- rather than vendoring 18 MB of binary STL
+# that Git LFS made every clone pay for.
 #
 # Nothing calls this at build time: an isolated PEP-517 wheel build must not
 # reach the network, so it is an explicit step and the app names it at startup.
@@ -15,27 +16,55 @@ set -euo pipefail
 COMMIT="fda892cba81032c46c40976a48c9ceadbf40a9ca"
 REPO="TheRobotStudio/SO-ARM100"
 
-DEST="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/python/isaacteleop_examples/mujoco_xr/assets/leader"
+DEST="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/python/isaacteleop_examples/mujoco_xr/assets"
 
-# upstream path <SPACE> local name <SPACE> sha256
+# upstream path <SPACE> destination relative to assets/ <SPACE> sha256
+#
+# The destination is per entry, not per script: the two tools are separate MJCF
+# fragments in separate directories. Both land FLAT beside their fragment --
+# MuJoCo drops an included file's own `meshdir`, so meshes under a further
+# assets/ subdirectory fail to open.
 #
 # The URDF is where app.py's trigger hinge comes from, and having it on disk is
 # what lets test_ghost.py check those constants against their source.
+#
+# sts3215_03a_v1.stl is fetched TWICE, once per tool, because each fragment
+# resolves its meshes against its own directory. A symlink or a `../leader/`
+# path would tie the follower fragment's layout to the leader's.
+#
+# joints_properties.xml is deliberately absent: upstream inlines its `<default>`
+# block into so101_new_calib.xml rather than <include>ing it, so the file is
+# never read.
 ASSETS=(
-  "STL/SO101/Individual/Wrist_Roll_SO101.stl Wrist_Roll_SO101.stl de3a65044dd4ae8bcb9659d8ca2b49598e3f5571edf89f45ad975e9776a7ffee"
-  "STL/SO101/Individual/Trigger_SO101.stl Trigger_SO101.stl 48ecec3a3710cffdc0ae96d28547e49ddf4cbc93ccd915be7549f78e00ad2850"
-  "STL/SO101/Individual/Handle_SO101.stl Handle_SO101.stl fb8757bdff009c04c207481dd664813ccdac2ad989acea6057df780b52327281"
-  "Simulation/SO101/assets/sts3215_03a_v1.stl STS3215_03a.stl a37c871fb502483ab96c256baf457d36f2e97afc9205313d9c5ab275ef941cd0"
-  "Simulation/SO101/so101_new_calib.urdf so101_new_calib.urdf 3a65d2d35e68a8d2f0c2cc176d19b884506543c93ba72980145b80abe276022c"
-  "LICENSE LICENSE c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+  "STL/SO101/Individual/Wrist_Roll_SO101.stl leader/Wrist_Roll_SO101.stl de3a65044dd4ae8bcb9659d8ca2b49598e3f5571edf89f45ad975e9776a7ffee"
+  "STL/SO101/Individual/Trigger_SO101.stl leader/Trigger_SO101.stl 48ecec3a3710cffdc0ae96d28547e49ddf4cbc93ccd915be7549f78e00ad2850"
+  "STL/SO101/Individual/Handle_SO101.stl leader/Handle_SO101.stl fb8757bdff009c04c207481dd664813ccdac2ad989acea6057df780b52327281"
+  "Simulation/SO101/assets/sts3215_03a_v1.stl leader/STS3215_03a.stl a37c871fb502483ab96c256baf457d36f2e97afc9205313d9c5ab275ef941cd0"
+  "Simulation/SO101/so101_new_calib.urdf leader/so101_new_calib.urdf 3a65d2d35e68a8d2f0c2cc176d19b884506543c93ba72980145b80abe276022c"
+  "LICENSE leader/LICENSE c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4"
+
+  "Simulation/SO101/so101_new_calib.xml follower/so101_new_calib.xml d75253eb568e8a7214db9c631ab7bed4217f608a26f7276ebe9a7636cac82580"
+  "Simulation/SO101/assets/base_motor_holder_so101_v1.stl follower/base_motor_holder_so101_v1.stl 8cd2f241037ea377af1191fffe0dd9d9006beea6dcc48543660ed41647072424"
+  "Simulation/SO101/assets/base_so101_v2.stl follower/base_so101_v2.stl bb12b7026575e1f70ccc7240051f9d943553bf34e5128537de6cd86fae33924d"
+  "Simulation/SO101/assets/motor_holder_so101_base_v1.stl follower/motor_holder_so101_base_v1.stl 31242ae6fb59d8b15c66617b88ad8e9bded62d57c35d11c0c43a70d2f4caa95b"
+  "Simulation/SO101/assets/motor_holder_so101_wrist_v1.stl follower/motor_holder_so101_wrist_v1.stl 887f92e6013cb64ea3a1ab8675e92da1e0beacfd5e001f972523540545e08011"
+  "Simulation/SO101/assets/moving_jaw_so101_v1.stl follower/moving_jaw_so101_v1.stl 785a9dded2f474bc1d869e0d3dae398a3dcd9c0c345640040472210d2861fa9d"
+  "Simulation/SO101/assets/rotation_pitch_so101_v1.stl follower/rotation_pitch_so101_v1.stl 9be900cc2a2bf718102841ef82ef8d2873842427648092c8ed2ca1e2ef4ffa34"
+  "Simulation/SO101/assets/sts3215_03a_no_horn_v1.stl follower/sts3215_03a_no_horn_v1.stl 75ef3781b752e4065891aea855e34dc161a38a549549cd0970cedd07eae6f887"
+  "Simulation/SO101/assets/sts3215_03a_v1.stl follower/sts3215_03a_v1.stl a37c871fb502483ab96c256baf457d36f2e97afc9205313d9c5ab275ef941cd0"
+  "Simulation/SO101/assets/under_arm_so101_v1.stl follower/under_arm_so101_v1.stl d01d1f2de365651dcad9d6669e94ff87ff7652b5bb2d10752a66a456a86dbc71"
+  "Simulation/SO101/assets/upper_arm_so101_v1.stl follower/upper_arm_so101_v1.stl 475056e03a17e71919b82fd88ab9a0b898ab50164f2a7943652a6b2941bb2d4f"
+  "Simulation/SO101/assets/waveshare_mounting_plate_so101_v2.stl follower/waveshare_mounting_plate_so101_v2.stl e197e24005a07d01bbc06a8c42311664eaeda415bf859f68fa247884d0f1a6e9"
+  "Simulation/SO101/assets/wrist_roll_follower_so101_v1.stl follower/wrist_roll_follower_so101_v1.stl 4b17b410a12d64ec39554abc3e8054d8a97384b2dc4a8d95a5ecb2a93670f5f4"
+  "Simulation/SO101/assets/wrist_roll_pitch_so101_v2.stl follower/wrist_roll_pitch_so101_v2.stl 6c7ec5525b4d8b9e397a30ab4bb0037156a5d5f38a4adf2c7d943d6c56eda5ae"
 )
 
-mkdir -p "$DEST"
 echo "Fetching SO-ARM100 assets at ${COMMIT:0:12} into ${DEST}"
 
 for entry in "${ASSETS[@]}"; do
   read -r remote local sha <<<"$entry"
   target="${DEST}/${local}"
+  mkdir -p "$(dirname "$target")"
   if [[ -f "$target" ]] && echo "${sha}  ${target}" | sha256sum --check --status; then
     echo "  ok       ${local}"
     continue

--- a/examples/mujoco_xr/tests/test_ghost.py
+++ b/examples/mujoco_xr/tests/test_ghost.py
@@ -37,10 +37,10 @@ def _default_scene():
 
     Saying which meshes are missing beats MuJoCo's "Error opening file".
     """
-    missing = app._missing_leader_assets()
+    missing = app._missing_assets()
     if missing:
         pytest.skip(
-            f"leader meshes not fetched ({', '.join(missing)}); run {app.FETCH_SCRIPT}"
+            f"SO-101 assets not fetched ({', '.join(missing)}); run {app.FETCH_SCRIPT}"
         )
     return mujoco.MjModel.from_xml_path(str(app.DEFAULT_SCENE))
 
@@ -78,8 +78,8 @@ def _nearest_gap(a, b, stride=7, block=200):
 
 
 # ---------------------------------------------------------------------------
-# A stubbed pipeline result. ``app._update_ghost`` reads three fields through
-# the mapping protocol, and stubbing them is what keeps this file headless.
+# A stubbed controller. ``_place`` turns it into the pose ``app._update_ghost``
+# takes, and stubbing it is what keeps this file headless.
 # ---------------------------------------------------------------------------
 
 
@@ -106,18 +106,22 @@ class _NoController:
         raise AssertionError("an is_none controller must never be read")
 
 
-def _result(controller, closedness=0.0):
-    """Both hands plus the jaw channel, shaped like the real combiner output."""
-    other = (
-        app.ControllersSource.LEFT
-        if app.GHOST_HAND == app.ControllersSource.RIGHT
-        else app.ControllersSource.RIGHT
+def _place(data, ghost, controller, closedness=0.0):
+    """One frame of the loop: place the ghost only when the harness has a pose."""
+    if controller.is_none or not controller[ControllerInputIndex.GRIP_IS_VALID]:
+        return
+    app._update_ghost(
+        data,
+        ghost,
+        np.array(
+            [
+                *controller[ControllerInputIndex.GRIP_POSITION],
+                *controller[ControllerInputIndex.GRIP_ORIENTATION],
+            ],
+            dtype=float,
+        ),
+        closedness,
     )
-    return {
-        app.GHOST_HAND: controller,
-        other: _NoController(),
-        app.GRIPPER_COMMAND_KEY: [closedness],
-    }
 
 
 def test_the_ghost_is_opaque_and_collides_with_nothing():
@@ -248,9 +252,7 @@ def test_the_ghost_is_rigidly_attached_to_the_grip_frame():
         ((0.31, 1.24, -0.42), (0.0, 0.3826834, 0.0, 0.9238795)),
         ((-0.2, 0.9, -0.8), (0.5, 0.5, 0.5, 0.5)),
     ):
-        app._update_ghost(
-            data, ghost, _result(_Controller(True, grip_pos, grip_quat_xyzw))
-        )
+        _place(data, ghost, _Controller(True, grip_pos, grip_quat_xyzw))
         q_world_from_grip = np.array(_mujoco_xr.mj_from_xr_quat(list(grip_quat_xyzw)))
         inverse, relative = np.empty(4), np.empty(4)
         mujoco.mju_negQuat(inverse, q_world_from_grip)
@@ -274,8 +276,8 @@ def test_the_ghost_is_rigidly_attached_to_the_grip_frame():
             "orientation -- the translation is not being rotated with the grip"
         )
     # And it is the configured correction, not some other rigid attachment.
-    assert np.allclose(seen[0][0], app._QUAT_GRIP_FROM_GHOST, atol=1e-6)
-    assert np.allclose(seen[0][1], app._POS_GRIP_FROM_GHOST, atol=1e-6)
+    assert np.allclose(seen[0][0], app._QUAT_HAND_FROM_GHOST, atol=1e-6)
+    assert np.allclose(seen[0][1], app._POS_HAND_FROM_GHOST, atol=1e-6)
 
 
 def test_squeezing_drives_the_jaw_from_released_to_squeezed():
@@ -290,7 +292,7 @@ def test_squeezing_drives_the_jaw_from_released_to_squeezed():
     controller = _Controller(True, (0.0, 1.2, -0.5))
 
     def hinge_angle_at(closedness):
-        app._update_ghost(data, ghost, _result(controller, closedness))
+        _place(data, ghost, controller, closedness)
         mujoco.mj_forward(model, data)
         inverse, hinge = np.empty(4), np.empty(4)
         mujoco.mju_negQuat(inverse, np.array(data.mocap_quat[ghost.body]))
@@ -311,7 +313,7 @@ def test_squeezing_drives_the_jaw_from_released_to_squeezed():
 
     # And it is big enough to see: the far end of the lever sweeps ~90 mm.
     def trigger_at(closedness):
-        app._update_ghost(data, ghost, _result(controller, closedness))
+        _place(data, ghost, controller, closedness)
         mujoco.mj_forward(model, data)
         return _geom_verts_world(model, data, "leader_ghost_trigger")
 
@@ -363,9 +365,7 @@ def test_the_trigger_clears_the_whole_gripper_across_its_driven_range():
     worst = (0.0, "", 1e9)
     for step in range(9):
         closedness = step / 8
-        app._update_ghost(
-            data, ghost, _result(_Controller(True, (0.0, 1.2, -0.5)), closedness)
-        )
+        _place(data, ghost, _Controller(True, (0.0, 1.2, -0.5)), closedness)
         mujoco.mj_forward(model, data)
         trigger = _geom_verts_world(model, data, "leader_ghost_trigger")
         for part in others:
@@ -412,7 +412,9 @@ def test_the_shipped_retargeter_drives_the_jaw_channel():
         )
         return ControllerSnapshotTrackedT(ControllerSnapshot(pose, pose, state))
 
-    pipeline = app._build_pipeline()
+    from isaacteleop.retargeting_engine.interface import ValueInput
+
+    pipeline, _ = app._build_pipeline(np.eye(4, dtype=np.float32))
     spec = ControllersSource(name="controllers").input_spec()
 
     def closedness(trigger):
@@ -421,7 +423,12 @@ def test_the_shipped_retargeter_drives_the_jaw_channel():
             group = TensorGroup(spec[name])
             group[0] = snapshot(trigger)
             inputs[name] = group
-        out = pipeline.execute_pipeline({"controllers": inputs})
+        out = pipeline.execute_pipeline(
+            {
+                "controllers": inputs,
+                app.ENGAGE_PERMISSION_LEAF: {ValueInput.VALUE: app._permission(True)},
+            }
+        )
         assert app.GRIPPER_COMMAND_KEY in out
         return float(out[app.GRIPPER_COMMAND_KEY][0])
 
@@ -440,14 +447,12 @@ def test_an_untracked_controller_freezes_the_whole_gripper():
     model = _default_scene()
     data = mujoco.MjData(model)
     ghost = app._resolve_ghost(model)
-    app._update_ghost(
-        data, ghost, _result(_Controller(True, (0.2, 1.3, -0.5)), closedness=0.0)
-    )
+    _place(data, ghost, _Controller(True, (0.2, 1.3, -0.5)), closedness=0.0)
     seen_body = data.mocap_pos[ghost.body].copy()
     seen_jaw = data.mocap_quat[ghost.jaw].copy()
 
     for controller in (_Controller(False, (9.0, 9.0, 9.0)), _NoController()):
         for _ in range(3):
-            app._update_ghost(data, ghost, _result(controller, closedness=1.0))
+            _place(data, ghost, controller, closedness=1.0)
     assert np.array_equal(data.mocap_pos[ghost.body], seen_body)
     assert np.array_equal(data.mocap_quat[ghost.jaw], seen_jaw)

--- a/examples/mujoco_xr/tests/test_readback.py
+++ b/examples/mujoco_xr/tests/test_readback.py
@@ -19,6 +19,7 @@ mujoco = pytest.importorskip("mujoco")
 _mujoco_xr = pytest.importorskip("isaacteleop_examples.mujoco_xr._mujoco_xr")
 
 from isaacteleop_examples.mujoco_xr.app import DEFAULT_SCENE, FAR_Z, NEAR_Z  # noqa: E402
+from isaacteleop_examples.mujoco_xr import follower  # noqa: E402
 
 W = H = 256
 HALF_FOV = math.radians(45.0)
@@ -31,6 +32,10 @@ def rendered():
     """A live Renderer plus a device-to-host copier, or a skip saying why."""
     model = mujoco.MjModel.from_xml_path(str(DEFAULT_SCENE))
     data = mujoco.MjData(model)
+    # These tests measure where the drawn pixels are, so the ghost must be the only
+    # thing drawn; the scene also carries the follower arm, 30 of its 34 geoms.
+    # Follower.__init__ ends by hiding it, the same switch the app uses.
+    follower.Follower(model, data)
 
     try:
         gl = mujoco.GLContext(W, H)

--- a/src/core/retargeting_engine_tests/python/test_rate_limiter.py
+++ b/src/core/retargeting_engine_tests/python/test_rate_limiter.py
@@ -1,0 +1,765 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sim-free unit tests for the rate-limiting safety harness retargeters.
+
+Covers the safety-harness nodes that bound per-frame command velocity for bare
+position-servo followers (e.g. the SO-101):
+
+* :class:`~isaacteleop.retargeters.EePoseRateLimiter` -- linear/angular velocity
+  bounds on an absolute 7-D ``ee_pose`` stream.
+* :class:`~isaacteleop.retargeters.JointRateLimiter` -- per-joint velocity bounds
+  on a name-keyed ``joint_targets`` group.
+
+Each limiter is exercised at the pure-math level (the module-private clamp
+helpers) and at the ``BaseRetargeter.compute`` level (build inputs/outputs, drive
+frames with controlled ``GraphTime`` stamps, read the emitted tensors), with no
+``gym.make``, USD, GPU, or XR device.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+from isaacteleop.retargeting_engine.interface import (
+    ComputeContext,
+    ExecutionEvents,
+    ExecutionState,
+    OptionalTensorGroup,
+    TensorGroup,
+)
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import GraphTime
+from isaacteleop.retargeting_engine.interface.tensor_group_type import (
+    OptionalTensorGroupType,
+)
+from isaacteleop.retargeters import (
+    EePoseRateLimiter,
+    JointRateLimiter,
+    RateLimiterConfig,
+)
+from isaacteleop.retargeters.rate_limiter import (
+    EE_POSE_KEY,
+    JOINT_TARGETS_KEY,
+    _clamp_orientation_step,
+    _clamp_position_step,
+    _clamped_dt,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers (mirror the patterns in test_so101_retargeters.py)
+# ---------------------------------------------------------------------------
+
+_ID_QUAT = np.array([0.0, 0.0, 0.0, 1.0], dtype=np.float64)
+_NS = 1_000_000_000
+
+
+def _make_context(
+    *,
+    reset: bool = False,
+    state: ExecutionState = ExecutionState.RUNNING,
+    t_ns: int = 0,
+) -> ComputeContext:
+    """Build a ComputeContext with the given reset flag, state, and timestamp."""
+    return ComputeContext(
+        graph_time=GraphTime(sim_time_ns=t_ns, real_time_ns=t_ns),
+        execution_events=ExecutionEvents(reset=reset, execution_state=state),
+    )
+
+
+def _build_io(retargeter):
+    """Construct empty input/output containers for a retargeter (optionals start absent)."""
+    inputs = {}
+    for k, v in retargeter.input_spec().items():
+        inputs[k] = (
+            OptionalTensorGroup(v)
+            if isinstance(v, OptionalTensorGroupType)
+            else TensorGroup(v)
+        )
+    outputs = {}
+    for k, v in retargeter.output_spec().items():
+        outputs[k] = (
+            OptionalTensorGroup(v)
+            if isinstance(v, OptionalTensorGroupType)
+            else TensorGroup(v)
+        )
+    return inputs, outputs
+
+
+def _pose_group(spec_type, pos, ori=_ID_QUAT) -> TensorGroup:
+    """Build a present 7-D ee_pose TensorGroup from a position and quaternion."""
+    tg = TensorGroup(spec_type.inner_type)
+    tg[0] = np.concatenate(
+        [np.asarray(pos, dtype=np.float32), np.asarray(ori, dtype=np.float32)]
+    )
+    return tg
+
+
+def _set_pose_input(limiter, inputs, pos, ori=_ID_QUAT) -> None:
+    """Replace the limiter's ee_pose input with a present pose group."""
+    spec = limiter.input_spec()[EE_POSE_KEY]
+    inputs[EE_POSE_KEY] = _pose_group(spec, pos, ori)
+
+
+def _set_joint_input(limiter, inputs, values) -> None:
+    """Replace the limiter's joint_targets input with a present group."""
+    spec = limiter.input_spec()[JOINT_TARGETS_KEY]
+    tg = TensorGroup(spec.inner_type)
+    for i, v in enumerate(values):
+        tg[i] = float(v)
+    inputs[JOINT_TARGETS_KEY] = tg
+
+
+def _read_pose(outputs) -> np.ndarray:
+    """Read the 7-D ee_pose output as a numpy array."""
+    return np.asarray(np.from_dlpack(outputs[EE_POSE_KEY][0]), dtype=np.float64)
+
+
+def _read_joints(outputs, n: int) -> np.ndarray:
+    """Read the joint_targets output as a numpy array."""
+    return np.array(
+        [float(outputs[JOINT_TARGETS_KEY][i]) for i in range(n)], dtype=np.float64
+    )
+
+
+def _quat_xyzw(axis, angle_rad: float) -> np.ndarray:
+    """Build an [x, y, z, w] quaternion for a rotation of ``angle_rad`` about ``axis``."""
+    axis = np.asarray(axis, dtype=np.float64)
+    axis = axis / np.linalg.norm(axis)
+    half = 0.5 * angle_rad
+    xyz = axis * math.sin(half)
+    return np.array([xyz[0], xyz[1], xyz[2], math.cos(half)], dtype=np.float64)
+
+
+def _quat_angle(a: np.ndarray, b: np.ndarray) -> float:
+    """Geodesic angle [rad] between two unit quaternions (double-cover aware)."""
+    dot = abs(float(np.dot(a, b)))
+    return 2.0 * math.acos(min(1.0, dot))
+
+
+# ===========================================================================
+# Pure math helpers
+# ===========================================================================
+
+
+class TestClampedDt:
+    """The ``_clamped_dt`` frame-delta helper."""
+
+    def test_no_previous_uses_nominal(self):
+        """With no previous stamp the nominal dt is returned."""
+        assert _clamped_dt(None, 123, 0.02, 1e-4, 0.1) == pytest.approx(0.02)
+
+    def test_duplicate_stamp_uses_nominal(self):
+        """A non-advancing clock falls back to the nominal dt (no frozen limiter)."""
+        assert _clamped_dt(500, 500, 0.02, 1e-4, 0.1) == pytest.approx(0.02)
+        assert _clamped_dt(500, 400, 0.02, 1e-4, 0.1) == pytest.approx(0.02)
+
+    def test_normal_delta_passes(self):
+        """A delta within [min_dt, max_dt] is returned as-is."""
+        assert _clamped_dt(0, 20_000_000, 0.02, 1e-4, 0.1) == pytest.approx(0.02)
+
+    def test_stall_clamps_to_max(self):
+        """A multi-second stall is clamped to max_dt (no huge authorized step)."""
+        assert _clamped_dt(0, 5 * _NS, 0.02, 1e-4, 0.1) == pytest.approx(0.1)
+
+    def test_tiny_delta_clamps_to_min(self):
+        """A near-zero delta is clamped up to min_dt."""
+        assert _clamped_dt(0, 10, 0.02, 1e-4, 0.1) == pytest.approx(1e-4)
+
+
+class TestClampPositionStep:
+    """The ``_clamp_position_step`` Euclidean step clamp."""
+
+    def test_within_limit_passes_through(self):
+        """A step under the limit is returned untouched."""
+        prev = np.zeros(3)
+        tgt = np.array([0.001, 0.0, 0.0])
+        out = _clamp_position_step(tgt, prev, 0.01)
+        np.testing.assert_allclose(out, tgt)
+
+    def test_over_limit_is_clamped_along_line(self):
+        """An over-limit step lands exactly max_step along the straight line."""
+        prev = np.zeros(3)
+        tgt = np.array([1.0, 0.0, 0.0])
+        out = _clamp_position_step(tgt, prev, 0.01)
+        np.testing.assert_allclose(out, [0.01, 0.0, 0.0], atol=1e-12)
+
+    def test_zero_step_is_stable(self):
+        """target == previous returns target (no divide-by-zero)."""
+        p = np.array([0.2, 0.1, 0.3])
+        out = _clamp_position_step(p.copy(), p.copy(), 0.01)
+        np.testing.assert_allclose(out, p)
+
+
+class TestClampOrientationStep:
+    """The ``_clamp_orientation_step`` geodesic rotation clamp."""
+
+    def test_within_limit_passes_through(self):
+        """A rotation under the limit reaches the target orientation."""
+        tgt = _quat_xyzw([0, 0, 1], 0.01)
+        out = _clamp_orientation_step(tgt, _ID_QUAT.copy(), 0.1)
+        assert _quat_angle(out, tgt) == pytest.approx(0.0, abs=1e-9)
+
+    def test_over_limit_advances_exactly_max_step(self):
+        """An over-limit rotation advances exactly max_step along the arc."""
+        tgt = _quat_xyzw([0, 0, 1], 1.0)
+        out = _clamp_orientation_step(tgt, _ID_QUAT.copy(), 0.1)
+        assert _quat_angle(out, _ID_QUAT) == pytest.approx(0.1, abs=1e-9)
+
+    def test_double_cover_takes_shortest_arc(self):
+        """A sign-flipped target quaternion still rotates along the shortest arc."""
+        tgt = -_quat_xyzw([0, 0, 1], 1.0)  # same rotation, other hemisphere
+        out = _clamp_orientation_step(tgt, _ID_QUAT.copy(), 0.1)
+        assert _quat_angle(out, _ID_QUAT) == pytest.approx(0.1, abs=1e-9)
+
+    def test_identity_step_is_stable(self):
+        """target == previous is returned without axis extraction blowing up."""
+        q = _quat_xyzw([0, 1, 0], 0.3)
+        out = _clamp_orientation_step(q.copy(), q.copy(), 0.1)
+        # acos-based angle recovery amplifies float rounding near 0; 1e-6 rad is
+        # far below any meaningful command resolution.
+        assert _quat_angle(out, q) == pytest.approx(0.0, abs=1e-6)
+
+
+# ===========================================================================
+# RateLimiterConfig validation
+# ===========================================================================
+
+
+class TestRateLimiterConfig:
+    """Constructor validation of the shared config."""
+
+    def test_defaults_are_valid(self):
+        """The default config constructs without error."""
+        RateLimiterConfig()
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"max_linear_velocity": 0.0},
+            {"max_angular_velocity": -1.0},
+            {"max_joint_velocity": 0.0},
+            {"joint_velocity_overrides": {"elbow": 0.0}},
+            {"min_dt": 0.0},
+            {"min_dt": 0.05, "nominal_dt": 0.02},
+            {"nominal_dt": 0.2, "max_dt": 0.1},
+            {"reject_linear_velocity": 0.0},
+            {"reject_linear_velocity": float("nan")},
+            # Rejection threshold below the clamp limit would refuse motion the
+            # clamp band is meant to allow.
+            {"max_linear_velocity": 0.25, "reject_linear_velocity": 0.1},
+            {"max_angular_velocity": 1.5, "reject_angular_velocity": 1.0},
+            {"max_joint_velocity": 1.5, "reject_joint_velocity": 1.0},
+            # ... including per-joint overrides above the rejection threshold.
+            {
+                "joint_velocity_overrides": {"elbow": 5.0},
+                "reject_joint_velocity": 4.0,
+            },
+            {"max_consecutive_rejections": 0},
+        ],
+    )
+    def test_invalid_values_raise(self, kwargs):
+        """Non-positive limits and inconsistent dt/rejection bounds are rejected."""
+        with pytest.raises(ValueError):
+            RateLimiterConfig(**kwargs)
+
+    def test_rejection_thresholds_accept_valid_values(self):
+        """Rejection thresholds at or above the clamp limits construct fine."""
+        RateLimiterConfig(
+            reject_linear_velocity=0.25,
+            reject_angular_velocity=1.5,
+            reject_joint_velocity=1.5,
+            max_consecutive_rejections=None,
+        )
+
+
+# ===========================================================================
+# EePoseRateLimiter
+# ===========================================================================
+
+
+class TestEePoseRateLimiter:
+    """End-to-end ``compute`` behavior of the EE-pose limiter."""
+
+    def _limiter(self, **cfg_kwargs) -> EePoseRateLimiter:
+        cfg = RateLimiterConfig(**cfg_kwargs) if cfg_kwargs else RateLimiterConfig()
+        return EePoseRateLimiter(name="ee_limiter", config=cfg)
+
+    def test_first_frame_passes_through(self):
+        """The first valid frame latches and is emitted unclamped."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.3, 0.1, 0.2])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+        np.testing.assert_allclose(_read_pose(outputs)[:3], [0.3, 0.1, 0.2], atol=1e-6)
+
+    def test_slow_motion_is_untouched(self):
+        """Motion under the velocity limit is emitted exactly (no lag)."""
+        r = self._limiter(max_linear_velocity=0.25)
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.2, 0.0, 0.1])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # 1 mm in 20 ms = 0.05 m/s, well under the 0.25 m/s limit.
+        _set_pose_input(r, inputs, [0.201, 0.0, 0.1])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(
+            _read_pose(outputs)[:3], [0.201, 0.0, 0.1], atol=1e-6
+        )
+
+    def test_position_jump_is_rate_limited(self):
+        """A teleport-sized position jump advances only max_linear_velocity * dt."""
+        r = self._limiter(max_linear_velocity=0.25)
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # 0.5 m jump in 20 ms -> clamp to 0.25 * 0.02 = 5 mm.
+        _set_pose_input(r, inputs, [0.5, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(
+            _read_pose(outputs)[:3], [0.005, 0.0, 0.0], atol=1e-6
+        )
+
+    def test_persistent_target_is_approached_at_bounded_speed(self):
+        """A held far target is approached stepwise, never faster than the limit."""
+        r = self._limiter(max_linear_velocity=0.25)
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        last = np.zeros(3)
+        for k in range(1, 6):
+            _set_pose_input(r, inputs, [0.5, 0.0, 0.0])
+            r.compute(inputs, outputs, _make_context(t_ns=k * 20_000_000))
+            pos = _read_pose(outputs)[:3]
+            step = float(np.linalg.norm(pos - last))
+            assert step <= 0.25 * 0.02 + 1e-9
+            last = pos
+        # Monotonic progress toward the target.
+        assert last[0] == pytest.approx(5 * 0.005, abs=1e-6)
+
+    def test_orientation_jump_is_rate_limited(self):
+        """A large orientation flip advances only max_angular_velocity * dt."""
+        r = self._limiter(max_angular_velocity=1.5)
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.2, 0.0, 0.1], _ID_QUAT)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # pi/2 flip in 20 ms -> clamp to 1.5 * 0.02 = 0.03 rad.
+        tgt = _quat_xyzw([0, 0, 1], math.pi / 2)
+        _set_pose_input(r, inputs, [0.2, 0.0, 0.1], tgt)
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        emitted = _read_pose(outputs)[3:7]
+        # The emitted pose is float32; angle recovery through acos loses a few
+        # ulps, so compare at 1e-4 rad (~0.006 deg), far below command resolution.
+        assert _quat_angle(emitted, _ID_QUAT) == pytest.approx(0.03, abs=1e-4)
+
+    def test_stall_does_not_authorize_teleport(self):
+        """A 5 s pipeline stall authorizes at most max_linear_velocity * max_dt."""
+        r = self._limiter(max_linear_velocity=0.25, max_dt=0.1)
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_pose_input(r, inputs, [1.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=5 * _NS))
+        # 0.25 m/s * 0.1 s = 25 mm, not 1 m.
+        np.testing.assert_allclose(
+            _read_pose(outputs)[:3], [0.025, 0.0, 0.0], atol=1e-6
+        )
+
+    def test_dropped_frame_holds_last(self):
+        """An absent input frame re-emits the last limited pose."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.3, 0.1, 0.2])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        inputs2, outputs2 = _build_io(r)  # optionals start absent
+        r.compute(inputs2, outputs2, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_pose(outputs2)[:3], [0.3, 0.1, 0.2], atol=1e-6)
+
+    def test_reset_relatches_without_clamping(self):
+        """After a reset the next frame passes through instead of slewing from the old pose."""
+        r = self._limiter(max_linear_velocity=0.25)
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # Reset, then a far-away pose (the task has physically reset the arm).
+        _set_pose_input(r, inputs, [0.4, 0.2, 0.1])
+        r.compute(inputs, outputs, _make_context(reset=True, t_ns=20_000_000))
+        np.testing.assert_allclose(_read_pose(outputs)[:3], [0.4, 0.2, 0.1], atol=1e-6)
+
+    def test_degenerate_orientation_holds_previous(self):
+        """A zero quaternion in the target holds the last emitted orientation."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        start_ori = _quat_xyzw([0, 1, 0], 0.2)
+        _set_pose_input(r, inputs, [0.2, 0.0, 0.1], start_ori)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_pose_input(r, inputs, [0.2, 0.0, 0.1], np.zeros(4))
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        emitted = _read_pose(outputs)[3:7]
+        assert _quat_angle(emitted, start_ori) == pytest.approx(0.0, abs=1e-6)
+
+
+# ===========================================================================
+# JointRateLimiter
+# ===========================================================================
+
+_JOINTS = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll"]
+
+
+class TestJointRateLimiter:
+    """End-to-end ``compute`` behavior of the joint-space limiter."""
+
+    def _limiter(self, **cfg_kwargs) -> JointRateLimiter:
+        cfg = RateLimiterConfig(**cfg_kwargs) if cfg_kwargs else RateLimiterConfig()
+        return JointRateLimiter(name="joint_limiter", joint_names=_JOINTS, config=cfg)
+
+    def test_empty_joint_names_raises(self):
+        """An empty joint list is rejected at construction."""
+        with pytest.raises(ValueError):
+            JointRateLimiter(name="bad", joint_names=[])
+
+    def test_unknown_override_raises(self):
+        """A velocity override for a joint not in joint_names is rejected."""
+        with pytest.raises(ValueError):
+            JointRateLimiter(
+                name="bad",
+                joint_names=["a"],
+                config=RateLimiterConfig(joint_velocity_overrides={"zz": 1.0}),
+            )
+
+    def test_first_frame_passes_through(self):
+        """The first valid frame latches and is emitted unclamped."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.1, -0.5, 1.2, 0.0, 0.3])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+        np.testing.assert_allclose(
+            _read_joints(outputs, 5), [0.1, -0.5, 1.2, 0.0, 0.3], atol=1e-6
+        )
+
+    def test_slow_motion_is_untouched(self):
+        """Per-joint motion under the limit is emitted exactly."""
+        r = self._limiter(max_joint_velocity=1.5)
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # 0.01 rad in 20 ms = 0.5 rad/s, under the 1.5 rad/s limit.
+        _set_joint_input(r, inputs, [0.01] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_joints(outputs, 5), [0.01] * 5, atol=1e-6)
+
+    def test_jump_is_rate_limited_per_joint(self):
+        """An over-limit jump advances each joint by at most limit * dt, signed."""
+        r = self._limiter(max_joint_velocity=1.5)
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # +-2 rad jumps in 20 ms -> clamp to +-1.5 * 0.02 = +-0.03 rad.
+        _set_joint_input(r, inputs, [2.0, -2.0, 2.0, -2.0, 2.0])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(
+            _read_joints(outputs, 5), [0.03, -0.03, 0.03, -0.03, 0.03], atol=1e-6
+        )
+
+    def test_per_joint_override_applies(self):
+        """A per-joint override clamps that joint tighter than the default."""
+        r = self._limiter(
+            max_joint_velocity=1.5,
+            joint_velocity_overrides={"shoulder_lift": 0.5},
+        )
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_joint_input(r, inputs, [2.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        joints = _read_joints(outputs, 5)
+        assert joints[1] == pytest.approx(0.5 * 0.02, abs=1e-6)  # overridden
+        assert joints[0] == pytest.approx(1.5 * 0.02, abs=1e-6)  # default
+
+    def test_dropped_frame_holds_last(self):
+        """An absent input frame re-emits the last limited targets."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.1, 0.2, 0.3, 0.4, 0.5])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        inputs2, outputs2 = _build_io(r)  # optionals start absent
+        r.compute(inputs2, outputs2, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(
+            _read_joints(outputs2, 5), [0.1, 0.2, 0.3, 0.4, 0.5], atol=1e-6
+        )
+
+    def test_reset_relatches_without_clamping(self):
+        """After a reset the next frame passes through (fresh episode, fresh baseline)."""
+        r = self._limiter(max_joint_velocity=1.5)
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_joint_input(r, inputs, [1.0, -1.0, 0.5, -0.5, 0.2])
+        r.compute(inputs, outputs, _make_context(reset=True, t_ns=20_000_000))
+        np.testing.assert_allclose(
+            _read_joints(outputs, 5), [1.0, -1.0, 0.5, -0.5, 0.2], atol=1e-6
+        )
+
+    def test_stall_does_not_authorize_jump(self):
+        """A long stall authorizes at most limit * max_dt per joint."""
+        r = self._limiter(max_joint_velocity=1.5, max_dt=0.1)
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_joint_input(r, inputs, [3.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=10 * _NS))
+        np.testing.assert_allclose(_read_joints(outputs, 5), [0.15] * 5, atol=1e-6)
+
+
+# ===========================================================================
+# Anomaly rejection (reject_* thresholds)
+# ===========================================================================
+
+
+class TestEePoseAnomalyRejection:
+    """Rejection tier of the EE-pose limiter: anomalous frames are not executed."""
+
+    def _limiter(self, **cfg_kwargs) -> EePoseRateLimiter:
+        cfg = RateLimiterConfig(
+            max_linear_velocity=0.25,
+            reject_linear_velocity=2.0,
+            reject_angular_velocity=10.0,
+            **cfg_kwargs,
+        )
+        return EePoseRateLimiter(name="ee_limiter", config=cfg)
+
+    def test_anomalous_position_jump_is_not_approached(self):
+        """A teleport beyond the reject envelope holds the pose entirely (no slew)."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # 0.5 m in 20 ms = 25 m/s >> 2 m/s reject threshold: hold, do not creep.
+        _set_pose_input(r, inputs, [0.5, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_pose(outputs)[:3], [0.0, 0.0, 0.0], atol=1e-6)
+
+    def test_anomalous_orientation_flip_is_not_approached(self):
+        """An orientation teleport beyond the reject envelope holds entirely."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.2, 0.0, 0.1], _ID_QUAT)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # pi rad in 20 ms = ~157 rad/s >> 10 rad/s reject threshold.
+        tgt = _quat_xyzw([0, 0, 1], math.pi - 0.01)
+        _set_pose_input(r, inputs, [0.2, 0.0, 0.1], tgt)
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        emitted = _read_pose(outputs)[3:7]
+        assert _quat_angle(emitted, _ID_QUAT) == pytest.approx(0.0, abs=1e-6)
+
+    def test_fast_but_legal_motion_is_clamped_not_rejected(self):
+        """Motion between the clamp and reject thresholds is clamped, not refused."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # 20 mm in 20 ms = 1 m/s: above the 0.25 m/s clamp, below the 2 m/s
+        # reject threshold -> the clamp band handles it (5 mm step).
+        _set_pose_input(r, inputs, [0.02, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(
+            _read_pose(outputs)[:3], [0.005, 0.0, 0.0], atol=1e-6
+        )
+
+    def test_glitch_recovery_resumes_from_held_pose(self):
+        """After a one-frame teleport glitch, sane frames resume without a jump."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.1, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # Glitch frame: rejected, held at 0.1.
+        _set_pose_input(r, inputs, [0.9, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_pose(outputs)[:3], [0.1, 0.0, 0.0], atol=1e-6)
+
+        # Recovery frame near the pre-glitch input: accepted, small step allowed.
+        _set_pose_input(r, inputs, [0.101, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=40_000_000))
+        np.testing.assert_allclose(
+            _read_pose(outputs)[:3], [0.101, 0.0, 0.0], atol=1e-6
+        )
+
+    def test_persistent_target_reaccepted_after_cap(self):
+        """After max_consecutive_rejections the far target is re-accepted, clamped."""
+        r = self._limiter(max_consecutive_rejections=3)
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # 3 rejected frames, then the 4th trips the cap and re-accepts.
+        for k in range(1, 4):
+            _set_pose_input(r, inputs, [0.5, 0.0, 0.0])
+            r.compute(inputs, outputs, _make_context(t_ns=k * 20_000_000))
+            np.testing.assert_allclose(
+                _read_pose(outputs)[:3], [0.0, 0.0, 0.0], atol=1e-6
+            )
+        _set_pose_input(r, inputs, [0.5, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=4 * 20_000_000))
+        pos = _read_pose(outputs)[:3]
+        # Re-accepted but still clamped: at most max_linear_velocity * max_dt.
+        assert 0.0 < pos[0] <= 0.25 * 0.1 + 1e-9
+
+    def test_cap_none_holds_indefinitely(self):
+        """With max_consecutive_rejections=None an anomalous stream never executes."""
+        r = self._limiter(max_consecutive_rejections=None)
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        for k in range(1, 100):
+            _set_pose_input(r, inputs, [0.5, 0.0, 0.0])
+            r.compute(inputs, outputs, _make_context(t_ns=k * 20_000_000))
+            np.testing.assert_allclose(
+                _read_pose(outputs)[:3], [0.0, 0.0, 0.0], atol=1e-6
+            )
+
+    def test_reset_clears_rejection_state(self):
+        """A reset drops the rejection baseline: the next frame latches fresh."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_pose_input(r, inputs, [0.9, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))  # rejected
+
+        # Reset: the same far pose is now a fresh episode's first frame.
+        _set_pose_input(r, inputs, [0.9, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(reset=True, t_ns=40_000_000))
+        np.testing.assert_allclose(_read_pose(outputs)[:3], [0.9, 0.0, 0.0], atol=1e-6)
+
+    def test_rejection_disabled_by_default(self):
+        """Without reject thresholds a teleport is clamped (legacy behavior), not refused."""
+        r = EePoseRateLimiter(
+            name="ee_limiter", config=RateLimiterConfig(max_linear_velocity=0.25)
+        )
+        inputs, outputs = _build_io(r)
+        _set_pose_input(r, inputs, [0.0, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_pose_input(r, inputs, [0.5, 0.0, 0.0])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(
+            _read_pose(outputs)[:3], [0.005, 0.0, 0.0], atol=1e-6
+        )
+
+
+class TestJointAnomalyRejection:
+    """Rejection tier of the joint limiter: anomalous frames are not executed."""
+
+    def _limiter(self, **cfg_kwargs) -> JointRateLimiter:
+        cfg = RateLimiterConfig(
+            max_joint_velocity=1.5,
+            reject_joint_velocity=15.0,
+            **cfg_kwargs,
+        )
+        return JointRateLimiter(name="joint_limiter", joint_names=_JOINTS, config=cfg)
+
+    def test_anomalous_flip_is_not_approached(self):
+        """An IK-divergence-sized flip (>> reject threshold) holds all joints."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # ~100 deg (1.75 rad) in 20 ms = 87 rad/s >> 15 rad/s: refuse outright.
+        _set_joint_input(r, inputs, [1.75] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_joints(outputs, 5), [0.0] * 5, atol=1e-6)
+
+    def test_single_bad_joint_rejects_whole_frame(self):
+        """One joint over the reject threshold refuses the whole frame."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # Joints move together: executing the sane joints of an insane frame
+        # still produces an insane configuration.
+        _set_joint_input(r, inputs, [0.01, 0.01, 1.75, 0.01, 0.01])
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_joints(outputs, 5), [0.0] * 5, atol=1e-6)
+
+    def test_fast_but_legal_motion_is_clamped_not_rejected(self):
+        """Motion between the clamp and reject thresholds is clamped, not refused."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        # 0.1 rad in 20 ms = 5 rad/s: above the 1.5 rad/s clamp, below the
+        # 15 rad/s reject threshold -> clamped to 0.03 rad.
+        _set_joint_input(r, inputs, [0.1] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_joints(outputs, 5), [0.03] * 5, atol=1e-6)
+
+    def test_glitch_recovery_resumes_from_held_targets(self):
+        """After a one-frame glitch, sane frames resume without a jump."""
+        r = self._limiter()
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.1] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_joint_input(r, inputs, [1.75] * 5)  # glitch: rejected
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_joints(outputs, 5), [0.1] * 5, atol=1e-6)
+
+        _set_joint_input(r, inputs, [0.11] * 5)  # recovery: accepted
+        r.compute(inputs, outputs, _make_context(t_ns=40_000_000))
+        np.testing.assert_allclose(_read_joints(outputs, 5), [0.11] * 5, atol=1e-6)
+
+    def test_persistent_target_reaccepted_after_cap(self):
+        """After max_consecutive_rejections the far target is re-accepted, clamped."""
+        r = self._limiter(max_consecutive_rejections=2)
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        for k in range(1, 3):
+            _set_joint_input(r, inputs, [1.75] * 5)
+            r.compute(inputs, outputs, _make_context(t_ns=k * 20_000_000))
+            np.testing.assert_allclose(_read_joints(outputs, 5), [0.0] * 5, atol=1e-6)
+
+        _set_joint_input(r, inputs, [1.75] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=3 * 20_000_000))
+        joints = _read_joints(outputs, 5)
+        # Re-accepted but still clamped: at most max_joint_velocity * max_dt.
+        assert np.all(joints > 0.0)
+        assert np.all(joints <= 1.5 * 0.1 + 1e-9)
+
+    def test_rejection_disabled_by_default(self):
+        """Without reject_joint_velocity a flip is clamped (legacy behavior)."""
+        r = JointRateLimiter(
+            name="joint_limiter",
+            joint_names=_JOINTS,
+            config=RateLimiterConfig(max_joint_velocity=1.5),
+        )
+        inputs, outputs = _build_io(r)
+        _set_joint_input(r, inputs, [0.0] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=0))
+
+        _set_joint_input(r, inputs, [1.75] * 5)
+        r.compute(inputs, outputs, _make_context(t_ns=20_000_000))
+        np.testing.assert_allclose(_read_joints(outputs, 5), [0.03] * 5, atol=1e-6)

--- a/src/python/isaacteleop/retargeters/SO101/clutch_retargeter.py
+++ b/src/python/isaacteleop/retargeters/SO101/clutch_retargeter.py
@@ -90,6 +90,7 @@ from isaacteleop.retargeting_engine.interface.tensor_group_type import (
     TensorGroupType,
 )
 from isaacteleop.retargeting_engine.tensor_types import (
+    BoolType,
     ControllerInput,
     ControllerInputIndex,
     DLDataType,
@@ -235,6 +236,8 @@ class SO101ClutchRetargeter(BaseRetargeter):
         - :data:`MEASURED_BASE_T_EE_INPUT` -- Optional ``base_T_ee`` 4x4 transform of the arm's
           *measured* EE pose. Only its translation block is read, and only on the engage frame.
           When absent, the home position falls back to the last commanded position.
+        - :data:`ENGAGE_PERMITTED_INPUT` -- Optional boolean gating the **latch**. Absent or
+          unwired is permitted, so this is backward compatible.
 
     Outputs:
         - ``ee_pose`` -- a single 7D ``[x, y, z, qx, qy, qz, qw]`` float32 ``NDArray``.
@@ -265,7 +268,26 @@ class SO101ClutchRetargeter(BaseRetargeter):
     #: ``TeleopSession`` validates every external leaf name is present in ``external_inputs`` on
     #: every step, independently of ``OptionalType``. Such a producer must send the key
     #: unconditionally, carrying an absent ``OptionalTensorGroup`` on frames with no pose.
+    #:
+    #: .. warning::
+    #:    **Position only.** ``_latch`` reads the translation block and always takes the
+    #:    orientation from ``_last_commanded_rot``, so an owner whose arm has rotated away
+    #:    from the configured home engages at the measured position and the stale
+    #:    orientation. When the achieved rotation matters, :meth:`set_home_base_T_ee` is the
+    #:    only route: it reads both blocks.
     MEASURED_BASE_T_EE_INPUT = "measured_base_T_ee"
+
+    #: Optional boolean input: may the clutch **latch** on this frame? Absent, unwired, or
+    #: ``True`` all mean permitted, so an existing consumer is unaffected.
+    #:
+    #: Read **only** where a latch is owed, so it gates the latch and never the engagement:
+    #: :attr:`is_engaged` stays exactly ``_origin is not None``, and revoking permission
+    #: mid-engagement does nothing. An **enable precondition, not a safety-rated stop**.
+    #: The same every-step ``ValueInput``-leaf rule as :data:`MEASURED_BASE_T_EE_INPUT`
+    #: applies. See ``docs/source/references/retargeting/so101.rst``.
+    ENGAGE_PERMITTED_INPUT = "engage_permitted"
+    #: Element index of the permission flag inside the input's tensor group.
+    PERMITTED_INDEX = 0
 
     def __init__(
         self,
@@ -273,6 +295,7 @@ class SO101ClutchRetargeter(BaseRetargeter):
         home_base_T_ee: np.ndarray,  # noqa: N803
         *,
         input_device: str = ControllersSource.RIGHT,
+        controller_pose: str = "grip",
         position_scale: float = 1.0,
         squeeze_threshold: float = 0.5,
     ) -> None:
@@ -287,7 +310,13 @@ class SO101ClutchRetargeter(BaseRetargeter):
                 pose a ``reset`` re-seeds to. When the pose is not known until after construction
                 (e.g. the graph is built before the arm is homed), pass a placeholder and call
                 :meth:`set_home_base_T_ee` before the first ``RUNNING`` frame.
-            input_device: Controller source key to read the grip pose from.
+            input_device: Controller source key to read the controller pose from.
+            controller_pose: Which standard OpenXR controller pose to clutch off, ``"grip"``
+                (default) or ``"aim"``. Translation only: the orientation delta is identical
+                either way, since for a fixed body-frame ``T``, ``(R T)(R_o T)^-1 == R R_o^-1``.
+                The two poses sit at different points on the device, so a wrist rotation sweeps
+                one origin about the other and that lever arm enters the engage-relative delta.
+                ``"grip"`` is the palm centroid, the conventional pivot for a held object.
             position_scale: Dimensionless controller-to-EE translation gain applied to the
                 engage-relative delta. ``1.0`` is 1:1 motion; a value ``< 1`` shrinks robot travel
                 relative to hand travel, which is what lets a comfortable operator arm sweep
@@ -309,6 +338,23 @@ class SO101ClutchRetargeter(BaseRetargeter):
                 ``home_base_T_ee`` is not a 4x4 transform with an orthonormal rotation block.
         """
         self._input_device = input_device
+        if controller_pose not in ("grip", "aim"):
+            raise ValueError(
+                f"controller_pose must be 'grip' or 'aim', got {controller_pose!r}."
+            )
+        self._pose_indices = (
+            (
+                ControllerInputIndex.GRIP_POSITION,
+                ControllerInputIndex.GRIP_ORIENTATION,
+                ControllerInputIndex.GRIP_IS_VALID,
+            )
+            if controller_pose == "grip"
+            else (
+                ControllerInputIndex.AIM_POSITION,
+                ControllerInputIndex.AIM_ORIENTATION,
+                ControllerInputIndex.AIM_IS_VALID,
+            )
+        )
 
         position_scale = float(position_scale)
         if not np.isfinite(position_scale) or position_scale <= 0.0:
@@ -361,9 +407,12 @@ class SO101ClutchRetargeter(BaseRetargeter):
         re-seeds to, so an owner that re-homes its arm mid-session should call this rather than
         letting reset drag the arm back to the construction-time pose.
 
-        Call this only while the clutch is not engaged -- typically while the session holds
-        ``STOPPED``, which makes latching impossible and so makes the ordering unambiguous: the new
-        home takes effect before the first ``RUNNING`` frame.
+        Call this only while the clutch is not engaged -- the rule is about the engaged
+        state, not the cadence. Once, while the session holds ``STOPPED``, makes the
+        ordering unambiguous. Calling it on **every** non-engaged frame of a ``RUNNING``
+        session is equally sound, and is what an owner whose arm moves while disengaged
+        wants: the home stays on the arm's live pose, so an engage from anywhere is
+        jump-free (``examples/mujoco_xr`` does this at frame rate).
 
         The pending latch is re-armed as a safety net rather than the call being rejected. Without
         it, a call made while engaged would leave the *old* controller origin latched against the
@@ -460,10 +509,13 @@ class SO101ClutchRetargeter(BaseRetargeter):
     # ------------------------------------------------------------------ specs
 
     def input_spec(self) -> RetargeterIOType:
-        """Controller grip pose (base frame) plus the optional measured EE pose for the home."""
+        """Controller grip pose (base frame), the optional measured EE pose, and latch permission."""
         return {
             self._input_device: OptionalType(ControllerInput()),
             self.MEASURED_BASE_T_EE_INPUT: OptionalType(TransformMatrix()),
+            self.ENGAGE_PERMITTED_INPUT: OptionalType(
+                TensorGroupType(self.ENGAGE_PERMITTED_INPUT, [BoolType("permitted")])
+            ),
         }
 
     def output_spec(self) -> RetargeterIOType:
@@ -480,6 +532,13 @@ class SO101ClutchRetargeter(BaseRetargeter):
         }
 
     # ---------------------------------------------------------------- compute
+
+    def _engage_permitted(self, inputs: RetargeterIO) -> bool:
+        """Whether a latch is allowed this frame. Fails **open**: unwired or absent is permitted."""
+        permitted = inputs.get(self.ENGAGE_PERMITTED_INPUT)
+        if permitted is None or permitted.is_none:
+            return True
+        return bool(permitted[self.PERMITTED_INDEX])
 
     def _latch(
         self, inputs: RetargeterIO, grip_pos: np.ndarray, grip_rot: np.ndarray
@@ -525,20 +584,17 @@ class SO101ClutchRetargeter(BaseRetargeter):
             ee_pose[0] = self._last_pose
             return
 
-        if not bool(inp[ControllerInputIndex.GRIP_IS_VALID]):
-            # Controller present but its grip pose is not localizable this frame (the OpenXR
+        position_index, orientation_index, valid_index = self._pose_indices
+        if not bool(inp[valid_index]):
+            # Controller present but the pose is not localizable this frame (the OpenXR
             # XR_SPACE_LOCATION_*_VALID_BITs are clear), so the source passes through an untrusted
             # pose. Treat it like a dropped frame and never latch the clutch origin off it.
             self._origin = None
             ee_pose[0] = self._last_pose
             return
 
-        grip_pos = np.from_dlpack(inp[ControllerInputIndex.GRIP_POSITION]).astype(
-            np.float64
-        )
-        grip_rot = np.from_dlpack(inp[ControllerInputIndex.GRIP_ORIENTATION]).astype(
-            np.float64
-        )  # XYZW
+        grip_pos = np.from_dlpack(inp[position_index]).astype(np.float64)
+        grip_rot = np.from_dlpack(inp[orientation_index]).astype(np.float64)  # XYZW
         squeeze = float(inp[ControllerInputIndex.SQUEEZE_VALUE])
 
         grip_norm = float(np.linalg.norm(grip_rot))
@@ -563,6 +619,13 @@ class SO101ClutchRetargeter(BaseRetargeter):
             return
 
         if self._origin is None:
+            if not self._engage_permitted(inputs):
+                # A latch is owed and the owner says not yet. Hold, and stay armed: the
+                # sentinel is untouched, so the latch fires on the first permitted frame.
+                # Checked HERE and nowhere else, which is what keeps a revoked permission
+                # from dropping a live engagement.
+                ee_pose[0] = self._last_pose
+                return
             self._latch(inputs, grip_pos, grip_rot)
 
         pos = self._home_pos + self._position_scale * (grip_pos - self._origin)

--- a/src/python/isaacteleop/retargeters/__init__.py
+++ b/src/python/isaacteleop/retargeters/__init__.py
@@ -22,6 +22,7 @@ Available Retargeters:
     - SO101GripperRetargeter: Proportional (analog) jaw closedness for the SO-101 gripper
     - WujiHandRetargeter: Retargeting for the Wuji hand via wuji_sdk.retargeting
     - JointStateRetargeter: Generic joint-space device (leader arm, exoskeleton) -> joint or EE action
+    - EePoseRateLimiter / JointRateLimiter: Safety-harness velocity bounds for EE-pose / joint streams
     - SharpaHandRetargeter: Pinocchio/Pink IK-based retargeting for Sharpa hand
     - SharpaBiManualRetargeter: Bimanual version of SharpaHandRetargeter
     - Se3AbsRetargeter: Absolute EE pose control
@@ -138,6 +139,10 @@ _LAZY_IMPORTS: dict[str, tuple[str, str, str | None]] = {
         "JointStateRetargeterConfig",
         None,
     ),
+    # .rate_limiter (safety harness: per-frame velocity bounds for EE / joint streams)
+    "EePoseRateLimiter": (".rate_limiter", "EePoseRateLimiter", None),
+    "JointRateLimiter": (".rate_limiter", "JointRateLimiter", None),
+    "RateLimiterConfig": (".rate_limiter", "RateLimiterConfig", None),
     # .se3_retargeter  (requires retargeters-lite extra: scipy)
     "Se3AbsRetargeter": (".se3_retargeter", "Se3AbsRetargeter", "retargeters-lite"),
     "Se3RelRetargeter": (".se3_retargeter", "Se3RelRetargeter", "retargeters-lite"),
@@ -238,6 +243,10 @@ __all__ = [
     # Generic joint-space device retargeters (leader arms, exoskeletons, ...)
     "JointStateRetargeter",
     "JointStateRetargeterConfig",
+    # Safety-harness rate limiters (per-frame velocity bounds)
+    "EePoseRateLimiter",
+    "JointRateLimiter",
+    "RateLimiterConfig",
     "Se3AbsRetargeter",
     "Se3RelRetargeter",
     "Se3RetargeterConfig",

--- a/src/python/isaacteleop/retargeters/rate_limiter.py
+++ b/src/python/isaacteleop/retargeters/rate_limiter.py
@@ -1,0 +1,634 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Rate-limiting safety harness retargeters (EE-pose and joint-space).
+
+Low-cost follower arms such as the SO-101 run bare position servos with no
+controller-side handling of anomalous targets: whatever position command reaches the
+bus is tracked at full servo torque. A single bad frame -- an IK jump near a
+singularity, a controller tracking glitch, a leader-stream hiccup, an operator
+flick -- becomes a full-speed slew that can strip gears or stall motors on real
+hardware.
+
+This module provides two composable harness nodes that bound the *step per frame*
+of an existing command stream without changing its contract, so they can be
+inserted between a producing retargeter and the downstream action wiring:
+
+* :class:`EePoseRateLimiter` -- wraps a 7-D absolute ``ee_pose`` stream (e.g. the
+  output of ``SO101ClutchRetargeter`` or ``Se3AbsRetargeter``), clamping linear
+  velocity [m/s] and angular velocity [rad/s].
+* :class:`JointRateLimiter` -- wraps a name-keyed joint-target group (e.g. the
+  ``joint`` mode output of ``JointStateRetargeter``), clamping per-joint velocity
+  [rad/s or m/s], with optional per-joint overrides.
+
+Both limiters are pure trajectory governors:
+
+- The **first valid frame** after construction or a pipeline reset passes through
+  unclamped and latches the baseline. Engage-time placement is owned by the
+  upstream clutch / align logic (which already guarantees no snap on engage); the
+  limiter bounds *motion between frames*, not absolute placement.
+- Each subsequent frame may move at most ``max_velocity * dt`` from the last
+  *emitted* command (not the last input), so a persistent far-away target is
+  approached at bounded speed instead of in one jump.
+- ``dt`` is derived from ``context.graph_time.real_time_ns`` and clamped to
+  ``[min_dt, max_dt]``: a stalled or resumed pipeline (huge wall-clock gap) must
+  not authorize a proportionally huge step, and a duplicate timestamp must not
+  freeze the limiter. When no usable timestamp is available (both deltas zero or
+  negative), ``nominal_dt`` is used.
+- A dropped input frame holds the last emitted command (matching the upstream
+  retargeters' hold-last convention) and does not advance the time baseline.
+- A pipeline **reset** clears the baseline: the next valid frame passes through
+  and re-latches (the owning task resets the arm pose; re-clamping against a
+  stale pre-reset baseline would slew the arm across the workspace).
+- **Anomaly rejection** (second tier, above the clamp): a frame whose *input*
+  velocity relative to the last accepted input exceeds the ``reject_*``
+  thresholds is a discontinuity -- an IK divergence, a tracking teleport, a
+  stream catch-up step -- not motion to follow, and is **not executed at all**:
+  the limiter holds the last emitted command instead of slewing toward the
+  anomaly. After ``max_consecutive_rejections`` consecutive anomalous frames the
+  input is treated as a persistent new target and re-accepted (still velocity
+  clamped), so rejection cannot deadlock the pipeline; ``None`` holds
+  indefinitely until the input returns within the envelope or a reset arrives.
+
+The result is a three-band governor: normal motion passes through untouched,
+modest overshoot is clamped to the velocity limit, and wild discontinuity is
+refused outright. The clamp is intentionally a hard per-frame velocity bound (a
+first-order rate limiter), not a smoothing filter: it adds no lag below the
+limit -- teleop feel is untouched until the harness actually has to intervene.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from isaacteleop.retargeting_engine.interface import (
+    BaseRetargeter,
+    RetargeterIOType,
+)
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import RetargeterIO
+from isaacteleop.retargeting_engine.interface.tensor_group_type import (
+    OptionalType,
+    TensorGroupType,
+)
+from isaacteleop.retargeting_engine.tensor_types import (
+    DLDataType,
+    FloatType,
+    NDArrayType,
+)
+
+# Output group key of the EE-pose limiter -- matches the upstream SO-101 clutch /
+# Se3 retargeters so the limiter is a drop-in insertion in the pipeline wiring.
+EE_POSE_KEY = "ee_pose"
+# Output group key of the joint limiter -- matches JointStateRetargeter's
+# ``joint`` mode output so the limiter is a drop-in insertion.
+JOINT_TARGETS_KEY = "joint_targets"
+
+# Numerical floor below which a quaternion norm is treated as degenerate and the
+# previous orientation is held instead (never divide by ~zero; mirrors the
+# defense-in-depth net in the SO-101 clutch retargeter).
+_MIN_QUAT_NORM = 1e-6
+# Angular steps below this [rad] pass through without axis extraction: the
+# rotation axis is numerically meaningless near identity and the step is
+# guaranteed under any sane limit.
+_MIN_ANGLE_RAD = 1e-9
+
+
+@dataclass
+class RateLimiterConfig:
+    """Configuration shared by the rate-limiting harness nodes.
+
+    Args:
+        max_linear_velocity: EE limiter only -- maximum linear speed [m/s] of the
+            emitted position. The default is a deliberately conservative
+            tabletop-arm bring-up value; raise it once the setup is trusted.
+        max_angular_velocity: EE limiter only -- maximum angular speed [rad/s] of
+            the emitted orientation (geodesic angle per second).
+        max_joint_velocity: Joint limiter only -- default maximum per-joint speed
+            [rad/s (revolute) or m/s (prismatic)] applied to every joint not
+            overridden in ``joint_velocity_overrides``.
+        joint_velocity_overrides: Joint limiter only -- per-joint ``{name: limit}``
+            overrides of ``max_joint_velocity`` (e.g. a slower shoulder, a faster
+            gripper).
+        nominal_dt: Fallback frame period [s] used when the graph timestamps do
+            not advance (first frame after a latch, duplicate timestamps).
+        max_dt: Upper clamp [s] on the wall-clock frame delta. Bounds the step
+            authorized after a pipeline stall/resume; a gap larger than this is
+            treated as ``max_dt``.
+        min_dt: Lower clamp [s] on the wall-clock frame delta, guarding against
+            zero/near-zero deltas producing a frozen limiter.
+        reject_linear_velocity: EE limiter only -- input linear speed [m/s]
+            (measured against the last **accepted input**, over the clamped
+            ``dt``) above which the frame is rejected outright instead of being
+            approached at the clamp limit. ``None`` (default) disables
+            rejection. Must be >= ``max_linear_velocity`` when set: a rejection
+            threshold below the clamp limit would refuse motion the clamp band
+            is meant to allow.
+        reject_angular_velocity: EE limiter only -- input angular speed [rad/s]
+            above which the frame is rejected outright. ``None`` disables.
+            Must be >= ``max_angular_velocity`` when set.
+        reject_joint_velocity: Joint limiter only -- per-joint input speed
+            [rad/s or m/s] above which the whole frame is rejected outright
+            (any single joint over the threshold rejects the frame -- joints
+            move together; executing the sane joints of an insane frame still
+            produces an insane configuration). ``None`` disables. Must be
+            >= ``max_joint_velocity`` and every ``joint_velocity_overrides``
+            entry when set.
+        max_consecutive_rejections: Number of consecutive rejected frames after
+            which the input is re-accepted as a persistent new target (then
+            still approached at the clamp limits). Guards against a legitimate
+            regime change (e.g. the leader really did move far during a stream
+            outage) freezing the follower forever. ``None`` holds indefinitely;
+            the default trips after ~1 s of anomalous input at 30 FPS.
+    """
+
+    max_linear_velocity: float = 0.25
+    max_angular_velocity: float = 1.5
+    max_joint_velocity: float = 1.5
+    joint_velocity_overrides: dict[str, float] = field(default_factory=dict)
+    nominal_dt: float = 1.0 / 60.0
+    max_dt: float = 0.1
+    min_dt: float = 1e-4
+    reject_linear_velocity: float | None = None
+    reject_angular_velocity: float | None = None
+    reject_joint_velocity: float | None = None
+    max_consecutive_rejections: int | None = 30
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "max_linear_velocity",
+            "max_angular_velocity",
+            "max_joint_velocity",
+            "nominal_dt",
+            "max_dt",
+            "min_dt",
+        ):
+            value = getattr(self, field_name)
+            if not np.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{field_name} must be finite and > 0")
+        for name, limit in self.joint_velocity_overrides.items():
+            if not np.isfinite(limit) or limit <= 0.0:
+                raise ValueError(
+                    f"joint_velocity_overrides[{name!r}] must be finite and > 0"
+                )
+        if not self.min_dt <= self.nominal_dt <= self.max_dt:
+            raise ValueError("require 0 < min_dt <= nominal_dt <= max_dt")
+        for reject_name, clamp_name in (
+            ("reject_linear_velocity", "max_linear_velocity"),
+            ("reject_angular_velocity", "max_angular_velocity"),
+            ("reject_joint_velocity", "max_joint_velocity"),
+        ):
+            reject = getattr(self, reject_name)
+            if reject is None:
+                continue
+            if not np.isfinite(reject) or reject <= 0.0:
+                raise ValueError(f"{reject_name} must be finite and > 0")
+            if reject < getattr(self, clamp_name):
+                raise ValueError(f"require {reject_name} >= {clamp_name}")
+        if self.reject_joint_velocity is not None:
+            for name, limit in self.joint_velocity_overrides.items():
+                if self.reject_joint_velocity < limit:
+                    raise ValueError(
+                        "require reject_joint_velocity >= "
+                        f"joint_velocity_overrides[{name!r}]"
+                    )
+        if self.max_consecutive_rejections is not None and (
+            self.max_consecutive_rejections < 1
+        ):
+            raise ValueError("max_consecutive_rejections must be >= 1 or None")
+
+
+def _clamped_dt(
+    prev_ns: int | None, now_ns: int, nominal: float, lo: float, hi: float
+) -> float:
+    """Frame delta [s] from two ``real_time_ns`` stamps, clamped to ``[lo, hi]``.
+
+    Falls back to ``nominal`` when there is no previous stamp or the clock did not
+    advance (duplicate or non-monotonic timestamps).
+    """
+    if prev_ns is None:
+        return nominal
+    delta = (now_ns - prev_ns) * 1e-9
+    if delta <= 0.0:
+        return nominal
+    return min(max(delta, lo), hi)
+
+
+def _clamp_position_step(
+    target: np.ndarray, previous: np.ndarray, max_step: float
+) -> np.ndarray:
+    """Clamp the Euclidean step from ``previous`` toward ``target`` to ``max_step`` [m].
+
+    Returns ``target`` unchanged when it is within reach, else the point at
+    ``max_step`` along the straight line from ``previous`` to ``target``.
+    """
+    delta = target - previous
+    dist = float(np.linalg.norm(delta))
+    if dist <= max_step or dist == 0.0:
+        return target
+    return previous + delta * (max_step / dist)
+
+
+def _quat_normalize(q: np.ndarray) -> np.ndarray | None:
+    """Return ``q`` normalized, or ``None`` when degenerate (zero / non-finite)."""
+    norm = float(np.linalg.norm(q))
+    if not np.isfinite(norm) or norm < _MIN_QUAT_NORM:
+        return None
+    return q / norm
+
+
+def _quat_mul(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    """Hamilton product ``a (x) b`` of two ``[x, y, z, w]`` quaternions (scalar-last)."""
+    ax, ay, az, aw = a
+    bx, by, bz, bw = b
+    return np.array(
+        [
+            aw * bx + ax * bw + ay * bz - az * by,
+            aw * by - ax * bz + ay * bw + az * bx,
+            aw * bz + ax * by - ay * bx + az * bw,
+            aw * bw - ax * bx - ay * by - az * bz,
+        ],
+        dtype=np.float64,
+    )
+
+
+def _quat_conjugate(q: np.ndarray) -> np.ndarray:
+    """Conjugate (== inverse for unit quaternions) of an ``[x, y, z, w]`` quaternion."""
+    return np.array([-q[0], -q[1], -q[2], q[3]], dtype=np.float64)
+
+
+def _quat_geodesic_angle(a: np.ndarray, b: np.ndarray) -> float:
+    """Geodesic angle [rad] between two unit quaternions (double-cover aware)."""
+    dot = min(1.0, abs(float(np.dot(a, b))))
+    return 2.0 * float(np.arccos(dot))
+
+
+def _clamp_orientation_step(
+    target: np.ndarray, previous: np.ndarray, max_step: float
+) -> np.ndarray:
+    """Clamp the geodesic rotation from ``previous`` toward ``target`` to ``max_step`` [rad].
+
+    Both quaternions are ``[x, y, z, w]`` unit quaternions. Returns ``target``
+    (sign-aligned with the shortest arc) when the relative rotation is within
+    ``max_step``, else the orientation reached by rotating ``max_step`` along the
+    shortest arc from ``previous`` toward ``target``.
+    """
+    # Relative rotation in the previous frame's body frame: q_rel = prev^-1 (x) target.
+    q_rel = _quat_mul(_quat_conjugate(previous), target)
+    # Shortest arc: flip the double-cover sign so w >= 0.
+    if q_rel[3] < 0.0:
+        q_rel = -q_rel
+    sin_half = float(np.linalg.norm(q_rel[:3]))
+    angle = 2.0 * float(np.arctan2(sin_half, q_rel[3]))
+    if angle <= max_step or angle < _MIN_ANGLE_RAD:
+        # Within the limit: emit the target, but from the shortest-arc branch so
+        # consecutive emitted quaternions never flip hemisphere spuriously.
+        return _quat_mul(previous, q_rel)
+    axis = q_rel[:3] / sin_half
+    half = 0.5 * max_step
+    q_step = np.array(
+        [
+            axis[0] * np.sin(half),
+            axis[1] * np.sin(half),
+            axis[2] * np.sin(half),
+            np.cos(half),
+        ],
+        dtype=np.float64,
+    )
+    return _quat_mul(previous, q_step)
+
+
+class EePoseRateLimiter(BaseRetargeter):
+    """Bounds the per-frame linear/angular velocity of an absolute 7-D ``ee_pose`` stream.
+
+    Input and output are both a single 7-D ``ee_pose`` (position [m] + orientation
+    quaternion ``[x, y, z, w]``), the exact contract of ``SO101ClutchRetargeter`` /
+    ``Se3AbsRetargeter``, so this node inserts between the pose producer and the
+    downstream reorderer without any wiring changes.
+
+    The first valid frame after construction / reset passes through and latches the
+    baseline; each later frame is clamped to ``max_linear_velocity * dt`` [m] and
+    ``max_angular_velocity * dt`` [rad] from the last **emitted** pose (see the
+    module docstring for the dt and reset semantics).
+
+    When ``reject_linear_velocity`` / ``reject_angular_velocity`` are set, a frame
+    whose **input** moves faster than those thresholds relative to the last
+    accepted input is rejected outright -- the last emitted pose is held and the
+    anomalous target is never approached (see the module docstring's anomaly
+    rejection tier).
+    """
+
+    def __init__(self, name: str, config: RateLimiterConfig | None = None) -> None:
+        """Initialize the EE-pose rate limiter.
+
+        Args:
+            name: Name identifier for this retargeter node.
+            config: Velocity limits and dt clamping; ``None`` uses the
+                conservative :class:`RateLimiterConfig` defaults.
+        """
+        self._cfg = config if config is not None else RateLimiterConfig()
+        super().__init__(name=name)
+        self._last_pose: np.ndarray | None = None
+        self._last_time_ns: int | None = None
+        # Anomaly-rejection reference: the last *accepted* input (position +
+        # normalized orientation), distinct from the last *emitted* pose -- the
+        # emitted pose lags a far target by design, and measuring input velocity
+        # against it would misread bounded catch-up as an anomaly.
+        self._last_input_pos: np.ndarray | None = None
+        self._last_input_ori: np.ndarray | None = None
+        self._rejections: int = 0
+
+    def input_spec(self) -> RetargeterIOType:
+        """Requires an (optional) absolute 7-D ``ee_pose`` to govern."""
+        return {
+            EE_POSE_KEY: OptionalType(
+                TensorGroupType(
+                    EE_POSE_KEY,
+                    [
+                        NDArrayType(
+                            "pose", shape=(7,), dtype=DLDataType.FLOAT, dtype_bits=32
+                        )
+                    ],
+                )
+            )
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        """Outputs the rate-limited absolute 7-D ``ee_pose``."""
+        return {
+            EE_POSE_KEY: TensorGroupType(
+                EE_POSE_KEY,
+                [
+                    NDArrayType(
+                        "pose", shape=(7,), dtype=DLDataType.FLOAT, dtype_bits=32
+                    )
+                ],
+            )
+        }
+
+    def _is_anomalous(self, pos: np.ndarray, ori: np.ndarray | None, dt: float) -> bool:
+        """True when the input step from the last accepted input breaks the reject envelope."""
+        cfg = self._cfg
+        if (
+            cfg.reject_linear_velocity is not None
+            and self._last_input_pos is not None
+            and float(np.linalg.norm(pos - self._last_input_pos))
+            > cfg.reject_linear_velocity * dt
+        ):
+            return True
+        return (
+            cfg.reject_angular_velocity is not None
+            and ori is not None
+            and self._last_input_ori is not None
+            and _quat_geodesic_angle(ori, self._last_input_ori)
+            > cfg.reject_angular_velocity * dt
+        )
+
+    def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
+        """Emits the input pose clamped to the configured per-frame step."""
+        if context.execution_events.reset:
+            # Fresh episode: forget the baseline. The next valid frame passes
+            # through and re-latches -- clamping against the stale pre-reset pose
+            # would command a long cross-workspace slew.
+            self._last_pose = None
+            self._last_time_ns = None
+            self._last_input_pos = None
+            self._last_input_ori = None
+            self._rejections = 0
+
+        out = outputs[EE_POSE_KEY]
+        inp = inputs[EE_POSE_KEY]
+        if inp.is_none:
+            # Dropped frame: hold the last emitted pose (upstream convention).
+            # Keep the time baseline -- max_dt bounds the catch-up step anyway.
+            if self._last_pose is not None:
+                out[0] = self._last_pose.astype(np.float32)
+            return
+
+        pose = np.asarray(np.from_dlpack(inp[0]), dtype=np.float64)
+        if not np.all(np.isfinite(pose[:3])):
+            if self._last_pose is not None:
+                out[0] = self._last_pose.astype(np.float32)
+            return
+        ori = _quat_normalize(pose[3:7])
+
+        if self._last_pose is None:
+            if ori is None:
+                # Degenerate first orientation: nothing sane to latch; hold off.
+                return
+            # First valid frame: pass through, latch the baseline.
+            latched = np.concatenate([pose[:3], ori])
+            self._last_pose = latched
+            self._last_time_ns = int(context.graph_time.real_time_ns)
+            self._last_input_pos = pose[:3].copy()
+            self._last_input_ori = ori.copy()
+            self._rejections = 0
+            out[0] = latched.astype(np.float32)
+            return
+
+        now_ns = int(context.graph_time.real_time_ns)
+        dt = _clamped_dt(
+            self._last_time_ns,
+            now_ns,
+            self._cfg.nominal_dt,
+            self._cfg.min_dt,
+            self._cfg.max_dt,
+        )
+
+        if self._is_anomalous(pose[:3], ori, dt):
+            self._rejections += 1
+            cap = self._cfg.max_consecutive_rejections
+            if cap is None or self._rejections <= cap:
+                # Anomalous frame (IK divergence, tracking teleport, stream
+                # catch-up): refuse it entirely -- hold the last emitted pose
+                # and advance no baseline (mirrors the dropped-frame path), so
+                # the arm never starts moving toward a discontinuity.
+                out[0] = self._last_pose.astype(np.float32)
+                return
+            # Cap tripped: the far input is persistent, so it is a new regime,
+            # not a glitch. Fall through and re-accept it -- the clamp below
+            # still bounds the approach velocity.
+            self._rejections = 0
+        else:
+            self._rejections = 0
+
+        pos = _clamp_position_step(
+            pose[:3], self._last_pose[:3], self._cfg.max_linear_velocity * dt
+        )
+        if ori is None:
+            # Degenerate target orientation: keep the last emitted one.
+            ori_limited = self._last_pose[3:7]
+        else:
+            ori_limited = _clamp_orientation_step(
+                ori, self._last_pose[3:7], self._cfg.max_angular_velocity * dt
+            )
+
+        self._last_input_pos = pose[:3].copy()
+        if ori is not None:
+            self._last_input_ori = ori.copy()
+        limited = np.concatenate([pos, ori_limited])
+        self._last_pose = limited
+        self._last_time_ns = now_ns
+        out[0] = limited.astype(np.float32)
+
+
+class JointRateLimiter(BaseRetargeter):
+    """Bounds the per-frame velocity of a name-keyed joint-target group.
+
+    Input and output are both a ``joint_targets`` group with one ``FloatType`` per
+    configured joint name, the exact contract of ``JointStateRetargeter``'s
+    ``joint`` mode, so this node inserts between the leader mirror and the action
+    wiring without changes. Every joint is clamped to ``limit * dt`` per frame,
+    where ``limit`` is ``config.joint_velocity_overrides[name]`` when present,
+    else ``config.max_joint_velocity``.
+
+    The first valid frame after construction / reset passes through and latches the
+    baseline (startup alignment is owned upstream); later frames are clamped
+    against the last **emitted** targets (see the module docstring).
+
+    When ``reject_joint_velocity`` is set, a frame in which **any** joint's input
+    moves faster than that threshold relative to the last accepted input is
+    rejected outright -- the last emitted targets are held and the anomalous
+    frame is never approached (joints move together, so the whole frame is
+    refused; see the module docstring's anomaly rejection tier).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        joint_names: list[str],
+        config: RateLimiterConfig | None = None,
+    ) -> None:
+        """Initialize the joint-space rate limiter.
+
+        Args:
+            name: Name identifier for this retargeter node.
+            joint_names: Ordered joint names; must match the upstream producer's
+                output element names/order (checked by the graph at connect time).
+            config: Velocity limits and dt clamping; ``None`` uses the
+                conservative :class:`RateLimiterConfig` defaults.
+        """
+        if not joint_names:
+            raise ValueError("joint_names must be non-empty")
+        self._cfg = config if config is not None else RateLimiterConfig()
+        self._joint_names = list(joint_names)
+        unknown = set(self._cfg.joint_velocity_overrides) - set(self._joint_names)
+        if unknown:
+            raise ValueError(
+                f"joint_velocity_overrides for unknown joints: {sorted(unknown)}"
+            )
+        super().__init__(name=name)
+        self._limits = np.array(
+            [
+                self._cfg.joint_velocity_overrides.get(n, self._cfg.max_joint_velocity)
+                for n in self._joint_names
+            ],
+            dtype=np.float64,
+        )
+        self._last_targets: np.ndarray | None = None
+        self._last_time_ns: int | None = None
+        # Anomaly-rejection reference: the last *accepted* input, distinct from
+        # the last *emitted* targets (which lag a far target by design; measuring
+        # input velocity against them would misread catch-up as an anomaly).
+        self._last_input_targets: np.ndarray | None = None
+        self._rejections: int = 0
+
+    def input_spec(self) -> RetargeterIOType:
+        """Requires an (optional) name-keyed joint-target group to govern."""
+        return {
+            JOINT_TARGETS_KEY: OptionalType(
+                TensorGroupType(
+                    JOINT_TARGETS_KEY, [FloatType(n) for n in self._joint_names]
+                )
+            )
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        """Outputs the rate-limited joint targets, one ``FloatType`` per joint."""
+        return {
+            JOINT_TARGETS_KEY: TensorGroupType(
+                JOINT_TARGETS_KEY, [FloatType(n) for n in self._joint_names]
+            )
+        }
+
+    def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
+        """Emits the input targets clamped to the configured per-frame step."""
+        if context.execution_events.reset:
+            # Fresh episode: forget the baseline (see EePoseRateLimiter).
+            self._last_targets = None
+            self._last_time_ns = None
+            self._last_input_targets = None
+            self._rejections = 0
+
+        out = outputs[JOINT_TARGETS_KEY]
+        jin = inputs[JOINT_TARGETS_KEY]
+        n = len(self._joint_names)
+        if jin.is_none:
+            # Dropped frame: hold the last emitted targets.
+            if self._last_targets is not None:
+                for i in range(n):
+                    out[i] = float(self._last_targets[i])
+            return
+
+        targets = np.array([float(jin[i]) for i in range(n)], dtype=np.float64)
+        if not np.all(np.isfinite(targets)):
+            if self._last_targets is not None:
+                for i in range(n):
+                    out[i] = float(self._last_targets[i])
+            return
+
+        if self._last_targets is None:
+            # First valid frame: pass through, latch the baseline.
+            self._last_targets = targets
+            self._last_time_ns = int(context.graph_time.real_time_ns)
+            self._last_input_targets = targets.copy()
+            self._rejections = 0
+            for i in range(n):
+                out[i] = float(targets[i])
+            return
+
+        now_ns = int(context.graph_time.real_time_ns)
+        dt = _clamped_dt(
+            self._last_time_ns,
+            now_ns,
+            self._cfg.nominal_dt,
+            self._cfg.min_dt,
+            self._cfg.max_dt,
+        )
+
+        if (
+            self._cfg.reject_joint_velocity is not None
+            and self._last_input_targets is not None
+            and bool(
+                np.any(
+                    np.abs(targets - self._last_input_targets)
+                    > self._cfg.reject_joint_velocity * dt
+                )
+            )
+        ):
+            self._rejections += 1
+            cap = self._cfg.max_consecutive_rejections
+            if cap is None or self._rejections <= cap:
+                # Anomalous frame (e.g. IK output flipping tens of degrees in
+                # one frame): refuse the whole frame -- hold the last emitted
+                # targets and advance no baseline (mirrors the dropped-frame
+                # path), so the servos never start slewing toward it.
+                for i in range(n):
+                    out[i] = float(self._last_targets[i])
+                return
+            # Cap tripped: the far input is persistent -- a new regime, not a
+            # glitch. Fall through and re-accept it; the clamp below still
+            # bounds the approach velocity.
+            self._rejections = 0
+        else:
+            self._rejections = 0
+
+        max_step = self._limits * dt
+        delta = np.clip(targets - self._last_targets, -max_step, max_step)
+        limited = self._last_targets + delta
+        self._last_targets = limited
+        self._last_time_ns = now_ns
+        self._last_input_targets = targets.copy()
+        for i in range(n):
+            out[i] = float(limited[i])

--- a/src/python/isaacteleop/retargeters/rate_limiter.py
+++ b/src/python/isaacteleop/retargeters/rate_limiter.py
@@ -284,19 +284,26 @@ def _clamp_orientation_step(
     if angle <= max_step or angle < _MIN_ANGLE_RAD:
         # Within the limit: emit the target, but from the shortest-arc branch so
         # consecutive emitted quaternions never flip hemisphere spuriously.
-        return _quat_mul(previous, q_rel)
-    axis = q_rel[:3] / sin_half
-    half = 0.5 * max_step
-    q_step = np.array(
-        [
-            axis[0] * np.sin(half),
-            axis[1] * np.sin(half),
-            axis[2] * np.sin(half),
-            np.cos(half),
-        ],
-        dtype=np.float64,
-    )
-    return _quat_mul(previous, q_step)
+        composed = _quat_mul(previous, q_rel)
+    else:
+        axis = q_rel[:3] / sin_half
+        half = 0.5 * max_step
+        q_step = np.array(
+            [
+                axis[0] * np.sin(half),
+                axis[1] * np.sin(half),
+                axis[2] * np.sin(half),
+                np.cos(half),
+            ],
+            dtype=np.float64,
+        )
+        composed = _quat_mul(previous, q_step)
+    # Renormalize: the result becomes the next frame's ``previous``, and the
+    # pass-through branch is prev (x) (prev^-1 (x) target), whose norm is |prev|^2. Fed
+    # back, that SQUARES the deviation from unit every frame, so float64's 1e-16 reaches
+    # float32 overflow in ~60 frames (0.9 s at 72 Hz). Do not drop this.
+    normalized = _quat_normalize(composed)
+    return previous if normalized is None else normalized
 
 
 class EePoseRateLimiter(BaseRetargeter):


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

<img width="480" height="480" alt="so101-alignment" src="https://github.com/user-attachments/assets/4718075b-4317-4117-9263-3f05ecf47d8f" />

Adds an SO-101 follower preview to `mujoco_xr`: disengaged the operator aims a locked-joint arm, and squeezing while it is green hands over to the leader gripper ghost. Driven from the OpenXR **aim** pose, not grip, whose `-Z` is the fist axis rather than a pointing ray.

- **Position** — the jaw tracks the controller on all three axes, at a grip offset carried on the controller's own facing.
- **Yaw** — the base takes the controller's yaw every frame, pivoting about the jaw (`gripperframe`): the jaw holds still and the arm swings around it. No button.
- **Thumbstick** — trims that offset in the controller's frame, 0.20 m/s and clamped to ±0.60 m: forward/back along the pointing ray, left/right beside it. **B** resets it; **A** + stick trims the yaw.
- **Squeeze** — engages once the wrist is within 20° of the demanded posture (level and unrolled, solved from `Q_HOME`), the limiter passes through, and both hold for 0.1 s.

`SO101ClutchRetargeter` gains `ENGAGE_PERMITTED_INPUT` and `controller_pose`; `EePoseRateLimiter` renormalizes its quaternion.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

564 passed, 16 skipped on Jetson AGX Orin. Geometry verified numerically: jaw pivot 0.000 mm over ±90° of yaw, yaw 1:1, 0.00° roll and pitch leak, gate 0.00° at a level hold.

No new tests; what remains is headset feel — draw order, resting posture — which nothing headless here reaches.

## Checklist

- [ ] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)