### PR TITLE
[Televiz] doc improvement - document recorded-camera streaming and the Televiz submit contract

### DIFF
--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -564,58 +564,6 @@ without it the fields read zero.
        print(f"{stats.render_fps:.1f}/{stats.target_fps:.0f} fps, "
              f"gpu {stats.gpu_time_ms:.2f} ms, stale layers {stats.stale_layers}")
 
-Latency budget
-^^^^^^^^^^^^^^
-
-Where the milliseconds go between a photon hitting the camera sensor and the operator seeing it:
-
-#. **Capture + decode** — the camera's own exposure and readout, USB / MIPI transfer, and any
-   decode. Sources vary by an order of magnitude here; this is usually the largest term and it is
-   entirely outside Televiz.
-#. **Color conversion + upload to VRAM** — the producer's own CUDA work, if the source doesn't
-   already deliver RGBA8 on the GPU.
-#. **submit()** — a device-to-device copy plus a stream synchronize, on the producer's thread.
-#. **Mailbox wait** — up to one display interval, since a frame published just after the renderer
-   sampled waits for the next one. Submitting faster than the display rate cuts this term but
-   drops the extra frames.
-#. **Composite** — Televiz's render pass. In XR, layers with ``openxr_composition`` left on are
-   handed to the runtime rather than drawn by Televiz, so this term barely exists; what shows up
-   in ``gpu_time_ms`` is mostly the built-in-compositor path (window, offscreen, and quads that
-   opted out).
-#. **Runtime present + transport** — the XR runtime's own composition and reprojection, and with
-   CloudXR the encode, network hop, and headset-side decode.
-
-Steps 3–5 are the part Televiz controls, and on a desktop dGPU they are small. Measured on an
-RTX 6000 Ada in offscreen mode, one quad layer with default mipmap generation, median over 180
-frames:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 24 22 24
-
-   * - Layer
-     - ``submit()``
-     - ``render()``
-     - GPU composite
-   * - 1920×1080 mono
-     - 0.10 ms
-     - 0.13 ms
-     - 0.02 ms
-   * - 1920×1080 stereo
-     - 0.12 ms
-     - 0.14 ms
-     - 0.03 ms
-   * - 3840×2160 mono
-     - 0.15 ms
-     - 0.15 ms
-     - 0.04 ms
-
-Read these as an order of magnitude rather than a promise: they scale with pixel count, they are
-larger on Jetson, and the ``render()`` column excludes the frame wait a real display imposes.
-Steps 1 and 6 dominate any real deployment — budget by measuring your source's
-capture-to-``submit`` time, and CloudXR's own latency reporting for the transport, rather than by
-assuming the compositor is the problem.
-
 Session state
 -------------
 

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -64,9 +64,7 @@ Four layer types are available:
   ``(color, depth)`` buffers. Use it to present a rendered 3D scene from the current head pose.
 
 A session holds **either** one ``ProjectionLayer`` **or** any number of texture layers
-(``QuadLayer`` / ``CylinderLayer`` / ``EquirectLayer``), not both. The texture layers share one
-submission API and differ only in the surface the texture is mapped onto; a projection layer is
-presented directly (see `ProjectionLayer`_).
+(``QuadLayer`` / ``CylinderLayer`` / ``EquirectLayer``), never both — see `Layers`_.
 
 All symbols are imported from the top-level module::
 
@@ -176,14 +174,58 @@ Construct the session with the factory; never call the class directly:
 Layers
 ------
 
+Layers come in two families, and a session holds one family or the other:
+
+* **Texture layers** — ``QuadLayer``, ``CylinderLayer``, ``EquirectLayer``. A session can hold any
+  number of them. All three take the same configuration, are fed by the same ``submit()``, and are
+  composited the same way; they differ *only* in the surface the texture is mapped onto — a flat
+  plane, a curved arc, or a sphere. The three sections at the end of this chapter cover just that
+  difference; everything before them applies to all of them.
+* **Projection layer** — one ``ProjectionLayer``, a full-view RGBD layer for an in-loop renderer.
+  A session holds at most one, and never alongside a texture layer. See `ProjectionLayer`_.
+
 Layers render in **insertion order** — the first added renders first (underneath). A layer is owned
 by the session; ``add_quad_layer`` returns a **non-owning** handle, so don't keep it past the
 session's lifetime.
 
