### PR TITLE
build: check that docs do not reference code that is not there

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,3 +59,11 @@ repos:
         # COMMIT_EDITMSG path (outside the work tree), which makes the script's
         # `git check-attr` fail with "outside repository" (exit 128).
         stages: [pre-commit]
+      - id: check-doc-refs
+        name: "Check :code-file:/:code-dir: targets exist in the tree"
+        entry: python3 scripts/check_doc_refs.py
+        language: system
+        # The roles in docs/source/conf.py build a github.com URL from the target
+        # without validating it, so a moved file ships a live 404 and the Sphinx
+        # build still passes. Only .rst carries these roles.
+        files: ^docs/source/.*\.rst$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,10 +60,13 @@ repos:
         # `git check-attr` fail with "outside repository" (exit 128).
         stages: [pre-commit]
       - id: check-doc-refs
-        name: "Check :code-file:/:code-dir: targets exist in the tree"
+        name: "Check docs do not reference code that is not there"
         entry: python3 scripts/check_doc_refs.py
         language: system
-        # The roles in docs/source/conf.py build a github.com URL from the target
-        # without validating it, so a moved file ships a live 404 and the Sphinx
-        # build still passes. Only .rst carries these roles.
-        files: ^docs/source/.*\.rst$
+        # Roles: the code-file/code-dir roles in docs/source/conf.py build a
+        # github.com URL from the target without validating it, so a moved file
+        # ships a live 404 while the Sphinx build still passes. .rst only.
+        # Imports: documented isaacteleop.* imports must resolve under
+        # src/python/, so a package rename cannot leave copy-pasteable examples
+        # that raise ModuleNotFoundError. .rst and .md both carry those.
+        files: ^(docs/source/.*\.rst|(?!.*/(build|_build|\.venv|node_modules)/).*\.md)$

--- a/docs/source/getting_started/build_from_source/index.rst
+++ b/docs/source/getting_started/build_from_source/index.rst
@@ -122,7 +122,7 @@ tarballs such as:
   those platforms.
 - ``nvidia-cloudxr-<version-for-web-sdk>.tgz`` (CloudXR Web SDK)
 
-You can place them in the :code-file:`deps/cloudxr/` directory and update the ``deps/cloudxr/.env``
+You can place them in the :code-dir:`deps/cloudxr/` directory and update the ``deps/cloudxr/.env``
 file to locally override the default version defined in :code-file:`deps/cloudxr/.env.default`,
 like this:
 

--- a/docs/source/getting_started/build_from_source/webxr.rst
+++ b/docs/source/getting_started/build_from_source/webxr.rst
@@ -13,7 +13,7 @@ The Isaac Teleop WebXR client is built with React, Three.js, and WebXR. It strea
 from a CloudXR Runtime server to the browser.  For more details about CloudXR.js SDK and its advanced features, see the
 `CloudXR.js documentation`_.
 
-The source is located at :code-file:`deps/cloudxr/webxr_client/ <deps/cloudxr/webxr_client/>`.
+The source is located at :code-dir:`deps/cloudxr/webxr_client/`.
 
 .. contents:: Steps
    :local:

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -52,14 +52,7 @@ KNOWN_BROKEN: dict[str, str] = {}
 
 # Documented imports that are known wrong and not fixed yet, for the same reason
 # as KNOWN_BROKEN: the fix is not mechanical. Each value says why.
