### PR TITLE
docs: link generated trackers to their manifest, not to build output

### DIFF
--- a/docs/source/device/oglo.rst
+++ b/docs/source/device/oglo.rst
@@ -30,10 +30,10 @@ Components
 - **Schema** — :code-file:`src/core/schema/fbs/oglo_tactile.fbs`
   (``OgloGloveSample`` / ``OgloGloveSampleRecord``).
 - **Plugin** — :code-dir:`src/plugins/oglo_tactile` (BLE read → parse → OpenXR push).
-- **Tracker** — ``OgloTactileTracker``
-  (:code-file:`src/core/deviceio_trackers/cpp/inc/deviceio_trackers/oglo_tactile_tracker.hpp`)
-  with live backend ``LiveOgloTactileTrackerImpl``
-  (:code-file:`src/core/live_trackers/cpp/live_oglo_tactile_tracker_impl.cpp`).
+- **Tracker** — ``OgloTactileTracker``, with live backend
+  ``LiveOgloTactileTrackerImpl``. Both are generated at configure time from the
+  ``oglo_tactile`` entry in
+  :code-file:`src/core/deviceio_trackers/trackers.toml`.
 
 Build
 -----

--- a/docs/source/device/trackers.rst
+++ b/docs/source/device/trackers.rst
@@ -21,9 +21,9 @@ reading it from OpenXR tensor collections via the
 :code-file:`SchemaTracker <src/core/live_trackers/cpp/inc/live_trackers/schema_tracker.hpp>` utility.
 
 - :code-file:`FrameMetadataTrackerOak <src/core/deviceio_trackers/trackers.toml>` -- frame metadata for one OAK camera stream (generated)
-- :code-file:`Generic3AxisPedalTracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/generic_3axis_pedal_tracker.hpp>` -- foot pedal axis values
-- :code-file:`JointStateTracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/joint_state_tracker.hpp>` -- named joint-space device state (leader arms, exoskeletons, gloves, ...)
-- :code-file:`Se3Tracker <src/core/deviceio_trackers/cpp/inc/deviceio_trackers/se3_tracker.hpp>` -- generic SE3 (6-DoF) pose sources (tracker pucks, mocap rigid bodies, logical trackers)
+- :code-file:`Generic3AxisPedalTracker <src/core/deviceio_trackers/trackers.toml>` -- foot pedal axis values (generated)
+- :code-file:`JointStateTracker <src/core/deviceio_trackers/trackers.toml>` -- named joint-space device state (leader arms, exoskeletons, gloves, ...) (generated)
+- :code-file:`Se3Tracker <src/core/deviceio_trackers/trackers.toml>` -- generic SE3 (6-DoF) pose sources (tracker pucks, mocap rigid bodies, logical trackers) (generated)
 
 All trackers follow the same lifecycle:
 


### PR DESCRIPTION
Five links on the published docs are permanent 404s.

## Root cause

These trackers are generated at CMake **configure** time into `${CMAKE_BINARY_DIR}/generated/trackers/` (`cmake/GenerateTrackers.cmake:11`, included from `src/core/CMakeLists.txt:25`). They are never in the repo, so the `github.com/blob/` URL that the `:code-file:` role builds cannot resolve — and never could.

Live today (verified with `curl`, control links return 200):

| page | link | |
|---|---|---|
| [device/trackers.html](https://nvidia.github.io/IsaacTeleop/main/device/trackers.html) | `Generic3AxisPedalTracker` | 404 |
| [device/trackers.html](https://nvidia.github.io/IsaacTeleop/main/device/trackers.html) | `JointStateTracker` | 404 |
| [device/trackers.html](https://nvidia.github.io/IsaacTeleop/main/device/trackers.html) | `Se3Tracker` | 404 |
| [device/oglo.html](https://nvidia.github.io/IsaacTeleop/main/device/oglo.html) | `OgloTactileTracker` | 404 |
| [device/oglo.html](https://nvidia.github.io/IsaacTeleop/main/device/oglo.html) | `LiveOgloTactileTrackerImpl` | 404 |

The three on `trackers.rst` render as a bare type name, so the page gives no hint the link is dead until it is clicked.

## Fix

The convention the same list already uses one line above: `FrameMetadataTrackerOak` points at `trackers.toml` and is marked `(generated)`. This applies that to the other four, so the reader lands on the declaration that causes the tracker to exist instead of a 404. All four have manifest entries (`trackers.toml:5,10,17,23`).

Docs-only, 2 files, +7/-7. No behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated tracker documentation to identify `OgloTactileTracker` and `LiveOgloTactileTrackerImpl` as generated components.
  - Updated SchemaTracker documentation to reference the generated `trackers.toml` manifest.
  - Clarified which listed trackers are generated during configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->