-QuadLayer
-^^^^^^^^^
+.. _openxr-composition-layers:
 
-A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
+Composition model
+^^^^^^^^^^^^^^^^^
+
+In XR, each texture layer is handed to the OpenXR runtime as its own composition layer
+(``XrCompositionLayerQuad`` / ``CylinderKHR`` / ``Equirect2KHR``) rather than drawn by Televiz; the
+runtime places, samples, and reprojects it at display rate. That keeps text and fine detail sharp
+under head motion, and it lets CloudXR stream color-only video when every visible layer is
+runtime-composited and opaque — the headset then rebuilds the composition from the layer geometry
+at lower bandwidth.
+
+Three consequences, in rough order of how often they bite:
+
+* **Runtime-composited layers carry no depth.** They blend in insertion order, so a foreground
+  overlay added before a camera feed renders *behind* it no matter where the two sit in 3D. Add
+  backgrounds — an ``EquirectLayer`` panorama, say — first.
+* **Alpha is ignored unless you ask for it.** ``alpha_blend`` (default off) makes the runtime honor
+  the texture's alpha channel — turn it on for translucent content such as a HUD. Keep it off on
+  opaque camera feeds: as long as no visible layer uses source alpha, CloudXR can stream the layers
+  themselves and let the headset rebuild the composition, rather than sending a fully composited
+  stereo frame. That is less to encode and less on the wire every frame — lower bandwidth, and
+  lower latency on a constrained link. A single visible alpha-blended layer disqualifies the whole
+  frame.
+* **Mipmaps only exist on the built-in path.** ``generate_mipmaps`` applies when Televiz does the
+  drawing; the runtime samples native layers itself. On the default XR path the flag has no effect.
+
+``QuadLayer`` is the one layer with a choice, which is why ``openxr_composition`` and
+``generate_mipmaps`` appear on its config and on no other. Set ``openxr_composition = False`` to
+draw the quad with Televiz's built-in compositor instead, where 3D-placed quads depth-test against
+each other in a shared render target — the way out of the no-depth constraint above. Cylinder and
+equirect layers have no such switch: they exist only as native runtime layers, and therefore only in
+XR. Window and offscreen modes always use the built-in compositor.
+
+Shared configuration
+^^^^^^^^^^^^^^^^^^^^
+
+``QuadLayerConfig``, ``CylinderLayerConfig``, and ``EquirectLayerConfig`` all carry these fields:
 
 .. list-table::
    :header-rows: 1
@@ -203,30 +245,93 @@ A 2D plane fed by a CUDA buffer. Configure it with ``QuadLayerConfig``:
      - ``PixelFormat`` of the source (typically ``kRGBA8``).
    * - ``placement``
      - —
-     - Optional ``QuadLayerPlacement`` (``pose`` + ``size_meters``) for 3D placement in XR.
+     - Where and how big the surface is. Each layer has its own placement type describing its own
+       geometry — see the per-layer sections below.
    * - ``stereo``
      - ``False``
      - Per-eye stereo. When ``True``, ``submit`` requires both eyes' buffers; view 0 (left) samples
        the left buffer, view 1 (right) the right. Memory doubles.
    * - ``stereo_baseline_mm``
      - ``0``
-     - Horizontal disparity between the left/right planes (mm), along the placement's local +x axis.
-       ``0`` → both eyes see the same world quad. XR + stereo only.
-   * - ``generate_mipmaps``
-     - ``True``
-     - Allocate + regenerate a capped mip chain each frame; sampler uses trilinear filtering.
-   * - ``openxr_composition``
-     - ``True``
-     - Who composites the quad in XR: ``True`` = the OpenXR runtime (submitted as an
-       ``XrCompositionLayerQuad``), ``False`` = Televiz's built-in compositor (shared render
-       target, where 3D-placed quads depth-test against each other). See
-       `OpenXR composition layers`_.
+     - Horizontal disparity between the per-eye surfaces (mm), along the placement's local +x axis.
+       ``0`` → both eyes see the same surface in the world, and any parallax comes from the frames
+       themselves. XR + stereo only, and no effect on an infinite-radius equirect sphere.
    * - ``alpha_blend``
      - ``False``
