### PR TITLE
ci(docs): clean and sweep stale gh-pages PR previews

### DIFF
--- a/.github/scripts/remove_docs_preview.sh
+++ b/.github/scripts/remove_docs_preview.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Remove documentation previews from the gh-pages branch.
+#
+# remove_docs_preview.sh [pr-number ...]
+#
+# Several numbers are removed in one commit so the nightly sweep does not push
+# once per stale preview. Idempotent: a missing branch or a missing directory is
+# success, so it is safe to call speculatively. Callers that also push gh-pages
+# should share a concurrency group.
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: remove_docs_preview.sh [pr-number ...]" >&2
+  exit 1
+fi
+: "${GITHUB_TOKEN:?GITHUB_TOKEN is required}"
+: "${GITHUB_REPOSITORY:?GITHUB_REPOSITORY is required}"
+
+remote="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+if ! git ls-remote --exit-code --heads "$remote" gh-pages >/dev/null 2>&1; then
+  echo "No gh-pages branch; nothing to remove."
+  exit 0
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+git clone --quiet --depth 1 --branch gh-pages "$remote" "$work"
+cd "$work"
+
+removed=()
+for pr in "$@"; do
+  if [[ -d "preview/pr-${pr}" ]]; then
+    rm -rf "preview/pr-${pr}"
+    removed+=("#${pr}")
+  else
+    echo "No preview for PR #${pr}."
+  fi
+done
+
+if [[ ${#removed[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ ${#removed[@]} -eq 1 ]]; then
+  message="docs: drop preview for PR ${removed[0]}"
+else
+  message="docs: drop previews for PRs ${removed[*]}"
+fi
+
+git config user.name "github-actions[bot]"
+git config user.email "github-actions[bot]@users.noreply.github.com"
+git add --all
+git commit --quiet --message "$message"
+
+for attempt in 1 2 3; do
+  if git push --quiet origin gh-pages; then
+    echo "Removed ${#removed[@]} preview(s): ${removed[*]}"
+    exit 0
+  fi
+  echo "Push rejected (attempt ${attempt}); rebasing onto the current branch."
+  git fetch --quiet --depth 1 origin gh-pages
+  git rebase --quiet FETCH_HEAD
+done
+
+echo "Could not remove previews ${removed[*]} after 3 attempts." >&2
+exit 1

--- a/.github/workflows/docs-cleanup-preview.yaml
+++ b/.github/workflows/docs-cleanup-preview.yaml
@@ -1,21 +1,59 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Manual workflow to remove accumulated PR preview deployments from GitHub Pages.
-# Run from the Actions tab when you want to clean up preview/pr-* directories.
-
+# Remove docs PR preview deployments from GitHub Pages.
+# - pull_request_target closed: delete preview/pr-<N>/.
+# - workflow_dispatch: wipe all of preview/.
+#
+# Close cleanup uses pull_request_target so fork-PR closes still get a write
+# token. Never checkout or run PR-head code; the only untrusted input is the
+# PR number. docs-preview-sweep.yaml reconciles anything still left.
 name: Clean docs PR previews
 
 on:
   workflow_dispatch:
+  pull_request_target:
+    types: [closed]
 
 permissions:
   contents: write
 
 jobs:
-  clean-previews:
-    name: Remove PR preview dirs from gh-pages
+  clean-one-preview:
+    name: Remove one PR preview from gh-pages
+    if: >-
+      github.repository == 'NVIDIA/IsaacTeleop'
+      && github.event_name == 'pull_request_target'
     runs-on: ubuntu-latest
+    concurrency:
+      group: docs-gh-pages
+      cancel-in-progress: false
+      queue: max
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/scripts
+
+      - name: Remove preview/pr-${{ github.event.pull_request.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          .github/scripts/remove_docs_preview.sh "$PR_NUMBER"
+
+  clean-previews:
+    name: Remove all PR preview dirs from gh-pages
+    if: >-
+      github.repository == 'NVIDIA/IsaacTeleop'
+      && github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: docs-gh-pages
+      cancel-in-progress: false
+      queue: max
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -29,13 +67,14 @@ jobs:
 
       - name: Clean PR preview deployments
         run: |
+          set -euo pipefail
           git fetch origin gh-pages 2>/dev/null || true
           if ! git rev-parse --verify origin/gh-pages >/dev/null 2>&1; then
             echo "No gh-pages branch found. Nothing to clean."
             exit 0
           fi
           git checkout gh-pages
-          if [ ! -d preview ]; then
+          if [[ ! -d preview ]]; then
             echo "No preview/ directory. Nothing to clean."
             exit 0
           fi

--- a/.github/workflows/docs-preview-on-demand.yaml
+++ b/.github/workflows/docs-preview-on-demand.yaml
@@ -62,8 +62,9 @@ jobs:
       && (github.event.comment.body == '/preview-docs' || startsWith(github.event.comment.body, '/preview-docs '))
     runs-on: ubuntu-latest
     concurrency:
-      group: preview-pr-${{ github.event.issue.number }}
-      cancel-in-progress: true
+      group: docs-gh-pages
+      cancel-in-progress: false
+      queue: max
     permissions:
       actions: read         # download artifacts from the matching docs.yaml run
       contents: write       # push to gh-pages

--- a/.github/workflows/docs-preview-sweep.yaml
+++ b/.github/workflows/docs-preview-sweep.yaml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Nightly reconciliation for docs previews on the gh-pages branch.
+#
+# docs-cleanup-preview.yaml removes a preview when its PR closes. This sweep
+# exists so the branch does not depend on every event firing correctly: it
+# compares what is on the branch against what is actually open and removes the
+# difference. It covers a cleanup job that failed its pushes and previews
+# written before this workflow reached the default branch.
+#
+# Pushing gh-pages triggers Pages (branch source); no separate deploy action.
+name: Docs preview sweep
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+
+jobs:
+  sweep:
+    name: Remove previews for closed PRs
+    if: github.repository == 'NVIDIA/IsaacTeleop'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    concurrency:
+      # Shares the publisher's group: both push the gh-pages branch.
+      group: docs-gh-pages
+      cancel-in-progress: false
+      queue: max
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          sparse-checkout: |
+            .github/scripts
+
+      - name: Remove previews whose PR is no longer open
+        id: sweep
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          err="$(mktemp)"
+
+          # Only a 404 means there is nothing there; any other failure is
+          # operational and must not be read as "no previews".
+          if previews="$(gh api "repos/${GITHUB_REPOSITORY}/contents/preview?ref=gh-pages" \
+              --jq '.[] | select(.type == "dir") | .name' 2>"$err")"; then
+            :
+          elif grep -q 'HTTP 404' "$err"; then
+            previews=""
+          else
+            echo "::error::Could not list previews: $(cat "$err")"
+            exit 1
+          fi
+
+          if [[ -z "$previews" ]]; then
+            echo "No previews on gh-pages."
+            exit 0
+          fi
+
+          stale=()
+          for name in $previews; do
+            [[ "$name" =~ ^pr-([0-9]+)$ ]] || { echo "Ignoring '$name'."; continue; }
+            pr="${BASH_REMATCH[1]}"
+            # Only a confirmed state removes a preview. A 404 means the number
+            # never resolved to a PR and is safe to drop; rate limiting, a 5xx,
+            # or an auth failure must fail the sweep instead of deleting a live
+            # preview. The next run reconciles whatever this one skipped.
+            if state="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${pr}" --jq .state 2>"$err")"; then
+              :
+            elif grep -q 'HTTP 404' "$err"; then
+              state="missing"
+            else
+              echo "::error::Could not read PR #${pr}: $(cat "$err")"
+              exit 1
+            fi
+            if [[ "$state" == open ]]; then
+              echo "PR #${pr} is open; keeping its preview."
+            else
+              echo "PR #${pr} is ${state}; queuing its preview for removal."
+              stale+=("$pr")
+            fi
+          done
+
+          if [[ ${#stale[@]} -eq 0 ]]; then
+            echo "Every preview belongs to an open PR."
+            exit 0
+          fi
+
+          .github/scripts/remove_docs_preview.sh "${stale[@]}"
+          printf 'Swept %d stale preview(s): %s\n' "${#stale[@]}" "${stale[*]}" \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -8,8 +8,12 @@
 # - Fork PR: build only; a maintainer can deploy via `/preview-docs` (see
 #   docs-preview-on-demand.yaml).
 #
+# - PR close: docs-cleanup-preview.yaml removes preview/pr-<N>/.
+# - Nightly/manual: docs-preview-sweep.yaml drops previews whose PRs are closed.
+#
 # Builds are gated on changed paths by the `changes` job; gh-pages
 # `keep_files: true` preserves whichever artifact was skipped.
+# Deploy writers share concurrency group `docs-gh-pages` with cleanup/sweep.
 #
 # The web client downloads its CloudXR SDK anonymously from public NGC resources.
 
@@ -172,6 +176,10 @@ jobs:
       && needs.build-docs.result != 'failure'
       && needs.build-app.result != 'failure'
       && (needs.build-docs.result == 'success' || needs.build-app.result == 'success')
+    concurrency:
+      group: docs-gh-pages
+      cancel-in-progress: false
+      queue: max
     permissions:
       contents: write  # push to gh-pages
     steps:

--- a/.github/workflows/promote-stable-client.yaml
+++ b/.github/workflows/promote-stable-client.yaml
@@ -27,6 +27,10 @@ jobs:
         || (github.event.ref_type == 'tag' && startsWith(github.event.ref, 'v'))
       )
     runs-on: ubuntu-latest
+    concurrency:
+      group: docs-gh-pages
+      cancel-in-progress: false
+      queue: max
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Docs PR previews under `preview/pr-<N>/` on `gh-pages` were never removed after PRs closed. With `keep_files: true` they accumulated (~9.5 GB) and pushed the GitHub Pages deploy artifact over the hard 10 GB limit.

This change:

- Extends `docs-cleanup-preview.yaml` so a closed PR deletes `preview/pr-<N>/` (keeps the existing manual wipe of all of `preview/`).
- Adds `docs-preview-sweep.yaml` (nightly `17 4 * * *` UTC + `workflow_dispatch`) to remove previews whose PRs are no longer open.
- Adds `.github/scripts/remove_docs_preview.sh` for shared removals.
- Serializes `gh-pages` writers with concurrency group `docs-gh-pages` (`queue: max`) across cleanup, sweep, docs deploy, on-demand preview, and promote-stable.

Production docs for `main` / `release/**` are not purged. After merge to `main`, the next scheduled sweep (or a manual **Docs preview sweep** run) clears the backlog while keeping open-PR previews.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

- `SKIP=check-copyright-year pre-commit run --files` on the touched workflow/script files (passed).
- After merge: close a docs PR and confirm `preview/pr-<N>/` is removed; dispatch **Docs preview sweep** and confirm closed-PR dirs are gone while open-PR previews remain; confirm `main/` / `release/` / `client/` are untouched.
- No unit tests: GitHub Actions / shell workflow only.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup of documentation previews when pull requests close.
  * Added nightly and manual reconciliation of previews, removing those no longer associated with open pull requests.
  * Added reliable cleanup with validation, retry handling, and clear status reporting.

* **Bug Fixes**
  * Prevented concurrent documentation publishing and cleanup jobs from overwriting one another.
  * Ensured active previews are preserved while stale previews are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->