### PR TITLE
build: fail early and actionably on missing build tools

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   # Shared apt build dependencies. Each job installs these plus its own extras
   # (ccache, clang-format, the OAK camera autotools chain).
-  CORE_APT_DEPS: build-essential cmake glslang-tools libvulkan-dev libwayland-dev libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev wayland-protocols
+  CORE_APT_DEPS: build-essential cmake glslang-tools libvulkan-dev libwayland-dev libx11-dev libxcursor-dev libxext-dev libxi-dev libxinerama-dev libxkbcommon-dev libxrandr-dev patchelf pkg-config wayland-protocols
   # Pin vcpkg to an immutable commit for reproducible, supply-chain-stable CI
   # instead of tracking its moving default branch. Port versions are fixed by the
   # consuming manifest's builtin-baseline (e.g. DepthAI's vcpkg.json), so this
@@ -58,19 +58,13 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y $CORE_APT_DEPS \
           ccache clang-format-14 \
-          autoconf automake libtool pkg-config libudev-dev
+          autoconf automake libtool libudev-dev
 
     - name: Install coverage tooling
       if: ${{ matrix.build_type == 'Debug' && matrix.python_version == '3.11' && matrix.arch == 'x64' }}
       run: |
         sudo apt-get update
         sudo apt-get install -y gcovr
