### PR TITLE
ROS: add Wuji hand retargeting

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -698,10 +698,20 @@ jobs:
           --entrypoint bash teleop_ros2_ref:${{ env.ROS_DISTRO }} -c \
           "source /usr/local/bin/teleop-env-setup && exec /opt/isaacteleop/install/examples/teleop_ros2/cpp/integration_tests/teleop_ros2_mcap_generator '$REPLAY_MCAP'"
 
-        for mode in controller_teleop hand_teleop controller_raw full_body; do
-          echo "Testing mode: $mode"
-          LOG_FILE="${LOG_FILE_BASE}_${mode}.log"
-          RUN_NAME="teleop-ros2-${PROJECT_NAME}-${mode//_/-}"
+        scenarios=(
+          "controller_teleop mode_default"
+          "hand_teleop mode_default"
+          "controller_raw mode_default"
+          "full_body mode_default"
+          "controller_teleop wuji"
+          "hand_teleop wuji"
+        )
+        for scenario in "${scenarios[@]}"; do
+          read -r mode hand_retargeter <<< "$scenario"
+          scenario_name="${mode}_${hand_retargeter}"
+          echo "Testing mode: $mode (hand_retargeter=$hand_retargeter)"
+          LOG_FILE="${LOG_FILE_BASE}_${scenario_name}.log"
+          RUN_NAME="teleop-ros2-${PROJECT_NAME}-${scenario_name//_/-}"
           verifier_rc=0
           docker_rc=0
           started=false
@@ -714,7 +724,7 @@ jobs:
             -v /tmp:/tmp \
             -e PYTHONUNBUFFERED=1 \
             --entrypoint bash teleop_ros2_ref:${{ env.ROS_DISTRO }} -c \
-            "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$mode -p mcap_replay_path:=$REPLAY_MCAP" >/dev/null
+            "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$mode -p hand_retargeter:=$hand_retargeter -p mcap_replay_path:=$REPLAY_MCAP" >/dev/null
 
           deadline=$((SECONDS + READINESS_TIMEOUT_SEC))
           while [ "$SECONDS" -lt "$deadline" ]; do
@@ -740,7 +750,7 @@ jobs:
             if docker exec \
               -e PYTHONUNBUFFERED=1 \
               "$RUN_NAME" bash -c \
-              "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync python -m integration_tests.teleop_ros2_topic_verifier --mode $mode"; then
+              "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync python -m integration_tests.teleop_ros2_topic_verifier --mode $mode --hand-retargeter $hand_retargeter"; then
               verifier_rc=0
             else
               verifier_rc=$?
@@ -751,11 +761,11 @@ jobs:
           else
             running=$(docker inspect -f '{{.State.Running}}' "$RUN_NAME" 2>/dev/null || echo false)
             if [ "$running" = "true" ]; then
-              echo "Error: TeleopSession did not report readiness within ${READINESS_TIMEOUT_SEC}s in mode $mode"
+              echo "Error: TeleopSession did not report readiness within ${READINESS_TIMEOUT_SEC}s for $scenario_name"
               docker stop --time 5 "$RUN_NAME" >/dev/null || true
               docker wait "$RUN_NAME" >/dev/null || true
             else
-              echo "Error: teleop_ros2_node exited before readiness in mode $mode (exit code $docker_rc)"
+              echo "Error: teleop_ros2_node exited before readiness for $scenario_name (exit code $docker_rc)"
             fi
           fi
 
@@ -771,7 +781,7 @@ jobs:
             exit 1
           fi
           if [ "$verifier_rc" -ne 0 ]; then
-            echo "Error: topic verifier failed in mode $mode (exit code $verifier_rc)"
+            echo "Error: topic verifier failed for $scenario_name (exit code $verifier_rc)"
             exit "$verifier_rc"
           fi
         done

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -673,6 +673,25 @@ jobs:
           --build-arg BUNDLE_ROBOTIC_GROUNDING=${{ steps.setup-v2d-src.outputs.bundled || 'false' }} \
           -t teleop_ros2_ref:${{ env.ROS_DISTRO }} .
 
+    - name: Run teleop_ros2 Python unit tests
+      run: |
+        set -euo pipefail
+        TEST_IMAGE="teleop_ros2_ref-tests:${{ env.ROS_DISTRO }}"
+        trap 'docker image rm -f "$TEST_IMAGE" >/dev/null 2>&1 || true' EXIT
+
+        docker build -f examples/teleop_ros2/Dockerfile \
+          --target test \
+          --build-arg ROS_DISTRO=${{ env.ROS_DISTRO }} \
+          --build-arg PYTHON_VERSION=${{ matrix.python_version }} \
+          --build-arg BUNDLE_ROBOTIC_GROUNDING=${{ steps.setup-v2d-src.outputs.bundled || 'false' }} \
+          -t "$TEST_IMAGE" .
+
+        docker run --rm \
+          -e PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+          --entrypoint bash "$TEST_IMAGE" -c \
+          "source /usr/local/bin/teleop-env-setup && \
+           exec uv run --with pytest --no-sync pytest -v --tb=short tests"
+
     # MCAP replay path: feed a recorded fixture through the node
     # (SessionMode.REPLAY, no CloudXR runtime / GPU) across all teleop modes and
     # verify the published topics. The cheaper, deterministic check; runs before

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -172,6 +172,7 @@ ENV VK_DRIVER_FILES=/etc/vulkan/icd.d/nvidia_icd.json
 COPY src/core/python/requirements.txt \
      src/core/python/requirements-retargeters.txt \
      src/core/python/requirements-grounding.txt \
+     src/core/python/requirements-wuji.txt \
      src/core/python/requirements-cloudxr.txt \
      /tmp/
 RUN uv venv --python=${PYTHON_VERSION} && \
@@ -180,11 +181,13 @@ RUN uv venv --python=${PYTHON_VERSION} && \
         -r /tmp/requirements.txt \
         -r /tmp/requirements-retargeters.txt \
         -r /tmp/requirements-grounding.txt \
+        -r /tmp/requirements-wuji.txt \
         -r /tmp/requirements-cloudxr.txt \
         msgpack msgpack-numpy && \
     rm /tmp/requirements.txt \
        /tmp/requirements-retargeters.txt \
        /tmp/requirements-grounding.txt \
+       /tmp/requirements-wuji.txt \
        /tmp/requirements-cloudxr.txt
 
 COPY --from=builder /opt/isaacteleop/install /opt/isaacteleop/install

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -152,9 +152,9 @@ exec "$@"
 EOF
 
 # -----------------------------------------------------------------------------