-     - Honor the texture's alpha channel (translucent content). OpenXR composition only;
-       ignored on the built-in compositor path.
+     - Honor the texture's alpha channel (translucent content). Runtime composition only; ignored
+       on the built-in compositor path.
 
-Submit and place a frame:
+Stereo works the same way on every surface, following the VR-video convention: per-eye textures on
+the *same* surface, with ``stereo_baseline_mm`` adding an optional per-eye pose shift on top.
+
+Submitting frames
+^^^^^^^^^^^^^^^^^
+
+Every texture layer (``QuadLayer`` / ``CylinderLayer`` / ``EquirectLayer``) takes content through
+the same ``submit()``. What a frame must be:
+
+* **GPU-resident.** A ``VizBuffer`` in device memory, or any object exposing
+  ``__cuda_array_interface__`` (CuPy, PyTorch, Numba). A host buffer is rejected — the teleop hot
+  path never round-trips through system memory.
+* **RGBA8**, matching the layer's ``format``.
+* **Exactly the layer's resolution.** Submitted dimensions are checked against ``resolution``, not
+  scaled — resize upstream.
+
+Three properties of ``submit()`` decide how you structure the producer around it:
+
+**It is a latest-wins mailbox, not a queue.** Each layer owns a small ring of device images.
+``submit()`` copies your pixels into a slot no in-flight frame is reading, then publishes it; the
+renderer always picks up the most recent completed publish. A producer faster than the display
+rate therefore **drops** frames rather than queueing or blocking, and a producer slower than the
+display rate has its last frame re-presented. Neither side waits on the other, and no frame is
+ever shown half-updated.
+
+**It blocks until the copy completes.** ``submit()`` synchronizes ``stream`` before returning, so
+your source buffer is free to reuse the moment it does — no fences to manage, no lifetime rules
+past the call. The cost lands on the calling thread (see `Performance and diagnostics`_), not on
+the render path, which is why capture threads should call ``submit()`` directly rather than
+funnelling frames to the render thread.
+
+**One producer per layer.** ``submit()`` is safe against the renderer consuming the same layer
+concurrently, but *not* against a second thread submitting to the same layer. Give each producer
+its own layer.
+
+.. warning::
+
+   **Stereo submits carry a stream precondition.** ``submit(left, right, stream=...)`` copies both
+   eyes on the single ``stream`` you pass. CUDA orders work only within one stream, so if either
+   buffer was produced on a *different* stream, synchronize that stream first — either
+   ``cudaStreamSynchronize`` on the producer stream, or record an event there and
+   ``cudaStreamWaitEvent`` it on ``stream``. Skip it and that eye can be copied mid-write: torn or
+   stale pixels, with no error raised. The in-tree ZED and OAK-D sources synchronize per eye
+   before publishing, which is what makes their plain ``submit(left, right)`` (stream 0) safe.
+
+
+QuadLayer
+^^^^^^^^^
+
+A flat plane — the default surface, and the right one for normal-FOV camera feeds. Beyond the
+`Shared configuration`_ fields, ``QuadLayerConfig`` adds the two composition knobs, which exist here
+because the quad is the only layer that can be drawn either way:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 26 14 60
+
+   * - Field
+     - Default
+     - Description
+   * - ``generate_mipmaps``
+     - ``True``
+     - Allocate + regenerate a capped mip chain each frame; sampler uses trilinear filtering. Only
+       applies on the built-in compositor path.
+   * - ``openxr_composition``
+     - ``True``
+     - ``True`` = the OpenXR runtime composites the quad, ``False`` = Televiz's built-in
+       compositor. See `Composition model`_.
+
+Its placement is a ``QuadLayerPlacement`` — a ``pose`` plus ``size_meters``. It is optional:
+a quad with no placement fills the window in window mode.
 
 .. code-block:: python
 
@@ -244,23 +349,16 @@ Submit and place a frame:
    layer.set_placement(placement)
    layer.set_visible(True)
 