-KNOWN_BROKEN_IMPORTS = {
-    "isaacteleop.retargeting_engine.examples": (
-        "GripperRetargeter is exported from isaacteleop.retargeters. The import is "
-        "only one of four faults in that block — the call also omits the required "
-        "config arg and uses port names no longer in input_spec/output_spec — so "
-        "the example needs an author rewrite, not a one-line import swap."
-    ),
-}
+KNOWN_BROKEN_IMPORTS: dict[str, str] = {}
 
 
 def _repo_root() -> Path:

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -1,7 +1,23 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Pre-commit hook: :code-file:/:code-dir: targets in docs must exist in the tree."""
+"""Pre-commit hook: docs must not point at code that is not there.
+
+Two checks, both deliberately exact rather than heuristic:
+
+1. `:code-file:` / `:code-dir:` targets must exist, with the shape the role
+   implies. The roles in docs/source/conf.py build a github.com blob/tree URL
+   out of whatever string they are given and validate nothing, so a moved file
+   ships a live 404 while the Sphinx build stays green.
+2. `isaacteleop.*` imports inside documented Python must resolve to a real
+   module under src/python/. A renamed package leaves examples that raise
+   ModuleNotFoundError on the reader's first paste.
+
+Prose and shell paths are out of scope: matching those needs heuristics, and a
+doc-wide sweep of them produced mostly false positives (build artifacts,
+`cd`-relative paths, other repos' trees). A committer-facing gate has to be
+right every time to stay worth having.
+"""
 
 from __future__ import annotations
 
@@ -11,15 +27,25 @@ import subprocess
 import sys
 from pathlib import Path
 
-# The roles build a github.com blob/tree URL out of whatever string they are given
-# (docs/source/conf.py). Nothing validates the path, so a moved or mistyped target
-# ships a live link to a 404 and the Sphinx build still passes. This hook is that
-# missing validation.
 ROLE_RE = re.compile(r":code-(file|dir):`([^`]*)`", re.S)
+
+# `.. code-block:: python` (reST) and ```python (Markdown).
+RST_PY_BLOCK_RE = re.compile(
+    r"^([ \t]*)\.\. code-block:: *(?:python|py)\s*$", re.MULTILINE
+)
+MD_PY_BLOCK_RE = re.compile(r"^```+ *(?:python|py)\s*$(.*?)^```+\s*$", re.M | re.S)
+
+IMPORT_RE = re.compile(
+    r"^\s*(?:from\s+(isaacteleop(?:\.[\w.]+)?)\s+import\b"
+    r"|import\s+(isaacteleop(?:\.[\w.]+)?))",
+    re.MULTILINE,
+)
+
+PYTHON_ROOT = "src/python"
 
 # Targets that are known to be wrong and are not fixed yet. Keep the reason, and
 # delete the entry rather than let it settle in: every line here is a 404 on the
-# published docs. See docs/AGENTS.md for the audit that found them.
+# published docs.
 KNOWN_BROKEN = {
     "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/oglo_tactile_tracker.hpp": (
         "generated at configure time into ${CMAKE_BINARY_DIR}/generated/trackers/; "
@@ -38,6 +64,18 @@ KNOWN_BROKEN = {
         "generated at configure time; see the oglo_tactile_tracker.hpp entry. "
         "The generator emits both .hpp and .cpp (generate_trackers.py:59,62), "
         "so the extension is right and only the location is wrong."
+    ),
+}
+
+
+# Documented imports that are known wrong and not fixed yet, for the same reason
+# as KNOWN_BROKEN: the fix is not mechanical. Each value says why.
+KNOWN_BROKEN_IMPORTS = {
+    "isaacteleop.retargeting_engine.examples": (
+        "GripperRetargeter is exported from isaacteleop.retargeters. The import is "
+        "only one of four faults in that block — the call also omits the required "
+        "config arg and uses port names no longer in input_spec/output_spec — so "
+        "the example needs an author rewrite, not a one-line import swap."
     ),
 }
 
@@ -67,79 +105,143 @@ def _parse_role(text: str) -> str:
     return text
 
 
-def _targets(path: Path) -> list[tuple[int, str, str]]:
-    """Return (line, kind, target) for every code-file/code-dir role in path."""
+def _role_targets(source: str) -> list[tuple[int, str, str]]:
+    """Return (line, kind, target) for every code-file/code-dir role."""
+    found: list[tuple[int, str, str]] = []
+    for match in ROLE_RE.finditer(source):
+        target = _parse_role(match.group(2))
+        if target:
+            line = source.count("\n", 0, match.start()) + 1
+            found.append((line, match.group(1), target))
+    return found
+
+
+def _rst_python_blocks(source: str) -> list[tuple[int, str]]:
+    """Return (start_line, body) for each reST python code-block."""
+    lines = source.splitlines()
+    blocks: list[tuple[int, str]] = []
+    for match in RST_PY_BLOCK_RE.finditer(source):
+        indent = len(match.group(1))
+        start = source.count("\n", 0, match.start()) + 1
+        body: list[str] = []
+        for index in range(start, len(lines)):
+            line = lines[index]
+            if not line.strip():
+                body.append("")
+                continue
+            if len(line) - len(line.lstrip()) <= indent:
+                break
+            body.append(line.strip())
+        blocks.append((start, "\n".join(body)))
+    return blocks
+
+
+def _python_blocks(path: Path, source: str) -> list[tuple[int, str]]:
+    """Return (start_line, body) for each documented Python block in path."""
+    if path.suffix == ".rst":
+        return _rst_python_blocks(source)
+    return [
+        (source.count("\n", 0, m.start()) + 1, m.group(1))
+        for m in MD_PY_BLOCK_RE.finditer(source)
+    ]
+
+
+def _module_exists(root: Path, module: str) -> bool:
+    """Return whether an isaacteleop.* dotted path resolves under src/python/."""
+    base = root.joinpath(PYTHON_ROOT, *module.split("."))
+    return (
+        base.is_dir() or base.with_suffix(".py").is_file() or (base / "__init__.py").is_file()
+    )
+
+
+def _check(root: Path, path: Path) -> list[str]:
+    """Return one message per broken reference in path."""
     try:
         source = path.read_text(encoding="utf-8", errors="ignore")
     except OSError:
         return []
 
-    found: list[tuple[int, str, str]] = []
-    for match in ROLE_RE.finditer(source):
-        kind = match.group(1)
-        target = _parse_role(match.group(2))
-        if not target:
-            continue
-        line = source.count("\n", 0, match.start()) + 1
-        found.append((line, kind, target))
-    return found
+    rel = path.relative_to(root) if path.is_absolute() else path
+    problems: list[str] = []
 
+    if path.suffix == ".rst":
+        for line, kind, target in _role_targets(source):
+            if target in KNOWN_BROKEN:
+                continue
+            resolved = root / target.rstrip("/")
+            if resolved.is_dir() if kind == "dir" else resolved.is_file():
+                continue
+            problems.append(
+                f"{rel}:{line}: :code-{kind}: target does not exist: {target}"
+            )
 
-def _resolve(root: Path, kind: str, target: str) -> bool:
-    """Return whether target exists in the tree with the shape its role implies."""
-    resolved = root / target.rstrip("/")
-    if kind == "dir":
-        return resolved.is_dir()
-    return resolved.is_file()
+    for start, body in _python_blocks(path, source):
+        for match in IMPORT_RE.finditer(body):
+            module = match.group(1) or match.group(2)
+            if module in KNOWN_BROKEN_IMPORTS or _module_exists(root, module):
+                continue
+            line = start + body.count("\n", 0, match.start())
+            problems.append(
+                f"{rel}:{line}: documented import does not resolve under "
+                f"{PYTHON_ROOT}/: {module}"
+            )
+    return problems
 
 
 def main(argv: list[str]) -> int:
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(description="Check doc references.")
     parser.add_argument("filenames", nargs="*", help="files to check (from pre-commit)")
     parser.add_argument(
         "--all",
         action="store_true",
-        help="check every .rst under docs/source instead of the passed filenames",
+        help="sweep every doc in the tree instead of the passed filenames",
     )
     args = parser.parse_args(argv)
 
     root = _repo_root()
     if args.all:
         paths = sorted(root.glob("docs/source/**/*.rst"))
+        paths += [
+            path
+            for path in root.glob("**/*.md")
+            if not any(
+                part in {".git", "build", "_build", ".venv", "node_modules"}
+                for part in path.parts
+            )
+        ]
     else:
-        paths = [Path(name) for name in args.filenames if name.endswith(".rst")]
+        paths = [
+            Path(name) for name in args.filenames if name.endswith((".rst", ".md"))
+        ]
     if not paths:
         return 0
 
     violations: list[str] = []
-    stale_allowlist = set(KNOWN_BROKEN)
     for path in paths:
-        for line, kind, target in _targets(path):
-            if _resolve(root, kind, target):
-                continue
-            stale_allowlist.discard(target)
-            if target in KNOWN_BROKEN:
-                continue
-            rel = path.relative_to(root) if path.is_absolute() else path
-            violations.append(
-                f"{rel}:{line}: :code-{kind}: target does not exist: {target}"
-            )
+        violations.extend(_check(root, path))
 
     if violations:
-        print("Docs reference paths that are not in the tree.", file=sys.stderr)
-        print(
-            "These roles render as github.com links, so each one ships a 404.",
-            file=sys.stderr,
-        )
+        print("Docs reference code that is not in the tree.", file=sys.stderr)
         for violation in violations:
             print(f"  {violation}", file=sys.stderr)
         return 1
 
-    # Only meaningful for a full sweep: a partial run simply did not visit them.
-    if args.all and stale_allowlist:
-        print("KNOWN_BROKEN entries that now resolve — delete them from the hook:")
-        for target in sorted(stale_allowlist):
-            print(f"  {target}")
+    if args.all:
+        # Only meaningful for a full sweep: a partial run simply did not visit them.
+        stale = {
+            target
+            for target in KNOWN_BROKEN
+            if (root / target.rstrip("/")).exists()
+        }
+        stale |= {
+            module
+            for module in KNOWN_BROKEN_IMPORTS
+            if _module_exists(root, module)
+        }
+        if stale:
+            print("KNOWN_BROKEN entries that now resolve — delete them from the hook:")
+            for target in sorted(stale):
+                print(f"  {target}")
 
     return 0
 

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -171,11 +171,21 @@ def _check(root: Path, path: Path) -> list[str]:
             if target in KNOWN_BROKEN:
                 continue
             resolved = root / target.rstrip("/")
-            if resolved.is_dir() if kind == "dir" else resolved.is_file():
+            want_dir = kind == "dir"
+            if resolved.is_dir() if want_dir else resolved.is_file():
                 continue
-            problems.append(
-                f"{rel}:{line}: :code-{kind}: target does not exist: {target}"
-            )
+            # A role held to the wrong kind still names something real, so saying
+            # it "does not exist" sends the reader to ls, which finds the path and
+            # makes the hook look broken. Name the mismatch and the role that fits.
+            # The target leads and the role trails, because a role ends in a colon
+            # and a trailing "use :code-file:: path" reads as a typo.
+            if not resolved.exists():
+                reason = "does not exist"
+            else:
+                found = "a directory" if resolved.is_dir() else "a file"
+                fits = "code-dir" if resolved.is_dir() else "code-file"
+                reason = f"is {found}; use :{fits}:"
+            problems.append(f"{rel}:{line}: :code-{kind}: `{target}` {reason}")
 
     for start, body in _python_blocks(path, source):
         for match in IMPORT_RE.finditer(body):

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Pre-commit hook: :code-file:/:code-dir: targets in docs must exist in the tree."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# The roles build a github.com blob/tree URL out of whatever string they are given
+# (docs/source/conf.py). Nothing validates the path, so a moved or mistyped target
+# ships a live link to a 404 and the Sphinx build still passes. This hook is that
+# missing validation.
+ROLE_RE = re.compile(r":code-(file|dir):`([^`]*)`", re.S)
+
+# Targets that are known to be wrong and are not fixed yet. Keep the reason, and
+# delete the entry rather than let it settle in: every line here is a 404 on the
+# published docs. See docs/AGENTS.md for the audit that found them.
+KNOWN_BROKEN = {
+    "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/oglo_tactile_tracker.hpp": (
+        "generated at configure time into ${CMAKE_BINARY_DIR}/generated/trackers/; "
+        "never in the repo. Needs an author decision on what to link instead."
+    ),
+    "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/generic_3axis_pedal_tracker.hpp": (
+        "generated at configure time; see the oglo_tactile_tracker.hpp entry."
+    ),
+    "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/joint_state_tracker.hpp": (
+        "generated at configure time; see the oglo_tactile_tracker.hpp entry."
+    ),
+    "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/se3_tracker.hpp": (
+        "generated at configure time; see the oglo_tactile_tracker.hpp entry."
+    ),
+    "src/core/live_trackers/cpp/live_oglo_tactile_tracker_impl.cpp": (
+        "generated at configure time; see the oglo_tactile_tracker.hpp entry. "
+        "The generator emits both .hpp and .cpp (generate_trackers.py:59,62), "
+        "so the extension is right and only the location is wrong."
+    ),
+}
+
+
+def _repo_root() -> Path:
+    """Return the work tree root, so the hook can run from any subdirectory."""
+    proc = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(proc.stdout.strip())
+
+
+def _parse_role(text: str) -> str:
+    """Return the target of a role body, which is 'path' or 'label <path>'.
+
+    Mirrors _parse_code_role in docs/source/conf.py, including the whitespace
+    collapse: a role may wrap across source lines, and the label half may itself
+    look like a path, so only the part inside <> counts when both are present.
+    """
+    text = " ".join(text.split())
+    if " <" in text and text.endswith(">"):
+        _, path = text.rsplit(" <", 1)
+        return path[:-1].strip()
+    return text
+
+
+def _targets(path: Path) -> list[tuple[int, str, str]]:
+    """Return (line, kind, target) for every code-file/code-dir role in path."""
+    try:
+        source = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return []
+
+    found: list[tuple[int, str, str]] = []
+    for match in ROLE_RE.finditer(source):
+        kind = match.group(1)
+        target = _parse_role(match.group(2))
+        if not target:
+            continue
+        line = source.count("\n", 0, match.start()) + 1
+        found.append((line, kind, target))
+    return found
+
+
+def _resolve(root: Path, kind: str, target: str) -> bool:
+    """Return whether target exists in the tree with the shape its role implies."""
+    resolved = root / target.rstrip("/")
+    if kind == "dir":
+        return resolved.is_dir()
+    return resolved.is_file()
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("filenames", nargs="*", help="files to check (from pre-commit)")
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="check every .rst under docs/source instead of the passed filenames",
+    )
+    args = parser.parse_args(argv)
+
+    root = _repo_root()
+    if args.all:
+        paths = sorted(root.glob("docs/source/**/*.rst"))
+    else:
+        paths = [Path(name) for name in args.filenames if name.endswith(".rst")]
+    if not paths:
+        return 0
+
+    violations: list[str] = []
+    stale_allowlist = set(KNOWN_BROKEN)
+    for path in paths:
+        for line, kind, target in _targets(path):
+            if _resolve(root, kind, target):
+                continue
+            stale_allowlist.discard(target)
+            if target in KNOWN_BROKEN:
+                continue
+            rel = path.relative_to(root) if path.is_absolute() else path
+            violations.append(
+                f"{rel}:{line}: :code-{kind}: target does not exist: {target}"
+            )
+
+    if violations:
+        print("Docs reference paths that are not in the tree.", file=sys.stderr)
+        print(
+            "These roles render as github.com links, so each one ships a 404.",
+            file=sys.stderr,
+        )
+        for violation in violations:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+
+    # Only meaningful for a full sweep: a partial run simply did not visit them.
+    if args.all and stale_allowlist:
+        print("KNOWN_BROKEN entries that now resolve — delete them from the hook:")
+        for target in sorted(stale_allowlist):
+            print(f"  {target}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -131,6 +131,19 @@ def _module_exists(root: Path, module: str) -> bool:
     )
 
 
+def _within(root: Path, candidate: Path) -> bool:
+    """Return whether candidate is inside root once symlinks are followed.
+
+    resolve() is what closes the symlink case: a link inside the tree pointing
+    out of it would otherwise read as contained.
+    """
+    try:
+        candidate.resolve().relative_to(root.resolve())
+    except (ValueError, OSError):
+        return False
+    return True
+
+
 def _references(path: Path) -> tuple[set[str], set[str]]:
     """Return (role targets, imported modules) named anywhere in path.
 
@@ -168,6 +181,18 @@ def _check(root: Path, path: Path) -> list[str]:
             if target in KNOWN_BROKEN:
                 continue
             resolved = root / target.rstrip("/")
+            # The role renders as {repo}/blob/{branch}/{target}, so a target that
+            # leaves the work tree cannot resolve on GitHub however real it is on
+            # this machine. Check containment before existence: `root / "/etc/x"`
+            # is "/etc/x" (an absolute right operand discards the left), and
+            # enough `..` walks out too, so both would otherwise pass on a file
+            # that ships a 404.
+            if not _within(root, resolved):
+                problems.append(
+                    f"{rel}:{line}: :code-{kind}: `{target}` resolves outside the "
+                    f"repository; the link it builds cannot resolve on GitHub"
+                )
+                continue
             want_dir = kind == "dir"
             if resolved.is_dir() if want_dir else resolved.is_file():
                 continue

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -156,6 +156,28 @@ def _module_exists(root: Path, module: str) -> bool:
     )
 
 
