### PR TITLE
docs: move the version and search boxes into the navbar

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -80,20 +80,19 @@ a:focus {
     color: #7FDBFF;
 }
 
-/* Version switcher: match sidebar search box appearance */
+/* Version switcher: a navbar pill next to the search field */
 .version-switcher {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    margin-bottom: 0.75rem;
-    padding: 0.35rem 0.5rem;
+    gap: 0.4rem;
+    padding: 0.35em 0.75em;
     border: 1px solid var(--pst-color-border);
-    border-radius: 6px;
-    background: var(--pst-color-background);
+    border-radius: 1.5em;
+    background: var(--pst-color-surface);
 }
+.version-switcher:hover,
 .version-switcher:focus-within {
-    border-color: var(--pst-color-primary);
-    box-shadow: 0 0 0 2px rgba(118, 185, 0, 0.2);
+    box-shadow: 0 0 0 0.1875rem var(--pst-color-link-hover);
 }
 .version-switcher__label {
     font-weight: 600;
@@ -102,8 +101,8 @@ a:focus {
     white-space: nowrap;
 }
 .version-switcher__select {
-    flex: 1;
-    min-width: 0;
+    /* Bounded so a long ref name cannot wrap the navbar's right-hand row. */
+    max-width: 11rem;
     border: none;
     outline: none;
     background: transparent;
@@ -115,40 +114,15 @@ a:focus {
     box-shadow: none;
 }
 
-/* Sidebar search box: one unified bar; green highlight wraps icon + input + shortcut */
-.sidebar-primary-item .bd-search {
+/* Desktop search is the navbar field; the persistent magnifier is mobile-only. */
+.bd-header .navbar-persistent--container {
+    display: none;
+}
+
+/* The nvidia theme hides the field's label and shortcut (``.search-button-field
+   span``), leaving a bare magnifier that readers overlook. Show the full pill. */
+.bd-header .search-button-field span {
     display: flex;
-    align-items: center;
-    gap: 0;
-    margin-bottom: 0.75rem;
-    padding: 0 0.5rem;
-    border: 1px solid var(--pst-color-border);
-    border-radius: 6px;
-    background: var(--pst-color-background);
-}
-.sidebar-primary-item .bd-search:focus-within {
-    border-color: var(--pst-color-primary);
-    box-shadow: 0 0 0 2px rgba(118, 185, 0, 0.2);
-}
-.sidebar-primary-item .bd-search .form-control {
-    flex: 1;
-    min-width: 0;
-    padding: 0.35rem 0.5rem;
-    border: none;
-    border-radius: 0;
-    outline: none;
-    font-size: 0.9em;
-    background: transparent;
-}
-.sidebar-primary-item .bd-search .form-control:focus {
-    box-shadow: none;
-}
-.sidebar-primary-item .bd-search .fa-magnifying-glass {
-    color: var(--pst-color-text-muted);
-    flex-shrink: 0;
-}
-.sidebar-primary-item .bd-search .search-button__kbd-shortcut {
-    flex-shrink: 0;
 }
 
 /* Reduce top padding in left sidebar */

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -85,7 +85,7 @@ a:focus {
     display: flex;
     align-items: center;
     gap: 0.4rem;
-    padding: 0.35em 0.75em;
+    padding: 0.6em 0.75em;
     border: 1px solid var(--pst-color-border);
     border-radius: 1.5em;
     background: var(--pst-color-surface);
@@ -97,6 +97,9 @@ a:focus {
 .version-switcher__label {
     font-weight: 600;
     font-size: 0.9em;
+    /* The select's line box is the UA's ``normal``; a taller one here rounds the
+       two texts onto different baselines at fractional zoom. */
+    line-height: normal;
     color: var(--pst-color-text-muted);
     white-space: nowrap;
 }

--- a/docs/source/_templates/versioning.html
+++ b/docs/source/_templates/versioning.html
@@ -2,9 +2,11 @@
 <!-- SPDX-License-Identifier: Apache-2.0 -->
 
 {% if versions %}
-<div class="version-switcher">
-  <label for="version-select" class="version-switcher__label">Version</label>
-  <select id="version-select" class="version-switcher__select" onchange="location = this.value;">
+<!-- The theme mirrors every navbar item into the mobile drawer, so this renders
+     twice per page: label implicitly, or the two copies collide on one id. -->
+<label class="version-switcher">
+  <span class="version-switcher__label">Version</span>
+  <select class="version-switcher__select" onchange="location = this.value;">
     {%- for item in versions.branches %}
     <option value="{{ item.url }}" {% if item == current_version %}selected{% endif %}>{{ item.name }}</option>
     {%- endfor %}
@@ -12,5 +14,5 @@
     <option value="{{ item.url }}" {% if item == current_version %}selected{% endif %}>{{ item.name }}</option>
     {%- endfor %}
   </select>
-</div>
+</label>
 {% endif %}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -163,13 +163,17 @@ html_theme_options = {
             "type": "url",
         },
     ],
-    "navbar_end": ["theme-switcher"],
+    # The nvidia theme defaults navbar_center to its own version switcher, which
+    # needs a switcher JSON; sphinx-multiversion feeds ``versioning.html`` instead.
+    "navbar_center": [],
+    "navbar_end": ["versioning.html", "search-button-field", "theme-switcher"],
+    # Below 960px the theme hides navbar_end, so search survives as this magnifier.
     "navbar_persistent": ["search-button"],
 }
 
-# Primary sidebar (left): icon links row, search, then TOC (like Isaac Lab)
+# Primary sidebar (left): icon links row, then TOC (like Isaac Lab)
 html_sidebars = {
-    "**": ["versioning.html", "icon-links", "search-field", "sidebar-nav-bs"],
+    "**": ["icon-links", "sidebar-nav-bs"],
 }
 
 # Edit page button: link to GitHub so users can suggest edits (PyData theme uses html_context)


### PR DESCRIPTION
## Description

The version switcher and the search box sat at the top of the left sidebar, above a long table of contents, so readers scroll past them. Both now sit at the right end of the navbar as pills beside the theme switcher. The icon links (GitHub, CloudXR, Isaac Lab) stay in the sidebar.

<img width="782" height="338" alt="image" src="https://github.com/user-attachments/assets/15d7d09a-175d-49a9-abb3-916f66bc24f8" />


Two theme details are worth a look in review. The nvidia theme hides the search field's label and shortcut (`.search-button-field span`), which would leave a bare magnifier — one rule restores the full pill, since discoverability is the point of the move. And `versioning.html` drops its element id: the theme mirrors every navbar item into the mobile drawer, so as a navbar item it renders twice per page, and the duplicate id left the drawer's label pointing at the hidden header copy.

Below 960px nothing changes for readers: the theme hides `navbar_end` and mirrors those items into the drawer, with the persistent magnifier still in the header.

## Type of change

- [x] Documentation update

## Testing

`make current-docs` (`-W --keep-going`) and `sphinx-multiversion` both clean — the switcher only renders under the latter, since it needs the `versions` global.

Rendered in headless Chromium at 1440/1280/1000/430px and in dark mode: no wrap at 1000px with `release/1.4.x` selected, and the mobile drawer still carries version + search.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not) — presentation-only change; verified by build and screenshots
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the documentation version switcher with pill styling, improved spacing, and clearer hover and focus states.
  * Improved navbar search presentation across screen sizes.
* **Documentation**
  * Added the version switcher and search controls directly to the documentation navigation.
  * Simplified the primary sidebar to focus on navigation and icon links.
  * Preserved version selection and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->