### PR TITLE
ci(docs): build every docs version with main's config

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -137,6 +137,12 @@ jobs:
           # smudges LFS files from the local object cache. `lfs: true` above only
           # fetched HEAD's objects, so pull the rest for every built ref here.
           git lfs fetch --all
+          # Every version is built with the `conf.py` of *this* checkout, which
+          # sphinx-multiversion passes as `-c`, so a release or tag push would render
+          # main's pages with an older config: roles and directives from extensions it
+          # does not load come out as raw text, and its CSS is dropped. This step
+          # deploys the whole site, so take the docs config from main either way.
+          git -C "$GITHUB_WORKSPACE" checkout origin/main -- docs
           make multi-docs
 
       - name: Upload docs artifact

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,9 +16,15 @@ is what CI runs, so a new warning fails the build. Check a docs change with that
 rather than a bare `sphinx-build`.
 
 `make multi-docs` is the other half, and it constrains how extensions are written:
-sphinx-multiversion builds every whitelisted ref with `-c` pointing at that ref's own
-checkout. Resolve data and asset paths from `app.confdir`, never from the working
-directory or the repo root, or building an old tag reads today's files.
+sphinx-multiversion builds every whitelisted ref with `-c` pointing at the checkout that
+invoked it, so `app.confdir` is that checkout while `app.srcdir` is the ref being built.
+Resolve paths from one of those two, never from the working directory or the repo root.
+
+The config is therefore a site-wide input, not a per-version one: the deploy job takes
+`docs/` from `main` before building, or a release or tag push renders main's pages with an
+older `conf.py` and anything its extensions provide disappears. A push runs the workflow
+file from its own ref, so that step has to stay alive on every release branch that still
+receives pushes.
 
 Images follow `.gitattributes` like everything else, Git LFS included. A checkout without
 LFS holds pointer text and Sphinx copies it into the site verbatim, so a page that looks


### PR DESCRIPTION
## Description

The Ecosystem page on the published site rendered as raw text: `:device-count:` printed literally, the device tables were gone, and `ecosystem.css` was missing. It deployed correctly from `main` at 19:05, and a push to `release/1.4.x` redeployed the whole site 35 minutes later and overwrote it.

sphinx-multiversion passes the invoking checkout's `conf.py` to every ref it builds (as `-c`), so that release push rebuilt main's sources with a config that never loads `ecosystem_grid`. `make multi-docs` cannot run with `-W` — older refs already emit errors — so the deploy reported success with the page broken. The deploy job now takes `docs/` from `main` before building, whichever ref triggered it.

A push runs the workflow file from its own ref, so this needs a backport to the release branches that still receive pushes (`release/1.4.x`, `release/1.5.x`); separate PRs follow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Reproduced in a `release/1.4.x` worktree, building `main` with sphinx-multiversion:

| | unknown role/directive errors | device rows | `ecosystem.css` |
|---|---|---|---|
| before | 8 | 0 | missing |
| after | 0 | 13 | present |

`release/1.4.x`'s own page still renders its 10 `list-table`s, so building old refs with main's config is safe.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified configuration and path guidance for building multi-version documentation.
  * Documented deployment configuration and release-branch workflow requirements.

* **Chores**
  * Improved the multi-version documentation build process by using the latest documentation configuration from the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->