### PR TITLE
disable visualization and clang-format checking when running the manus install

### DIFF
--- a/src/plugins/manus/install_manus.sh
+++ b/src/plugins/manus/install_manus.sh
@@ -228,6 +228,7 @@ done_ok
 step "[4/4] Building Manus plugin"
 cd "$TELEOP_ROOT"
 run cmake -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -DBUILD_PLUGINS=ON \
+    -DBUILD_VIZ=OFF -DENABLE_CLANG_FORMAT_CHECK=OFF \
     || die "cmake configure failed"
 run cmake --build "$BUILD_DIR" \
     --target manus_hand_plugin manus_hand_tracker_printer -j"$(nproc)" \


### PR DESCRIPTION
Add CMake args to disable (1) building TeleViz and (2) checking with clang-format when installing the Manus plugin

<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

These two dependencies aren't required for Manus so disabling them helps minimize dependencies required in other projects that aren't using these features.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

<!-- Describe how you tested your changes, including commands and platforms. -->

My testing strategy was inside the Isaac ROS container:
1. Install Isaac ROS Teleop's dependencies
2. Clone this repository 
3. Run the Manus install plugin script and ensure that the build completes 

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [ ] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [ ] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the plugin build configuration to exclude visualization components, resulting in a leaner installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->