### PR TITLE
cloudxr: bump CXR_WEB_SDK_VERSION to 6.3.0

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -6,7 +6,7 @@
 # CloudXR Docker Images and Configs
 ###########################################################
 CXR_RUNTIME_SDK_VERSION=6.3.0
-CXR_WEB_SDK_VERSION=6.3.0-rc4
+CXR_WEB_SDK_VERSION=6.3.0
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 
 ###########################################################


### PR DESCRIPTION
## Description

Bumps the CloudXR Web SDK from the `6.3.0-rc4` candidate to the public `6.3.0` release, matching `CXR_RUNTIME_SDK_VERSION` which was already bumped in #1012.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Version string change only; no code paths touched.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CloudXR Web SDK to stable version 6.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
