### PR TITLE
examples: write down the Python example convention

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -22,12 +22,6 @@ precedence = "override"
 SPDX-FileCopyrightText = "Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved."
 SPDX-License-Identifier = "Apache-2.0"
 
-[[annotations]]
-path = "examples/cxrjs/**"
-precedence = "override"
-SPDX-FileCopyrightText = "Copyright (c) NVIDIA CORPORATION & AFFILIATES. All rights reserved."
-SPDX-License-Identifier = "Apache-2.0"
-
 # Cursor rule files (.mdc) keep frontmatter clean (no SPDX header); cover them
 # here so REUSE lint passes, mirroring the .github/** override above.
 [[annotations]]

--- a/docs/source/getting_started/teleop_session.rst
+++ b/docs/source/getting_started/teleop_session.rst
@@ -444,7 +444,7 @@ Examples
 Complete Examples
 ^^^^^^^^^^^^^^^^^
 
-#. **Simplified Gripper Example**: ``examples/retargeting/python/gripper_retargeting_simple.py``
+#. **Simplified Gripper Example**: ``examples/teleop/python/gripper_retargeting_example_simple.py``
    -- Shows the minimal configuration approach and demonstrates auto-creation
    of input sources.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,96 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Isaac Teleop examples
+
+Each subdirectory is a self-contained example. Read one, run it, or copy it into
+your own project — the last of those is the reason for the layout below.
+
+## Running an example
+
+```bash
+uv pip install -e ./examples/<name>
+python -m isaacteleop_examples.<name>
+```
+
+Every example runs this way, and its `README.md` gives the exact command.
+
+An example with one obvious entry point puts it in `__main__.py`, so
+`python -m isaacteleop_examples.<name>` runs it. An example that is several
+co-equal demos has no `__main__.py` at all — each is a submodule, run as
+`python -m isaacteleop_examples.<name>.<mod>`, and the README lists them.
+Promoting one of several peers to the default only makes it look privileged.
+
+## Layout
+
+```
+examples/<name>/
+├── README.md            — what it does, and the command to run it
+├── pyproject.toml       — the distribution, named isaacteleop-examples-<name>
+└── python/
+    └── isaacteleop_examples/
+        └── <name>/
+            ├── __init__.py
+            ├── __main__.py   — only if there is one obvious entry point
+            └── ...
+```
+
+`pyproject.toml` sits at the example root, so `uv pip install ./examples/<name>`
+works for every example without knowing anything about its internals.
+
+`python/` is the namespace root. **`isaacteleop_examples/` has no
+`__init__.py`** and must never get one: it is a [PEP 420][pep420] namespace
+shared by every example distribution, and giving one distribution ownership of
+it makes the others collide or vanish when two are installed together.
+
+[pep420]: https://peps.python.org/pep-0420/
+
+## Importing within an example
+
+Modules in the same example import each other **relatively**:
+
+```python
+from .pipeline import Frame        # yes
+from pipeline import Frame         # no
+```
+
+A bare `from pipeline import Frame` resolves only because the directory of the
+script you invoked lands on `sys.path`. It breaks under `python -m`, breaks the
+moment someone copies the file into a package of their own, and claims a
+generic top-level name — `pipeline`, `common`, `messages` — for the whole
+interpreter. Do not paper over it with a `try: from .x / except ImportError:
+from x` guard; that doubles every import site to tolerate an invocation that
+should simply not be used.
+
+## What this does not cover
+
+An example with no importable Python is left alone. `rebot` is the case: its
+only `.py` is a root-run `/dev/mem` helper that a systemd unit installs to
+`/opt/` and executes with the system interpreter, and its `pyproject.toml`
+exists to resolve a CLI dependency. Packaging that would break the thing that
+runs it. The rule below is about examples you `import`.
+
+## Adding an example
+
+Copy the layout above and match an existing example — `deviceio_live_view` is
+the smallest complete one.
+
+- Name the distribution `isaacteleop-examples-<name>`, mirroring the import
+  path, so nothing claims a bare top-level name in `site-packages`.
+- With hatchling, use `only-include` + `sources`, **not** `packages`:
+
+  ```toml
+  [tool.hatch.build.targets.wheel]
+  only-include = ["python/isaacteleop_examples/<name>"]
+  sources = ["python"]
+  ```
+
+  `packages` keeps only the last path component, so it builds without complaint
+  and produces a wheel rooted at a bare top-level `<name>/`.
+- Keep `[tool.uv.sources]` last in the file. `install_python_example()` strips
+  it from the installed copy by matching up to the next `[`, so a block after it
+  loses its comments.
+- If the example ships in the install tree, add
+  `install_python_example(DESTINATION examples/<name>)` to its `CMakeLists.txt`.


### PR DESCRIPTION
## Description

Part of #985. First in a stack of 14 — the rest build on this.

Examples are split between two import styles and two `pyproject.toml` locations, so "what does a new example look like" has no answer, and copying one into your own project is a coin flip on whether its imports survive. This writes down the convention `examples/mujoco_xr` already follows and the rest are being moved to: one distribution per example, sources under `python/isaacteleop_examples/<name>/`, relative sibling imports, `isaacteleop_examples/` kept as a PEP 420 namespace, and one command that works for every example.

It also fixes two references that outlived what they named, both found while auditing for this:

- `gripper_retargeting_simple.py` moved directory *and* was renamed; the docs still pointed at the old path.
- `examples/cxrjs` was deleted in `a61389d27` and `b6e490af8`; its `REUSE.toml` annotation stayed behind. `reuse-lint-file` lints files, so an annotation naming a path that no longer exists never fails — which is why it survived six months.

No code changes; no example moves in this PR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

`SKIP=check-copyright-year pre-commit run --all-files` clean, which covers the `REUSE.toml` edit. Both corrected paths verified to exist; the removed `cxrjs` path verified absent from the tree.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<sub>No tests: documentation and a licence-metadata deletion, with nothing to assert against.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the teleoperation guide with the correct simplified gripper example path.
  - Added comprehensive guidance for navigating, installing, running, packaging, and extending the available examples.
  - Documented conventions for multi-entry-point examples, namespace packages, relative imports, and registering new examples with the build system.
- **Chores**
  - Simplified project licensing metadata for example content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->