-``submit(left, right=None, stream=0)`` accepts a ``VizBuffer`` or any
-``__cuda_array_interface__`` object; the binding converts it and releases the GIL across the copy.
-For a stereo layer both buffers are copied on the same stream and signaled together, so the renderer
-never sees a half-matched pair. Lock-mode placement strategies (``world`` / ``head`` / ``lazy`` / ``gimbal``) are
-**application policy** and ship in the sample, not in the module.
+Lock-mode placement strategies (``world`` / ``head`` / ``lazy`` / ``gimbal``) are **application
+policy** and ship in the sample, not in the module.
 
 CylinderLayer
 ^^^^^^^^^^^^^
 
-The same CUDA-fed texture, curved onto the inside of a vertical cylinder arc. Every point on the
-surface sits at the same distance from the cylinder's axis, which makes it the natural surface for
-wide-FOV camera feeds — a flat quad wide enough for a 110° image would put its edges much farther
-from the eye than its center.
-
-``CylinderLayerConfig`` carries the same ``name`` / ``resolution`` / ``format`` / ``stereo`` /
-``stereo_baseline_mm`` / ``alpha_blend`` fields as ``QuadLayerConfig``, plus a
-``CylinderLayerPlacement`` describing the arc:
+The texture curved onto the inside of a vertical cylinder arc. Every point on the surface sits at
+the same distance from the cylinder's axis, which makes it the natural surface for wide-FOV camera
+feeds — a flat quad wide enough for a 110° image would put its edges much farther from the eye than
+its center. ``CylinderLayerPlacement`` describes the arc:
 
 .. list-table::
    :header-rows: 1
@@ -282,22 +380,15 @@ from the eye than its center.
      - ``0``
      - Arc width / height. ``0`` derives it from ``resolution`` (square texels).
 
-Cylinder layers exist only in XR: they are composited by the OpenXR runtime (see
-`OpenXR composition layers`_), so they require ``DisplayMode.kXr`` and a runtime with
-``XR_KHR_composition_layer_cylinder`` (CloudXR supports it). ``add_cylinder_layer`` raises
-``ValueError`` otherwise. ``submit`` and ``set_visible`` work exactly as on ``QuadLayer``.
+XR only, and the runtime must support ``XR_KHR_composition_layer_cylinder`` (CloudXR does).
+``add_cylinder_layer`` raises ``ValueError`` otherwise.
 
 EquirectLayer
 ^^^^^^^^^^^^^
 
 An equirectangular texture mapped onto the inside of a sphere centered on (by default) the
-operator, for 360°/180° panoramas and VR-video sources. Like ``CylinderLayer`` it is XR-only and
-composited by the OpenXR runtime — here the required extension is
-``XR_KHR_composition_layer_equirect2``.
-
-``EquirectLayerConfig`` carries the same common fields plus an ``EquirectLayerPlacement``. The
-defaults describe a full 360°×180° sphere at infinite radius, so a panorama needs no placement at
-all:
+operator, for 360°/180° panoramas and VR-video sources. The ``EquirectLayerPlacement`` defaults
+describe a full 360°×180° sphere at infinite radius, so a panorama needs no placement at all:
 
 .. list-table::
    :header-rows: 1
@@ -319,7 +410,11 @@ all:
      - ``π/2`` / ``−π/2``
      - Vertical span from the horizon, upper > lower.
 
-Combining the two — a panorama background with a camera feed on an arc in front of it:
+XR only, like the cylinder; the required extension here is
+``XR_KHR_composition_layer_equirect2``.
+
+Combining the two — a panorama background with a camera feed on an arc in front of it, background
+added first so it composites underneath:
 
 .. code-block:: python
 
@@ -338,34 +433,6 @@ Combining the two — a panorama background with a camera feed on an arc in fron
        sky.submit(panorama_rgba)
        cam.submit(camera_rgba)
        session.render()
