### PR TITLE
build: scrub VIRTUAL_ENV from the stubgen uv invocations

### DIFF
--- a/src/core/python/CMakeLists.txt
+++ b/src/core/python/CMakeLists.txt
@@ -113,10 +113,16 @@ if(BUILD_VIZ)
     list(APPEND STUBGEN_MODULES isaacteleop.viz._viz)
 endif()
 
+# --unset=VIRTUAL_ENV: an activated venv in the developer's shell is inherited
+# here, and any uv run that resolves no project falls back to it -- where
+# pybind11-stubgen is absent, so stub generation dies on ModuleNotFoundError.
+# --project makes current uv ignore VIRTUAL_ENV, but that is uv's guarantee to
+# withdraw, not the build's to rely on.
 set(STUBGEN_COMMANDS)
 foreach(_module IN LISTS STUBGEN_MODULES)
     list(APPEND STUBGEN_COMMANDS
-        COMMAND uv run --project "${CMAKE_BINARY_DIR}/stubgen" --python ${ISAAC_TELEOP_PYTHON_VERSION}
+        COMMAND ${CMAKE_COMMAND} -E env --unset=VIRTUAL_ENV
+            uv run --project "${CMAKE_BINARY_DIR}/stubgen" --python ${ISAAC_TELEOP_PYTHON_VERSION}
             python "${STUBGEN_SCRIPT}" ${_module} "${STUBGEN_PACKAGE_DIR}"
     )
 endforeach()


### PR DESCRIPTION
## Description

Stub generation inherits the developer's shell environment, so an activated venv reaches `uv`. Where `uv` resolves no project it falls back to that venv, `pybind11-stubgen` isn't installed there, and `generate_stubs.py` exits with `Error: pybind11-stubgen not installed` — a build failure whose only workaround is knowing to `unset VIRTUAL_ENV` first.

Worth being precise about how live this is: current `uv` ignores `VIRTUAL_ENV` whenever `--project` is given (verified back to 0.5.31, Jan 2025), which is why it's hard to hit today. But that's `uv`'s behavior to change, not an invariant this build states — and it holds only while the project actually resolves. `--unset` costs one `cmake -E env` per module and makes the commands independent of both.

Related: #736 (BUILD_VIZ pitfalls, item 6), #737

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Ubuntu 24.04 ARM64 (Jetson AGX Orin). Ran the real `generate_stubs.py` against an already-staged `python_package` tree with a foreign venv exported, rather than rebuilding:

- **Fix, `VIRTUAL_ENV` leaked** — `cmake -E env --unset=VIRTUAL_ENV uv run --project ...` generated a 29 KB `isaacteleop/schema/_schema.pyi`.
- **Failure mode reproduced** — `uv run` resolving no project with the same `VIRTUAL_ENV` set gives exactly `Error: pybind11-stubgen not installed` / `Stub generation failed.`
- **`--unset` does what it claims** — `printenv VIRTUAL_ENV` under it exits 1.
- **Generated rules** — `cmake -B build -DBUILD_VIZ=OFF` configures clean; every stubgen line in `build.make` carries the `cmake -E env --unset=VIRTUAL_ENV` prefix.

`SKIP=check-copyright-year pre-commit run` clean.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (see below)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

No automated test: asserting on env scrubbing inside a custom command means driving a full stub build with a poisoned environment, which is more CI time than the one-line guard is worth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stub generation reliability by preventing inherited virtual-environment settings from interfering with dependency resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->