### PR TITLE
docs(cloudxr): explain why Quest3 is the right default for PICO

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -115,11 +115,14 @@ remembered for subsequent runs.
    does not impose. Either rename the profile or add a generic alias (e.g.
    ``webxr``) in the runtime, then update the default and the values listed below.
 
-The CloudXR runtime uses the ``Quest3`` device profile by default; Apple Vision
-Pro needs ``auto-native``. The profile is set on the *runtime*, so applications
-inherit whatever the runtime they connect to was started with. To override it,
-or any other setting, write a ``KEY=value`` env file and start the service with
-it:
+The CloudXR runtime uses the ``Quest3`` device profile by default. The name is
+narrower than the profile: ``Quest3`` serves every WebXR client — Quest, PICO,
+and the desktop-browser IWER emulator — so PICO users should keep it. Apple
+Vision Pro connects natively and needs ``auto-native`` instead; the default is
+not derived from the connected headset, so set it yourself. The profile is set
+on the *runtime*, so applications inherit whatever the runtime they connect to
+was started with. To override it, or any other setting, write a ``KEY=value``
+env file and start the service with it:
 
 .. code-block:: bash
 


### PR DESCRIPTION
A PICO user reading the Quick Start sees the CloudXR default profile named `Quest3` and nothing telling them it applies to their headset.

**1.4.x** — [quick_start](https://nvidia.github.io/IsaacTeleop/release/1.4.x/getting_started/quick_start.html)
> The name is narrower than the profile: `Quest3` serves every WebXR client — Quest, PICO, and the desktop-browser IWER emulator — **so PICO users should keep it.**

**1.5.x / main** — [quick_start](https://nvidia.github.io/IsaacTeleop/release/1.5.x/getting_started/quick_start.html)
> The CloudXR runtime uses the `Quest3` device profile by default;

The 1.4.x wording came from `22335b9ce` (#935), which never landed on main.

## Why not cherry-pick

1.5 moved the override from the example's `--cloudxr-env-config` to `service start`, paired with a "the profile is set on the *runtime*" sentence 1.4.x does not have. Cherry-picking `22335b9ce` conflicts, and resolving it in 1.4.x's favour would restore the older instruction. This ports only the two explanatory sentences.

## Scope

- 1.5's runtime-inheritance sentence and `service start` flow kept
- Code block unchanged
- Both branches pin CloudXR 6.3.0-rc4, so the 1.4.x statement still holds

Verified with `make current-docs` (`sphinx-build -W --keep-going`, what CI runs): build succeeded, and the explanation renders on the page.

Docs only. A cherry-pick to `release/1.5.x` follows once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified CloudXR device-profile behavior for WebXR clients.
  - Documented that `Quest3` is the default profile, while Apple Vision Pro requires explicitly selecting `auto-native`.
  - Explained that profiles are chosen by the runtime rather than inferred from the connected headset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->