### PR TITLE
🍒 ci(docs): build every docs version with main's config (backport of #1053)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -133,6 +133,12 @@ jobs:
           # smudges LFS files from the local object cache. `lfs: true` above only
           # fetched HEAD's objects, so pull the rest for every built ref here.
           git lfs fetch --all
+          # Every version is built with the `conf.py` of *this* checkout, which
+          # sphinx-multiversion passes as `-c`, so a release or tag push would render
+          # main's pages with an older config: roles and directives from extensions it
+          # does not load come out as raw text, and its CSS is dropped. This step
+          # deploys the whole site, so take the docs config from main either way.
+          git -C "$GITHUB_WORKSPACE" checkout origin/main -- docs
           make multi-docs
 
       - name: Upload docs artifact


### PR DESCRIPTION
## Description

Backport of #1053, workflow only — this branch has no `docs/AGENTS.md`.

A push to this branch redeploys the whole multi-version site, and sphinx-multiversion builds every ref with the invoking checkout's `conf.py`, so main's pages came out rendered against this branch's older config: custom roles printed as raw text, custom directives dropped, page CSS missing. That is what broke `/main/overview/ecosystem.html` after the last cherry-pick here. A push runs the workflow file from its own ref, so the fix has to live on this branch as well.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Verified on main in #1053: reproduced from a `release/1.4.x` worktree, 8 unknown role/directive errors and 0 device rows before, 0 errors and 13 rows after, and this branch's own page still renders its 10 `list-table`s.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)