### PR TITLE
ROS: bundle and manage glove plugins

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -805,12 +805,10 @@ jobs:
           fi
         done
 
-    # Live CloudXR bring-up on the same GPU runner, reusing the teleop_ros2_ref
-    # image built above. Runs the teleop_ros2 node against a real in-process
-    # CloudXR runtime (CloudXRLauncher launches the runtime + WSS proxy) and
-    # asserts clean bring-up. No XR client connects, so the session never starts
-    # and topics are not verified here; this exercises the CloudXR launch path
-    # the replay phase above cannot.
+    # Live CloudXR and managed-plugin bring-up on the same GPU runner, reusing
+    # the teleop_ros2_ref image built above. Runs the teleop_ros2 node against a
+    # real in-process CloudXR runtime and requires the bundled Wuji plugin to
+    # start through TeleopSession. No XR client or glove is required.
     - name: Verify live CloudXR bring-up
       run: |
         set -euo pipefail
@@ -819,17 +817,16 @@ jobs:
         RUN_NAME="teleop-ros2-cloudxr-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${{ matrix.arch }}-${{ env.ROS_DISTRO }}"
         LOG_FILE="/tmp/ros2_cloudxr_output_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_${{ matrix.arch }}_${{ env.ROS_DISTRO }}.log"
         MODE="controller_teleop"
+        HAND_RETARGETER="dexpilot"
+        HAND_TRACKING_PLUGIN="wuji"
 
         # The node logs this after CloudXRLauncher returns: runtime ready + WSS
         # proxy up. This is the primary bring-up marker.
         BRINGUP_MARKER="CloudXR runtime and WSS proxy started"
-        # After bring-up the node enters the live session loop. With no XR client
-        # connected it logs the retry warning; if a device/system is present it
-        # logs session start. Either proves the loop is live.
-        LOOP_MARKER_A="TeleopSession started successfully"
-        LOOP_MARKER_B="No XR client connected"
-        # Hard failures from the launcher/runtime.
-        FAIL_RE="CloudXR runtime failed to start|SDK missing libcloudxr.so|CloudXR EULA was not accepted|CloudXR launcher is not running|runtime process exited unexpectedly|WSS proxy thread stopped unexpectedly"
+        SESSION_MARKER="TeleopSession started successfully"
+        PLUGIN_MARKER="WujiGlovePlugin initialized and running"
+        # Hard failures from the launcher, runtime, or plugin lifecycle.
+        FAIL_RE="CloudXR runtime failed to start|SDK missing libcloudxr.so|CloudXR EULA was not accepted|CloudXR launcher is not running|runtime process exited unexpectedly|WSS proxy thread stopped unexpectedly|Plugin process exited immediately|Required plugin .* was not discovered"
 
         BRINGUP_TIMEOUT_SEC=180
         LOOP_TIMEOUT_SEC=30
@@ -853,7 +850,7 @@ jobs:
           -e PYTHONUNBUFFERED=1 \
           -e ACCEPT_CLOUDXR_EULA=Y \
           --entrypoint bash "$IMAGE" -c \
