### PR TITLE
feat(teleop-session): support required plugins

### DIFF
--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -328,7 +328,14 @@ Configure plugins:
        search_paths=[Path("/path/to/plugins")],
        enabled=True,
        plugin_args=["--arg1=val1", "--arg2=val2"],
+       required=True,
    )
+
+Plugins are optional by default: if none of their search paths exist or the
+configured plugin is not discovered, session startup continues without them.
+Set ``required=True`` to make either condition fail session startup with a
+``RuntimeError``. Setting ``enabled=False`` always disables the plugin,
+regardless of ``required``.
 
 .. note::
 

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1445,12 +1445,39 @@ class TestPluginInitialization:
 
         message = str(exc_info.value)
         assert (
-            "Required plugin 'required_plugin' has no existing search paths" in message
+            "Required plugin 'required_plugin' has no existing search directories"
+            in message
         )
         assert f"Configured search paths: ['{missing_path}']" in message
         assert session.plugin_managers == []
         assert session.oxr_session is None
         assert session._in_context is False
+
+    def test_required_regular_file_search_path_raises(self, tmp_path):
+        """Required plugin search paths must be directories, not regular files."""
+        pipeline = MockPipeline(leaf_nodes=[])
+        file_path = tmp_path / "not-a-directory"
+        file_path.write_text("")
+        plugin_config = PluginConfig(
+            plugin_name="required_plugin",
+            plugin_root_id="/root",
+            search_paths=[file_path],
+            required=True,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with pytest.raises(RuntimeError) as exc_info:
+                session.__enter__()
+
+        message = str(exc_info.value)
+        assert (
+            "Required plugin 'required_plugin' has no existing search directories"
+            in message
+        )
+        assert f"Configured search paths: ['{file_path}']" in message
+        assert session.plugin_managers == []
 
     def test_no_plugins_configured(self):
         """Session works fine with no plugins configured."""

--- a/src/core/teleop_session_manager_tests/python/test_teleop_session.py
+++ b/src/core/teleop_session_manager_tests/python/test_teleop_session.py
@@ -1318,7 +1318,7 @@ class TestPluginInitialization:
     """Test plugin initialization in __enter__."""
 
     def test_plugins_initialized(self, tmp_path):
-        """Enabled plugins with valid paths are started."""
+        """Required plugins with valid paths are started."""
         pipeline = MockPipeline(leaf_nodes=[])
 
         mock_pm = MockPluginManager(plugin_names=["test_plugin"])
@@ -1328,6 +1328,7 @@ class TestPluginInitialization:
             plugin_root_id="/root",
             search_paths=[tmp_path],
             enabled=True,
+            required=True,
         )
 
         config = make_config(pipeline, plugins=[plugin_config])
@@ -1338,7 +1339,7 @@ class TestPluginInitialization:
                 assert len(session.plugin_contexts) == 1
 
     def test_disabled_plugin_skipped(self, tmp_path):
-        """Disabled plugins are not started."""
+        """Disabled plugins are not started even when marked required."""
         pipeline = MockPipeline(leaf_nodes=[])
 
         mock_pm = MockPluginManager(plugin_names=["test_plugin"])
@@ -1348,6 +1349,7 @@ class TestPluginInitialization:
             plugin_root_id="/root",
             search_paths=[tmp_path],
             enabled=False,
+            required=True,
         )
 
         config = make_config(pipeline, plugins=[plugin_config])
@@ -1379,6 +1381,30 @@ class TestPluginInitialization:
                 assert len(session.plugin_managers) == 1
                 assert len(session.plugin_contexts) == 0
 