-
-.. _openxr-composition-layers:
-
-OpenXR composition layers
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In XR mode, texture layers are not drawn by Televiz — each one is submitted to the OpenXR runtime
-as its own composition layer (``XrCompositionLayerQuad`` / ``CylinderKHR`` / ``Equirect2KHR``),
-and the runtime places, samples, and reprojects it at display rate. This keeps text and fine
-detail sharp under head motion, and it lets CloudXR stream color-only video when every visible
-layer is runtime-composited and opaque — the headset then rebuilds the composition from the layer
-geometry at lower bandwidth.
-
-Two things follow from handing composition to the runtime:
-
-* Runtime-composited layers carry no depth; they blend in **insertion order**. Add backgrounds
-  (e.g. an ``EquirectLayer`` panorama) before foreground layers.
-* ``alpha_blend`` (default off) makes the runtime honor the texture's alpha channel — use it for
-  translucent HUDs. Leave it off for opaque feeds so CloudXR's color-only streaming stays
-  available.
-
-``QuadLayer`` is the one layer with a choice: set ``openxr_composition = False`` to draw the quad
-with Televiz's built-in compositor instead, where 3D-placed quads depth-test against each other in
-a shared render target. Window and offscreen modes always use the built-in compositor.
-
-For stereo, all texture layers follow the VR-video convention: per-eye textures on the *same*
-surface, with ``stereo_baseline_mm`` adding an optional per-eye pose shift on top (no effect on an
-infinite-radius equirect sphere).
 
 ProjectionLayer
 ^^^^^^^^^^^^^^^
@@ -456,6 +523,98 @@ skip expensive decode when not visible):
 XR), ``delta_time`` (CPU wall-clock seconds — usable without any XR knowledge), ``should_render``,
 ``resolution``, and ``views``. Each ``ViewInfo`` in ``views`` has ``viewport``, ``fov``, and
 ``pose`` — 2 entries in XR stereo, 1 (identity pose) in window / offscreen.
+
+Performance and diagnostics
+---------------------------
+
+``get_frame_timing_stats()`` is the first thing to reach for when the view stutters. It costs
+nothing to call and needs no configuration:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 76
+
+   * - Field
+     - Meaning
+   * - ``render_fps``
+     - Smoothed frame rate over a recent window — what you are actually achieving.
+   * - ``target_fps``
+     - What you should be achieving: the headset's display rate in XR (60 / 72 / 90 / 120), the
+       vsync rate in window mode.
+   * - ``missed_frames``
+     - Cumulative count of frames whose GPU work didn't finish inside the budget. Rising while
+       ``render_fps`` holds means you are on the edge; rising with ``render_fps`` below
+       ``target_fps`` means you are over it.
+   * - ``avg_frame_time_ms``
+     - Mean total frame time.
+   * - ``gpu_time_ms``
+     - Last frame's GPU-side render time.
+   * - ``stale_layers``
+     - Layers whose producer missed the stale timeout this frame — the signal that a *capture*
+       thread, not the compositor, is behind. Non-zero here points you upstream.
+
+``get_gpu_timing()`` breaks the GPU side into ``total_ms`` / ``render_pass_ms`` / ``post_pass_ms``.
+It requires ``gpu_timing = True`` on ``VizSessionConfig`` (timestamp queries are off by default);
+without it the fields read zero.
+
+.. code-block:: python
+
+   stats = session.get_frame_timing_stats()
+   if stats.missed_frames > last_missed or stats.stale_layers:
+       print(f"{stats.render_fps:.1f}/{stats.target_fps:.0f} fps, "
+             f"gpu {stats.gpu_time_ms:.2f} ms, stale layers {stats.stale_layers}")
+
+Latency budget
+^^^^^^^^^^^^^^
+
+Where the milliseconds go between a photon hitting the camera sensor and the operator seeing it:
+
+#. **Capture + decode** — the camera's own exposure and readout, USB / MIPI transfer, and any
+   decode. Sources vary by an order of magnitude here; this is usually the largest term and it is
+   entirely outside Televiz.
+#. **Color conversion + upload to VRAM** — the producer's own CUDA work, if the source doesn't
+   already deliver RGBA8 on the GPU.
+#. **submit()** — a device-to-device copy plus a stream synchronize, on the producer's thread.
+#. **Mailbox wait** — up to one display interval, since a frame published just after the renderer
+   sampled waits for the next one. Submitting faster than the display rate cuts this term but
+   drops the extra frames.
+#. **Composite** — Televiz's render pass. In XR, layers with ``openxr_composition`` left on are
+   handed to the runtime rather than drawn by Televiz, so this term barely exists; what shows up
+   in ``gpu_time_ms`` is mostly the built-in-compositor path (window, offscreen, and quads that
+   opted out).
+#. **Runtime present + transport** — the XR runtime's own composition and reprojection, and with
+   CloudXR the encode, network hop, and headset-side decode.
+
+Steps 3–5 are the part Televiz controls, and on a desktop dGPU they are small. Measured on an
+RTX 6000 Ada in offscreen mode, one quad layer with default mipmap generation, median over 180
+frames:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 24 22 24
+
+   * - Layer
+     - ``submit()``
+     - ``render()``
+     - GPU composite
+   * - 1920×1080 mono
+     - 0.10 ms
+     - 0.13 ms
+     - 0.02 ms
+   * - 1920×1080 stereo
+     - 0.12 ms
+     - 0.14 ms
+     - 0.03 ms
+   * - 3840×2160 mono
+     - 0.15 ms
+     - 0.15 ms
+     - 0.04 ms
+
+Read these as an order of magnitude rather than a promise: they scale with pixel count, they are
+larger on Jetson, and the ``render()`` column excludes the frame wait a real display imposes.
+Steps 1 and 6 dominate any real deployment — budget by measuring your source's
+capture-to-``submit`` time, and CloudXR's own latency reporting for the transport, rather than by
+assuming the compositor is the problem.
 
 Session state
 -------------

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -559,10 +559,16 @@ without it the fields read zero.
 
 .. code-block:: python
 
