### PR TITLE
🍒 cloudxr: bump CXR_WEB_SDK_VERSION to 6.3.0 (1.4.x)

### DIFF
--- a/deps/cloudxr/.env.default
+++ b/deps/cloudxr/.env.default
@@ -6,7 +6,7 @@
 # CloudXR Docker Images and Configs
 ###########################################################
 CXR_RUNTIME_SDK_VERSION=6.3.0
-CXR_WEB_SDK_VERSION=6.3.0-rc4
+CXR_WEB_SDK_VERSION=6.3.0
 CXR_HOST_VOLUME_PATH=$HOME/.cloudxr
 
 ###########################################################


### PR DESCRIPTION
## Description

Cherry-pick of #1056 onto `release/1.4.x` (`-x` reference to d410561af). Bumps the CloudXR Web SDK pin in `deps/cloudxr/.env.default` from `6.3.0-rc4` to the public `6.3.0` release, so 1.4.x stops shipping a release candidate. `CXR_RUNTIME_SDK_VERSION` is already at `6.3.0` here via #1025.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Clean cherry-pick, no conflicts. Version string change only; no code paths touched.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)