### PR TITLE
Fix plugin installers for reused build directories

### DIFF
--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -68,6 +68,9 @@ Run this **inside the build environment** (devcontainer or Isaac ROS container):
    cd src/plugins/manus
    ./install_manus.sh
 
+Pass ``--build-dir <path>`` to reuse a non-default top-level CMake build
+directory.
+
 The script will:
 
 1. Install the required system packages for MANUS Core Integrated.

--- a/docs/source/device/wuji_glove.rst
+++ b/docs/source/device/wuji_glove.rst
@@ -48,21 +48,25 @@ Installation
 
 ``install.sh`` downloads the pinned C SDK release, verifies it against a
 per-architecture SHA-256, extracts it next to the script (re-runs reuse the
-extracted copy), and configures + builds the plugin target:
+extracted copy), and configures, builds, and installs the plugin:
 
 .. code-block:: bash
 
    ./src/plugins/wuji_glove/install.sh
+
+Pass ``--build-dir <path>`` to reuse a non-default top-level CMake build
+directory.
 
 To build offline, point ``WUJI_SDK_C_DIR`` at an already-extracted SDK copy —
 or drive CMake directly:
 
 .. code-block:: bash
 
-   cmake -B build -DBUILD_PLUGIN_WUJI_GLOVE=ON \
+   cmake -B build -DBUILD_PLUGINS=ON -DBUILD_PLUGIN_WUJI_GLOVE=ON \
        -DWUJI_SDK_INCLUDE_DIR=/path/to/wuji-sdk-c/include \
        -DWUJI_SDK_LIB=/path/to/wuji-sdk-c/lib/libwuji_sdk_c.so
    cmake --build build --target wuji_glove_plugin
+   cmake --install build --component wuji_glove
 
 Running the Plugin
 ------------------
@@ -75,7 +79,7 @@ the plugin:
 
    python -m isaacteleop.cloudxr.service start   # runs in the background
    source ~/.cloudxr/run/cloudxr.env
-   ./build/src/plugins/wuji_glove/wuji_glove_plugin
+   ./install/plugins/wuji_glove/wuji_glove_plugin
 
 See :ref:`dedicated-cloudxr-runtime` and
 :ref:`load-cloudxr-environment-variables` for the full service setup. The plugin resolves each glove's side from device

--- a/src/plugins/manus/install_manus.sh
+++ b/src/plugins/manus/install_manus.sh
@@ -16,24 +16,8 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         -v|--verbose) VERBOSE=1; shift ;;
         --build-dir)
-            if [[ $# -lt 2 ]]; then
-                echo "--build-dir requires a path" >&2
-                exit 1
-            fi
-            BUILD_DIR="$2"
-            if [[ -z "$BUILD_DIR" ]]; then
-                echo "--build-dir requires a non-empty path" >&2
-                exit 1
-            fi
+            BUILD_DIR="${2:?--build-dir requires a non-empty path}"
             shift 2
-            ;;
-        --build-dir=*)
-            BUILD_DIR="${1#*=}"
-            if [[ -z "$BUILD_DIR" ]]; then
-                echo "--build-dir requires a non-empty path" >&2
-                exit 1
-            fi
-            shift
             ;;
         -h|--help)
             cat <<EOF

--- a/src/plugins/manus/install_manus.sh
+++ b/src/plugins/manus/install_manus.sh
@@ -11,18 +11,40 @@ set -euo pipefail
 
 # --- Arg parsing ---------------------------------------------------------
 VERBOSE=0
+BUILD_DIR=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -v|--verbose) VERBOSE=1; shift ;;
+        --build-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "--build-dir requires a path" >&2
+                exit 1
+            fi
+            BUILD_DIR="$2"
+            if [[ -z "$BUILD_DIR" ]]; then
+                echo "--build-dir requires a non-empty path" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --build-dir=*)
+            BUILD_DIR="${1#*=}"
+            if [[ -z "$BUILD_DIR" ]]; then
+                echo "--build-dir requires a non-empty path" >&2
+                exit 1
+            fi
+            shift
+            ;;
         -h|--help)
             cat <<EOF