-   stats = session.get_frame_timing_stats()
-   if stats.missed_frames > last_missed or stats.stale_layers:
-       print(f"{stats.render_fps:.1f}/{stats.target_fps:.0f} fps, "
-             f"gpu {stats.gpu_time_ms:.2f} ms, stale layers {stats.stale_layers}")
+   last_missed = 0
+
+   while running:
+       session.render()
+
+       stats = session.get_frame_timing_stats()
+       if stats.missed_frames > last_missed or stats.stale_layers:
+           print(f"{stats.render_fps:.1f}/{stats.target_fps:.0f} fps, "
+                 f"gpu {stats.gpu_time_ms:.2f} ms, stale layers {stats.stale_layers}")
+       last_missed = stats.missed_frames
 
 Session state
 -------------

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -7,8 +7,9 @@ Camera Streaming
 ``camera_viz`` is the reference camera-streaming sample built on :doc:`Televiz
 </getting_started/televiz>` (``isaacteleop.viz``). It captures frames from one or more cameras
 and streams them to an XR headset — one plane per camera, aspect-fit — either directly or from a
-robot to a workstation over the network (split mode). For development and debugging it can also
-replay a video file in place of a camera, and render to a desktop window instead of the headset.
+robot to a workstation over the network (split mode). It can also stream :ref:`recorded camera
+data <recorded-camera-streaming>` — a video file replayed in place of a live camera — and render
+to a desktop window instead of the headset.
 
 The sample lives at :code-dir:`examples/camera_viz/ <examples/camera_viz>`. This page walks you
 from setup and a hardware-free first run to real cameras and the robot → workstation split mode.
@@ -50,29 +51,15 @@ run the sample's one-time setup:
    examples/camera_viz/camera_viz.sh setup
    source examples/camera_viz/.venv/bin/activate
 
