### PR TITLE
build: preflight wayland-scanner for the GLFW Wayland backend

### DIFF
--- a/cmake/CheckBuildDeps.cmake
+++ b/cmake/CheckBuildDeps.cmake
@@ -40,6 +40,21 @@ function(isaac_teleop_check_build_deps)
         endif()
     endif()
 
+    # wayland-scanner generates the protocol sources for GLFW's Wayland backend,
+    # which GLFW 3.4 builds by default on Linux and hard-fails without. The cache
+    # entry is GLFW's own, so resolving it here also satisfies its find_program.
+    # libwayland-dev is the package to name: it pulls in libwayland-bin, which
+    # owns the binary, plus the wayland-client/cursor/egl .pc files that same
+    # backend pkg_check_modules(... REQUIRED).
+    if(BUILD_VIZ AND (NOT DEFINED GLFW_BUILD_WAYLAND OR GLFW_BUILD_WAYLAND))
+        find_program(WAYLAND_SCANNER_EXECUTABLE wayland-scanner)
+        if(NOT WAYLAND_SCANNER_EXECUTABLE)
+            list(APPEND _missing_tools "wayland-scanner  (BUILD_VIZ=ON -- GLFW Wayland backend)")
+            list(APPEND _missing_pkgs "libwayland-dev")
+            set(_wayland_gap TRUE)
+        endif()
+    endif()
+
     # glslangValidator compiles src/viz's GLSL to SPIR-V. Caching it here also
     # satisfies the find_program(... REQUIRED) in src/viz/shaders/cpp.
     if(BUILD_VIZ)
@@ -67,8 +82,13 @@ function(isaac_teleop_check_build_deps)
     list(JOIN _missing_tools "\n  " _tools)
     list(JOIN _missing_pkgs " " _pkgs)
     set(_viz_hint "")
-    if(BUILD_VIZ AND (NOT GLSLANG_VALIDATOR OR NOT PkgConfig_FOUND))
-        set(_viz_hint "Or build Isaac Teleop without Televiz:\n  cmake -B build -DBUILD_VIZ=OFF\n")
+    # Dropping Wayland keeps Televiz -- GLFW's X11 backend is a complete build --
+    # so offer that before offering to drop the module.
+    if(_wayland_gap)
+        set(_viz_hint "Or build Televiz against X11 only:\n  cmake -B build -DGLFW_BUILD_WAYLAND=OFF\n")
+    endif()
+    if(BUILD_VIZ AND (NOT GLSLANG_VALIDATOR OR NOT PkgConfig_FOUND OR _wayland_gap))
+        string(APPEND _viz_hint "Or build Isaac Teleop without Televiz:\n  cmake -B build -DBUILD_VIZ=OFF\n")
     endif()
     # Single newlines only: message() already blank-lines between unindented lines
     # and keeps 2-space-indented runs together, so "\n\n" renders as three blanks.

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -40,8 +40,10 @@ Prerequisites
 
    ``BUILD_VIZ=ON`` additionally requires **glslangValidator** to compile shaders to SPIR-V
    (``glslang-tools`` on Linux, ``brew install glslang`` on macOS; ships with the Vulkan SDK
-   on Windows). It does *not* gate the auto-default: if it is missing, the configure fails
-   naming it rather than quietly dropping the module. Most users do not need any of this:
+   on Windows), and on Linux **wayland-scanner** (``libwayland-dev``) for GLFW's Wayland
+   backend — pass ``-DGLFW_BUILD_WAYLAND=OFF`` to build Televiz against X11 only instead.
+   Neither gates the auto-default: if one is missing, the configure fails naming it rather
+   than quietly dropping the module. Most users do not need any of this:
    ``pip install isaacteleop`` already ships the compiled ``isaacteleop.viz`` module. See
    `Other Build options`_ for the full option table.
 
@@ -56,7 +58,7 @@ the list of dependencies. On **Ubuntu**, install build tools and clang-format:
 .. code-block:: bash
 
    sudo apt-get update
-   sudo apt-get install -y build-essential cmake libx11-dev clang-format-14 ccache patchelf pkg-config glslang-tools
+   sudo apt-get install -y build-essential cmake libx11-dev libwayland-dev clang-format-14 ccache patchelf pkg-config glslang-tools
 
 Runtime-only dependencies (needed to actually run teleop, not to build):
 


### PR DESCRIPTION
## Description

`BUILD_VIZ=ON` on a host without `wayland-scanner` spends 75 s fetching OpenXR, FlatBuffers, Catch2, MCAP and glm, then dies inside `_deps/glfw-src/src/CMakeLists.txt:76` with a bare `Failed to find wayland-scanner` — no package name, no way to proceed. GLFW 3.4 builds its Wayland backend by default on Linux and hard-fails without the generator. This is the failure mode the tool preflight from #983 exists to remove, and `wayland-scanner` was the one tool it didn't cover.

The check is gated on `GLFW_BUILD_WAYLAND` so opting out isn't punished, and the package named is `libwayland-dev` rather than `libwayland-bin`: it pulls in the binary's owner *and* the `wayland-client`/`cursor`/`egl` `.pc` files the same backend requires via `pkg_check_modules(... REQUIRED)`.

The first escape offered is `-DGLFW_BUILD_WAYLAND=OFF`, not `-DBUILD_VIZ=OFF` — GLFW's X11 backend is a complete build, so there's no reason to drop Televiz to get past this.

Still not covered, and out of scope here: the X11 dev set GLFW needs (`libxrandr-dev`, `libxinerama-dev`, `libxcursor-dev`, `libxi-dev`, `libxext-dev`, `libxkbcommon-dev`) is absent from the docs' apt line, so a doc-following `BUILD_VIZ=ON` build can still fail deep in GLFW on a bare host.

Related: #736 (BUILD_VIZ pitfalls, item 6), #737

<img width="490" height="456" alt="image" src="https://github.com/user-attachments/assets/140680d7-7dfc-41c3-86d3-c0cce71df01e" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Ubuntu 24.04 ARM64 (Jetson AGX Orin) with `wayland-scanner` genuinely absent, Vulkan + CUDA + `glslangValidator` + `pkg-config` + `patchelf` all present — i.e. the preflight passes and GLFW is what breaks.

| configure | before | after |
|---|---|---|
| `-DBUILD_VIZ=ON` | 75 s, `FATAL_ERROR` in `glfw-src/src/CMakeLists.txt:76` | 1.9 s, names `libwayland-dev` + both escapes |
| `-DBUILD_VIZ=ON -DGLFW_BUILD_WAYLAND=OFF` | — | exit 0, 84 s, `Including X11 support`, Televiz kept |
| `-DBUILD_VIZ=OFF` | — | exit 0, check skipped |

The `-DGLFW_BUILD_WAYLAND=OFF` row is what makes the printed hint trustworthy — it configures all the way through, so the advice isn't just plausible.

`SKIP=check-copyright-year pre-commit run` clean on both changed files.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (see below)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

No automated test, for the reason given in #983: a regression test needs `CMAKE_IGNORE_PATH` plus one configure per scenario.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build checks to clearly identify missing Linux Wayland dependencies.
  * Added guidance for resolving configuration failures by installing the required packages or disabling optional Wayland and visualization support.

* **Documentation**
  * Updated Linux build prerequisites to include Wayland tooling.
  * Clarified configuration requirements and documented X11-only build options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->