+def _references(path: Path) -> tuple[set[str], set[str]]:
+    """Return (role targets, imported modules) named anywhere in path.
+
+    Every reference, not just the broken ones: a full sweep uses this to find
+    allowlist entries nothing points at any more.
+    """
+    try:
+        source = path.read_text(encoding="utf-8", errors="ignore")
+    except OSError:
+        return set(), set()
+
+    targets = (
+        {t for _, _, t in _role_targets(source)} if path.suffix == ".rst" else set()
+    )
+    modules = {
+        match.group(1) or match.group(2)
+        for _, body in _python_blocks(path, source)
+        for match in IMPORT_RE.finditer(body)
+    }
+    return targets, modules
+
+
 def _check(root: Path, path: Path) -> list[str]:
     """Return one message per broken reference in path."""
     try:
@@ -229,8 +251,14 @@ def main(argv: list[str]) -> int:
         return 0
 
     violations: list[str] = []
+    seen_targets: set[str] = set()
+    seen_modules: set[str] = set()
     for path in paths:
         violations.extend(_check(root, path))
+        if args.all:
+            targets, modules = _references(path)
+            seen_targets |= targets
+            seen_modules |= modules
 
     if violations:
         print("Docs reference code that is not in the tree.", file=sys.stderr)
@@ -238,17 +266,33 @@ def main(argv: list[str]) -> int:
             print(f"  {violation}", file=sys.stderr)
         return 1
 