-There is no need to install the ``isaacteleop`` pip package yourself — ``setup`` creates the
-sample's own environment: it installs ``isaacteleop[cloudxr]`` (which bundles Televiz) and every
-other Python dependency into ``.venv/`` via ``uv``, then probes the system packages it needs
-(cairo / girepository headers, GStreamer plugins and the native NVENC/NVDEC codec under
-``--with-rtp``, JetPack ``cuda-nvrtc`` + ``ld.so`` wiring). When something is missing it prints
-the exact ``apt-get`` line and prompts ``[y/N]`` — answering ``n`` or running non-interactively
-aborts. The ``cloudxr`` extra is not optional for this sample: XR is the default display mode
-and the viewer launches the CloudXR runtime itself.
-
-camera_viz needs an ``isaacteleop`` new enough to carry the features it uses, so ``setup`` works
-down a ladder to get one:
-
-#. the newest **final release** on the package index, if one meets that minimum;
-#. otherwise the newest **release candidate** — Isaac Teleop publishes an rc from every
-   release-branch commit, and PEP 440 keeps pre-releases out of a plain minimum-version
-   specifier;
-#. otherwise a **source build** of the surrounding checkout, after asking. This is a full
-   C++ / CUDA / Vulkan build and needs CMake, the CUDA toolkit, Vulkan headers,
-   ``glslangValidator``, and ``clang-format-14``.
-
-The ladder is automatic, so ``setup`` starts preferring final releases the moment one qualifies.
-Override it with ``--wheel PATH`` or ``--build-from-source``. The minimum version itself lives in
-:code-file:`scripts/_install_deps.sh <examples/camera_viz/scripts/_install_deps.sh>`.
+There is no need to install the ``isaacteleop`` pip package yourself. ``setup`` builds the
+sample's own environment: ``isaacteleop[cloudxr]`` — the ``cloudxr`` extra is not optional here,
+since XR is the default display mode and the viewer launches the runtime itself — plus every
+other Python dependency, into ``.venv/`` via ``uv``. It resolves a version new enough for the
+sample on its own, falling back to a release candidate and then, after asking, to a source build
+of the surrounding checkout (:code-file:`scripts/_install_deps.sh
+<examples/camera_viz/scripts/_install_deps.sh>` holds the minimum; ``--wheel`` and
+``--build-from-source`` override the choice). Finally it probes the system packages it needs and
+prints the exact ``apt-get`` line to approve — declining, or a non-interactive run, aborts.
 
 By default ``setup`` provisions the direct-mode path — USB / UVC and OAK-D camera support. Split
 mode (RTP) and ZED support are opt-in, since both pull in dependencies the direct path never
@@ -103,18 +90,22 @@ needs. Flags trim or extend that:
      - Install into an existing virtual environment instead of creating ``.venv/``.
    * - ``--wheel PATH``
      - Install a locally built ``isaacteleop`` wheel instead of resolving one from the index — for
-       developing Isaac Teleop itself (see :doc:`/getting_started/build_from_source/index`).
+       developing Isaac Teleop itself.
    * - ``--build-from-source``
-     - Skip the index entirely and build ``isaacteleop`` from the surrounding checkout, and
-       answer step 3's prompt without asking.
+     - Skip the package index and build ``isaacteleop`` from the surrounding checkout without
+       prompting — a full C++ / CUDA / Vulkan build (see
+       :doc:`/getting_started/build_from_source/index`).
 
-First run — no camera required
-------------------------------
+.. _recorded-camera-streaming:
 
-The video-replay source (``type: video``) plays a recording through exactly the same path a live
-camera uses, so it doubles as the quickest end-to-end check and as a stand-in feed while the real
-camera isn't available. A test clip ships with the repo and ``configs/replay.yaml`` already points
-at it:
+First run — a recording, no camera required
+-------------------------------------------
+
+The recorded-camera source (``type: video``) replays a video file through exactly the same
+source → layer → Televiz path a live camera uses. It is the supported way to stream recorded
+camera data, it needs no extra setup, and it is the quickest end-to-end check. A test clip ships
+with the repo, and :code-file:`configs/replay.yaml <examples/camera_viz/configs/replay.yaml>`
+already points at it:
 
 .. code-block:: bash
 
@@ -134,10 +125,38 @@ coming up::
 and the clip looping on a plane in the headset once it connects — or in a desktop window
 (``mode=window, xr=False``) with the ``--mode window`` override, which starts no runtime.
 
-To replay your own video, set a custom ``path:`` in :code-file:`configs/replay.yaml
-<examples/camera_viz/configs/replay.yaml>` — relative paths resolve against the YAML's directory.
-``loop: false`` holds the last frame instead of rewinding; ``stereo: true`` replays a side-by-side
-recording (e.g. from a ZED) as stereo, splitting each frame into per-eye views (direct mode only).
+Replaying your own recording
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Point ``path`` at any file OpenCV's FFmpeg backend reads — mp4 / mkv / webm carrying H.264,
+HEVC, AV1, and so on. The file is probed once at startup for its size and frame rate (a missing
+or absurd rate falls back to 30 fps); a missing or unreadable file is a configuration error and
+fails immediately instead of retrying like a camera would. A complete config:
+
+.. code-block:: yaml
+
+   source: local
+
+   cameras:
+     - name: replay
+       enabled: true
+       type: video
+       path: ../test_data/recording.mp4   # required; relative to this YAML's directory
+       loop: true                         # false = hold the last frame at end of file
+       fps: 0                             # 0 = the file's native rate
+       stereo: false                      # true = split a side-by-side recording into eyes
+       # width/height default to the file's native size (per eye when stereo)
+
+   display:
+     mode: xr                             # or: window
+     placements:
+       replay: { lock_mode: lazy, distance: 1.5 }
+
+With ``source: rtp``, ``width``, ``height``, and ``fps`` become required — the sender paces its
+encode loop at ``fps`` and the receiver sizes its decoder from the config — and ``stereo`` is
+rejected, since the sender needs per-eye streams. A mono recording is otherwise a fine capture
+side for :ref:`split mode <split-mode>` and for ``loopback``, which exercises the whole
+encode → UDP → decode path with no camera attached.
 
 Supported sources
 -----------------
