### PR TITLE
fix: make check_copyright_year run on Python 3.9

### DIFF
--- a/scripts/check_copyright_year.py
+++ b/scripts/check_copyright_year.py
@@ -4,6 +4,8 @@
 """Check that SPDX-FileCopyrightText year includes the last-modified year (from git).
 Use --fix to update. Falls back to current year if not in a git repo."""
 
+from __future__ import annotations
+
 import os
 import re
 import subprocess


### PR DESCRIPTION
scripts/check_copyright_year.py:21 annotates `-> int | None`. PEP 604 unions in annotations are evaluated at import time before Python 3.10, so on 3.9 the hook raises before it checks anything:

```
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
```

**Fix:** one line — `from __future__ import annotations`, matching what `check_lfs_pointers.py:6` already does.

**Why this went unnoticed since February.** Two things compound: `.github/workflows/pre-commit.yaml:23` sets `SKIP: check-copyright-year`, so CI never runs it; and anyone on Python 3.10+ sees it pass. Only a 3.9 contributor hits it — and it fails *open* for them: it never reports a stale year because it never starts.

**Tested** on 3.9.6 and 3.12.13, plain and `--fix`, plus `pre-commit run` over the changed file. Before: 3.9 raises, 3.12 passes. After: both pass.

**One thing to know before merging.** With the hook alive again, `pre-commit run --all-files` wants to update the year on ~101 files that drifted while it was dead — headers that stopped at 2025 while git says the file was touched in 2026. That backlog is deliberately **not** in this PR: it is a bulk, legal-adjacent edit that deserves its own review. It also self-heals, since the next commit touching any of those files fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved import formatting in the copyright-year checking script.
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->