-Usage: $(basename "$0") [--verbose]
+Usage: $(basename "$0") [--verbose] [--build-dir <path>]
 
 Installs the MANUS SDK and builds the Manus Teleop plugin.
 
 Options:
-  -v, --verbose   Show full output from apt-get, curl, cmake, etc.
-  -h, --help      Show this help.
+  --build-dir <path>  CMake build directory (default: <isaacteleop-root>/build).
+  -v, --verbose       Show full output from apt-get, curl, cmake, etc.
+  -h, --help          Show this help.
 EOF
             exit 0
             ;;
@@ -44,6 +66,10 @@ MANUS_SDK_SHA256_ACCEPTED=(
 )
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TELEOP_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+BUILD_DIR="${BUILD_DIR:-$TELEOP_ROOT/build}"
+if [[ "$BUILD_DIR" != /* ]]; then
+    BUILD_DIR="$PWD/$BUILD_DIR"
+fi
 
 # --- Output helpers ------------------------------------------------------
 LOG_FILE=$(mktemp -t manus_install.XXXXXX.log)
@@ -214,19 +240,22 @@ done_ok
 # --- 4. Build the plugin ------------------------------------------------
 step "[4/4] Building Manus plugin"
 cd "$TELEOP_ROOT"
-run cmake -S . -B build -DCMAKE_BUILD_TYPE=Release || die "cmake configure failed"
-run cmake --build build --target manus_hand_plugin manus_hand_tracker_printer -j"$(nproc)" \
+run cmake -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -DBUILD_PLUGINS=ON \
+    || die "cmake configure failed"
+run cmake --build "$BUILD_DIR" \
+    --target manus_hand_plugin manus_hand_tracker_printer -j"$(nproc)" \
     || die "build failed"
-run cmake --install build --component manus || die "install failed"
+run cmake --install "$BUILD_DIR" --component manus || die "install failed"
 done_ok
 
 # --- Done ---------------------------------------------------------------
+INSTALL_PREFIX="$(awk '/^CMAKE_INSTALL_PREFIX:PATH=/{sub(/^[^=]*=/, ""); print; exit}' "$BUILD_DIR/CMakeCache.txt")"
 cat <<EOF
 
 === Installation Complete ===
   SDK:                $SCRIPT_DIR/ManusSDK
-  Plugin executable:  $TELEOP_ROOT/install/plugins/manus/manus_hand_plugin
-  Printer diagnostic: $TELEOP_ROOT/build/bin/manus_hand_tracker_printer
+  Plugin executable:  $INSTALL_PREFIX/plugins/manus/manus_hand_plugin
+  Printer diagnostic: $BUILD_DIR/bin/manus_hand_tracker_printer
 EOF
 
 if [[ "$CONTAINER" -eq 1 ]]; then

--- a/src/plugins/wuji_glove/CMakeLists.txt
+++ b/src/plugins/wuji_glove/CMakeLists.txt
@@ -53,20 +53,24 @@ set_target_properties(wuji_glove_plugin PROPERTIES
 
 install(TARGETS wuji_glove_plugin
     RUNTIME DESTINATION plugins/wuji_glove
+    COMPONENT wuji_glove
 )
 
 install(FILES plugin.yaml README.md
     DESTINATION plugins/wuji_glove
+    COMPONENT wuji_glove
 )
 
 install(FILES "${WUJI_SDK_LIB}" "${WUJI_HAND_CPP_LIB}"
     DESTINATION plugins/wuji_glove
+    COMPONENT wuji_glove
 )
 
 # OPTIONAL: a user-provided WUJI_SDK_C_DIR may not ship the LICENSE file.
 get_filename_component(WUJI_SDK_ROOT_DIR "${WUJI_SDK_LIBRARY_DIR}" DIRECTORY)
 install(FILES "${WUJI_SDK_ROOT_DIR}/LICENSE"
     DESTINATION plugins/wuji_glove
+    COMPONENT wuji_glove
     RENAME LICENSE.wuji-sdk-c
     OPTIONAL
 )

--- a/src/plugins/wuji_glove/README.md
+++ b/src/plugins/wuji_glove/README.md
@@ -16,5 +16,5 @@ troubleshooting — lives in the docs tree:
 Quick start:
 
 ```bash
-./install.sh   # fetches the pinned wuji_sdk C SDK and builds the plugin
+./install.sh   # fetches the pinned wuji_sdk C SDK, then builds and installs the plugin
 ```

--- a/src/plugins/wuji_glove/install.sh
+++ b/src/plugins/wuji_glove/install.sh
@@ -2,14 +2,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 Wuji Technology. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Build the Wuji glove plugin.
+# Install the Wuji glove plugin.
 #
 # Two steps: (1) fetch the released wuji_sdk C SDK the plugin links against,
-# (2) configure + build the plugin target. The explicit fetch keeps the vendor
-# SDK out of normal builds when this optional plugin is disabled.
+# (2) configure, build, and install the plugin target. The explicit fetch keeps
+# the vendor SDK out of normal builds when this optional plugin is disabled.
 #
 # Usage:
-#   ./install.sh [<isaacteleop-root>]
+#   ./install.sh [--build-dir <path>] [<isaacteleop-root>]
 #
 # Env:
 #   WUJI_SDK_C_DIR      skip the download and use an already-extracted C SDK dir
@@ -31,8 +31,64 @@ declare -A WUJI_SDK_C_SHA256=(
     ["x86_64-linux-gnu"]="5217e51a88c8c9c4055669f8a3f856e5ec2242bc72a0383a5b9d39479e32c0b1"
     ["aarch64-linux-gnu"]="66f1562a7f6f8c3d2cff932f9d86a6e03c24d3557fb57ab3f9f3308e4b49069c"
 )
+
+build_dir=""
+isaac_root=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --build-dir)
+            if [[ $# -lt 2 ]]; then
+                echo "--build-dir requires a path" >&2
+                exit 1
+            fi
+            build_dir="$2"
+            if [[ -z "$build_dir" ]]; then
+                echo "--build-dir requires a non-empty path" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        --build-dir=*)
+            build_dir="${1#*=}"
+            if [[ -z "$build_dir" ]]; then
+                echo "--build-dir requires a non-empty path" >&2
+                exit 1
+            fi
+            shift
+            ;;
+        -h | --help)
+            cat <<EOF
+Usage: $(basename "$0") [--build-dir <path>] [<isaacteleop-root>]
+
+Downloads the Wuji C SDK, then builds and installs the glove plugin.
+
+Options:
+  --build-dir <path>  CMake build directory (default: <isaacteleop-root>/build).
+  -h, --help          Show this help.
+EOF
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+        *)
+            if [[ -n "$isaac_root" ]]; then
+                echo "Only one Isaac Teleop root may be specified" >&2
+                exit 1
+            fi
+            isaac_root="$1"
+            shift
+            ;;
+    esac
+done
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-ISAAC_ROOT="${1:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+ISAAC_ROOT="${isaac_root:-$(cd "$SCRIPT_DIR/../../.." && pwd)}"
+BUILD_DIR="${build_dir:-$ISAAC_ROOT/build}"
+if [[ "$BUILD_DIR" != /* ]]; then
+    BUILD_DIR="$PWD/$BUILD_DIR"
+fi
 work=""
 trap '[[ -z "$work" ]] || rm -rf "$work"' EXIT
 
@@ -81,18 +137,21 @@ wuji_hand_cpp_lib="$sdk_dir/lib/libwujihandcpp.so"
     exit 1
 }
 
-# 2. Configure + build the plugin target.
+# 2. Configure, build, and install the plugin target.
 echo "==> Building wuji_glove_plugin"
-cmake -B "$ISAAC_ROOT/build" -S "$ISAAC_ROOT" -DCMAKE_BUILD_TYPE=Release \
+cmake -B "$BUILD_DIR" -S "$ISAAC_ROOT" -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_PLUGINS=ON \
     -DBUILD_PLUGIN_WUJI_GLOVE=ON \
     -DWUJI_SDK_INCLUDE_DIR="$wuji_sdk_include_dir" \
     -DWUJI_SDK_LIB="$wuji_sdk_lib"
-cmake --build "$ISAAC_ROOT/build" --target wuji_glove_plugin --parallel
+cmake --build "$BUILD_DIR" --target wuji_glove_plugin --parallel
 
 # Co-locate the metadata and vendor libraries with the build-tree binary so the
 # $ORIGIN build RPATH resolves them regardless of where the SDK was extracted;
 # `cmake --install` lays them out the same way under plugins/wuji_glove/.
-cp "$SCRIPT_DIR/plugin.yaml" "$ISAAC_ROOT/build/src/plugins/wuji_glove/"
-cp "$wuji_sdk_lib" "$wuji_hand_cpp_lib" "$ISAAC_ROOT/build/src/plugins/wuji_glove/"
+cp "$SCRIPT_DIR/plugin.yaml" "$BUILD_DIR/src/plugins/wuji_glove/"
+cp "$wuji_sdk_lib" "$wuji_hand_cpp_lib" "$BUILD_DIR/src/plugins/wuji_glove/"
+cmake --install "$BUILD_DIR" --component wuji_glove
 
-echo "==> Done: $ISAAC_ROOT/build/src/plugins/wuji_glove/wuji_glove_plugin"
+install_prefix="$(awk '/^CMAKE_INSTALL_PREFIX:PATH=/{sub(/^[^=]*=/, ""); print; exit}' "$BUILD_DIR/CMakeCache.txt")"
+echo "==> Done: $install_prefix/plugins/wuji_glove/wuji_glove_plugin"

--- a/src/plugins/wuji_glove/install.sh
+++ b/src/plugins/wuji_glove/install.sh
@@ -37,24 +37,8 @@ isaac_root=""
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --build-dir)
-            if [[ $# -lt 2 ]]; then
-                echo "--build-dir requires a path" >&2
-                exit 1
-            fi
-            build_dir="$2"
-            if [[ -z "$build_dir" ]]; then
-                echo "--build-dir requires a non-empty path" >&2
-                exit 1
-            fi
+            build_dir="${2:?--build-dir requires a non-empty path}"
             shift 2
-            ;;
-        --build-dir=*)
-            build_dir="${1#*=}"
-            if [[ -z "$build_dir" ]]; then
-                echo "--build-dir requires a non-empty path" >&2
-                exit 1
-            fi
-            shift
             ;;
         -h | --help)
             cat <<EOF


### PR DESCRIPTION
## Summary
- let the MANUS and Wuji installers reuse a configurable top-level CMake build directory
- explicitly enable the plugin master switch so cached `BUILD_PLUGINS=OFF` configurations recover correctly
- install Wuji through a dedicated component and document the canonical installed path

Fixes #1021

## Test plan
- [x] Run `SKIP=check-copyright-year pre-commit run --all-files`
- [x] Validate both scripts with `bash -n`, `--help`, and invalid empty build-directory arguments
- [x] Configure a custom build directory with `BUILD_PLUGINS=OFF`, then run the Wuji installer against it
- [x] Verify the installed Wuji executable, metadata, and runtime library resolution with `ldd`
- [x] Build MANUS end-to-end (requires accepting and downloading the proprietary MANUS SDK)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation scripts now support choosing a custom build directory.
  * Plugin installation can reuse existing SDK copies and reports the configured installation location.
  * Wuji Glove installation supports component-based deployment.

* **Documentation**
  * Updated installation and launch instructions for Manus and Wuji Glove plugins.
  * Clarified build, installation, offline setup, and installed plugin path usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->