### PR TITLE
docs/teleop session quick start gripper

### DIFF
--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -36,14 +36,28 @@ Here's a minimal example:
        TeleopSessionConfig,
    )
    from isaacteleop.retargeting_engine.deviceio_source_nodes import ControllersSource
-   from isaacteleop.retargeting_engine.examples import GripperRetargeter
+   from isaacteleop.retargeting_engine.interface import OutputCombiner
+   from isaacteleop.retargeters import GripperRetargeter, GripperRetargeterConfig
 
-   # Create source and build pipeline
+   # Create source and build pipeline (one GripperRetargeter per side)
    controllers = ControllersSource(name="controllers")
-   gripper = GripperRetargeter(name="gripper")
-   pipeline = gripper.connect({
-       "controller_left": controllers.output("controller_left"),
-       "controller_right": controllers.output("controller_right")
+   gripper_left = GripperRetargeter(
+       GripperRetargeterConfig(hand_side="left"),
+       name="gripper_left",
+   )
+   connected_left = gripper_left.connect({
+       ControllersSource.LEFT: controllers.output(ControllersSource.LEFT),
+   })
+   gripper_right = GripperRetargeter(
+       GripperRetargeterConfig(hand_side="right"),
+       name="gripper_right",
+   )
+   connected_right = gripper_right.connect({
+       ControllersSource.RIGHT: controllers.output(ControllersSource.RIGHT),
+   })
+   pipeline = OutputCombiner({
+       "gripper_left": connected_left.output("gripper_command"),
+       "gripper_right": connected_right.output("gripper_command"),
    })
 
    # Configure session
@@ -462,8 +476,24 @@ Before vs After
 
    # Setup pipeline
    controllers = ControllersSource(name="controllers")
-   gripper = GripperRetargeter(name="gripper")
-   pipeline = gripper.connect({...})
+   gripper_left = GripperRetargeter(
+       GripperRetargeterConfig(hand_side="left"),
+       name="gripper_left",
+   )
+   connected_left = gripper_left.connect({
+       ControllersSource.LEFT: controllers.output(ControllersSource.LEFT),
+   })
+   gripper_right = GripperRetargeter(
+       GripperRetargeterConfig(hand_side="right"),
+       name="gripper_right",
+   )
+   connected_right = gripper_right.connect({
+       ControllersSource.RIGHT: controllers.output(ControllersSource.RIGHT),
+   })
+   pipeline = OutputCombiner({
+       "gripper_left": connected_left.output("gripper_command"),
+       "gripper_right": connected_right.output("gripper_command"),
+   })
 
    # Main loop
    while True:

--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -118,7 +118,7 @@ argument is a ``uint64`` handle value.
 
 .. code-block:: python
 
-   from teleopcore.oxr import OpenXRSessionHandles
+   from isaacteleop.oxr import OpenXRSessionHandles
 
    handles = OpenXRSessionHandles(
        instance_handle, session_handle, space_handle, proc_addr

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -606,7 +606,7 @@ extensions automatically), then pass the handles through:
    import isaacteleop.viz as televiz
    from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
    from isaacteleop.deviceio import DeviceIOSession
-   from teleopcore.oxr import OpenXRSessionHandles
+   from isaacteleop.oxr import OpenXRSessionHandles
 
    viz_cfg = televiz.VizSessionConfig()
    viz_cfg.mode = televiz.DisplayMode.kXr

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -198,7 +198,7 @@ Only one OpenXR session is allowed per process. `VizSession` can own it and hand
 
 ```python
 import isaacteleop.viz as viz
-from teleopcore.oxr import OpenXRSessionHandles
+from isaacteleop.oxr import OpenXRSessionHandles
 
 cfg = viz.VizSessionConfig()
 cfg.mode = viz.DisplayMode.kXr

--- a/src/python/isaacteleop/teleop_session_manager/config.py
+++ b/src/python/isaacteleop/teleop_session_manager/config.py
@@ -349,11 +349,24 @@ class TeleopSessionConfig:
         # Source creates its own tracker automatically!
         controllers = ControllersSource(name="controllers")
 
-        # Build retargeting pipeline
-        gripper = GripperRetargeter(name="gripper")
-        pipeline = gripper.connect({
-            "controller_left": controllers.output("controller_left"),
-            "controller_right": controllers.output("controller_right")
+        # Build retargeting pipeline (one GripperRetargeter per side)
+        gripper_left = GripperRetargeter(
+            GripperRetargeterConfig(hand_side="left"),
+            name="gripper_left",
+        )
+        connected_left = gripper_left.connect({
+            ControllersSource.LEFT: controllers.output(ControllersSource.LEFT),
+        })
+        gripper_right = GripperRetargeter(
+            GripperRetargeterConfig(hand_side="right"),
+            name="gripper_right",
+        )
+        connected_right = gripper_right.connect({
+            ControllersSource.RIGHT: controllers.output(ControllersSource.RIGHT),
+        })
+        pipeline = OutputCombiner({
+            "gripper_left": connected_left.output("gripper_command"),
+            "gripper_right": connected_right.output("gripper_command"),
         })
 
         # Configure session - NO TRACKERS NEEDED!

--- a/src/python/isaacteleop/teleop_session_manager/config.py
+++ b/src/python/isaacteleop/teleop_session_manager/config.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
         McapRecordingConfig,
         McapReplayConfig,
     )
-    from teleopcore.oxr import OpenXRSessionHandles
+    from isaacteleop.oxr import OpenXRSessionHandles
 
 
 class SessionMode(Enum):
@@ -382,7 +382,7 @@ class TeleopSessionConfig:
                 left_gripper = result["gripper_left"][0]
 
     Example (external OpenXR handles from Kit):
-        from teleopcore.oxr import OpenXRSessionHandles
+        from isaacteleop.oxr import OpenXRSessionHandles
 
         handles = OpenXRSessionHandles(
             instance_handle, session_handle, space_handle, proc_addr

--- a/src/python/isaacteleop/teleop_session_manager/teleop_session.py
+++ b/src/python/isaacteleop/teleop_session_manager/teleop_session.py
@@ -121,10 +121,23 @@ class TeleopSession:
 
     Usage with DeviceIO-only pipeline:
         controllers = ControllersSource(name="controllers")
-        gripper = GripperRetargeter(name="gripper")
-        pipeline = gripper.connect({
-            "controller_left": controllers.output("controller_left"),
-            "controller_right": controllers.output("controller_right")
+        gripper_left = GripperRetargeter(
+            GripperRetargeterConfig(hand_side="left"),
+            name="gripper_left",
+        )
+        connected_left = gripper_left.connect({
+            ControllersSource.LEFT: controllers.output(ControllersSource.LEFT),
+        })
+        gripper_right = GripperRetargeter(
+            GripperRetargeterConfig(hand_side="right"),
+            name="gripper_right",
+        )
+        connected_right = gripper_right.connect({
+            ControllersSource.RIGHT: controllers.output(ControllersSource.RIGHT),
+        })
+        pipeline = OutputCombiner({
+            "gripper_left": connected_left.output("gripper_command"),
+            "gripper_right": connected_right.output("gripper_command"),
         })
 
         config = TeleopSessionConfig(app_name="MyApp", pipeline=pipeline)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Update Teleop Session and Televiz documentation so the copy-paste snippets import and construct the current public types.

The Quick Start now builds a left and right gripper pipeline with `isaacteleop.retargeters`, `GripperRetargeterConfig`, and `OutputCombiner`. External OpenXR handle examples now import `OpenXRSessionHandles` from `isaacteleop.oxr`.

Matching docstring samples in `TeleopSessionConfig` and `TeleopSession` are updated similarly, along with `examples/camera_viz/README.md`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Docs and docstring only; no runtime behavior change.

```bash
python3 -c "from isaacteleop.retargeters import GripperRetargeter, GripperRetargeterConfig; GripperRetargeter(GripperRetargeterConfig(hand_side='right'), name='gripper')"
python3 -c "from isaacteleop.oxr import OpenXRSessionHandles"
```

Also ran `SKIP=check-copyright-year pre-commit run --files` on the touched files.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated teleoperation examples to configure separate left- and right-hand gripper retargeting pipelines.
  * Added combined gripper output handling to setup and DeviceIO examples.
  * Updated OpenXR session-sharing examples to use the current import location.
  * Applied these updates across getting-started guides, configuration references, and camera visualization documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->