### PR TITLE
ROS: gate finger joint publishing on hand_valid

### DIFF
--- a/examples/teleop_ros2/python/session_config.py
+++ b/examples/teleop_ros2/python/session_config.py
@@ -50,7 +50,10 @@ from isaacteleop.teleop_session_manager import (
     TeleopSessionConfig,
 )
 from node_parameters import NodeParameters
-from teleop_ros2_retargeters import JointNameAliasRetargeter
+from teleop_ros2_retargeters import (
+    HandTrackingGateRetargeter,
+    JointNameAliasRetargeter,
+)
 from tensor_group_helpers import joint_names_from_group_type
 
 
@@ -72,6 +75,37 @@ def _maybe_alias_hand_joints(
         {"hand_joints": connected_hand_retargeter.output("hand_joints")}
     )
     return alias_connected.output("hand_joints")
+
+
+def _maybe_gate_hand_joints_on_tracking(
+    hand_retargeter,
+    connected_hand_retargeter,
+    finger_joints,
+    output_joint_names,
+    name: str,
+):
+    """Gate a side's hand joints on tracking validity, where it is reported.
+
+    Retargeters that report validity separately get a HandTrackingGateRetargeter
+    inserted, and the gated ``hand_joints`` output is returned. Retargeters
+    without a ``hand_valid`` output get ``finger_joints`` back unchanged, so they
+    stay connected directly and this remains invisible to the publisher and to
+    profile validation.
+    """
+    if "hand_valid" not in hand_retargeter.output_spec():
+        return finger_joints
+
+    joint_names = output_joint_names or joint_names_from_group_type(
+        hand_retargeter.output_spec()["hand_joints"]
+    )
+    gate = HandTrackingGateRetargeter(joint_names=joint_names, name=name)
+    gate_connected = gate.connect(
+        {
+            "hand_joints": finger_joints,
+            "hand_valid": connected_hand_retargeter.output("hand_valid"),
+        }
+    )
+    return gate_connected.output("hand_joints")
 
 
 def _resolve_hand_tracking_plugin_configs(
@@ -459,5 +493,19 @@ def build_tracked_hand_finger_joint_outputs(
         joint_names_from_group_type(right_hand_retargeter.output_spec()["hand_joints"]),
         right_output_joint_names,
         right_alias_name,
+    )
+    left_finger_joints = _maybe_gate_hand_joints_on_tracking(
+        left_hand_retargeter,
+        left_hand_connected,
+        left_finger_joints,
+        left_output_joint_names,
+        f"{left_alias_name}_tracking_gate",
+    )
+    right_finger_joints = _maybe_gate_hand_joints_on_tracking(
+        right_hand_retargeter,
+        right_hand_connected,
+        right_finger_joints,
+        right_output_joint_names,
+        f"{right_alias_name}_tracking_gate",
     )
     return left_finger_joints, right_finger_joints

--- a/examples/teleop_ros2/python/teleop_ros2_retargeters/__init__.py
+++ b/examples/teleop_ros2/python/teleop_ros2_retargeters/__init__.py
@@ -4,6 +4,7 @@
 
 """Package-local retargeters for the ROS 2 teleop publisher."""
 
+from .hand_tracking_gate_retargeter import HandTrackingGateRetargeter
 from .joint_name_alias_retargeter import JointNameAliasRetargeter
 
-__all__ = ["JointNameAliasRetargeter"]
+__all__ = ["HandTrackingGateRetargeter", "JointNameAliasRetargeter"]

--- a/examples/teleop_ros2/python/teleop_ros2_retargeters/hand_tracking_gate_retargeter.py
+++ b/examples/teleop_ros2/python/teleop_ros2_retargeters/hand_tracking_gate_retargeter.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Retargeter adapter that withholds hand joints while tracking is invalid."""
+
+from typing import Sequence
+
+from isaacteleop.retargeting_engine.interface import (
+    BaseRetargeter,
+    OptionalType,
+    RetargeterIOType,
+    TensorGroupType,
+)
+from isaacteleop.retargeting_engine.interface.retargeter_core_types import RetargeterIO
+from isaacteleop.retargeting_engine.tensor_types import FloatType
+
+
+class HandTrackingGateRetargeter(BaseRetargeter):
+    """Pass hand joints through while tracked, emit an absent group otherwise.
+
+    Retargeters that can tell tracked from untracked report it separately,
+    because an all-zero pose is also a legitimate flat-open hand and the joint
+    values alone cannot distinguish the two. Downstream consumers already treat
+    an absent group as "no data for this side", so converting the flag into
+    absence here keeps that knowledge out of the publisher: the message builder
+    omits the side, and consumers holding their last command hold through a
+    dropout instead of snapping the hand open.
+
+    Insert only for retargeters whose output spec includes ``hand_valid``.
+    """
+
+    def __init__(self, joint_names: Sequence[str], name: str) -> None:
+        self._joint_names = list(joint_names)
+        super().__init__(name=name)
+
+    def input_spec(self) -> RetargeterIOType:
+        return {
+            "hand_joints": TensorGroupType(
+                "hand_joints_input",
+                [FloatType(name) for name in self._joint_names],
+            ),
+            "hand_valid": TensorGroupType("hand_valid_input", [FloatType("valid")]),
+        }
+
+    def output_spec(self) -> RetargeterIOType:
+        return {
+            "hand_joints": OptionalType(
+                TensorGroupType(
+                    "hand_joints",
+                    [FloatType(name) for name in self._joint_names],
+                )
+            )
+        }
+
+    def _compute_fn(self, inputs: RetargeterIO, outputs: RetargeterIO, context) -> None:
+        target = outputs["hand_joints"]
+        valid = inputs["hand_valid"]
+        if valid.is_none or float(valid[0]) <= 0.5:
+            target.set_none()
+            return
+        source = inputs["hand_joints"]
+        # Writing to an absent group marks it present again, so a resumed frame
+        # needs no explicit clear.
+        for index in range(len(self._joint_names)):
+            target[index] = float(source[index])

--- a/tests/python/examples/teleop_ros2/test_hand_tracking_gate_retargeter.py
+++ b/tests/python/examples/teleop_ros2/test_hand_tracking_gate_retargeter.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the tracking gate that withholds untracked hand joints."""
+
+from isaacteleop.retargeting_engine.interface import (
+    OptionalTensorGroup,
+    OptionalTensorGroupType,
+    OptionalType,
+    TensorGroup,
+    TensorGroupType,
+)
+from teleop_ros2_retargeters import HandTrackingGateRetargeter
+
+JOINTS = ["thumb_j0", "thumb_j1"]
+
+
+def _make_io(gate: HandTrackingGateRetargeter, joints, valid):
+    inputs = {}
+    for key, group_type in gate.input_spec().items():
+        group = TensorGroup(group_type)
+        inputs[key] = group
+    for index, value in enumerate(joints):
+        inputs["hand_joints"][index] = value
+    inputs["hand_valid"][0] = valid
+    outputs = {
+        "hand_joints": OptionalTensorGroup(gate.output_spec()["hand_joints"]),
+    }
+    return inputs, outputs
+
+
+def _gate() -> HandTrackingGateRetargeter:
+    return HandTrackingGateRetargeter(joint_names=JOINTS, name="gate")
+
+
+def test_output_is_optional() -> None:
+    """The absent state is how a dropout is signalled downstream."""
+    assert isinstance(_gate().output_spec()["hand_joints"], OptionalTensorGroupType)
+
+
+def test_tracked_frames_pass_through() -> None:
+    gate = _gate()
+    inputs, outputs = _make_io(gate, [0.25, -0.5], valid=1.0)
+
+    gate._compute_fn(inputs, outputs, None)
+
+    assert not outputs["hand_joints"].is_none
+    assert outputs["hand_joints"][0] == 0.25
+    assert outputs["hand_joints"][1] == -0.5
+
+
+def test_untracked_frames_emit_an_absent_group() -> None:
+    """An all-zero pose is also a legitimate flat-open hand, so absence -- not
+    zeros -- is what tells a consumer tracking was lost."""
+    gate = _gate()
+    inputs, outputs = _make_io(gate, [0.25, -0.5], valid=0.0)
+
+    gate._compute_fn(inputs, outputs, None)
+
+    assert outputs["hand_joints"].is_none
+
+
+def test_tracking_resumes_after_a_dropout() -> None:
+    gate = _gate()
+    inputs, outputs = _make_io(gate, [0.25, -0.5], valid=0.0)
+    gate._compute_fn(inputs, outputs, None)
+    assert outputs["hand_joints"].is_none
+
+    inputs["hand_valid"][0] = 1.0
+    gate._compute_fn(inputs, outputs, None)
+
+    assert not outputs["hand_joints"].is_none
+    assert outputs["hand_joints"][0] == 0.25
+
+
+def test_absent_validity_is_treated_as_untracked() -> None:
+    gate = _gate()
+    inputs, outputs = _make_io(gate, [0.25, -0.5], valid=1.0)
+    inputs["hand_valid"] = OptionalTensorGroup(
+        OptionalType(
+            TensorGroupType(
+                "hand_valid_input", list(gate.input_spec()["hand_valid"].types)
+            )
+        )
+    )
+
+    gate._compute_fn(inputs, outputs, None)
+
+    assert outputs["hand_joints"].is_none


### PR DESCRIPTION
## Problem

`WujiHandRetargeter` reports tracking validity separately from the joint values,
because an all-zero pose is also a legitimate flat-open hand. Its docstring says
so explicitly:

> Consumers deciding whether to forward commands to hardware must check this
> rather than inspect the joint values (an all-zero pose is also a legitimate
> result for a flat-open hand).

`examples/retargeting/python/wuji_hand_retargeter_demo.py` does exactly that.
The ROS example did not: `hand_valid` was never wired into the session result,
so on tracking loss `xr_teleop/finger_joints` carried the zero pose and
downstream controllers drove the hand open rather than holding.

Consumers cannot compensate for this downstream, because the flag never reaches
ROS at all and the zeros are indistinguishable from a real flat hand.

## Change

Surface `hand_valid` where a retargeter provides it, and omit that side from the
message when it reports untracked. Controllers that hold the last commanded
position for absent joints then hold through a dropout instead of snapping the
hand open.

Gating is per side, so one glove dropping out does not freeze both hands, and
no message is published when neither side is tracked.

Retargeters with no `hand_valid` output pass `None` and are treated as always
valid, so DexPilot, Pink IK and TriHand behaviour is unchanged.

## Tests

Four cases added to `tests/python/examples/teleop_ros2/test_messages.py`:
untracked side omitted, both sides kept when tracked, no message when neither is
tracked, and the no-validity path preserved for retargeters that do not report
it.

## Context

Found while wiring Wuji glove teleoperation of a simulated Wuji Hand 2 in Isaac
ROS (ISAACOS-1062), where a dropout mid-grasp visibly flung the simulated hand
open.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-hand tracking validity support for finger-joint publishing.
  * Hand data continues publishing independently when only one hand is tracked.
  * Missing tracking-validity information preserves existing publishing behavior.

* **Bug Fixes**
  * Prevents untracked hand data from being published.
  * Suppresses output when neither hand has valid tracking.

* **Tests**
  * Added coverage for tracked, untracked, missing-validity, and no-hand scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->