### PR TITLE
cloudxr: bump CXR_RUNTIME_SDK_VERSION to 6.3.0

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.3.0-rc4
+CXR_RUNTIME_SDK_VERSION=6.3.0
 CXR_WEB_SDK_VERSION=6.3.0-rc4
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 


### PR DESCRIPTION
## Description

Bumps the CloudXR Runtime SDK pin in `deps/cloudxr/.env.default` from `6.3.0-rc4` to `6.3.0-rc8`, so `scripts/download_cloudxr_runtime_sdk.sh` and the runtime container pick up the newer release candidate. `CXR_WEB_SDK_VERSION` is deliberately left at `6.3.0-rc4` — only the runtime tarball moves.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Downloaded and ran the rc8 runtime SDK locally on aarch64.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CloudXR runtime SDK to version 6.3.0-rc8.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->