### PR TITLE
ci(docs): build every docs version with main's config (backport of #1053)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -137,6 +137,12 @@ jobs:
           # smudges LFS files from the local object cache. `lfs: true` above only
           # fetched HEAD's objects, so pull the rest for every built ref here.
           git lfs fetch --all
+          # Every version is built with the `conf.py` of *this* checkout, which
+          # sphinx-multiversion passes as `-c`, so a release or tag push would render
+          # main's pages with an older config: roles and directives from extensions it
+          # does not load come out as raw text, and its CSS is dropped. This step
+          # deploys the whole site, so take the docs config from main either way.
+          git -C "$GITHUB_WORKSPACE" checkout origin/main -- docs
           make multi-docs
 
       - name: Upload docs artifact

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -16,9 +16,15 @@ is what CI runs, so a new warning fails the build. Check a docs change with that
 rather than a bare `sphinx-build`.
 
 `make multi-docs` is the other half, and it constrains how extensions are written:
-sphinx-multiversion builds every whitelisted ref with `-c` pointing at that ref's own
-checkout. Resolve data and asset paths from `app.confdir`, never from the working
-directory or the repo root, or building an old tag reads today's files.
+sphinx-multiversion builds every whitelisted ref with `-c` pointing at the checkout that
+invoked it, so `app.confdir` is that checkout while `app.srcdir` is the ref being built.
+Resolve paths from one of those two, never from the working directory or the repo root.
+
+The config is therefore a site-wide input, not a per-version one: the deploy job takes
+`docs/` from `main` before building, or a release or tag push renders main's pages with an
+older `conf.py` and anything its extensions provide disappears. A push runs the workflow
+file from its own ref, so that step has to stay alive on every release branch that still
+receives pushes.
 
 Images follow `.gitattributes` like everything else, Git LFS included. A checkout without
 LFS holds pointer text and Sphinx copies it into the site verbatim, so a page that looks


### PR DESCRIPTION
## Description

Backport of #1053, cherry-picked as-is.

A push to this branch redeploys the whole multi-version site, and sphinx-multiversion builds every ref with the invoking checkout's `conf.py`. A push runs the workflow file from its own ref, so the fix has to live on this branch as well or it stops applying the moment this branch diverges from main.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Verified on main in #1053: reproduced from a `release/1.4.x` worktree, 8 unknown role/directive errors and 0 device rows before, 0 errors and 13 rows after.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)