### PR TITLE
🍒 docs(camera-streaming): list JetPack 6.2.x and 7.x per platform

### DIFF
--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -32,9 +32,11 @@ Requirements
 
 - A workstation meeting the :doc:`system requirements </references/requirements>` (Ubuntu, NVIDIA
   GPU, CUDA driver) — every source hands frames to the renderer GPU-resident via CuPy.
-- For Jetson platforms, use
-  `JetPack 6.2.1 <https://developer.nvidia.com/embedded/jetpack-sdk-621>`_ on Orin or
-  `JetPack 7.1 <https://developer.nvidia.com/embedded/jetpack/downloads/archive-7.1>`_ on Thor.
+- For Jetson platforms:
+
+  - **Orin:** `JetPack 6.2.x <https://developer.nvidia.com/embedded/jetpack-sdk-62>`__ or
+    `7.2.x <https://developer.nvidia.com/embedded/jetpack/downloads/archive-7.2>`__
+  - **Thor:** `JetPack 7.x <https://developer.nvidia.com/embedded/jetpack>`__
 - For the default XR mode, a headset to connect as the CloudXR client — follow the
   :doc:`quick start </getting_started/quick_start>` step :ref:`connect-xr-headset`. The viewer
   launches the CloudXR runtime itself; nothing to start separately. No headset handy?


### PR DESCRIPTION
## Description

Cherry Pick https://github.com/NVIDIA/IsaacTeleop/pull/1050

Update camera streaming pins for Orin to JetPack 6.2.1 or greater and Thor to JetPack 7.1 or greater.

This updates the requirements to:

- **Orin:** JetPack 6.2.x or 7.2.x
- **Thor:** JetPack 7.x

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Ran `SKIP=check-copyright-year pre-commit run --all-files`; all hooks passed.

No runtime tests: the page only records supported JetPack series, with no code or sample behavior change.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Jetson platform requirements to specify supported JetPack major-version ranges for Orin and Thor.
  * Replaced references to specific pinned JetPack versions with broader compatibility guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->