-# Stage 3: runtime image (install tree only)
+# Stage 3: runtime base (install tree only)
 # -----------------------------------------------------------------------------
-FROM base
+FROM base AS runtime_base
 ARG PYTHON_VERSION
 
 WORKDIR /opt/isaacteleop/install/examples/teleop_ros2/python
@@ -219,6 +219,13 @@ RUN set -eu; \
     version=$(basename "$wheel" | sed -E 's/^isaacteleop-([^-]+)-.*$/\1/'); \
     echo "== pinning isaacteleop==${version} =="; \
     uv sync --no-dev --upgrade-package "isaacteleop==${version}"
+
+# Test-only image: keep the production runtime free of source tests.
+FROM runtime_base AS test
+COPY tests/python/examples/teleop_ros2/ tests/
+
+# Production image.
+FROM runtime_base AS runtime
 
 # Use --no-sync because the venv is already provisioned above.
 ENTRYPOINT ["/usr/local/bin/teleop-entrypoint", "uv", "run", "--no-sync", "teleop_ros2_node.py"]

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -20,8 +20,8 @@ publisher uses a different ID.
 
 ## Prerequisite: Hand Retargeting
 
-`hand_teleop` and the Sharpa variants of `controller_teleop` retarget OpenXR
-hand tracking to Sharpa hand joint commands via the `hand_retargeter`
+`hand_teleop` and the tracked-hand variants of `controller_teleop` retarget
+OpenXR hand tracking to robot hand joint commands via the `hand_retargeter`
 parameter:
 
 - `hand_retargeter:=mode_default` (default): keeps the mode-specific default
@@ -40,11 +40,26 @@ parameter:
 - `hand_retargeter:=pink_ik`: uses `SharpaHandRetargeter`. It requires the
   `isaacteleop[grounding]` runtime dependencies and the bundled
   `robotic_grounding` package data that provides the Sharpa MJCF assets.
+- `hand_retargeter:=wuji`: uses `WujiHandRetargeter` and requires
+  `isaacteleop[wuji]`. `wuji_hand_model` selects `wuji_hand` or `wuji_hand_2`
+  for both sides and defaults to `wuji_hand_2`. Each side publishes 20
+  firmware-order joints named `left_thumb_j0` through
+  `left_pinky_j3` and `right_thumb_j0` through `right_pinky_j3`. Missing or
+  invalid tracking currently publishes zero joint values, matching the other
+  retargeters in this example.
 
 In `controller_teleop`, explicitly setting `hand_retargeter:=dexpilot` or
 `hand_retargeter:=pink_ik` keeps XR controllers responsible for EE poses, wrist
 TFs, locomotion, and `controller_data`, while Manus/OpenXR hand data drives
 `xr_teleop/hand` and Sharpa `xr_teleop/finger_joints`.
+
+With `controller_teleop` and `hand_retargeter:=wuji`, controllers still provide
+locomotion and `controller_data`, while the ROS node obtains
+`xr_teleop/hand`, `xr_teleop/finger_joints`, EE poses, and wrist TFs from the
+Wuji plugin-injected OpenXR hand stream. The injected wrist pose comes from
+optical hand tracking when available, or from the controller aim pose plus the
+configured aim-to-wrist transform as fallback. The ROS node therefore does not
+apply the MANUS mount transform to this already-calibrated wrist pose.
 
 The Docker build fetches the pinned official Sharpa Wave URDFs and installs them
 at `/opt/isaacteleop/install/examples/teleop_ros2/assets/urdf/sharpa_standalone/`.