+    def test_required_missing_plugin_raises(self, tmp_path):
+        """Required plugins must be discovered in an existing search path."""
+        pipeline = MockPipeline(leaf_nodes=[])
+        mock_pm = MockPluginManager(plugin_names=["z_plugin", "a_plugin"])
+        plugin_config = PluginConfig(
+            plugin_name="required_plugin",
+            plugin_root_id="/root",
+            search_paths=[tmp_path],
+            required=True,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies(mock_pm=mock_pm):
+            session = TeleopSession(config)
+            with pytest.raises(RuntimeError) as exc_info:
+                session.__enter__()
+
+        message = str(exc_info.value)
+        assert "Required plugin 'required_plugin' was not discovered" in message
+        assert f"search paths ['{tmp_path}']" in message
+        assert "Discovered plugins: ['a_plugin', 'z_plugin']" in message
+        assert session.oxr_session is None
+        assert session._in_context is False
+
     def test_invalid_search_paths_skipped(self):
         """Plugins with no valid search paths are skipped entirely."""
         pipeline = MockPipeline(leaf_nodes=[])
@@ -1399,6 +1425,32 @@ class TestPluginInitialization:
                 # Skipped because no valid search paths
                 assert len(session.plugin_managers) == 0
                 assert len(session.plugin_contexts) == 0
+
+    def test_required_invalid_search_paths_raise(self, tmp_path):
+        """Required plugins must have at least one existing search path."""
+        pipeline = MockPipeline(leaf_nodes=[])
+        missing_path = tmp_path / "missing"
+        plugin_config = PluginConfig(
+            plugin_name="required_plugin",
+            plugin_root_id="/root",
+            search_paths=[missing_path],
+            required=True,
+        )
+
+        config = make_config(pipeline, plugins=[plugin_config])
+        with mock_session_dependencies():
+            session = TeleopSession(config)
+            with pytest.raises(RuntimeError) as exc_info:
+                session.__enter__()
+
+        message = str(exc_info.value)
+        assert (
+            "Required plugin 'required_plugin' has no existing search paths" in message
+        )
+        assert f"Configured search paths: ['{missing_path}']" in message
+        assert session.plugin_managers == []
+        assert session.oxr_session is None
+        assert session._in_context is False
 
     def test_no_plugins_configured(self):
         """Session works fine with no plugins configured."""
@@ -2519,7 +2571,7 @@ class TestConfiguration:
         assert not hasattr(teleop_session_manager, "RetargetingPacingConfig")
 
     def test_plugin_config_defaults(self, tmp_path):
-        """PluginConfig should have enabled=True by default."""
+        """PluginConfig should be enabled and optional by default."""
         config = PluginConfig(
             plugin_name="test",
             plugin_root_id="/root",
@@ -2527,17 +2579,20 @@ class TestConfiguration:
         )
 
         assert config.enabled is True
+        assert config.required is False
 
-    def test_plugin_config_disabled(self, tmp_path):
-        """PluginConfig can be created with enabled=False."""
+    def test_plugin_config_disabled_and_required(self, tmp_path):
+        """PluginConfig accepts explicit lifecycle policy flags."""
         config = PluginConfig(
             plugin_name="test",
             plugin_root_id="/root",
             search_paths=[tmp_path],
             enabled=False,
+            required=True,
         )
 
         assert config.enabled is False
+        assert config.required is True
 
 
 class TestSessionReuse:

--- a/src/python/isaacteleop/teleop_session_manager/config.py
+++ b/src/python/isaacteleop/teleop_session_manager/config.py
@@ -280,6 +280,7 @@ class PluginConfig:
         search_paths: List of directories to search for plugins
         enabled: Whether to load and use this plugin
         plugin_args: Optional list of arguments passed to the plugin process
+        required: Whether session startup should fail if the plugin cannot be found
     """
 
     plugin_name: str
@@ -287,6 +288,7 @@ class PluginConfig:
     search_paths: List[Path]
     enabled: bool = True
     plugin_args: List[str] = field(default_factory=list)
+    required: bool = False
 
 
 @dataclass

--- a/src/python/isaacteleop/teleop_session_manager/teleop_session.py
+++ b/src/python/isaacteleop/teleop_session_manager/teleop_session.py
@@ -1075,7 +1075,7 @@ class TeleopSession:
             if not plugin_config.enabled:
                 continue
 
-            valid_paths = [p for p in plugin_config.search_paths if p.exists()]
+            valid_paths = [p for p in plugin_config.search_paths if p.is_dir()]
             if not valid_paths:
                 if plugin_config.required:
                     configured_paths = [
@@ -1083,7 +1083,7 @@ class TeleopSession:
                     ]
                     raise RuntimeError(
                         f"Required plugin {plugin_config.plugin_name!r} has no existing "
-                        f"search paths. Configured search paths: {configured_paths!r}. "
+                        f"search directories. Configured search paths: {configured_paths!r}. "
                         "Build or install the plugin, or correct PluginConfig.search_paths."
                     )
                 continue

--- a/src/python/isaacteleop/teleop_session_manager/teleop_session.py
+++ b/src/python/isaacteleop/teleop_session_manager/teleop_session.py
@@ -1077,13 +1077,29 @@ class TeleopSession:
 
             valid_paths = [p for p in plugin_config.search_paths if p.exists()]
             if not valid_paths:
+                if plugin_config.required:
+                    configured_paths = [
+                        str(path) for path in plugin_config.search_paths
+                    ]
+                    raise RuntimeError(
+                        f"Required plugin {plugin_config.plugin_name!r} has no existing "
+                        f"search paths. Configured search paths: {configured_paths!r}. "
+                        "Build or install the plugin, or correct PluginConfig.search_paths."
+                    )
                 continue
 
             manager = pm.PluginManager([str(p) for p in valid_paths])
             self.plugin_managers.append(manager)
 
-            plugins = manager.get_plugin_names()
+            plugins = sorted(manager.get_plugin_names())
             if plugin_config.plugin_name not in plugins:
+                if plugin_config.required:
+                    raise RuntimeError(
+                        f"Required plugin {plugin_config.plugin_name!r} was not discovered "
+                        f"in search paths {[str(path) for path in valid_paths]!r}. "
+                        f"Discovered plugins: {plugins!r}. Build or install the plugin, "
+                        "or correct PluginConfig.plugin_name or PluginConfig.search_paths."
+                    )
                 continue
 
             context = manager.start(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Add an opt-in `required` flag to `PluginConfig` so applications can fail during startup when a configured device plugin is unavailable.

Plugins remain optional by default for backward compatibility. When `required=True`, `TeleopSession` raises an actionable `RuntimeError` if no configured search path exists or the plugin is not discovered. Setting `enabled=False` still disables the plugin regardless of `required`.

Error messages include the configured search paths and discovered plugin names to help diagnose missing or unbuilt plugin artifacts.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update

## Testing

Verified with test and E2E run


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `required` plugin configuration option, defaulting to optional.
  * Required plugins now prevent session startup when search paths are invalid or the plugin cannot be found.
  * Disabled plugins remain skipped, even when marked as required.
  * Plugin discovery results are now handled consistently during startup.

* **Documentation**
  * Updated plugin configuration guidance to explain optional and required startup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->