-          "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$MODE -p cloudxr_accept_eula:=true" >/dev/null
+          "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$MODE -p hand_retargeter:=$HAND_RETARGETER -p hand_tracking_plugin:=$HAND_TRACKING_PLUGIN -p cloudxr_accept_eula:=true" >/dev/null
 
         fail() {
           echo "Error: $1"
@@ -870,7 +867,7 @@ jobs:
           docker logs "$RUN_NAME" > "$LOG_FILE" 2>&1 || true
 
           if grep -Eq "$FAIL_RE" "$LOG_FILE"; then
-            fail "CloudXR runtime/launcher reported a fatal error during bring-up"
+            fail "live bring-up reported a fatal error"
           fi
           if grep -qF "$BRINGUP_MARKER" "$LOG_FILE"; then
             bringup=true
@@ -891,30 +888,33 @@ jobs:
         fi
         echo "CloudXR runtime + WSS proxy came up."
 
-        # Phase 2: confirm the node entered the live session loop.
-        loop=false
+        # Phase 2: require both the live session and managed Wuji plugin.
+        ready=false
         deadline=$((SECONDS + LOOP_TIMEOUT_SEC))
         while [ "$SECONDS" -lt "$deadline" ]; do
           docker logs "$RUN_NAME" > "$LOG_FILE" 2>&1 || true
           if grep -Eq "$FAIL_RE" "$LOG_FILE"; then
-            fail "CloudXR runtime/launcher reported a fatal error after bring-up"
+            fail "live bring-up reported a fatal error after CloudXR startup"
           fi
-          if grep -qF "$LOOP_MARKER_A" "$LOG_FILE" || grep -qF "$LOOP_MARKER_B" "$LOG_FILE"; then
-            loop=true
+          if grep -qF "$SESSION_MARKER" "$LOG_FILE" && grep -qF "$PLUGIN_MARKER" "$LOG_FILE"; then
+            ready=true
             break
           fi
           running=$(docker inspect -f '{{.State.Running}}' "$RUN_NAME" 2>/dev/null || echo false)
           if [ "$running" != "true" ]; then
             rc=$(docker inspect -f '{{.State.ExitCode}}' "$RUN_NAME" 2>/dev/null || echo 1)
-            fail "node exited before entering the live session loop (exit code $rc)"
+            fail "node exited before the live session and Wuji plugin started (exit code $rc)"
           fi
           sleep "$POLL_INTERVAL_SEC"
         done
 
-        if [ "$loop" != true ]; then
-          fail "node did not enter the live session loop within ${LOOP_TIMEOUT_SEC}s"
+        if [ "$ready" != true ]; then
+          fail "live session and Wuji plugin did not start within ${LOOP_TIMEOUT_SEC}s"
         fi
-        echo "Node entered the live session loop."
+        if ! docker exec "$RUN_NAME" pgrep -f '(^|/)wuji_glove_plugin( |$)' >/dev/null; then
+          fail "Wuji plugin process is not running after startup"
+        fi
+        echo "Live session and managed Wuji plugin started."
 
         # Phase 3: soak. The node calls launcher.health_check() every loop, so a
         # dead runtime/WSS proxy would crash it. Surviving the soak with no fatal
@@ -922,18 +922,21 @@ jobs:
         sleep "$SOAK_SEC"
         docker logs "$RUN_NAME" > "$LOG_FILE" 2>&1 || true
         if grep -Eq "$FAIL_RE" "$LOG_FILE"; then
-          fail "CloudXR runtime/launcher reported a fatal error during soak"
+          fail "live bring-up reported a fatal error during soak"
         fi
         running=$(docker inspect -f '{{.State.Running}}' "$RUN_NAME" 2>/dev/null || echo false)
         if [ "$running" != "true" ]; then
           rc=$(docker inspect -f '{{.State.ExitCode}}' "$RUN_NAME" 2>/dev/null || echo 1)
           fail "node exited during the ${SOAK_SEC}s soak (exit code $rc)"
         fi
+        if ! docker exec "$RUN_NAME" pgrep -f '(^|/)wuji_glove_plugin( |$)' >/dev/null; then
+          fail "Wuji plugin process exited during the ${SOAK_SEC}s soak"
+        fi
 
         docker stop --time 5 "$RUN_NAME" >/dev/null || true
         echo "===== teleop_ros2 (live) container log ====="
         cat "$LOG_FILE" 2>/dev/null || echo "No log captured"
-        echo "Live CloudXR bring-up verified for mode $MODE (${{ env.ROS_DISTRO }}, ${{ matrix.arch }})."
+        echo "Live CloudXR and Wuji plugin bring-up verified for mode $MODE (${{ env.ROS_DISTRO }}, ${{ matrix.arch }})."
 
   # These are the actual dependency jobs for publish-wheel. publish-wheel
   # depends only on wheel-gate so the dependency list lives in one place, while

--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -79,7 +79,9 @@ The script will:
 4. Build the plugin and the diagnostic tool.
 
 When run inside a container, ``install_manus.sh`` skips the udev step and
-reminds you to run ``install_udev_rules.sh`` on the host.
+reminds you to run ``install_udev_rules.sh`` on the host. Pass ``--container``
+when the build environment does not expose standard container markers, such as
+during a Docker BuildKit build.
 
 Manual installation
 ~~~~~~~~~~~~~~~~~~~

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -7,6 +7,7 @@
 # against the distro's own interpreter.
 ARG ROS_DISTRO=jazzy
 ARG PYTHON_VERSION=3.12
+ARG MANUS_ACCEPT_EULA=
 
 # -----------------------------------------------------------------------------
 # Base: common runtime deps + uv + Python (shared by builder and runtime)
@@ -77,6 +78,7 @@ ARG ROS_DISTRO
 ARG PYTHON_VERSION
 ARG BUNDLE_ROBOTIC_GROUNDING=false
 ARG TARGETARCH
+ARG MANUS_ACCEPT_EULA
 
 # Compiler cache. CCACHE_DIR points at a BuildKit cache mount kept on the
 # runner's local BuildKit storage (not the image, not GitHub Actions cache),
@@ -89,12 +91,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ccache \
     clang-format \
     cmake \
+    curl \
     git \
+    libvulkan-dev \
     patchelf \
     pkg-config \
     python3-colcon-common-extensions \
     ros-${ROS_DISTRO}-ament-cmake-auto \
     ros-${ROS_DISTRO}-rosidl-default-generators \
+    sudo \
+    unzip \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/isaacteleop
@@ -136,6 +142,26 @@ RUN --mount=type=cache,target=/ccache,id=isaacteleop-teleop-ros2-ccache-${ROS_DI
                 -DCMAKE_BUILD_TYPE=Release \
                 -DPython3_EXECUTABLE=/usr/bin/python3" \
     && ccache --show-stats
+
+RUN --mount=type=cache,target=/ccache,id=isaacteleop-teleop-ros2-ccache-${ROS_DISTRO}-${TARGETARCH} \
+    src/plugins/wuji_glove/install.sh --build-dir /opt/isaacteleop/build \
+    && if [ "${MANUS_ACCEPT_EULA}" = "YES" ] && [ "${TARGETARCH}" = "amd64" ]; then \
+        src/plugins/manus/install_manus.sh --container \
+            --build-dir /opt/isaacteleop/build; \
+    fi \
+    && ccache --show-stats
+
+RUN set -eu; \
+    wuji_plugin=/opt/isaacteleop/install/plugins/wuji_glove/wuji_glove_plugin; \
+    test -x "$wuji_plugin"; \
+    test -f /opt/isaacteleop/install/plugins/wuji_glove/plugin.yaml; \
+    ldd "$wuji_plugin" | awk '/not found/ { missing=1 } END { exit missing ? 1 : 0 }'; \
+    if [ "${MANUS_ACCEPT_EULA}" = "YES" ] && [ "${TARGETARCH}" = "amd64" ]; then \
+        manus_plugin=/opt/isaacteleop/install/plugins/manus/manus_hand_plugin; \
+        test -x "$manus_plugin"; \
+        test -f /opt/isaacteleop/install/plugins/manus/plugin.yaml; \
+        ldd "$manus_plugin" | awk '/not found/ { missing=1 } END { exit missing ? 1 : 0 }'; \
+    fi
 
 COPY --chmod=644 <<EOF /usr/local/bin/teleop-env-setup
 source /opt/ros/${ROS_DISTRO}/setup.bash

--- a/examples/teleop_ros2/Dockerfile
+++ b/examples/teleop_ros2/Dockerfile
@@ -155,12 +155,14 @@ RUN set -eu; \
     wuji_plugin=/opt/isaacteleop/install/plugins/wuji_glove/wuji_glove_plugin; \
     test -x "$wuji_plugin"; \
     test -f /opt/isaacteleop/install/plugins/wuji_glove/plugin.yaml; \
-    ldd "$wuji_plugin" | awk '/not found/ { missing=1 } END { exit missing ? 1 : 0 }'; \
+    ldd_output="$(ldd "$wuji_plugin")"; \
+    printf '%s\n' "$ldd_output" | awk '/not found/ { missing=1 } END { exit missing ? 1 : 0 }'; \
     if [ "${MANUS_ACCEPT_EULA}" = "YES" ] && [ "${TARGETARCH}" = "amd64" ]; then \
         manus_plugin=/opt/isaacteleop/install/plugins/manus/manus_hand_plugin; \
         test -x "$manus_plugin"; \
         test -f /opt/isaacteleop/install/plugins/manus/plugin.yaml; \
-        ldd "$manus_plugin" | awk '/not found/ { missing=1 } END { exit missing ? 1 : 0 }'; \
+        ldd_output="$(ldd "$manus_plugin")"; \
+        printf '%s\n' "$ldd_output" | awk '/not found/ { missing=1 } END { exit missing ? 1 : 0 }'; \
     fi
 
 COPY --chmod=644 <<EOF /usr/local/bin/teleop-env-setup

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -68,12 +68,15 @@ tracking, MANUS gloves, or Wuji gloves. Choose the retargeter for the robot hand
 independently from the OpenXR input source, and use only one input source at a
 time. Native OpenXR hand tracking needs no additional input plugin.
 
-The ROS image does not build or launch either glove plugin. Build and run the
-selected plugin separately. For either external glove plugin, the node and
-plugin must use the same CloudXR runtime path and network namespace. Use host
-networking and the same absolute CloudXR mount path when running the node in
-Docker, as shown in the Wuji launch example below. The glove must also be
-reachable from the plugin environment.
+Set `hand_tracking_plugin` to `wuji` or `manus` to have the ROS node manage that
+plugin with its live teleoperation session. The default `none` keeps native
+OpenXR hand tracking or the manual plugin workflow below. Managed plugins require
+`hand_teleop`, or `controller_teleop` with `dexpilot`, `pink_ik`, or `wuji`, and
+are not launched during MCAP replay.
+
+When launching a plugin manually, the plugin and node must use the same CloudXR
+runtime path and network namespace, and the glove must be reachable from the
+plugin environment.
 
 #### MANUS glove input
 
@@ -101,7 +104,7 @@ After starting the ROS node, attach the plugin to the same CloudXR runtime:
 
 ```bash
 source "$HOME/.cloudxr/run/cloudxr.env"
-./build/src/plugins/wuji_glove/wuji_glove_plugin
+./install/plugins/wuji_glove/wuji_glove_plugin
 ```
 
 The Wuji glove plugin defaults to automatic wrist-source selection: optical
@@ -153,6 +156,19 @@ docker build -f examples/teleop_ros2/Dockerfile --build-arg ROS_DISTRO=<distro> 
 
 You can tag by distro (e.g. `teleop_ros2_ref:jazzy`) to build and run several side by side.
 
+The default image includes the Wuji glove plugin on amd64 and arm64. To include
+the MANUS plugin in an amd64 image, review the
+[MANUS Software License Agreement](https://www.manus-meta.com/software-license-agreement),
+confirm that your license permits this use, and explicitly accept it:
+
+```bash
+export MANUS_ACCEPT_EULA=YES
+docker build --build-arg MANUS_ACCEPT_EULA \
+  -f examples/teleop_ros2/Dockerfile -t teleop_ros2_ref:manus .
+```
+
+MANUS is skipped on non-amd64 builds.
+
 Incremental rebuilds use Docker BuildKit cache. Ensure BuildKit is enabled (default in Docker 23+), or run with `DOCKER_BUILDKIT=1 docker build ...`.
 
 ### Run the container
@@ -166,6 +182,19 @@ docker run --rm --gpus all --net=host --ipc=host \
   --name teleop_ros2_ref \
   teleop_ros2_ref --ros-args -p cloudxr_accept_eula:=true
 ```
+
+Select the managed input plugin independently from the robot-hand retargeter:
+
+- Wuji gloves driving Sharpa hands:
+  `-p hand_tracking_plugin:=wuji -p hand_retargeter:=dexpilot`
+- MANUS gloves driving Wuji Hand 2:
+  `-p hand_tracking_plugin:=manus -p hand_retargeter:=wuji -p wuji_hand_model:=wuji_hand_2`
+
+Wuji gloves must be reachable through the container's host network. Pass Wuji
+configuration overrides into the container with `docker run -e <name>=<value>`.
+MANUS also requires the
+[host udev setup](../../docs/source/device/manus.rst) and USB access; add
+`-v /dev/bus/usb:/dev/bus/usb` to the MANUS `docker run` command.
 
 ### Overriding parameters and remapping topics
 
@@ -183,7 +212,7 @@ docker run --rm --gpus all --net=host --ipc=host \
   -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `wuji_hand_model`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `hand_tracking_plugin`, `wuji_hand_model`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 

--- a/examples/teleop_ros2/python/constants.py
+++ b/examples/teleop_ros2/python/constants.py
@@ -20,6 +20,12 @@ class HandRetargeter(StrEnum):
     WUJI = "wuji"
 
 
+class HandTrackingPlugin(StrEnum):
+    NONE = "none"
+    MANUS = "manus"
+    WUJI = "wuji"
+
+
 class TeleopMode(StrEnum):
     CONTROLLER_TELEOP = "controller_teleop"
     HAND_TELEOP = "hand_teleop"
@@ -34,6 +40,7 @@ HAND_POSE_JOINT_INDICES = tuple(
 )
 HAND_POSE_NAMES = [joint.name for joint in HAND_POSE_JOINT_INDICES]
 HAND_RETARGETERS = tuple(retargeter.value for retargeter in HandRetargeter)
+HAND_TRACKING_PLUGINS = tuple(plugin.value for plugin in HandTrackingPlugin)
 SHARPA_HAND_RETARGETERS = (HandRetargeter.PINK_IK, HandRetargeter.DEXPILOT)
 TRACKED_HAND_RETARGETERS = (*SHARPA_HAND_RETARGETERS, HandRetargeter.WUJI)
 TELEOP_MODES = tuple(mode.value for mode in TeleopMode)
@@ -108,12 +115,3 @@ def resolve_hand_retargeter(
         )
 
     return hand_retargeter
-
-
-def applies_manus_controller_to_hand_transform(
-    mode: TeleopMode, hand_retargeter: HandRetargeter
-) -> bool:
-    return (
-        mode == TeleopMode.CONTROLLER_TELEOP
-        and hand_retargeter in SHARPA_HAND_RETARGETERS
-    )

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -391,7 +391,7 @@ def _load_hand_tracking_plugin(
         node.get_logger().info(
             f"Ignoring hand_tracking_plugin:={plugin} during MCAP replay."
         )
-        return plugin, search_paths
+        return HandTrackingPlugin.NONE, search_paths
 
     consumes_tracked_hands = mode == TeleopMode.HAND_TELEOP or (
         mode == TeleopMode.CONTROLLER_TELEOP

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -21,11 +21,13 @@ from pathlib import Path
 import numpy as np
 from constants import (
     HAND_RETARGETERS,
+    HAND_TRACKING_PLUGINS,
     TELEOP_MODES,
+    TRACKED_HAND_RETARGETERS,
     WUJI_HAND_MODELS,
     HandRetargeter,
+    HandTrackingPlugin,
     TeleopMode,
-    applies_manus_controller_to_hand_transform,
     resolve_hand_retargeter,
 )
 from isaacteleop.cloudxr.oob_teleop_env import TELEOP_CLIENT_ROUTE_ENV
@@ -64,7 +66,8 @@ class NodeParameters:
     sleep_period_s: float
     hand_retargeter: HandRetargeter
     resolved_hand_retargeter: HandRetargeter
-    apply_manus_controller_to_hand_transform: bool
+    hand_tracking_plugin: HandTrackingPlugin
+    plugin_search_paths: tuple[Path, ...]
     wuji_hand_model: str
     config_asset_root: Path
     session_mode: SessionMode
@@ -312,7 +315,7 @@ def _load_frames(node: Node) -> tuple[str, str, str, str]:
 
 def _load_hand_retargeter(
     node: Node, mode: TeleopMode
-) -> tuple[HandRetargeter, HandRetargeter, bool]:
+) -> tuple[HandRetargeter, HandRetargeter]:
     node.declare_parameter(
         "hand_retargeter",
         HandRetargeter.MODE_DEFAULT.value,
@@ -336,16 +339,78 @@ def _load_hand_retargeter(
             f"got {raw_hand_retargeter!r}"
         ) from exc
     resolved_hand_retargeter = resolve_hand_retargeter(mode, hand_retargeter)
-    apply_manus_transform = applies_manus_controller_to_hand_transform(
-        mode, resolved_hand_retargeter
-    )
     if mode in (TeleopMode.HAND_TELEOP, TeleopMode.CONTROLLER_TELEOP):
         node.get_logger().info(f"Hand retargeter: {resolved_hand_retargeter}")
-    if apply_manus_transform:
-        node.get_logger().info(
-            "Applying MANUS controller-to-hand transform after pose transform."
+    return hand_retargeter, resolved_hand_retargeter
+
+
+def _load_hand_tracking_plugin(
+    node: Node,
+    mode: TeleopMode,
+    resolved_hand_retargeter: HandRetargeter,
+    session_mode: SessionMode,
+) -> tuple[HandTrackingPlugin, tuple[Path, ...]]:
+    node.declare_parameter(
+        "hand_tracking_plugin",
+        HandTrackingPlugin.NONE.value,
+        ParameterDescriptor(
+            description=(
+                "Optional hand-tracking input plugin managed by this node. "
+                "Use 'none' for native OpenXR or a manually launched plugin. "
+                "Valid managed plugins: 'manus' or 'wuji'."
+            ),
+            additional_constraints=f"Must be one of {HAND_TRACKING_PLUGINS}.",
+        ),
+    )
+    raw_plugin = (
+        node.get_parameter("hand_tracking_plugin")
+        .get_parameter_value()
+        .string_value.strip()
+    )
+    try:
+        plugin = HandTrackingPlugin(raw_plugin)
+    except ValueError as exc:
+        raise ValueError(
+            f"Parameter 'hand_tracking_plugin' must be one of "
+            f"{HAND_TRACKING_PLUGINS}, got {raw_plugin!r}"
+        ) from exc
+
+    search_paths = tuple(
+        dict.fromkeys(
+            Path(value).expanduser().resolve()
+            for value in os.environ.get("ISAAC_TELEOP_PLUGIN_PATH", "").split(
+                os.pathsep
+            )
+            if value.strip()
         )
-    return hand_retargeter, resolved_hand_retargeter, apply_manus_transform
+    )
+    if plugin == HandTrackingPlugin.NONE:
+        return plugin, search_paths
+
+    consumes_tracked_hands = mode == TeleopMode.HAND_TELEOP or (
+        mode == TeleopMode.CONTROLLER_TELEOP
+        and resolved_hand_retargeter in TRACKED_HAND_RETARGETERS
+    )
+    if not consumes_tracked_hands:
+        raise ValueError(
+            f"hand_tracking_plugin:={plugin} requires a tracked-hand mode; "
+            f"mode:={mode} with hand_retargeter:={resolved_hand_retargeter} "
+            "does not consume OpenXR hand tracking"
+        )
+
+    if session_mode == SessionMode.REPLAY:
+        node.get_logger().info(
+            f"Ignoring hand_tracking_plugin:={plugin} during MCAP replay."
+        )
+        return plugin, search_paths
+
+    if not any(path.is_dir() for path in search_paths):
+        raise FileNotFoundError(
+            "No existing plugin search directory was found in ISAAC_TELEOP_PLUGIN_PATH"
+        )
+
+    node.get_logger().info(f"Managed hand-tracking plugin: {plugin}")
+    return plugin, search_paths
 
 
 def _load_mcap_replay(
@@ -514,14 +579,16 @@ def create_node_parameters(node: Node) -> NodeParameters:
     """Declare every ROS parameter on ``node``, validate, and return the snapshot."""
     rate_hz = _load_rate_hz(node)
     mode = _load_mode(node)
-    (
-        hand_retargeter,
-        resolved_hand_retargeter,
-        apply_manus_controller_to_hand_transform,
-    ) = _load_hand_retargeter(node, mode)
+    hand_retargeter, resolved_hand_retargeter = _load_hand_retargeter(node, mode)
     wuji_hand_model = _load_wuji_hand_model(node)
     config_asset_root = _load_config_asset_root(node)
     session_mode, mcap_config = _load_mcap_replay(node)
+    hand_tracking_plugin, plugin_search_paths = _load_hand_tracking_plugin(
+        node,
+        mode,
+        resolved_hand_retargeter,
+        session_mode,
+    )
     cloudxr_params = _load_cloudxr(node)
     pedal_collection_id = _load_pedal_collection_id(node)
     world_frame, right_wrist_frame, left_wrist_frame, head_frame = _load_frames(node)
@@ -535,9 +602,8 @@ def create_node_parameters(node: Node) -> NodeParameters:
         sleep_period_s=1.0 / rate_hz,
         hand_retargeter=hand_retargeter,
         resolved_hand_retargeter=resolved_hand_retargeter,
-        apply_manus_controller_to_hand_transform=(
-            apply_manus_controller_to_hand_transform
-        ),
+        hand_tracking_plugin=hand_tracking_plugin,
+        plugin_search_paths=plugin_search_paths,
         wuji_hand_model=wuji_hand_model,
         config_asset_root=config_asset_root,
         session_mode=session_mode,

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -387,6 +387,12 @@ def _load_hand_tracking_plugin(
     if plugin == HandTrackingPlugin.NONE:
         return plugin, search_paths
 
+    if session_mode == SessionMode.REPLAY:
+        node.get_logger().info(
+            f"Ignoring hand_tracking_plugin:={plugin} during MCAP replay."
+        )
+        return plugin, search_paths
+
     consumes_tracked_hands = mode == TeleopMode.HAND_TELEOP or (
         mode == TeleopMode.CONTROLLER_TELEOP
         and resolved_hand_retargeter in TRACKED_HAND_RETARGETERS
@@ -397,12 +403,6 @@ def _load_hand_tracking_plugin(
             f"mode:={mode} with hand_retargeter:={resolved_hand_retargeter} "
             "does not consume OpenXR hand tracking"
         )
-
-    if session_mode == SessionMode.REPLAY:
-        node.get_logger().info(
-            f"Ignoring hand_tracking_plugin:={plugin} during MCAP replay."
-        )
-        return plugin, search_paths
 
     if not any(path.is_dir() for path in search_paths):
         raise FileNotFoundError(

--- a/examples/teleop_ros2/python/session_config.py
+++ b/examples/teleop_ros2/python/session_config.py
@@ -23,6 +23,7 @@ from constants import (
     TRACKED_HAND_RETARGETERS,
     WUJI_HAND_JOINT_COUNT,
     HandRetargeter,
+    HandTrackingPlugin,
     TeleopMode,
 )
 from isaacteleop.retargeters import (
@@ -43,10 +44,47 @@ from isaacteleop.retargeting_engine.deviceio_source_nodes import (
     HeadSource,
 )
 from isaacteleop.retargeting_engine.interface import OutputCombiner
-from isaacteleop.teleop_session_manager import TeleopSessionConfig
+from isaacteleop.teleop_session_manager import (
+    PluginConfig,
+    SessionMode,
+    TeleopSessionConfig,
+)
 from node_parameters import NodeParameters
 from teleop_ros2_retargeters import JointNameAliasRetargeter
 from tensor_group_helpers import joint_names_from_group_type
+
+
+def _resolve_hand_tracking_plugin_configs(
+    params: NodeParameters,
+) -> list[PluginConfig]:
+    if (
+        params.hand_tracking_plugin == HandTrackingPlugin.NONE
+        or params.session_mode == SessionMode.REPLAY
+    ):
+        return []
+
+    if params.hand_tracking_plugin == HandTrackingPlugin.MANUS:
+        return [
+            PluginConfig(
+                plugin_name="manus_hand_plugin",
+                plugin_root_id="manus",
+                search_paths=list(params.plugin_search_paths),
+                plugin_args=["--datasets=human"],
+                required=True,
+            )
+        ]
+    if params.hand_tracking_plugin == HandTrackingPlugin.WUJI:
+        return [
+            PluginConfig(
+                plugin_name="wuji_glove_plugin",
+                plugin_root_id="wuji_glove",
+                search_paths=list(params.plugin_search_paths),
+                required=True,
+            )
+        ]
+    raise ValueError(
+        f"Unsupported hand-tracking plugin {params.hand_tracking_plugin!r}"
+    )
 
 
 def build_controller_raw_config(params: NodeParameters) -> TeleopSessionConfig:
@@ -161,6 +199,7 @@ def build_controller_teleop_config(params: NodeParameters) -> TeleopSessionConfi
         pipeline=pipeline,
         mode=params.session_mode,
         mcap_config=params.mcap_config,
+        plugins=_resolve_hand_tracking_plugin_configs(params),
     )
 
 
@@ -214,6 +253,7 @@ def build_hand_teleop_config(params: NodeParameters) -> TeleopSessionConfig:
         pipeline=pipeline,
         mode=params.session_mode,
         mcap_config=params.mcap_config,
+        plugins=_resolve_hand_tracking_plugin_configs(params),
     )
 
 

--- a/examples/teleop_ros2/python/teleop_profiles.py
+++ b/examples/teleop_ros2/python/teleop_profiles.py
@@ -8,7 +8,13 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import TypedDict, cast
 
-from constants import SHARPA_HAND_RETARGETERS, HandRetargeter, StrEnum, TeleopMode
+from constants import (
+    SHARPA_HAND_RETARGETERS,
+    HandRetargeter,
+    HandTrackingPlugin,
+    StrEnum,
+    TeleopMode,
+)
 from isaacteleop.retargeting_engine.interface import OptionalTensorGroup
 
 
@@ -53,6 +59,7 @@ class TeleopProfileSpec:
     mode: TeleopMode
     required_result_keys: frozenset[str]
     publish_types: frozenset[PublishType]
+    apply_manus_controller_to_hand_transform: bool = False
 
 
 TELEOP_PROFILE_SPECS = {
@@ -102,6 +109,7 @@ TELEOP_PROFILE_SPECS = {
                 PublishType.ROOT_COMMAND,
             }
         ),
+        apply_manus_controller_to_hand_transform=True,
     ),
     TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE: TeleopProfileSpec(
         mode=TeleopMode.CONTROLLER_TELEOP,
@@ -171,12 +179,17 @@ TELEOP_PROFILE_SPECS = {
 
 
 def resolve_teleop_profile_spec(
-    mode: TeleopMode, resolved_hand_retargeter: HandRetargeter
+    mode: TeleopMode,
+    resolved_hand_retargeter: HandRetargeter,
+    hand_tracking_plugin: HandTrackingPlugin = HandTrackingPlugin.NONE,
 ) -> TeleopProfileSpec:
     """Resolve user-facing settings to one complete immutable runtime profile."""
-    if (
-        mode == TeleopMode.CONTROLLER_TELEOP
-        and resolved_hand_retargeter == HandRetargeter.WUJI
+    if mode == TeleopMode.CONTROLLER_TELEOP and (
+        resolved_hand_retargeter == HandRetargeter.WUJI
+        or (
+            resolved_hand_retargeter in SHARPA_HAND_RETARGETERS
+            and hand_tracking_plugin == HandTrackingPlugin.WUJI
+        )
     ):
         profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE
     elif (

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -85,8 +85,14 @@ class TeleopRos2Node(Node):
         super().__init__("teleop_ros2_node")
         self._params: NodeParameters = create_node_parameters(self)
         self._profile_spec = resolve_teleop_profile_spec(
-            self._params.mode, self._params.resolved_hand_retargeter
+            self._params.mode,
+            self._params.resolved_hand_retargeter,
+            self._params.hand_tracking_plugin,
         )
+        if self._profile_spec.apply_manus_controller_to_hand_transform:
+            self.get_logger().info(
+                "Applying MANUS controller-to-hand transform after pose transform."
+            )
         self._tf_broadcaster = TransformBroadcaster(self)
         self._create_publishers()
         self._config = build_session_config(self._params)
@@ -123,7 +129,7 @@ class TeleopRos2Node(Node):
             self._params.right_wrist_frame,
             self._params.transform_rotation,
             self._params.transform_translation,
-            self._params.apply_manus_controller_to_hand_transform,
+            self._profile_spec.apply_manus_controller_to_hand_transform,
         )
         self._pub_ee_poses.publish(ee_poses_msg)
         if wrist_tfs:

--- a/src/plugins/manus/install_manus.sh
+++ b/src/plugins/manus/install_manus.sh
@@ -12,21 +12,24 @@ set -euo pipefail
 # --- Arg parsing ---------------------------------------------------------
 VERBOSE=0
 BUILD_DIR=""
+FORCE_CONTAINER=0
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -v|--verbose) VERBOSE=1; shift ;;
+        --container) FORCE_CONTAINER=1; shift ;;
         --build-dir)
             BUILD_DIR="${2:?--build-dir requires a non-empty path}"
             shift 2
             ;;
         -h|--help)
             cat <<EOF
-Usage: $(basename "$0") [--verbose] [--build-dir <path>]
+Usage: $(basename "$0") [--verbose] [--container] [--build-dir <path>]
 
 Installs the MANUS SDK and builds the Manus Teleop plugin.
 
 Options:
   --build-dir <path>  CMake build directory (default: <isaacteleop-root>/build).
+  --container         Skip host udev setup when auto-detection is unavailable.
   -v, --verbose       Show full output from apt-get, curl, cmake, etc.
   -h, --help          Show this help.
 EOF
@@ -97,7 +100,7 @@ in_container() {
 # --- Banner --------------------------------------------------------------
 echo "=== MANUS SDK Installation ==="
 echo "Architecture: $(uname -m)"
-if in_container; then
+if [[ "$FORCE_CONTAINER" -eq 1 ]] || in_container; then
     CONTAINER=1
     echo "Environment:  container (udev step will be skipped)"
 else

--- a/tests/python/examples/teleop_ros2/test_teleop_profiles.py
+++ b/tests/python/examples/teleop_ros2/test_teleop_profiles.py
@@ -14,8 +14,8 @@ from constants import (
     TELEOP_MODES,
     WUJI_HAND_JOINT_COUNT,
     HandRetargeter,
+    HandTrackingPlugin,
     TeleopMode,
-    applies_manus_controller_to_hand_transform,
     resolve_hand_retargeter,
 )
 from session_config import validate_joint_name_alias_count
@@ -150,16 +150,26 @@ def test_trihand_is_rejected_for_hand_teleop() -> None:
         resolve_hand_retargeter(TeleopMode.HAND_TELEOP, HandRetargeter.TRIHAND)
 
 
-def test_manus_transform_is_not_applied_to_wuji() -> None:
-    assert applies_manus_controller_to_hand_transform(
+def test_manus_transform_is_resolved_with_controller_ee_profile() -> None:
+    dexpilot_spec = resolve_teleop_profile_spec(
         TeleopMode.CONTROLLER_TELEOP, HandRetargeter.DEXPILOT
     )
-    assert applies_manus_controller_to_hand_transform(
+    pink_ik_spec = resolve_teleop_profile_spec(
         TeleopMode.CONTROLLER_TELEOP, HandRetargeter.PINK_IK
     )
-    assert not applies_manus_controller_to_hand_transform(
+    wuji_spec = resolve_teleop_profile_spec(
         TeleopMode.CONTROLLER_TELEOP, HandRetargeter.WUJI
     )
+    wuji_input_spec = resolve_teleop_profile_spec(
+        TeleopMode.CONTROLLER_TELEOP,
+        HandRetargeter.DEXPILOT,
+        HandTrackingPlugin.WUJI,
+    )
+
+    assert dexpilot_spec.apply_manus_controller_to_hand_transform
+    assert pink_ik_spec.apply_manus_controller_to_hand_transform
+    assert not wuji_spec.apply_manus_controller_to_hand_transform
+    assert not wuji_input_spec.apply_manus_controller_to_hand_transform
 
 
 def test_joint_alias_count_validation() -> None:


### PR DESCRIPTION
## Summary

- bundle the Wuji glove plugin in every ROS image and optionally include MANUS on amd64 after explicit EULA acceptance
- let `teleop_ros2_node` select and supervise MANUS or Wuji through `TeleopSession`, with EE source and calibration resolved together
- document managed input workflows and extend the GPU-backed CloudXR test to require Wuji plugin startup and process health

## Test plan

- [x] Build the current ROS image with Wuji and EULA-enabled MANUS plugins
- [x] Start both managed plugins through the ROS node and verify `TeleopSession` startup and process health
- [x] Run `SKIP=check-copyright-year pre-commit run --all-files`
- [x] Compile the modified Python modules and validate EE profile routing
- [ ] Pass the GitHub Actions matrix, including live Wuji startup on GPU runners

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable MANUS and Wuji hand-tracking plugin support for teleoperation.
  * Added automatic plugin selection and profile handling for supported tracking and retargeting configurations.
  * Added container-friendly installation options and conditional MANUS plugin installation.

* **Documentation**
  * Expanded setup guidance covering licensing, container configuration, USB/network requirements, launch prerequisites, and ROS parameters.

* **Bug Fixes**
  * Improved live test validation, including plugin startup, error detection, and liveness checks during soak testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->