@@ -55,6 +70,41 @@ python3 examples/teleop_ros2/scripts/fetch_sharpa_wave_urdfs.py
 ```
 
 Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
+
+### Wuji glove input plugin
+
+The Wuji hand retargeter accepts any OpenXR hand-tracking source. To use a Wuji
+glove, build its external input plugin from the repository root:
+
+```bash
+./src/plugins/wuji_glove/install.sh
+```
+
+Start `teleop_ros2_node.py` first so its CloudXR runtime is available. Then, in
+the shell that launches the plugin, source that same runtime environment and
+start the plugin:
+
+```bash
+source ~/.cloudxr/run/cloudxr.env
+./build/src/plugins/wuji_glove/wuji_glove_plugin
+```
+
+The node and plugin must share the CloudXR runtime files and network namespace,
+and the gloves must be reachable from the plugin host. With the Docker command
+below, keep the `$HOME/.cloudxr` mount and host networking so an external plugin
+process can use the generated environment. The current ROS image installs the
+Wuji Python retargeting dependency, but it does not build or auto-launch the
+C++ glove plugin.
+
+The plugin defaults to automatic wrist-source selection: optical hand tracking
+is preferred, with the mounted controller as fallback. Set
+`WUJI_GLOVE_WRIST_SOURCE` to `hand_tracking` or `controller` to force one source.
+Override mount calibration when needed:
+
+```bash
+export WUJI_GLOVE_AIM_TO_WRIST_LEFT="px,py,pz,qx,qy,qz,qw"
+export WUJI_GLOVE_AIM_TO_WRIST_RIGHT="px,py,pz,qx,qy,qz,qw"
+```
 
 ## Published Topics
 
@@ -68,7 +118,7 @@ Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
   - Head pose
 - `xr_teleop/controller_data` (`std_msgs/ByteMultiArray`, msgpack-encoded dictionary)
 - `xr_teleop/finger_joints` (`sensor_msgs/JointState`)
-  - Retargeted finger joint angles for the robot; contains joint names and position arrays corresponding to the robot finger joints (TriHand in default `controller_teleop`, selected Sharpa retargeter in `hand_teleop`, or explicit Sharpa retargeter in `controller_teleop`)
+  - Retargeted finger joint angles for the robot; contains joint names and position arrays corresponding to the robot finger joints (TriHand in default `controller_teleop`, or the selected Sharpa/Wuji retargeter in tracked-hand modes)
 - `/tf` (`tf2_msgs/TFMessage`)
   - `world_frame` → `right_wrist_frame`: Right wrist transform (published in `controller_teleop` and `hand_teleop` modes)
   - `world_frame` → `left_wrist_frame`: Left wrist transform (published in `controller_teleop` and `hand_teleop` modes)
@@ -125,7 +175,7 @@ docker run --rm --gpus all --net=host --ipc=host \
   -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `wuji_hand_model`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 
@@ -137,7 +187,7 @@ The `mode` parameter selects the teleoperation scenario and which topics are pub
 
 | Mode | Topics published |
 |------|------------------|
-| `controller_teleop` (default) | `ee_poses` (from controller aim poses), `root_twist`, `root_pose`, `head_pose`, `finger_joints` (TriHand by default; Sharpa from Manus/OpenXR hands when `hand_retargeter:=dexpilot` or `hand_retargeter:=pink_ik`), `controller_data`, `tf` (from controller aim poses and head pose), and `hand` only for the explicit Sharpa retargeter path |
+| `controller_teleop` (default) | `ee_poses`, `root_twist`, `root_pose`, `head_pose`, `finger_joints`, `controller_data`, and `tf`; TriHand uses controller-derived finger joints and EE poses, explicit Sharpa retargeters add `hand` and use controller-derived EE poses with the MANUS mount transform, and Wuji adds `hand` while using the plugin-injected OpenXR wrist for EE poses and wrist TFs |
 | `hand_teleop` | `ee_poses` (from hand tracking wrists), `hand` (named left and right joint poses), `finger_joints` (finger joints in joint space), `root_twist`, `root_pose`, `head_pose`, `tf` (from hand tracking wrists and head pose); locomotion comes from the configured foot pedal collection |
 | `controller_raw` | `controller_data` only |
 | `full_body` | `full_body` and `controller_data` |

--- a/examples/teleop_ros2/python/constants.py
+++ b/examples/teleop_ros2/python/constants.py
@@ -17,6 +17,7 @@ class HandRetargeter(StrEnum):
     TRIHAND = "trihand"
     PINK_IK = "pink_ik"
     DEXPILOT = "dexpilot"
+    WUJI = "wuji"
 
 
 class TeleopMode(StrEnum):
@@ -34,7 +35,9 @@ HAND_POSE_JOINT_INDICES = tuple(
 HAND_POSE_NAMES = [joint.name for joint in HAND_POSE_JOINT_INDICES]
 HAND_RETARGETERS = tuple(retargeter.value for retargeter in HandRetargeter)
 SHARPA_HAND_RETARGETERS = (HandRetargeter.PINK_IK, HandRetargeter.DEXPILOT)
+TRACKED_HAND_RETARGETERS = (*SHARPA_HAND_RETARGETERS, HandRetargeter.WUJI)
 TELEOP_MODES = tuple(mode.value for mode in TeleopMode)
+WUJI_HAND_MODELS = ("wuji_hand", "wuji_hand_2")
 
 TRIHAND_JOINT_NAMES = [
     "thumb_rotation",
@@ -76,6 +79,15 @@ SHARPA_FINGER_JOINT_COUNT = len(SHARPA_WAVE_JOINT_NAMES)
 LEFT_SHARPA_WAVE_JOINT_NAMES = [f"left_{n}" for n in SHARPA_WAVE_JOINT_NAMES]
 RIGHT_SHARPA_WAVE_JOINT_NAMES = [f"right_{n}" for n in SHARPA_WAVE_JOINT_NAMES]
 
+WUJI_HAND_JOINT_NAMES = [
+    f"{finger}_j{joint_index}"
+    for finger in ("thumb", "index", "middle", "ring", "pinky")
+    for joint_index in range(4)
+]
+WUJI_HAND_JOINT_COUNT = len(WUJI_HAND_JOINT_NAMES)
+LEFT_WUJI_HAND_JOINT_NAMES = [f"left_{n}" for n in WUJI_HAND_JOINT_NAMES]
+RIGHT_WUJI_HAND_JOINT_NAMES = [f"right_{n}" for n in WUJI_HAND_JOINT_NAMES]
+
 DEX_HANDTRACKING_TO_BASELINK_FRAME_TRANSFORM = (0, -1, 0, -1, 0, 0, 0, 0, -1)
 
 
@@ -98,7 +110,7 @@ def resolve_hand_retargeter(
     return hand_retargeter
 
 
-def uses_hands_source_for_controller(
+def applies_manus_controller_to_hand_transform(
     mode: TeleopMode, hand_retargeter: HandRetargeter
 ) -> bool:
     return (

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -12,10 +12,16 @@ import math
 import sys
 import time
 from collections.abc import Callable
+from functools import partial
 
 import msgpack
 import rclpy
-from constants import TELEOP_MODES
+from constants import (
+    HAND_RETARGETERS,
+    LEFT_WUJI_HAND_JOINT_NAMES,
+    RIGHT_WUJI_HAND_JOINT_NAMES,
+    TELEOP_MODES,
+)
 from geometry_msgs.msg import PoseStamped, TwistStamped
 from isaacteleop.retargeting_engine.tensor_types.indices import (
     BodyJointIndex,
@@ -172,15 +178,27 @@ def _assert_pose_stamped(
         raise ValueError("PoseStamped position is all zero")
 
 
-def _assert_joint_state(msg: JointState) -> None:
+def _assert_joint_state(
+    msg: JointState,
+    *,
+    expected_names: list[str] | None = None,
+    require_nonzero: bool = False,
+) -> None:
     if msg.header.frame_id != "world":
         raise ValueError(f"unexpected frame_id {msg.header.frame_id!r}")
-    if not msg.name:
+    names = list(msg.name)
+    if not names:
         raise ValueError("JointState names are empty")
-    if len(msg.position) != len(msg.name):
+    if len(set(names)) != len(names):
+        raise ValueError("JointState names are not unique")
+    if expected_names is not None and names != expected_names:
+        raise ValueError("JointState names do not match the expected order")
+    if len(msg.position) != len(names):
         raise ValueError("JointState names and positions differ in length")
     if not _is_finite_sequence(msg.position):
         raise ValueError("JointState positions contain non-finite values")
+    if require_nonzero and not any(abs(float(value)) > 1e-6 for value in msg.position):
+        raise ValueError("JointState positions are all zero")
 
 
 def _assert_twist(msg: TwistStamped) -> None:
@@ -260,16 +278,28 @@ def _assert_full_body_payload(msg: ByteMultiArray) -> None:
     _assert_noncollinear_positions(valid_positions, "full-body joint")
 
 
+def _finger_joint_validator(hand_retargeter: str) -> Callable:
+    if hand_retargeter == "wuji":
+        return partial(
+            _assert_joint_state,
+            expected_names=(LEFT_WUJI_HAND_JOINT_NAMES + RIGHT_WUJI_HAND_JOINT_NAMES),
+            require_nonzero=True,
+        )
+    return _assert_joint_state
+
+
 class TopicVerifier(Node):
     """Small ROS 2 node that waits for mode-specific verified messages."""
 
-    def __init__(self, mode: str) -> None:
+    def __init__(self, mode: str, hand_retargeter: str) -> None:
         super().__init__("teleop_ros2_topic_verifier")
         self._pending: set[str] = set()
         self._errors: dict[str, str] = {}
         self._seen_tf_frames: set[str] = set()
 
-        for name, topic, msg_type, validator in self._expected_subscriptions(mode):
+        for name, topic, msg_type, validator in self._expected_subscriptions(
+            mode, hand_retargeter
+        ):
             self._pending.add(name)
             self.create_subscription(
                 msg_type, topic, self._make_callback(name, validator), 10
@@ -315,10 +345,10 @@ class TopicVerifier(Node):
         self._pending.discard("tf")
 
     def _expected_subscriptions(
-        self, mode: str
+        self, mode: str, hand_retargeter: str
     ) -> list[tuple[str, str, type, Callable]]:
         if mode == "controller_teleop":
-            return [
+            subscriptions = [
                 (
                     "ee_poses",
                     "xr_teleop/ee_poses",
@@ -332,7 +362,7 @@ class TopicVerifier(Node):
                     "finger_joints",
                     "xr_teleop/finger_joints",
                     JointState,
-                    _assert_joint_state,
+                    _finger_joint_validator(hand_retargeter),
                 ),
                 (
                     "controller_data",
@@ -341,6 +371,17 @@ class TopicVerifier(Node):
                     _assert_controller_payload,
                 ),
             ]
+            if hand_retargeter in ("dexpilot", "pink_ik", "wuji"):
+                subscriptions.insert(
+                    0,
+                    (
+                        "hand",
+                        "xr_teleop/hand",
+                        NamedPoseArray,
+                        _assert_hand_pose_array,
+                    ),
+                )
+            return subscriptions
         if mode == "hand_teleop":
             return [
                 (
@@ -362,7 +403,7 @@ class TopicVerifier(Node):
                     "finger_joints",
                     "xr_teleop/finger_joints",
                     JointState,
-                    _assert_joint_state,
+                    _finger_joint_validator(hand_retargeter),
                 ),
             ]
         if mode == "controller_raw":
@@ -395,6 +436,11 @@ class TopicVerifier(Node):
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--mode", choices=TELEOP_MODES, required=True)
+    parser.add_argument(
+        "--hand-retargeter",
+        choices=HAND_RETARGETERS,
+        default="mode_default",
+    )
     parser.add_argument("--timeout", type=float, default=20.0)
     return parser.parse_args()
 
@@ -402,7 +448,7 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
     rclpy.init()
-    verifier = TopicVerifier(args.mode)
+    verifier = TopicVerifier(args.mode, args.hand_retargeter)
     try:
         deadline = time.monotonic() + args.timeout
         while verifier.pending and time.monotonic() < deadline:
@@ -417,7 +463,10 @@ def main() -> int:
                 print(f"  {name}: {error}", file=sys.stderr)
             return 1
 
-        print(f"Verified teleop_ros2 topics for mode {args.mode}")
+        print(
+            "Verified teleop_ros2 topics for "
+            f"mode {args.mode} and hand retargeter {args.hand_retargeter}"
+        )
         return 0
     finally:
         verifier.destroy_node()

--- a/examples/teleop_ros2/python/messages.py
+++ b/examples/teleop_ros2/python/messages.py
@@ -67,7 +67,7 @@ def _compute_ee_pose_from_controller(
     side: str,
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
-    controller_uses_hands_source: bool = False,
+    apply_manus_controller_to_hand_transform: bool = False,
 ) -> Pose | None:
     if not controller_aim_is_valid(ctrl):
         return None
@@ -79,7 +79,7 @@ def _compute_ee_pose_from_controller(
     if transform_rot is not None or transform_trans is not None:
         pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
 
-    if controller_uses_hands_source:
+    if apply_manus_controller_to_hand_transform:
         pose = apply_manus_controller_to_hand_pose(pose, side)
 
     return pose
@@ -244,7 +244,7 @@ def build_ee_output_from_controllers(
     right_wrist_frame: str,
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
-    controller_uses_hands_source: bool = False,
+    apply_manus_controller_to_hand_transform: bool = False,
 ) -> tuple[NamedPoseArray, list[TransformStamped]]:
     """Build the controller-derived EE message and its valid wrist TFs."""
     left_pose = _compute_ee_pose_from_controller(
@@ -252,14 +252,14 @@ def build_ee_output_from_controllers(
         "left",
         transform_rot,
         transform_trans,
-        controller_uses_hands_source,
+        apply_manus_controller_to_hand_transform,
     )
     right_pose = _compute_ee_pose_from_controller(
         right_ctrl,
         "right",
         transform_rot,
         transform_trans,
-        controller_uses_hands_source,
+        apply_manus_controller_to_hand_transform,
     )
     ee_msg = _compose_ee_msg(left_pose, right_pose, now, frame_id)
     return ee_msg, _wrist_tfs_from_ee_msg(

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -19,26 +19,25 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import numpy as np
-from rcl_interfaces.msg import ParameterDescriptor, ParameterType
-from rclpy.node import Node
-from rclpy.parameter import Parameter
-from scipy.spatial.transform import Rotation
-
+from constants import (
+    HAND_RETARGETERS,
+    TELEOP_MODES,
+    WUJI_HAND_MODELS,
+    HandRetargeter,
+    TeleopMode,
+    applies_manus_controller_to_hand_transform,
+    resolve_hand_retargeter,
+)
 from isaacteleop.cloudxr.oob_teleop_env import TELEOP_CLIENT_ROUTE_ENV
 from isaacteleop.deviceio import McapReplayConfig
 from isaacteleop.retargeting_engine.deviceio_source_nodes.pedals_source import (
     DEFAULT_PEDAL_COLLECTION_ID,
 )
 from isaacteleop.teleop_session_manager import SessionMode
-
-from constants import (
-    HAND_RETARGETERS,
-    TELEOP_MODES,
-    HandRetargeter,
-    TeleopMode,
-    resolve_hand_retargeter,
-    uses_hands_source_for_controller,
-)
+from rcl_interfaces.msg import ParameterDescriptor, ParameterType
+from rclpy.node import Node
+from rclpy.parameter import Parameter
+from scipy.spatial.transform import Rotation
 
 
 @dataclass(frozen=True)
@@ -65,7 +64,8 @@ class NodeParameters:
     sleep_period_s: float
     hand_retargeter: HandRetargeter
     resolved_hand_retargeter: HandRetargeter
-    controller_uses_hands_source: bool
+    apply_manus_controller_to_hand_transform: bool
+    wuji_hand_model: str
     config_asset_root: Path
     session_mode: SessionMode
     mcap_config: McapReplayConfig | None
@@ -321,7 +321,7 @@ def _load_hand_retargeter(
                 "Hand retargeter backend. 'mode_default' resolves to "
                 "'trihand' in controller_teleop and 'dexpilot' in "
                 "hand_teleop. Valid values: 'mode_default', 'trihand', "
-                "'pink_ik', or 'dexpilot'."
+                "'pink_ik', 'dexpilot', or 'wuji'."
             )
         ),
     )
@@ -336,16 +336,16 @@ def _load_hand_retargeter(
             f"got {raw_hand_retargeter!r}"
         ) from exc
     resolved_hand_retargeter = resolve_hand_retargeter(mode, hand_retargeter)
-    controller_uses_hands_source = uses_hands_source_for_controller(
+    apply_manus_transform = applies_manus_controller_to_hand_transform(
         mode, resolved_hand_retargeter
     )
     if mode in (TeleopMode.HAND_TELEOP, TeleopMode.CONTROLLER_TELEOP):
         node.get_logger().info(f"Hand retargeter: {resolved_hand_retargeter}")
-    if controller_uses_hands_source:
+    if apply_manus_transform:
         node.get_logger().info(
             "Applying MANUS controller-to-hand transform after pose transform."
         )
-    return hand_retargeter, resolved_hand_retargeter, controller_uses_hands_source
+    return hand_retargeter, resolved_hand_retargeter, apply_manus_transform
 
 
 def _load_mcap_replay(
@@ -486,6 +486,30 @@ def _load_transform_translation(node: Node) -> list[float] | None:
     return [float(x) for x in transform_trans_arr]
 
 
+def _load_wuji_hand_model(node: Node) -> str:
+    parameter_name = "wuji_hand_model"
+    node.declare_parameter(
+        parameter_name,
+        "wuji_hand_2",
+        ParameterDescriptor(
+            description=(
+                "Wuji model used for left- and right-hand retargeting. "
+                "Valid values: 'wuji_hand' or 'wuji_hand_2'."
+            ),
+            additional_constraints=f"Must be one of {WUJI_HAND_MODELS}.",
+        ),
+    )
+    model = (
+        node.get_parameter(parameter_name).get_parameter_value().string_value.strip()
+    )
+    if model not in WUJI_HAND_MODELS:
+        raise ValueError(
+            f"Parameter '{parameter_name}' must be one of {WUJI_HAND_MODELS}, "
+            f"got {model!r}"
+        )
+    return model
+
+
 def create_node_parameters(node: Node) -> NodeParameters:
     """Declare every ROS parameter on ``node``, validate, and return the snapshot."""
     rate_hz = _load_rate_hz(node)
@@ -493,8 +517,9 @@ def create_node_parameters(node: Node) -> NodeParameters:
     (
         hand_retargeter,
         resolved_hand_retargeter,
-        controller_uses_hands_source,
+        apply_manus_controller_to_hand_transform,
     ) = _load_hand_retargeter(node, mode)
+    wuji_hand_model = _load_wuji_hand_model(node)
     config_asset_root = _load_config_asset_root(node)
     session_mode, mcap_config = _load_mcap_replay(node)
     cloudxr_params = _load_cloudxr(node)
@@ -510,7 +535,10 @@ def create_node_parameters(node: Node) -> NodeParameters:
         sleep_period_s=1.0 / rate_hz,
         hand_retargeter=hand_retargeter,
         resolved_hand_retargeter=resolved_hand_retargeter,
-        controller_uses_hands_source=controller_uses_hands_source,
+        apply_manus_controller_to_hand_transform=(
+            apply_manus_controller_to_hand_transform
+        ),
+        wuji_hand_model=wuji_hand_model,
         config_asset_root=config_asset_root,
         session_mode=session_mode,
         mcap_config=mcap_config,

--- a/examples/teleop_ros2/python/pyproject.toml
+++ b/examples/teleop_ros2/python/pyproject.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 description = "Isaac Teleop ROS 2 reference publisher"
 requires-python = ">=3.11,<3.14"
 dependencies = [
-    "isaacteleop[cloudxr,grounding,retargeters]",
+    "isaacteleop[cloudxr,grounding,retargeters,wuji]",
     "msgpack",
     "msgpack-numpy",
     # The ROS node installs pink_ik and dexpilot together. Require nlopt>=2.8 so

--- a/examples/teleop_ros2/python/session_config.py
+++ b/examples/teleop_ros2/python/session_config.py
@@ -4,16 +4,27 @@
 
 """TeleopSession graph assembly for teleop_ros2_node."""
 
-from typing import Sequence
+from collections.abc import Sequence
 
-from isaacteleop.retargeting_engine.deviceio_source_nodes import (
-    ControllersSource,
-    FullBodySource,
-    Generic3AxisPedalSource,
-    HandsSource,
-    HeadSource,
+from assets import (
+    resolve_dex_sharpa_config,
+    resolve_dex_sharpa_urdf,
+    resolve_sharpa_mjcf,
 )
-from isaacteleop.retargeting_engine.interface import OutputCombiner
+from constants import (
+    DEX_HANDTRACKING_TO_BASELINK_FRAME_TRANSFORM,
+    LEFT_FINGER_JOINT_NAMES,
+    LEFT_SHARPA_WAVE_JOINT_NAMES,
+    LEFT_WUJI_HAND_JOINT_NAMES,
+    RIGHT_FINGER_JOINT_NAMES,
+    RIGHT_SHARPA_WAVE_JOINT_NAMES,
+    RIGHT_WUJI_HAND_JOINT_NAMES,
+    SHARPA_FINGER_JOINT_COUNT,
+    TRACKED_HAND_RETARGETERS,
+    WUJI_HAND_JOINT_COUNT,
+    HandRetargeter,
+    TeleopMode,
+)
 from isaacteleop.retargeters import (
     DexHandRetargeter,
     DexHandRetargeterConfig,
@@ -24,26 +35,17 @@ from isaacteleop.retargeters import (
     TriHandMotionControllerConfig,
     TriHandMotionControllerRetargeter,
 )
+from isaacteleop.retargeting_engine.deviceio_source_nodes import (
+    ControllersSource,
+    FullBodySource,
+    Generic3AxisPedalSource,
+    HandsSource,
+    HeadSource,
+)
+from isaacteleop.retargeting_engine.interface import OutputCombiner
 from isaacteleop.teleop_session_manager import TeleopSessionConfig
-from teleop_ros2_retargeters import JointNameAliasRetargeter
-
-from assets import (
-    resolve_dex_sharpa_config,
-    resolve_dex_sharpa_urdf,
-    resolve_sharpa_mjcf,
-)
-from constants import (
-    DEX_HANDTRACKING_TO_BASELINK_FRAME_TRANSFORM,
-    HandRetargeter,
-    LEFT_FINGER_JOINT_NAMES,
-    LEFT_SHARPA_WAVE_JOINT_NAMES,
-    RIGHT_FINGER_JOINT_NAMES,
-    RIGHT_SHARPA_WAVE_JOINT_NAMES,
-    SHARPA_FINGER_JOINT_COUNT,
-    SHARPA_HAND_RETARGETERS,
-    TeleopMode,
-)
 from node_parameters import NodeParameters
+from teleop_ros2_retargeters import JointNameAliasRetargeter
 from tensor_group_helpers import joint_names_from_group_type
 
 
@@ -130,20 +132,12 @@ def build_controller_teleop_config(params: NodeParameters) -> TeleopSessionConfi
                 "finger_joints_right": right_hand_connected.output("hand_joints"),
             }
         )
-    elif params.resolved_hand_retargeter in SHARPA_HAND_RETARGETERS:
-        validate_joint_name_alias_count(
-            "left_finger_joint_names",
-            params.left_finger_joint_name_aliases,
-            SHARPA_FINGER_JOINT_COUNT,
-        )
-        validate_joint_name_alias_count(
-            "right_finger_joint_names",
-            params.right_finger_joint_name_aliases,
-            SHARPA_FINGER_JOINT_COUNT,
-        )
+    elif params.resolved_hand_retargeter in TRACKED_HAND_RETARGETERS:
         hands = HandsSource(name="hands")
-        left_finger_joints, right_finger_joints = build_sharpa_finger_joint_outputs(
-            hands, params, TeleopMode.CONTROLLER_TELEOP.value
+        left_finger_joints, right_finger_joints = (
+            build_tracked_hand_finger_joint_outputs(
+                hands, params, TeleopMode.CONTROLLER_TELEOP.value
+            )
         )
         pipeline_outputs.update(
             {
@@ -156,7 +150,7 @@ def build_controller_teleop_config(params: NodeParameters) -> TeleopSessionConfi
     else:
         raise ValueError(
             "controller_teleop requires hand_retargeter to resolve to "
-            f"'trihand', 'dexpilot', or 'pink_ik', got "
+            f"'trihand', 'dexpilot', 'pink_ik', or 'wuji', got "
             f"{params.resolved_hand_retargeter!r}"
         )
 
@@ -190,17 +184,6 @@ def build_full_body_config(params: NodeParameters) -> TeleopSessionConfig:
 
 
 def build_hand_teleop_config(params: NodeParameters) -> TeleopSessionConfig:
-    validate_joint_name_alias_count(
-        "left_finger_joint_names",
-        params.left_finger_joint_name_aliases,
-        SHARPA_FINGER_JOINT_COUNT,
-    )
-    validate_joint_name_alias_count(
-        "right_finger_joint_names",
-        params.right_finger_joint_name_aliases,
-        SHARPA_FINGER_JOINT_COUNT,
-    )
-
     hands = HandsSource(name="hands")
     head = HeadSource(name="head")
     pedals = Generic3AxisPedalSource(
@@ -211,7 +194,7 @@ def build_hand_teleop_config(params: NodeParameters) -> TeleopSessionConfig:
         name="foot_pedal",
     )
     locomotion_connected = locomotion.connect({"pedals": pedals.output("pedals")})
-    left_finger_joints, right_finger_joints = build_sharpa_finger_joint_outputs(
+    left_finger_joints, right_finger_joints = build_tracked_hand_finger_joint_outputs(
         hands, params, TeleopMode.HAND_TELEOP.value
     )
 
@@ -246,11 +229,32 @@ def build_session_config(params: NodeParameters) -> TeleopSessionConfig:
     raise ValueError(f"Unsupported mode {params.mode!r}")
 
 
-def build_sharpa_finger_joint_outputs(
+def build_tracked_hand_finger_joint_outputs(
     hands: HandsSource,
     params: NodeParameters,
     mode_name: str,
 ):
+    if params.resolved_hand_retargeter not in TRACKED_HAND_RETARGETERS:
+        raise ValueError(
+            f"Tracked-hand retargeting requires one of {TRACKED_HAND_RETARGETERS}, "
+            f"got {params.resolved_hand_retargeter!r}"
+        )
+    expected_joint_count = (
+        WUJI_HAND_JOINT_COUNT
+        if params.resolved_hand_retargeter == HandRetargeter.WUJI
+        else SHARPA_FINGER_JOINT_COUNT
+    )
+    validate_joint_name_alias_count(
+        "left_finger_joint_names",
+        params.left_finger_joint_name_aliases,
+        expected_joint_count,
+    )
+    validate_joint_name_alias_count(
+        "right_finger_joint_names",
+        params.right_finger_joint_name_aliases,
+        expected_joint_count,
+    )
+
     if params.resolved_hand_retargeter == HandRetargeter.PINK_IK:
         try:
             from isaacteleop.retargeters import (
@@ -280,6 +284,8 @@ def build_sharpa_finger_joint_outputs(
         )
         left_alias_name = "sharpa_left_joint_aliases"
         right_alias_name = "sharpa_right_joint_aliases"
+        left_output_joint_names = params.left_finger_joint_name_aliases
+        right_output_joint_names = params.right_finger_joint_name_aliases
     elif params.resolved_hand_retargeter == HandRetargeter.DEXPILOT:
         left_hand_retargeter = DexHandRetargeter(
             DexHandRetargeterConfig(
@@ -319,9 +325,46 @@ def build_sharpa_finger_joint_outputs(
         )
         left_alias_name = "dex_sharpa_left_joint_aliases"
         right_alias_name = "dex_sharpa_right_joint_aliases"
+        left_output_joint_names = params.left_finger_joint_name_aliases
+        right_output_joint_names = params.right_finger_joint_name_aliases
+    elif params.resolved_hand_retargeter == HandRetargeter.WUJI:
+        try:
+            from isaacteleop.retargeters import (
+                WujiHandRetargeter,
+                WujiHandRetargeterConfig,
+            )
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                f"{mode_name} with hand_retargeter:=wuji requires Wuji "
+                "retargeting dependencies. Install/use a build with "
+                "isaacteleop[wuji]."
+            ) from exc
+
+        left_hand_retargeter = WujiHandRetargeter(
+            WujiHandRetargeterConfig(
+                model=params.wuji_hand_model,
+                hand_side="left",
+            ),
+            name="wuji_left",
+        )
+        right_hand_retargeter = WujiHandRetargeter(
+            WujiHandRetargeterConfig(
+                model=params.wuji_hand_model,
+                hand_side="right",
+            ),
+            name="wuji_right",
+        )
+        left_alias_name = "wuji_left_joint_aliases"
+        right_alias_name = "wuji_right_joint_aliases"
+        left_output_joint_names = (
+            params.left_finger_joint_name_aliases or LEFT_WUJI_HAND_JOINT_NAMES
+        )
+        right_output_joint_names = (
+            params.right_finger_joint_name_aliases or RIGHT_WUJI_HAND_JOINT_NAMES
+        )
     else:
         raise ValueError(
-            f"Sharpa hand retargeting requires one of {SHARPA_HAND_RETARGETERS}, "
+            f"Tracked-hand retargeting requires one of {TRACKED_HAND_RETARGETERS}, "
             f"got {params.resolved_hand_retargeter!r}"
         )
 
@@ -334,13 +377,13 @@ def build_sharpa_finger_joint_outputs(
     left_finger_joints = maybe_alias_hand_joints(
         left_hand_connected,
         joint_names_from_group_type(left_hand_retargeter.output_spec()["hand_joints"]),
-        params.left_finger_joint_name_aliases,
+        left_output_joint_names,
         left_alias_name,
     )
     right_finger_joints = maybe_alias_hand_joints(
         right_hand_connected,
         joint_names_from_group_type(right_hand_retargeter.output_spec()["hand_joints"]),
-        params.right_finger_joint_name_aliases,
+        right_output_joint_names,
         right_alias_name,
     )
     return left_finger_joints, right_finger_joints

--- a/examples/teleop_ros2/python/teleop_profiles.py
+++ b/examples/teleop_ros2/python/teleop_profiles.py
@@ -4,12 +4,12 @@
 
 """Resolved runtime profiles for teleoperation session results and publishing."""
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping, TypedDict, cast
-
-from isaacteleop.retargeting_engine.interface import OptionalTensorGroup
+from typing import TypedDict, cast
 
 from constants import SHARPA_HAND_RETARGETERS, HandRetargeter, StrEnum, TeleopMode
+from isaacteleop.retargeting_engine.interface import OptionalTensorGroup
 
 
 class PublishType(StrEnum):
@@ -25,7 +25,10 @@ class PublishType(StrEnum):
 
 class TeleopProfile(StrEnum):
     CONTROLLER_TELEOP = "controller_teleop"
-    CONTROLLER_TELEOP_WITH_HANDS = "controller_teleop_with_hands"
+    CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE = (
+        "controller_teleop_with_hand_controller_ee"
+    )
+    CONTROLLER_TELEOP_WITH_HAND_WRIST_EE = "controller_teleop_with_hand_wrist_ee"
     HAND_TELEOP = "hand_teleop"
     CONTROLLER_RAW = "controller_raw"
     FULL_BODY = "full_body"
@@ -75,7 +78,7 @@ TELEOP_PROFILE_SPECS = {
             }
         ),
     ),
-    TeleopProfile.CONTROLLER_TELEOP_WITH_HANDS: TeleopProfileSpec(
+    TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE: TeleopProfileSpec(
         mode=TeleopMode.CONTROLLER_TELEOP,
         required_result_keys=frozenset(
             {
@@ -93,6 +96,31 @@ TELEOP_PROFILE_SPECS = {
             {
                 PublishType.CONTROLLER_PAYLOAD,
                 PublishType.EE_FROM_CONTROLLERS,
+                PublishType.FINGER_JOINTS,
+                PublishType.HAND_POSES,
+                PublishType.HEAD,
+                PublishType.ROOT_COMMAND,
+            }
+        ),
+    ),
+    TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE: TeleopProfileSpec(
+        mode=TeleopMode.CONTROLLER_TELEOP,
+        required_result_keys=frozenset(
+            {
+                "controller_left",
+                "controller_right",
+                "finger_joints_left",
+                "finger_joints_right",
+                "hand_left",
+                "hand_right",
+                "head",
+                "root_command",
+            }
+        ),
+        publish_types=frozenset(
+            {
+                PublishType.CONTROLLER_PAYLOAD,
+                PublishType.EE_FROM_HANDS,
                 PublishType.FINGER_JOINTS,
                 PublishType.HAND_POSES,
                 PublishType.HEAD,
@@ -148,9 +176,14 @@ def resolve_teleop_profile_spec(
     """Resolve user-facing settings to one complete immutable runtime profile."""
     if (
         mode == TeleopMode.CONTROLLER_TELEOP
+        and resolved_hand_retargeter == HandRetargeter.WUJI
+    ):
+        profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE
+    elif (
+        mode == TeleopMode.CONTROLLER_TELEOP
         and resolved_hand_retargeter in SHARPA_HAND_RETARGETERS
     ):
-        profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HANDS
+        profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE
     else:
         profile = TeleopProfile(mode.value)
     return TELEOP_PROFILE_SPECS[profile]

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -16,7 +16,7 @@ published:
                        and TF transforms for left/right wrists and head
   - hand_teleop: ee_poses (from hand tracking wrists), hand (named left and
                  right joint poses),
-                 finger_joints (retargeted Sharpa joint angles),
+                 finger_joints (retargeted Sharpa or Wuji joint angles),
                  root_twist/root_pose (from foot pedal locomotion), head_pose,
                  and TF transforms for left/right wrists and head
   - controller_raw: controller_data only
@@ -123,7 +123,7 @@ class TeleopRos2Node(Node):
             self._params.right_wrist_frame,
             self._params.transform_rotation,
             self._params.transform_translation,
-            self._params.controller_uses_hands_source,
+            self._params.apply_manus_controller_to_hand_transform,
         )
         self._pub_ee_poses.publish(ee_poses_msg)
         if wrist_tfs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,12 @@ grounding = [
     "cmeel-urdfdom<5",
     "cmeel-tinyxml2<11",
 ]
+wuji = [
+    "wuji-sdk[retarget]==2026.7.14",
+    "pin>=2.7.0",
+    "cmeel-urdfdom<5",
+    "cmeel-tinyxml2<11",
+]
 cloudxr = [
     "cryptography>=3.0",
     "websockets>=14.0",

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -3,6 +3,10 @@
 
 add_subdirectory(core)
 
+if(BUILD_EXAMPLE_TELEOP_ROS2)
+    add_subdirectory(examples/teleop_ros2)
+endif()
+
 if(BUILD_VIZ AND BUILD_PYTHON_BINDINGS)
     add_subdirectory(viz)
 endif()

--- a/tests/python/examples/teleop_ros2/CMakeLists.txt
+++ b/tests/python/examples/teleop_ros2/CMakeLists.txt
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# teleop_ros2 unit tests. Each test_*.py registers as its own ctest entry under
+# the ``teleop_ros2`` label. BUILD_EXAMPLE_TELEOP_ROS2 supplies the required ROS
+# environment; the example source directory supplies its importable modules.
+
+file(GLOB TEST_FILES
+    RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+    "${CMAKE_CURRENT_SOURCE_DIR}/test_*.py"
+)
+
+foreach(test_file ${TEST_FILES})
+    get_filename_component(test_name "${test_file}" NAME_WE)
+    add_test(
+        NAME "teleop_ros2_${test_name}"
+        COMMAND uv run --python ${ISAAC_TELEOP_PYTHON_VERSION} --extra dev
+            pytest -v --tb=short "${test_file}"
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+    set_tests_properties("teleop_ros2_${test_name}" PROPERTIES
+        ENVIRONMENT
+            "PYTHONPATH=${CMAKE_BINARY_DIR}/python_package/$<CONFIG>:${CMAKE_SOURCE_DIR}/examples/teleop_ros2/python"
+        LABELS "teleop_ros2"
+    )
+endforeach()

--- a/tests/python/examples/teleop_ros2/test_teleop_profiles.py
+++ b/tests/python/examples/teleop_ros2/test_teleop_profiles.py
@@ -7,12 +7,15 @@
 from types import SimpleNamespace
 
 import pytest
-
 import session_config
 from constants import (
+    LEFT_WUJI_HAND_JOINT_NAMES,
+    RIGHT_WUJI_HAND_JOINT_NAMES,
     TELEOP_MODES,
+    WUJI_HAND_JOINT_COUNT,
     HandRetargeter,
     TeleopMode,
+    applies_manus_controller_to_hand_transform,
     resolve_hand_retargeter,
 )
 from session_config import validate_joint_name_alias_count
@@ -68,6 +71,9 @@ def test_controller_profile_spec_is_resolved_for_selected_retargeter() -> None:
     hands_spec = resolve_teleop_profile_spec(
         TeleopMode.CONTROLLER_TELEOP, HandRetargeter.DEXPILOT
     )
+    wuji_spec = resolve_teleop_profile_spec(
+        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.WUJI
+    )
 
     assert "hand_left" not in controller_spec.required_result_keys
     assert "hand_right" not in controller_spec.required_result_keys
@@ -75,14 +81,27 @@ def test_controller_profile_spec_is_resolved_for_selected_retargeter() -> None:
 
     assert {"hand_left", "hand_right"} <= hands_spec.required_result_keys
     assert PublishType.HAND_POSES in hands_spec.publish_types
+    assert {"hand_left", "hand_right"} <= wuji_spec.required_result_keys
+    assert PublishType.EE_FROM_HANDS in wuji_spec.publish_types
+    assert PublishType.EE_FROM_CONTROLLERS not in wuji_spec.publish_types
 
 
 @pytest.mark.parametrize(
     ("retargeter", "expected_profile"),
     (
         (HandRetargeter.TRIHAND, TeleopProfile.CONTROLLER_TELEOP),
-        (HandRetargeter.DEXPILOT, TeleopProfile.CONTROLLER_TELEOP_WITH_HANDS),
-        (HandRetargeter.PINK_IK, TeleopProfile.CONTROLLER_TELEOP_WITH_HANDS),
+        (
+            HandRetargeter.DEXPILOT,
+            TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE,
+        ),
+        (
+            HandRetargeter.PINK_IK,
+            TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE,
+        ),
+        (
+            HandRetargeter.WUJI,
+            TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE,
+        ),
     ),
 )
 def test_controller_profile_spec_resolution(
@@ -131,9 +150,46 @@ def test_trihand_is_rejected_for_hand_teleop() -> None:
         resolve_hand_retargeter(TeleopMode.HAND_TELEOP, HandRetargeter.TRIHAND)
 
 
+def test_manus_transform_is_not_applied_to_wuji() -> None:
+    assert applies_manus_controller_to_hand_transform(
+        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.DEXPILOT
+    )
+    assert applies_manus_controller_to_hand_transform(
+        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.PINK_IK
+    )
+    assert not applies_manus_controller_to_hand_transform(
+        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.WUJI
+    )
+
+
 def test_joint_alias_count_validation() -> None:
     validate_joint_name_alias_count("left_finger_joint_names", None, 2)
     validate_joint_name_alias_count("left_finger_joint_names", ["a", "b"], 2)
 
     with pytest.raises(ValueError, match="must contain exactly 2"):
         validate_joint_name_alias_count("left_finger_joint_names", ["a"], 2)
+
+
+def test_wuji_default_joint_names_are_side_qualified_and_unique() -> None:
+    assert WUJI_HAND_JOINT_COUNT == 20
+    assert len(LEFT_WUJI_HAND_JOINT_NAMES) == WUJI_HAND_JOINT_COUNT
+    assert len(RIGHT_WUJI_HAND_JOINT_NAMES) == WUJI_HAND_JOINT_COUNT
+    names = LEFT_WUJI_HAND_JOINT_NAMES + RIGHT_WUJI_HAND_JOINT_NAMES
+    assert len(set(names)) == 2 * WUJI_HAND_JOINT_COUNT
+    assert names[0] == "left_thumb_j0"
+    assert names[-1] == "right_pinky_j3"
+
+
+def test_wuji_joint_alias_count_validation() -> None:
+    validate_joint_name_alias_count(
+        "left_finger_joint_names",
+        [f"left_joint_{index}" for index in range(WUJI_HAND_JOINT_COUNT)],
+        WUJI_HAND_JOINT_COUNT,
+    )
+
+    with pytest.raises(ValueError, match="must contain exactly 20"):
+        validate_joint_name_alias_count(
+            "left_finger_joint_names",
+            ["left_joint"] * (WUJI_HAND_JOINT_COUNT - 1),
+            WUJI_HAND_JOINT_COUNT,
+        )


### PR DESCRIPTION


<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Support Wuji gloves in controller and hand teleoperation while preserving existing retargeter behavior and documenting external plugin setup.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Wuji hand retargeting support for ROS2 teleoperation.
  - Added Wuji hand models, joint mappings, wrist-source selection, calibration guidance, and topic documentation.
  - Added retargeter-specific controller and wrist end-effector profiles.
  - Added validation for Wuji joint names and published values.

- **Bug Fixes**
  - Improved scenario-specific replay verification and startup error reporting.
  - Refined controller-to-hand transform handling across teleoperation modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->