### PR TITLE
🍒 cloudxr: bump CXR_RUNTIME_SDK_VERSION to 6.3.0 (1.4.x)

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -5,7 +5,7 @@
 ###########################################################
 # CloudXR Docker Images and Configs
 ###########################################################
-CXR_RUNTIME_SDK_VERSION=6.3.0-rc4
+CXR_RUNTIME_SDK_VERSION=6.3.0
 CXR_WEB_SDK_VERSION=6.3.0-rc4
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 


### PR DESCRIPTION
## Description

Cherry-pick of #1012 onto `release/1.4.x` (`-x` reference to cb23472e7). Bumps the CloudXR Runtime SDK pin in `deps/cloudxr/.env.default` from `6.3.0-rc4` to the public `6.3.0` release, so `scripts/download_cloudxr_runtime_sdk.sh` and the runtime container stop pulling a release candidate. `CXR_WEB_SDK_VERSION` deliberately stays at `6.3.0-rc4` — only the runtime tarball moves.

The `-external` tarball-name fallback that 1.4.x already carries (a8bb10e25) still applies, so the download path needs no change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Clean cherry-pick, no conflicts. `SKIP=check-copyright-year pre-commit run --files deps/cloudxr/.env.default` passes. Runtime validation is covered by #1012.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)