### PR TITLE
fix: enforce the DCO identity match AGENTS.md already promises

### DIFF
--- a/scripts/check_dco_signoff.py
+++ b/scripts/check_dco_signoff.py
@@ -1,41 +1,107 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Commit-msg hook: reject commits that lack a DCO Signed-off-by line."""
+"""Commit-msg hook: require a DCO Signed-off-by that matches the committer.
+
+A sign-off certifies that *you* have the right to submit the work, so a trailer
+naming someone else certifies nothing. Presence alone was checked before this;
+the identity half was documented in AGENTS.md but never enforced.
+
+Extra trailers are fine — relaying a patch keeps the original author's sign-off
+and adds yours — so the rule is that at least one matches, not that all do.
+"""
+
+from __future__ import annotations
 
 import re
+import subprocess
 import sys
 
-# Matches a real git trailer line: "Signed-off-by: Name <email>" at the start
-# of a line, with at least one non-whitespace character before the angle bracket.
-_TRAILER_RE = re.compile(r"^Signed-off-by: \S.*<\S+>", re.MULTILINE)
+# A real git trailer: "Signed-off-by: Name <email>" at the start of a line, with
+# at least one non-whitespace character before the angle bracket.
+_TRAILER_RE = re.compile(r"^Signed-off-by:\s*(\S.*?)\s*<(\S+)>\s*$", re.MULTILINE)
+
+# `git var` returns "Name <email> 1234567890 +0000".
+_IDENT_RE = re.compile(r"^(.*?)\s*<(.*)>\s+\d+\s+[+-]\d{4}$")
 
 
-def main() -> None:
-    commit_msg_file = sys.argv[1]
-    with open(commit_msg_file) as f:
-        msg = f.read()
+def _committer() -> tuple[str, str] | None:
+    """Return the (name, email) `git commit -s` would sign off with.
 
-    # Strip comment lines that git inserts (e.g. with --verbose)
+    GIT_COMMITTER_IDENT rather than `git config user.name`, because that is what
+    --signoff itself uses: it honours the GIT_COMMITTER_* environment overrides
+    the config does not see, so the two can disagree.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "var", "GIT_COMMITTER_IDENT"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return None
+
+    match = _IDENT_RE.match(proc.stdout.strip())
+    return (match.group(1), match.group(2)) if match else None
+
+
+def main() -> int:
+    with open(sys.argv[1]) as handle:
+        msg = handle.read()
+
+    # Drop the comment lines git inserts (e.g. under --verbose).
     body = "\n".join(line for line in msg.splitlines() if not line.startswith("#"))
+    trailers = [(name, email) for name, email in _TRAILER_RE.findall(body)]
 
-    if _TRAILER_RE.search(body):
-        sys.exit(0)
+    if not trailers:
+        print(
+            "ERROR: commit message is missing a DCO Signed-off-by line.\n"
+            "\n"
+            "  Add it automatically:  git commit -s  (or --signoff)\n"
+            "  Or append manually:\n"
+            "\n"
+            "    Signed-off-by: Your Name <your@email.com>\n"
+            "\n"
+            "  See AGENTS.md § Commits for details.",
+            file=sys.stderr,
+        )
+        return 1
 
+    committer = _committer()
+    if committer is None:
+        # No identity to compare against — outside a repo, or git unavailable.
+        # The trailer is present and well-formed, which is as far as we can get.
+        return 0
+
+    name, email = committer
+    # Addresses are case-insensitive in practice; names are compared as written.
+    if any(t == name and e.lower() == email.lower() for t, e in trailers):
+        return 0
+
+    found = "\n".join(f"    Signed-off-by: {t} <{e}>" for t, e in trailers)
     print(
-        "ERROR: commit message is missing a DCO Signed-off-by line.\n"
+        "ERROR: no Signed-off-by line matches your git identity.\n"
         "\n"
-        "  Add it automatically:  git commit -s  (or --signoff)\n"
-        "  Or append manually:\n"
+        f"  Your identity:\n    {name} <{email}>\n"
         "\n"
-        "    Signed-off-by: Your Name <your@email.com>\n"
+        f"  Found:\n{found}\n"
         "\n"
-        "  Name/email must match: git config user.name / user.email\n"
+        "  A sign-off certifies that you have the right to submit the work, so\n"
+        "  it has to be yours. Keeping someone else's is fine — add yours too:\n"
+        "\n"
+        "    git commit --amend -s\n"
+        "\n"
+        "  If the identity above is wrong, fix it and amend:\n"
+        "\n"
+        "    git config user.name  'Your Name'\n"
+        "    git config user.email 'your@email.com'\n"
+        "\n"
         "  See AGENTS.md § Commits for details.",
         file=sys.stderr,
     )
-    sys.exit(1)
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
AGENTS.md says the sign-off name and e-mail "must match the committer's git identity" and that "a `commit-msg` pre-commit hook enforces this".

It does not. `check_dco_signoff.py` matched `^Signed-off-by: \S.*<\S+>` and stopped there — it never read git config, and the identity requirement appeared only inside its own error text. `dco.yml` is the same shape: present, well-formed, no identity comparison.

So this passed everywhere:

```
Signed-off-by: Anybody <a@b.c>
```

That matters because a sign-off certifies that **you** have the right to submit the work. A trailer naming someone else certifies nothing.

## What changed

At least one `Signed-off-by` must match the committer. **At least one, not all** — relaying a patch keeps the original author's sign-off and adds yours, and that stays legal.

Compared against `GIT_COMMITTER_IDENT`, not `git config user.name`, because that is what `--signoff` itself uses: it honours the `GIT_COMMITTER_*` environment overrides the config cannot see, so the two can disagree and only one is the identity that lands in the commit. E-mail compares case-insensitively; the name as written.

Failure prints your identity next to what it found, plus `git commit --amend -s`.

## Tested

| | |
|---|---|
| own sign-off | pass |
| relayed sign-off + own | pass |
| e-mail in different case | pass |
| no trailer | fail |
| someone else's trailer alone | fail |
| wrong name | fail |
| wrong e-mail | fail |
| `GIT_COMMITTER_NAME` override | picked up, where `git config` would have missed it |

## Scope

This closes the local half only. `dco.yml` still accepts any well-formed trailer, so a `--no-verify` commit reaches CI unchallenged. Worth a follow-up if we want the guarantee end to end — happy to do it in a separate PR, since it changes what CI rejects.

1 file, no behaviour change for anyone already using `git commit -s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-off validation to require an exact contributor name match and a case-insensitive email match.
  * Added clearer diagnostics when sign-off information is missing or does not match.
  * Improved handling of unavailable or malformed identity information while validating commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->