-
-    - name: Install patchelf (Release only)
-      if: ${{ matrix.build_type == 'Release' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y patchelf
 
     # CUDA toolkit needed at link time for viz_core (device_image
     # links libcudart). The wheel itself excludes libcuda.so.1 via
@@ -320,7 +314,7 @@ jobs:
         sudo apt-get update
         # clang-format-14: the pip build enforces the clang-format gate (no
         # cmake.define override), so the tool must be present or the build FATALs.
-        sudo apt-get install -y $CORE_APT_DEPS ccache patchelf clang-format-14
+        sudo apt-get install -y $CORE_APT_DEPS ccache clang-format-14
 
     - name: Build sdist (validates backend config + metadata)
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,23 +66,23 @@ option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_EXAMPLE_TELEOP_ROS2 "Build only the teleop_ros2 ROS 2 reference integration (e.g. for Docker)" OFF)
 option(BUILD_TESTING "Build unit tests" ON)
 # Televiz (src/viz) needs Vulkan, the CUDA Toolkit, and glslangValidator.
-# Default BUILD_VIZ ON when all three are present (so it builds out of the box)
-# and OFF otherwise (so a core-only source build still configures on machines
-# without them). Override explicitly with -DBUILD_VIZ=ON/OFF.
+# Only Vulkan and CUDA gate the default -- without them the machine cannot build
+# viz at all, so a core-only source build still configures. glslangValidator is
+# an apt package, not a GPU stack, so CheckBuildDeps fails on a missing one
+# rather than dropping the module. Override with -DBUILD_VIZ=ON/OFF.
 find_package(Vulkan QUIET)
 find_package(CUDAToolkit QUIET)
-find_program(_viz_glslang NAMES glslangValidator)
-if(Vulkan_FOUND AND CUDAToolkit_FOUND AND _viz_glslang)
+if(Vulkan_FOUND AND CUDAToolkit_FOUND)
     set(_viz_default ON)
 else()
     set(_viz_default OFF)
 endif()
-option(BUILD_VIZ "Build Televiz visualization module (auto-ON when Vulkan + CUDA + glslang are found)" ${_viz_default})
-if(BUILD_VIZ AND NOT (Vulkan_FOUND AND CUDAToolkit_FOUND AND _viz_glslang))
-    message(WARNING "BUILD_VIZ=ON but not all of Vulkan / CUDA Toolkit / glslangValidator were detected; "
-                    "the viz build may fail. Install the deps or pass -DBUILD_VIZ=OFF.")
+option(BUILD_VIZ "Build Televiz visualization module (auto-ON when Vulkan + CUDA are found)" ${_viz_default})
+if(BUILD_VIZ AND NOT (Vulkan_FOUND AND CUDAToolkit_FOUND))
+    message(WARNING "BUILD_VIZ=ON but Vulkan / the CUDA Toolkit were not detected; the viz build "
+                    "may fail. Install the deps or pass -DBUILD_VIZ=OFF.")
 endif()
-message(STATUS "BUILD_VIZ: ${BUILD_VIZ} (Vulkan=${Vulkan_FOUND} CUDAToolkit=${CUDAToolkit_FOUND} glslang=${_viz_glslang})")
+message(STATUS "BUILD_VIZ: ${BUILD_VIZ} (Vulkan=${Vulkan_FOUND} CUDAToolkit=${CUDAToolkit_FOUND})")
 option(ENABLE_EXPERIMENTAL_WINDOWS_BUILD "Enable experimental Windows build support (source code only)" OFF)
 
 # Note: This is used to check if the CloudXR bundle is available to be bundled with Isaac Teleop.
@@ -129,6 +129,11 @@ if(WIN32)
         cmake_language(DEFER CALL print_windows_warning)
     endif()
 endif()
+
+# Fail on missing build tools now, while the feature set is known and before
+# any FetchContent, rather than 60 s deep in a fetched dependency.
+include(cmake/CheckBuildDeps.cmake)
+isaac_teleop_check_build_deps()
 
 # Build dependencies (OpenXR SDK, etc.)
 add_subdirectory(deps)

--- a/cmake/CheckBuildDeps.cmake
+++ b/cmake/CheckBuildDeps.cmake
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ==============================================================================
+# CheckBuildDeps.cmake
+# ==============================================================================
+# Preflight for the command-line tools the build shells out to. Runs before any
+# FetchContent, so a missing tool is one error naming every gap at once instead
+# of a FATAL_ERROR ~60 s deep in a fetched dependency's CMake, or a feature
+# dropped from the build with no diagnostic louder than a `--` status line.
+#
+# Linux only; the install command it prints is apt.
+#
+# Usage (after the BUILD_* options are set, before deps are added):
+#   include(cmake/CheckBuildDeps.cmake)
+#   isaac_teleop_check_build_deps()
+# ==============================================================================
+
+function(isaac_teleop_check_build_deps)
+    if(NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        return()
+    endif()
+
+    set(_missing_tools "")
+    set(_missing_pkgs "")
+
+    # pkg-config, for GLFW's Wayland backend and the OAK / OGLO plugins, all of
+    # which pkg_check_modules(... REQUIRED). The vendored OpenXR SDK probes it
+    # too, but only to set XR_USE_PLATFORM_WAYLAND, which gates OpenGL-Wayland
+    # structs a Vulkan build never uses: libopenxr_loader.a is byte-identical
+    # either way, so do not require it for a core-only build.
+    # On Ubuntu 24.04 pkg-config is an empty transitional package and the binary
+    # belongs to pkgconf-bin, so probe for the tool but install the transitional
+    # name, which resolves correctly on 22.04 and 24.04 alike.
+    if(BUILD_VIZ OR BUILD_PLUGIN_OAK_CAMERA OR BUILD_PLUGIN_OGLO)
+        find_package(PkgConfig QUIET)
+        if(NOT PkgConfig_FOUND)
+            list(APPEND _missing_tools "pkg-config       (GLFW Wayland backend, OAK / OGLO plugins)")
+            list(APPEND _missing_pkgs "pkg-config")
+        endif()
+    endif()
+
+    # glslangValidator compiles src/viz's GLSL to SPIR-V. Caching it here also
+    # satisfies the find_program(... REQUIRED) in src/viz/shaders/cpp.
+    if(BUILD_VIZ)
+        find_program(GLSLANG_VALIDATOR glslangValidator)
+        if(NOT GLSLANG_VALIDATOR)
+            list(APPEND _missing_tools "glslangValidator (BUILD_VIZ=ON -- compiles Televiz shaders to SPIR-V)")
+            list(APPEND _missing_pkgs "glslang-tools")
+        endif()
+    endif()
+
+    # patchelf strips the spurious libssl.so.3 NEEDED entry from libcloudxr.so
+    # (src/core/cloudxr/python/CMakeLists.txt). Checked unconditionally: the SDK
+    # tarball that triggers it is downloaded *during* configure, so whether it
+    # will be needed cannot be known here.
+    find_program(PATCHELF_EXECUTABLE patchelf)
+    if(NOT PATCHELF_EXECUTABLE)
+        list(APPEND _missing_tools "patchelf         (CloudXR runtime bundle)")
+        list(APPEND _missing_pkgs "patchelf")
+    endif()
+
+    if(NOT _missing_tools)
+        return()
+    endif()
+
+    list(JOIN _missing_tools "\n  " _tools)
+    list(JOIN _missing_pkgs " " _pkgs)
+    set(_viz_hint "")
+    if(BUILD_VIZ AND (NOT GLSLANG_VALIDATOR OR NOT PkgConfig_FOUND))
+        set(_viz_hint "Or build Isaac Teleop without Televiz:\n  cmake -B build -DBUILD_VIZ=OFF\n")
+    endif()
+    # Single newlines only: message() already blank-lines between unindented lines
+    # and keeps 2-space-indented runs together, so "\n\n" renders as three blanks.
+    set(_bar "================================================================================")
+    set(_msg "${_bar}\n")
+    string(APPEND _msg "Missing build tools:\n  ${_tools}\n")
+    string(APPEND _msg "Install them:\n  sudo apt-get install -y ${_pkgs}\n")
+    string(APPEND _msg "${_viz_hint}${_bar}")
+    message(FATAL_ERROR "${_msg}")
+endfunction()

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -56,7 +56,7 @@ the list of dependencies. On **Ubuntu**, install build tools and clang-format:
 .. code-block:: bash
 
    sudo apt-get update
-   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf pkg-config
+   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf pkg-config glslang-tools
 
 Runtime-only dependencies (needed to actually run teleop, not to build):
 

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -28,22 +28,22 @@ Prerequisites
 
 .. note::
    **Optional — only needed to build the Televiz visualization module,** ``BUILD_VIZ``.
-   ``BUILD_VIZ`` is auto-detected: it defaults to ``ON`` when all three of the following are
-   found at configure time and to ``OFF`` otherwise, so a core-only source build still
-   configures on a machine without them. Watch the
-   ``-- BUILD_VIZ: <ON|OFF> (Vulkan=... CUDAToolkit=... glslang=...)`` configure line to see
-   which one is missing.
+   ``BUILD_VIZ`` is auto-detected from the GPU stack: it defaults to ``ON`` when both of the
+   following are found at configure time and to ``OFF`` otherwise, so a core-only source
+   build still configures on a machine without them. Watch the
+   ``-- BUILD_VIZ: <ON|OFF> (Vulkan=... CUDAToolkit=...)`` configure line to see which one
+   is missing.
 
    - **Vulkan headers + loader** — ``libvulkan-dev`` on Linux, the LunarG SDK on Windows.
    - **CUDA Toolkit** (cudart at link time) — ``nvidia-cuda-toolkit`` or the official NVIDIA
      installer.
-   - **glslangValidator** for compiling shaders to SPIR-V — ``glslang-tools`` on Linux,
-     ``brew install glslang`` on macOS; ships with the Vulkan SDK on Windows.
 
-   ``BUILD_VIZ=ON`` also pulls in GLFW, whose CMake uses ``pkg_check_modules()`` — install
-   ``pkg-config`` as well, or the configure fails before viz is reached. Most users do not
-   need any of this: ``pip install isaacteleop`` already ships the compiled ``isaacteleop.viz``
-   module. See `Other Build options`_ for the full option table.
+   ``BUILD_VIZ=ON`` additionally requires **glslangValidator** to compile shaders to SPIR-V
+   (``glslang-tools`` on Linux, ``brew install glslang`` on macOS; ships with the Vulkan SDK
+   on Windows). It does *not* gate the auto-default: if it is missing, the configure fails
+   naming it rather than quietly dropping the module. Most users do not need any of this:
+   ``pip install isaacteleop`` already ships the compiled ``isaacteleop.viz`` module. See
+   `Other Build options`_ for the full option table.
 
 .. _one-time-setup:
 
@@ -56,7 +56,7 @@ the list of dependencies. On **Ubuntu**, install build tools and clang-format:
 .. code-block:: bash
 
    sudo apt-get update
-   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf
+   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf pkg-config
 
 Runtime-only dependencies (needed to actually run teleop, not to build):
 
@@ -234,7 +234,7 @@ The CMake options (defined in root :code-file:`CMakeLists.txt` and :code-file:`c
      - ``ON`` on Linux
    * - **Televiz visualization**
      - ``BUILD_VIZ``
-     - Auto: ``ON`` when Vulkan, the CUDA Toolkit, and ``glslangValidator`` are detected, else ``OFF``. Force with ``-DBUILD_VIZ=ON`` / ``-DBUILD_VIZ=OFF``. (Most users don't need this — ``pip install isaacteleop`` already ships the compiled ``isaacteleop.viz`` module.)
+     - Auto: ``ON`` when Vulkan and the CUDA Toolkit are detected, else ``OFF``. Force with ``-DBUILD_VIZ=ON`` / ``-DBUILD_VIZ=OFF``. (Most users don't need this — ``pip install isaacteleop`` already ships the compiled ``isaacteleop.viz`` module.)
 
 .. list-table:: Plugin Specific Options
    :widths: 26 34 40

--- a/docs/source/getting_started/lerobot/data_collection_sim.rst
+++ b/docs/source/getting_started/lerobot/data_collection_sim.rst
@@ -120,7 +120,7 @@ Collect Teleop Data
       .. code-block:: bash
 
          sudo apt-get update
-         sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf pkg-config
+         sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf pkg-config glslang-tools
 
       Then clone, configure, build, and install (see
       :doc:`/getting_started/build_from_source/index` for the full prerequisite list and all

--- a/docs/source/getting_started/lerobot/data_collection_sim.rst
+++ b/docs/source/getting_started/lerobot/data_collection_sim.rst
@@ -120,7 +120,7 @@ Collect Teleop Data
       .. code-block:: bash
 
          sudo apt-get update
-         sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf
+         sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf pkg-config
 
       Then clone, configure, build, and install (see
       :doc:`/getting_started/build_from_source/index` for the full prerequisite list and all

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -577,7 +577,7 @@ symbols live in ``namespace viz``, and headers use nested include paths::
    #include <viz/layers/quad_layer.hpp>
    #include <viz/core/viz_buffer.hpp>
 
-``BUILD_VIZ`` auto-enables when Vulkan, the CUDA toolkit, and ``glslangValidator`` are detected
+``BUILD_VIZ`` auto-enables when Vulkan and the CUDA toolkit are detected
 (force it with ``-DBUILD_VIZ=ON`` / ``-DBUILD_VIZ=OFF``); link the relevant CMake target:
 
 .. list-table::

--- a/examples/oglo_tactile/README.md
+++ b/examples/oglo_tactile/README.md
@@ -30,6 +30,7 @@ session, records, and draws the overlay). `oglo_heatmap.py` is the renderer.
 
    ```bash
    sudo apt install libdbus-1-dev          # BlueZ for the BLE plugin
+   sudo apt install pkg-config glslang-tools libvulkan-dev   # BUILD_VIZ=ON below
    pip install pillow numpy                 # heatmap renderer
    pip install cupy-cuda12x                 # headset overlay GPU upload (match your CUDA)
    ```

--- a/src/plugins/oglo_tactile/README.md
+++ b/src/plugins/oglo_tactile/README.md
@@ -31,7 +31,7 @@ so packet sizes are never hardcoded (wire spec: the OGLO firmware packed12-v5 pa
 Linux only (BlueZ). Prerequisite:
 
 ```bash
-sudo apt install libdbus-1-dev
+sudo apt install libdbus-1-dev pkg-config
 ```
 
 ```bash

--- a/src/viz/shaders/cpp/CMakeLists.txt
+++ b/src/viz/shaders/cpp/CMakeLists.txt
@@ -3,9 +3,10 @@
 
 cmake_minimum_required(VERSION 3.20)
 
-# glslangValidator is part of the Vulkan SDK / glslang-tools package.
-# We don't FetchContent it — assume it's installed (libvulkan-dev pulls
-# it in on Ubuntu, brew install glslang on macOS).
+# glslangValidator is not fetched; it must be installed. On Ubuntu that is
+# glslang-tools -- libvulkan-dev does NOT pull it in. macOS: brew install
+# glslang. Windows: ships with the Vulkan SDK. Already resolved (and reported
+# against the apt package name) by cmake/CheckBuildDeps.cmake under BUILD_VIZ.
 find_program(GLSLANG_VALIDATOR glslangValidator REQUIRED)
 message(STATUS "Using glslangValidator: ${GLSLANG_VALIDATOR}")
 


### PR DESCRIPTION
## Description

Missing `glslangValidator`, `pkg-config` or `patchelf` each failed differently, none named the package to install, and because they nest, finding them all took three configure cycles. `cmake/CheckBuildDeps.cmake` now resolves them before any `FetchContent` and reports every gap in one error with the apt line to fix it — 1 s instead of 68 s.

Each check is scoped to what actually consumes it: `pkg-config` to `BUILD_VIZ` or the OAK/OGLO plugins, `glslangValidator` to `BUILD_VIZ`, `patchelf` unconditionally (the CloudXR tarball is fetched *during* configure, so the need isn't knowable up front).

`BUILD_VIZ` auto-detection now keys off Vulkan + CUDA only, so core-only builds and sdist `pip install` keep working. Two latent CI holes close as a side effect: `test-viz-sanitizers` was green only on runner preinstall, and Debug jobs built the CloudXR bundle without `patchelf`.

Fixes #982

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Ubuntu 24.04 ARM64 (Jetson AGX Orin), packages removed via apt — PATH shadowing can't hide `/usr/bin` from `find_program`.

| state | result |
|---|---|
| all three missing | 1 s, exit 1, all three named, one apt line |
| any subset missing | 1–2 s, names only those packages |
| `-DBUILD_VIZ=OFF`, viz deps missing | exit 0, configures clean |
| all present | exit 0, no warnings |

`viz_shaders_generate` emits SPIR-V, so `glslangValidator` is genuinely invoked. `libopenxr_loader.a` is byte-identical with `BUILD_WITH_WAYLAND_HEADERS` ON vs OFF — hence gating `pkg-config` rather than requiring it outright.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (see below)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

No automated test: a regression test needs `CMAKE_IGNORE_PATH` plus a configure per scenario. Happy to add one if wanted.
