### PR TITLE
fix: import OpenXRSessionHandles from isaacteleop.oxr, not teleopcore.oxr

### DIFF
--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -104,7 +104,7 @@ argument is a ``uint64`` handle value.
 
 .. code-block:: python
 
-   from teleopcore.oxr import OpenXRSessionHandles
+   from isaacteleop.oxr import OpenXRSessionHandles
 
    handles = OpenXRSessionHandles(
        instance_handle, session_handle, space_handle, proc_addr

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -606,7 +606,7 @@ extensions automatically), then pass the handles through:
    import isaacteleop.viz as televiz
    from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
    from isaacteleop.deviceio import DeviceIOSession
-   from teleopcore.oxr import OpenXRSessionHandles
+   from isaacteleop.oxr import OpenXRSessionHandles
 
    viz_cfg = televiz.VizSessionConfig()
    viz_cfg.mode = televiz.DisplayMode.kXr

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -198,7 +198,7 @@ Only one OpenXR session is allowed per process. `VizSession` can own it and hand
 
 ```python
 import isaacteleop.viz as viz
-from teleopcore.oxr import OpenXRSessionHandles
+from isaacteleop.oxr import OpenXRSessionHandles
 
 cfg = viz.VizSessionConfig()
 cfg.mode = viz.DisplayMode.kXr

--- a/src/python/isaacteleop/teleop_session_manager/config.py
+++ b/src/python/isaacteleop/teleop_session_manager/config.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
         McapRecordingConfig,
         McapReplayConfig,
     )
-    from teleopcore.oxr import OpenXRSessionHandles
+    from isaacteleop.oxr import OpenXRSessionHandles
 
 
 class SessionMode(Enum):
@@ -369,7 +369,7 @@ class TeleopSessionConfig:
                 left_gripper = result["gripper_left"][0]
 
     Example (external OpenXR handles from Kit):
-        from teleopcore.oxr import OpenXRSessionHandles
+        from isaacteleop.oxr import OpenXRSessionHandles
 
         handles = OpenXRSessionHandles(
             instance_handle, session_handle, space_handle, proc_addr


### PR DESCRIPTION
`teleopcore.oxr` never resolved. There is no importable `teleopcore` module — `importlib.util.find_spec("teleopcore")` returns `None` and no such directory exists in the tree. The three `teleopcore-*-tests` distributions (`src/core/{rig,cloudxr,teleop_session_manager}_tests/python/pyproject.toml:5`) share the prefix but ship no package: each is pytest-only, with `pythonpath = ["."]`, test files as siblings, and no `[tool.setuptools] packages`.

The importable distribution is `isaacteleop` (`pyproject.toml:12`), which exports `OpenXRSessionHandles` from `isaacteleop/oxr/__init__.py:10`.

## One of the five is not documentation

`config.py:35` is a real import inside `if TYPE_CHECKING:`. It never runs, so nothing crashes — but any type checker resolving that block fails to find the module, and every `OpenXRSessionHandles` annotation in the file silently degrades to unresolved. The sibling import two lines above already uses `isaacteleop.deviceio_session`, which is what makes this read as a leftover from the rename rather than an intentional alias.

Verified with pyright against an installed, stub-complete build: with `teleopcore.oxr` the import is unresolved and the annotation degrades; with `isaacteleop.oxr` the file type-checks clean, 1 error → 0.

## The other four are copy-pasteable

`docs/source/getting_started/teleop_session.rst`, `docs/source/getting_started/televiz.rst`, the `config.py` class docstring, and `examples/camera_viz/README.md`. A reader following any of them hit `ModuleNotFoundError` on line one.

4 files, +5/-5. No behaviour change at runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OpenXR session-sharing and external handle examples to use the current import path.
  * Updated the related configuration type-checking references for consistency.
  * Applied the same corrections across getting-started guides and the camera visualization example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->