### PR TITLE
fix(web): prevent scrolling from changing server port

### DIFF
--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -900,11 +900,10 @@ limitations under the License.
               <input
                 id="portInput"
                 class="ui-input"
-                type="number"
+                type="text"
+                inputmode="numeric"
                 placeholder="Port (default: 49100)"
                 spellcheck="false"
-                min="1"
-                max="65535"
               />
               <div id="certAcceptanceLink" class="cert-acceptance-link" style="display: none">
                 <span class="cert-icon">🔒</span>


### PR DESCRIPTION
## Summary

- render the CloudXR server port as a text field so mouse-wheel scrolling cannot step and persist a different port
- retain the numeric virtual keyboard hint with `inputmode="numeric"`
- keep existing port parsing, defaults, URL seeding, and local-storage persistence unchanged

## Validation

- `SKIP=check-copyright-year pre-commit run --all-files`
- `npm test -- --runInBand` (102 tests)
- `npm run build`
- `npx prettier --check src/index.html`
- parsed `src/index.html` with JSDOM and verified `portInput` has `type=text` and `inputMode=numeric`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the port field to provide a numeric keyboard on supported devices.
  * Removed restrictive built-in minimum and maximum value limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->