### PR TITLE
feat(examples/teleop_ros2): Add head-relative EE pose frame to teleop_ros2 example

### DIFF
--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -73,6 +73,7 @@ Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
   - `world_frame` → `right_wrist_frame`: Right wrist transform (published in `controller_teleop` and `hand_teleop` modes)
   - `world_frame` → `left_wrist_frame`: Left wrist transform (published in `controller_teleop` and `hand_teleop` modes)
   - `world_frame` → `head_frame`: Head transform (published in `controller_teleop` and `hand_teleop` modes)
+  - With `ee_poses_frame:=head` the wrist transforms are parented to `head_frame` instead of `world_frame`
 
 ## Run in Docker
 
@@ -125,7 +126,7 @@ docker run --rm --gpus all --net=host --ipc=host \
   -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `ee_poses_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 
@@ -143,6 +144,29 @@ The `mode` parameter selects the teleoperation scenario and which topics are pub
 | `full_body` | `full_body` and `controller_data` |
 
 Example: `--ros-args -p mode:=controller_raw`
+
+### EE Poses Frame
+
+The `ee_poses_frame` parameter selects the reference frame of `xr_teleop/ee_poses`:
+
+| Value | Behavior |
+|-------|----------|
+| `world` (default) | Absolute poses in `world_frame`; wrist TFs parented to `world_frame` |
+| `head` | Poses relative to the headset, stamped `head_frame`; wrist TFs parented to `head_frame` |
+
+Head-relative poses stay fixed when the operator walks or turns, so they track the
+hands as the robot's end effectors see them rather than as the session origin does.
+When no head pose is available the node warns and publishes in `world_frame`.
+
+```bash
+docker run --rm --gpus all --net=host --ipc=host \
+  -e NVIDIA_VISIBLE_DEVICES=all -e NVIDIA_DRIVER_CAPABILITIES=all \
+  -e ROS_LOCALHOST_ONLY=1 \
+  -v $HOME/.cloudxr:/root/.cloudxr \
+  --name teleop_ros2_ref \
+  teleop_ros2_ref --ros-args -p cloudxr_accept_eula:=true \
+  -p ee_poses_frame:=head
+```
 
 ### OOB Teleop Control
 

--- a/examples/teleop_ros2/python/constants.py
+++ b/examples/teleop_ros2/python/constants.py
@@ -26,6 +26,11 @@ class TeleopMode(StrEnum):
     FULL_BODY = "full_body"
 
 
+class EePoseFrame(StrEnum):
+    WORLD = "world"
+    HEAD = "head"
+
+
 BODY_JOINT_NAMES = [e.name for e in BodyJointIndex]
 HAND_POSE_JOINT_INDICES = tuple(
     HandJointIndex(i)
@@ -35,6 +40,7 @@ HAND_POSE_NAMES = [joint.name for joint in HAND_POSE_JOINT_INDICES]
 HAND_RETARGETERS = tuple(retargeter.value for retargeter in HandRetargeter)
 SHARPA_HAND_RETARGETERS = (HandRetargeter.PINK_IK, HandRetargeter.DEXPILOT)
 TELEOP_MODES = tuple(mode.value for mode in TeleopMode)
+EE_POSE_FRAMES = tuple(f.value for f in EePoseFrame)
 
 TRIHAND_JOINT_NAMES = [
     "thumb_rotation",

--- a/examples/teleop_ros2/python/geometry.py
+++ b/examples/teleop_ros2/python/geometry.py
@@ -11,6 +11,47 @@ from geometry_msgs.msg import Pose, TransformStamped
 from scipy.spatial.transform import Rotation
 
 
+def apply_relative_pose(reference: Pose, pose: Pose) -> Pose:
+    """
+    Transform ``pose`` in ``reference``'s frame, both poses needs to be
+    initially in the same frame.
+
+    This is equivalent to:
+
+        T_reference_pose = inv(T_world_reference) @ T_world_pose
+    """
+    reference_pos = np.array(
+        [reference.position.x, reference.position.y, reference.position.z],
+        dtype=float,
+    )
+    reference_rot = Rotation.from_quat(
+        [
+            reference.orientation.x,
+            reference.orientation.y,
+            reference.orientation.z,
+            reference.orientation.w,
+        ]
+    )
+    pos = np.array(
+        [pose.position.x, pose.position.y, pose.position.z],
+        dtype=float,
+    )
+    rot = Rotation.from_quat(
+        [
+            pose.orientation.x,
+            pose.orientation.y,
+            pose.orientation.z,
+            pose.orientation.w,
+        ]
+    )
+
+    reference_rot_inv = reference_rot.inv()
+    return to_pose(
+        reference_rot_inv.apply(pos - reference_pos),
+        (reference_rot_inv * rot).as_quat(),
+    )
+
+
 def apply_manus_controller_to_hand_pose(pose: Pose, side: str) -> Pose:
     """
     Apply MANUS controller-to-hand calibration in the pose's current frame.

--- a/examples/teleop_ros2/python/messages.py
+++ b/examples/teleop_ros2/python/messages.py
@@ -28,6 +28,7 @@ from isaacteleop.retargeting_engine.tensor_types.indices import (
 from constants import BODY_JOINT_NAMES, HAND_POSE_JOINT_INDICES, HAND_POSE_NAMES
 from geometry import (
     apply_manus_controller_to_hand_pose,
+    apply_relative_pose,
     apply_transform_to_pose,
     make_transform,
     to_pose,
@@ -235,6 +236,33 @@ def build_controller_msg(
     )
 
 
+def rebase_ee_poses_relative_to_head(
+    ee_poses_msg: NamedPoseArray,
+    head_msg: PoseStamped | None,
+    left_wrist_frame: str,
+    right_wrist_frame: str,
+) -> tuple[NamedPoseArray, list[TransformStamped]]:
+    relative_poses: list[Pose | None] = []
+    for pose, is_valid in zip(ee_poses_msg.pose, ee_poses_msg.is_valid):
+        if is_valid:
+            relative_poses.append(apply_relative_pose(head_msg.pose, pose))
+        else:
+            relative_poses.append(None)
+
+    rebased_msg = _compose_ee_msg(
+        relative_poses[0],
+        relative_poses[1],
+        ee_poses_msg.header.stamp,
+        "head",
+    )
+
+    return rebased_msg, _wrist_tfs_from_ee_msg(
+        rebased_msg,
+        left_wrist_frame,
+        right_wrist_frame,
+    )
+
+
 def build_ee_output_from_controllers(
     left_ctrl: OptionalTensorGroup,
     right_ctrl: OptionalTensorGroup,
@@ -278,6 +306,7 @@ def build_ee_output_from_hands(
     right_wrist_frame: str,
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
+    reference_pose: Pose | None = None,
 ) -> tuple[NamedPoseArray, list[TransformStamped]]:
     """Build the hand-derived EE message and its valid wrist TFs."""
     left_pose = _compute_ee_pose_from_hand(

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -32,8 +32,10 @@ from isaacteleop.teleop_session_manager import SessionMode
 from constants import (
     HAND_RETARGETERS,
     TELEOP_MODES,
+    EE_POSE_FRAMES,
     HandRetargeter,
     TeleopMode,
+    EePoseFrame,
     resolve_hand_retargeter,
     uses_hands_source_for_controller,
 )
@@ -76,6 +78,7 @@ class NodeParameters:
     transform_rotation: Rotation | None
     left_finger_joint_name_aliases: list[str] | None
     right_finger_joint_name_aliases: list[str] | None
+    ee_poses_frame: EePoseFrame
 
 
 def _load_cloudxr(node: Node) -> CloudXRParams:
@@ -363,6 +366,30 @@ def _load_mode(node: Node) -> TeleopMode:
     return mode
 
 
+def _load_ee_poses_frame(node: Node) -> EePoseFrame:
+    node.declare_parameter(
+        "ee_poses_frame",
+        EePoseFrame.WORLD.value,
+        ParameterDescriptor(
+            description=(
+                "Reference frame of the published end effector poses. "
+                "'world' (default) publishes absolute poses in world_frame; "
+                "'head' publishes poses relative to head_frame."
+            )
+        ),
+    )
+    raw_frame = node.get_parameter("ee_poses_frame").get_parameter_value().string_value
+    try:
+        ee_poses_frame = EePoseFrame(raw_frame)
+    except ValueError as exc:
+        raise ValueError(
+            f"Parameter 'ee_poses_frame' must be one of {EE_POSE_FRAMES}, "
+            f"got {raw_frame!r}"
+        ) from exc
+    node.get_logger().info(f"EE poses frame: {ee_poses_frame}")
+    return ee_poses_frame
+
+
 def _load_pedal_collection_id(node: Node) -> str:
     node.declare_parameter(
         "pedal_collection_id",
@@ -477,6 +504,7 @@ def create_node_parameters(node: Node) -> NodeParameters:
     transform_rotation = _load_transform_rotation(node)
     left_finger_joint_name_aliases = _load_finger_joint_name_aliases(node, "left")
     right_finger_joint_name_aliases = _load_finger_joint_name_aliases(node, "right")
+    ee_poses_frame = _load_ee_poses_frame(node)
 
     return NodeParameters(
         mode=mode,
@@ -497,4 +525,5 @@ def create_node_parameters(node: Node) -> NodeParameters:
         transform_rotation=transform_rotation,
         left_finger_joint_name_aliases=left_finger_joint_name_aliases,
         right_finger_joint_name_aliases=right_finger_joint_name_aliases,
+        ee_poses_frame=ee_poses_frame,
     )

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -36,6 +36,7 @@ TF frames published in hand_teleop and controller_teleop modes (configurable via
   - world_frame -> right_wrist_frame
   - world_frame -> left_wrist_frame
   - world_frame -> head_frame
+  - (With ee_poses_frame=head, world_frame -> head_frame -> left/right_wrist_frame)
 """
 
 import time
@@ -62,6 +63,7 @@ from messages import (
     build_hand_msg,
     build_head_output,
     build_root_command_output,
+    rebase_ee_poses_relative_to_head,
 )
 from teleop_profiles import (
     PublishType,
@@ -111,7 +113,9 @@ class TeleopRos2Node(Node):
         )
         self._pub_head = self.create_publisher(PoseStamped, "xr_teleop/head_pose", 10)
 
-    def _publish_ee_poses_from_controllers(self, result: SessionResult, now) -> None:
+    def _publish_ee_poses_from_controllers(
+        self, result: SessionResult, now, head_msg: PoseStamped | None
+    ) -> None:
         ee_poses_msg, wrist_tfs = build_ee_output_from_controllers(
             result["controller_left"],
             result["controller_right"],
@@ -123,6 +127,20 @@ class TeleopRos2Node(Node):
             self._params.transform_translation,
             self._params.controller_uses_hands_source,
         )
+        if self._params.ee_poses_frame.value == "head":
+            if head_msg is None:
+                self.get_logger().warn(
+                    "ee_poses_frame is 'head' but no head pose is available; "
+                    "publishing ee_poses_frame in default frame 'world'.",
+                    throttle_duration_sec=5.0,
+                )
+            else:
+                ee_poses_msg, wrist_tfs = rebase_ee_poses_relative_to_head(
+                    ee_poses_msg,
+                    head_msg,
+                    self._params.left_wrist_frame,
+                    self._params.right_wrist_frame,
+                )
         self._pub_ee_poses.publish(ee_poses_msg)
         if wrist_tfs:
             self._tf_broadcaster.sendTransform(wrist_tfs)
@@ -161,7 +179,9 @@ class TeleopRos2Node(Node):
         )
         self._pub_hand.publish(hand_msg)
 
-    def _publish_ee_poses_from_hands(self, result: SessionResult, now) -> None:
+    def _publish_ee_poses_from_hands(
+        self, result: SessionResult, now, head_msg: PoseStamped | None
+    ) -> None:
         ee_poses_msg, wrist_tfs = build_ee_output_from_hands(
             result["hand_left"],
             result["hand_right"],
@@ -172,11 +192,25 @@ class TeleopRos2Node(Node):
             self._params.transform_rotation,
             self._params.transform_translation,
         )
+        if self._params.ee_poses_frame.value == "head":
+            if head_msg is None:
+                self.get_logger().warn(
+                    "ee_poses_frame is 'head' but no head pose is available;"
+                    "publishing ee_poses_frame in default frame 'world'.",
+                    throttle_duration_sec=5.0,
+                )
+            else:
+                ee_poses_msg, wrist_tfs = rebase_ee_poses_relative_to_head(
+                    ee_poses_msg,
+                    head_msg,
+                    self._params.left_wrist_frame,
+                    self._params.right_wrist_frame,
+                )
         self._pub_ee_poses.publish(ee_poses_msg)
         if wrist_tfs:
             self._tf_broadcaster.sendTransform(wrist_tfs)
 
-    def _publish_head(self, result: SessionResult, now) -> None:
+    def _publish_head(self, result: SessionResult, now) -> PoseStamped | None:
         maybe_head_output = build_head_output(
             result["head"],
             now,
@@ -191,6 +225,8 @@ class TeleopRos2Node(Node):
         head_msg, head_tf = maybe_head_output
         self._pub_head.publish(head_msg)
         self._tf_broadcaster.sendTransform(head_tf)
+
+        return head_msg
 
     def _publish_root_command(self, result: SessionResult, now) -> None:
         maybe_root_output = build_root_command_output(
@@ -235,16 +271,22 @@ class TeleopRos2Node(Node):
 
                         now = self.get_clock().now().to_msg()
 
+                        if PublishType.HEAD in self._profile_spec.publish_types:
+                            head_messages = self._publish_head(result, now)
                         if (
                             PublishType.EE_FROM_HANDS
                             in self._profile_spec.publish_types
                         ):
-                            self._publish_ee_poses_from_hands(result, now)
+                            self._publish_ee_poses_from_hands(
+                                result, now, head_messages
+                            )
                         if (
                             PublishType.EE_FROM_CONTROLLERS
                             in self._profile_spec.publish_types
                         ):
-                            self._publish_ee_poses_from_controllers(result, now)
+                            self._publish_ee_poses_from_controllers(
+                                result, now, head_messages
+                            )
                         if PublishType.HAND_POSES in self._profile_spec.publish_types:
                             self._publish_hand_poses(result, now)
                         if PublishType.ROOT_COMMAND in self._profile_spec.publish_types:
@@ -254,8 +296,6 @@ class TeleopRos2Node(Node):
                             in self._profile_spec.publish_types
                         ):
                             self._publish_finger_joints(result, now)
-                        if PublishType.HEAD in self._profile_spec.publish_types:
-                            self._publish_head(result, now)
                         if (
                             PublishType.CONTROLLER_PAYLOAD
                             in self._profile_spec.publish_types

--- a/examples/teleop_ros2/python/tests/test_geometry.py
+++ b/examples/teleop_ros2/python/tests/test_geometry.py
@@ -10,6 +10,7 @@ from scipy.spatial.transform import Rotation
 
 from geometry import (
     apply_manus_controller_to_hand_pose,
+    apply_relative_pose,
     apply_transform_to_pose,
     to_pose,
 )
@@ -80,3 +81,55 @@ def test_manus_calibration_is_side_specific_and_finite() -> None:
 def test_manus_calibration_rejects_unknown_side() -> None:
     with pytest.raises(ValueError, match="side must be 'left' or 'right'"):
         apply_manus_controller_to_hand_pose(to_pose([0.0, 0.0, 0.0]), "center")
+
+
+def test_relative_pose_with_unrotated_reference_subtracts_position() -> None:
+    reference = to_pose([0.0, 0.10, 1.60])
+    pose = to_pose([-0.20, 0.15, 1.20])
+
+    relative = apply_relative_pose(reference, pose)
+
+    np.testing.assert_allclose(_position(relative), [-0.20, 0.05, -0.40], atol=1e-7)
+
+
+def test_relative_pose_rotates_the_offset_into_the_reference_basis() -> None:
+    # Subtracting positions alone would leave the offset unchanged, so a yawed
+    # reference is what distinguishes a correct implementation from that one.
+    reference = to_pose(
+        [0.0, 0.10, 1.60],
+        Rotation.from_euler("z", 90.0, degrees=True).as_quat(),
+    )
+    pose = to_pose([-0.20, 0.15, 1.20])
+
+    relative = apply_relative_pose(reference, pose)
+
+    np.testing.assert_allclose(_position(relative), [0.05, 0.20, -0.40], atol=1e-7)
+
+
+def test_relative_pose_composes_orientation_instead_of_changing_its_basis() -> None:
+    # Conjugation would return the pose orientation unchanged here; composition
+    # returns the reference's inverse.
+    reference_rotation = Rotation.from_euler("z", 40.0, degrees=True)
+    reference = to_pose([0.0, 0.0, 0.0], reference_rotation.as_quat())
+    pose = to_pose([0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0])
+
+    relative = apply_relative_pose(reference, pose)
+
+    np.testing.assert_allclose(
+        Rotation.from_quat(_orientation(relative)).as_matrix(),
+        reference_rotation.inv().as_matrix(),
+        atol=1e-7,
+    )
+
+
+def test_relative_pose_returns_a_new_pose_without_mutating_inputs() -> None:
+    reference = to_pose([1.0, 0.0, 0.0])
+    pose = to_pose([3.0, 0.0, 0.0])
+
+    relative = apply_relative_pose(reference, pose)
+
+    assert relative is not pose
+    assert relative is not reference
+    np.testing.assert_allclose(_position(reference), [1.0, 0.0, 0.0])
+    np.testing.assert_allclose(_position(pose), [3.0, 0.0, 0.0])
+    np.testing.assert_allclose(_position(relative), [2.0, 0.0, 0.0])

--- a/examples/teleop_ros2/python/tests/test_messages.py
+++ b/examples/teleop_ros2/python/tests/test_messages.py
@@ -7,7 +7,9 @@
 import msgpack
 import numpy as np
 from builtin_interfaces.msg import Time
+from geometry_msgs.msg import PoseStamped
 from std_msgs.msg import ByteMultiArray
+from teleop_ros2_interfaces.msg import NamedPoseArray
 
 from isaacteleop.retargeting_engine.interface import (
     OptionalTensorGroup,
@@ -32,6 +34,7 @@ from isaacteleop.retargeting_engine.tensor_types import (
 )
 
 from constants import BODY_JOINT_NAMES, HAND_POSE_NAMES
+from geometry import to_pose
 from messages import (
     build_controller_msg,
     build_ee_output_from_controllers,
@@ -41,6 +44,7 @@ from messages import (
     build_hand_msg,
     build_head_output,
     build_root_command_output,
+    rebase_ee_poses_relative_to_head,
 )
 
 
@@ -377,3 +381,65 @@ def test_build_root_command_output_maps_twist_and_height() -> None:
 
 def test_build_root_command_output_returns_none_when_input_is_absent() -> None:
     assert build_root_command_output(_root_command(None), Time(), "world") is None
+
+
+def _world_ee_msg(right_is_valid: bool = True) -> NamedPoseArray:
+    """Build a world-frame EE message with the left side always tracked."""
+    msg = NamedPoseArray()
+    msg.header.stamp = Time(sec=12, nanosec=34)
+    msg.header.frame_id = "world"
+    sides = (
+        ("left", [-0.20, 0.15, 1.20], True),
+        ("right", [0.20, 0.15, 1.20], right_is_valid),
+    )
+    for side, position, is_valid in sides:
+        msg.name.append(side)
+        msg.pose.append(to_pose(position if is_valid else [0.0, 0.0, 0.0]))
+        msg.is_valid.append(is_valid)
+    return msg
+
+
+def _head_msg() -> PoseStamped:
+    head = PoseStamped()
+    head.header.frame_id = "world"
+    head.pose = to_pose([0.0, 0.10, 1.60])
+    return head
+
+
+def _position(pose) -> list[float]:
+    return [pose.position.x, pose.position.y, pose.position.z]
+
+
+def test_rebase_ee_poses_expresses_message_and_tfs_in_the_head_frame() -> None:
+    rebased, transforms = rebase_ee_poses_relative_to_head(
+        _world_ee_msg(), _head_msg(), "left_wrist", "right_wrist"
+    )
+
+    assert rebased.header.frame_id == "head"
+    assert rebased.header.stamp.sec == 12
+    assert rebased.header.stamp.nanosec == 34
+    assert list(rebased.name) == ["left", "right"]
+    assert list(rebased.is_valid) == [True, True]
+    np.testing.assert_allclose(
+        _position(rebased.pose[0]), [-0.20, 0.05, -0.40], atol=1e-7
+    )
+    np.testing.assert_allclose(
+        _position(rebased.pose[1]), [0.20, 0.05, -0.40], atol=1e-7
+    )
+    assert [transform.header.frame_id for transform in transforms] == ["head", "head"]
+    assert [transform.child_frame_id for transform in transforms] == [
+        "left_wrist",
+        "right_wrist",
+    ]
+
+
+def test_rebase_ee_poses_keeps_untracked_sides_invalid() -> None:
+    rebased, transforms = rebase_ee_poses_relative_to_head(
+        _world_ee_msg(right_is_valid=False), _head_msg(), "left_wrist", "right_wrist"
+    )
+
+    assert list(rebased.is_valid) == [True, False]
+    np.testing.assert_allclose(_position(rebased.pose[1]), [0.0, 0.0, 0.0])
+    assert rebased.pose[1].orientation.w == 1.0
+    assert len(transforms) == 1
+    assert transforms[0].child_frame_id == "left_wrist"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Fixes #772  

In `examples/teleop_ros2`, adds a head-relative reference frame for `xr_teleop/ee_poses`, now the ee_poses contains relative position to head by specifying `ee_poses_frame:=head`. This will also change the parent of `left/right_wrist_frame` from default `world_frame` to `head_frame`. Previously the node only published EE poses in `world_frame`.

A new `ee_poses_frame` parameter selects the reference frame. `world` is the default and preserves existing behavior, `head` would transform the ee_poses pose relative to the head pose. 

| Value | Behavior |
|-------|----------|
| `world` (default) | Absolute poses in `world_frame`; wrist TFs parented to `world_frame` |
| `head` | Poses relative to the headset, stamped `head_frame`; wrist TFs parented to `head_frame` |

  Changes:

- `geometry.py`: `apply_relative_pose(reference, pose)` — transform a pose in a reference pose's frame, `inv(T_world_reference) @ T_world_pose`.
- `messages.py`: `rebase_ee_poses_relative_to_head()` — rebuilds the EE message with transformed poses and regenerates its wrist TFs for them.
- `node_parameters.py` / `constants.py`: `ee_poses_frame` parameter and `EePoseFrame` enum.
- `teleop_ros2_node.py`: the head message is built before the EE message. So the reference head pose comes from the same session step, and is passed to both EE publishers (controller and hand).
- Docs: README parameter list, an `EE Poses Frame` section, the `/tf` note, and the module docstring.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Ubuntu 24.04, ROS 2 Jazzy, container built from `examples/teleop_ros2/Dockerfile`. 

**Unit** 41 passed (35 existing, 6 new), via `uv run --no-sync --with pytest pytest -q`.

`tests/test_geometry.py` — `apply_relative_pose`:
  - unrotated reference subtracts position
  - rotated reference rotates the offset into its basis
  - orientation is composed transform (q_ref⁻¹ · q), not conjugated (R · q · R⁻¹)
  - inputs are not mutated

`tests/test_messages.py` — `rebase_ee_poses_relative_to_head`:
  - message and TFs land in the head frame, `frame_id`, stamp, names and validity preserved. Both poses rebased; wrist TFs reparented to `head` 
  - untracked sides stay invalid, `is_valid=False`, and no transform emitted.

**End-to-end** live CloudXR session driven by the browser VR emulator. With `ee_poses_frame:=head`, `xr_teleop/ee_poses` publishes `frame_id: head` and `is_valid: [true, true]`, and the poses change under head motion with the controllers stationary; with `world` the same motion leaves them unchanged.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the end-effector pose frame: `world` or `head`.
  * Added head-relative pose output with regenerated wrist transforms.
  * Added fallback to world-frame output when head tracking is unavailable.
  * Added configuration validation and a Docker usage example.

* **Documentation**
  * Updated available parameters and published transform behavior.

* **Tests**
  * Added coverage for pose rebasing, rotations, transforms, validity, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->