@@ -158,8 +177,9 @@ The source kind is selected by the ``type`` field of each entry in the YAML ``ca
    * - ``zed``
      - ZED 2 / Mini / X One; mono or ``stereo: true`` (per-eye SDK retrieve, zero-copy on the GPU).
    * - ``video``
-     - Video-file replay (anything OpenCV's FFmpeg backend reads). Loops by default;
-       ``stereo: true`` splits side-by-side recordings into eyes (viewer only).
+     - Recorded camera data — video-file replay (anything OpenCV's FFmpeg backend reads). Loops
+       by default; ``stereo: true`` splits side-by-side recordings into eyes (viewer only). See
+       :ref:`recorded-camera-streaming`.
    * - ``synthetic``
      - Debugging tool — GPU-generated test pattern, no hardware or file.
 
@@ -253,6 +273,8 @@ serving. Useful flags:
 - ``--cloudxr-device-profile PROFILE`` — ``NV_DEVICE_PROFILE`` (default ``Quest3``).
 
 Run ``camera_viz.py --help`` for the rest (install dir, env-config file, WSS proxy toggle).
+
+.. _split-mode:
 
 Split mode — robot → workstation over RTP
 -----------------------------------------


### PR DESCRIPTION
**Camera Streaming — QA finding (1.4).** QA reported that
`references/camera_streaming.html` had no documented workflow for streaming
recorded camera data. The `type: video` source was covered in two paragraphs
under a heading that never used the word "recorded", with no format list,
parameter reference, or standalone example — so users had to infer the setup or
read the implementation.

Adds an anchored section covering supported containers/codecs, the startup probe
and fps fallback, fail-fast on an unreadable path, a complete annotated config,
and the `source: rtp` rules (width/height/fps required, stereo rejected), cross-
linked from the intro and the Supported sources table. Also trims Setup, where
the release/rc/source-build ladder was 23 lines of packaging policy that belongs
with the build-from-source guide.

**Televiz — runtime behaviour and structure.** The page documented the API
surface but not the behaviour a developer has to get right, which lived only in
headers: `submit()` blocks on a stream synchronize (buffer reusable on return),
is single-producer per layer, and its stereo overload has a stream precondition
that silently corrupts an eye when missed; layers are a latest-wins mailbox, so
fast producers drop frames rather than queueing; frames must be GPU-resident
RGBA8 at exactly the layer's resolution.

Adds a Performance and diagnostics section — the field lists for
`get_frame_timing_stats()` / `get_gpu_timing()` (previously named with no
fields), and a latency budget covering the six stages end to end. The
compositor-side figures are measured on an RTX 6000 Ada in offscreen mode with
the method stated; capture and CloudXR transport are described structurally
rather than guessed at.

Restructures Layers so the shared model comes first: composition model → shared
configuration → submitting frames → the three surfaces → ProjectionLayer.
Previously the composition section came fourth, after three sections that
forward-referenced it, and Cylinder/Equirect defined their config by pointing
back at QuadLayer's table.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized Televiz layer guidance around texture and projection layers.
  * Added details on XR composition, blending, alpha handling, stereo behavior, frame submission, performance, and diagnostics.
  * Documented runtime requirements and validation for cylinder and equirectangular layers.
  * Added recorded video replay guidance for camera streaming, including setup, supported formats, looping, stereo handling, and RTP compatibility.
  * Documented dependency resolution, source builds, and the `--build-from-source` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->