+    # Both checks below are only meaningful for a full sweep: a partial run
+    # simply did not visit the docs that would have justified an entry.
     if args.all:
-        # Only meaningful for a full sweep: a partial run simply did not visit them.
-        stale = {
+        fixed = {
             target for target in KNOWN_BROKEN if (root / target.rstrip("/")).exists()
         }
-        stale |= {
+        fixed |= {
             module for module in KNOWN_BROKEN_IMPORTS if _module_exists(root, module)
         }
-        if stale:
-            print("KNOWN_BROKEN entries that now resolve — delete them from the hook:")
-            for target in sorted(stale):
+        if fixed:
+            print("Allowlisted entries that now resolve — delete them from the hook:")
+            for target in sorted(fixed):
+                print(f"  {target}")
+
+        # An entry can also go stale by losing its last reference rather than by
+        # starting to resolve — a doc that stops linking a generated file leaves
+        # one behind, and the check above never fires because the path is still
+        # absent. Without this, a dead allowlist reads as unpaid debt forever.
+        unreferenced = (set(KNOWN_BROKEN) - seen_targets) | (
+            set(KNOWN_BROKEN_IMPORTS) - seen_modules
+        )
+        # An entry can qualify both ways. Reporting it twice under two headings
+        # reads as two problems; "now resolves" is the more actionable reason.
+        unreferenced -= fixed
+        if unreferenced:
+            print("Allowlisted entries no longer referenced by any doc — delete them:")
+            for target in sorted(unreferenced):
                 print(f"  {target}")
 
     return 0

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -45,27 +45,9 @@ PYTHON_ROOT = "src/python"
 
 # Targets that are known to be wrong and are not fixed yet. Keep the reason, and
 # delete the entry rather than let it settle in: every line here is a 404 on the
-# published docs.
-KNOWN_BROKEN = {
-    "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/oglo_tactile_tracker.hpp": (
-        "generated at configure time into ${CMAKE_BINARY_DIR}/generated/trackers/; "
-        "never in the repo. Needs an author decision on what to link instead."
-    ),
-    "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/generic_3axis_pedal_tracker.hpp": (
-        "generated at configure time; see the oglo_tactile_tracker.hpp entry."
-    ),
-    "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/joint_state_tracker.hpp": (
-        "generated at configure time; see the oglo_tactile_tracker.hpp entry."
-    ),
-    "src/core/deviceio_trackers/cpp/inc/deviceio_trackers/se3_tracker.hpp": (
-        "generated at configure time; see the oglo_tactile_tracker.hpp entry."
-    ),
-    "src/core/live_trackers/cpp/live_oglo_tactile_tracker_impl.cpp": (
-        "generated at configure time; see the oglo_tactile_tracker.hpp entry. "
-        "The generator emits both .hpp and .cpp (generate_trackers.py:59,62), "
-        "so the extension is right and only the location is wrong."
-    ),
-}
+# published docs. A --all sweep reports entries that start resolving and entries
+# nothing references any more, so this cannot quietly outlive its problem.
+KNOWN_BROKEN: dict[str, str] = {}
 
 
 # Documented imports that are known wrong and not fixed yet, for the same reason

--- a/scripts/check_doc_refs.py
+++ b/scripts/check_doc_refs.py
@@ -150,7 +150,9 @@ def _module_exists(root: Path, module: str) -> bool:
     """Return whether an isaacteleop.* dotted path resolves under src/python/."""
     base = root.joinpath(PYTHON_ROOT, *module.split("."))
     return (
-        base.is_dir() or base.with_suffix(".py").is_file() or (base / "__init__.py").is_file()
+        base.is_dir()
+        or base.with_suffix(".py").is_file()
+        or (base / "__init__.py").is_file()
     )
 
 
@@ -229,14 +231,10 @@ def main(argv: list[str]) -> int:
     if args.all:
         # Only meaningful for a full sweep: a partial run simply did not visit them.
         stale = {
-            target
-            for target in KNOWN_BROKEN
-            if (root / target.rstrip("/")).exists()
+            target for target in KNOWN_BROKEN if (root / target.rstrip("/")).exists()
         }
         stale |= {
-            module
-            for module in KNOWN_BROKEN_IMPORTS
-            if _module_exists(root, module)
+            module for module in KNOWN_BROKEN_IMPORTS if _module_exists(root, module)
         }
         if stale:
             print("KNOWN_BROKEN entries that now resolve — delete them from the hook:")


### PR DESCRIPTION
Two classes of doc rot ship silently today. This adds one pre-commit hook that catches both.

## What goes wrong now

**Dead links.** The `:code-file:` / `:code-dir:` roles (`docs/source/conf.py`) build a `github.com` URL from whatever string they are handed and validate nothing. Move a file and the docs ship a live 404 while the Sphinx build stays green. 150 such references existed with nothing checking any of them — #1003 was five of them, found this way.

**Examples that raise on paste.** The `teleopcore` → `isaacteleop` rename left documented imports pointing at a package that does not exist (#1004). Nothing looks inside documented code, so nothing caught it.

## What the hook does

1. `:code-file:` / `:code-dir:` targets must exist, **with the shape the role implies** — a `:code-dir:` aimed at a file is reported as a kind mismatch, not as "missing". That check is what caught the two CloudXR links fixed in the first commit here.
2. `isaacteleop.*` imports inside documented Python (reST `code-block:: python` and Markdown ```python) must resolve under `src/python/`. Module paths only, not symbols — `isaacteleop.retargeters` uses a lazy export table a symbol check would have to interpret.

Prose and shell paths are **deliberately out of scope**. A sweep of those was mostly false positives (build artifacts, `cd`-relative paths, other repos), and a committer-facing gate has to be right every time to stay worth having.

## Allowlist

`KNOWN_BROKEN` ships empty. `KNOWN_BROKEN_IMPORTS` carries one entry — `teleop_session.rst:39`, whose example is broken four ways and needs an author rewrite, not an import swap. Entries carry their reason, and `--all` reports any that start resolving **or** that no doc references any more, so the list cannot outlive its problem. That second check already paid for itself: it is what flagged the five entries #1003 resolved, in the last commit here.

## Verification

Run under Python 3.12.13, matching `setup-python` in the pre-commit workflow:

```
full sweep, clean tree                        exit 0 (100 files, 150 roles, 50 blocks)
absent target                                 exit 1
:code-dir: at a real file                     exit 1, "use :code-file:"
:code-file: at a real directory               exit 1, "use :code-dir:"
unresolvable documented import                exit 1, correct file:line
all hooks x whole tree (CI's own default)      all pass, no file rewritten
```

+297/-2 across 4 files. No runtime code touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected source directory references in build-from-source and WebXR documentation.
  * Improved accuracy when directing readers to SDK and WebXR source locations.

* **Quality Improvements**
  * Added automated validation for documentation references and code examples.
  * Checks now identify missing or mismatched references before documentation changes are committed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->