### PR TITLE
fix(cloudxr): pin webxr_client to the 6.3.0 web SDK tarball

### DIFF
--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudxr-isaac-lab-teleop",
-  "version": "6.3.0-rc4",
+  "version": "6.3.0",
   "private": true,
   "description": "NVIDIA Isaac Teleop Web Client",
   "author": "NVIDIA Corporation",
@@ -38,7 +38,7 @@
     ]
   },
   "dependencies": {
-    "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.3.0-rc4.tgz",
+    "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.3.0.tgz",
     "@preact/signals-react": "^3.10.0",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.0",


### PR DESCRIPTION
## Description

#1056 bumped `CXR_WEB_SDK_VERSION` to `6.3.0` but left `deps/cloudxr/webxr_client/package.json` pinned to the rc4 tarball, so the two disagree on `main` today.

`scripts/download_cloudxr_sdk.sh` derives the filename from the version, so it now writes `nvidia-cloudxr-6.3.0.tgz`, while `package.json` still asks for `file:../nvidia-cloudxr-6.3.0-rc4.tgz` — a path that no longer exists. The bare `npm install` documented in `docs/source/getting_started/build_from_source/webxr.rst` therefore fails on a clean tree, which is also the step the docs describe as "The `package.json` is configured to install the SDK from the downloaded local package."

This aligns both fields with `.env.default`. The `version` field matters beyond cosmetics: `webpack.common.js` falls back to it for `CLIENT_SDK_VERSION` when `SDK_VERSION` is unset, so local dev builds would otherwise keep reporting themselves as rc4.

Precedent: `53a1b6e9e` (rc2 → rc4), `543293a49` (6.2.0 → 6.3.0-rc2) and `8b5740637` (6.1.0 → 6.2.0) all changed `.env.default` and `package.json` together.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Reproduced the failure on Linux / Node 22 from a clean clone of `main`, using the documented flow (`source scripts/setup_cloudxr_env.sh`, `scripts/download_cloudxr_sdk.sh`, then `npm install` in `deps/cloudxr/webxr_client`):

```
npm error code ENOENT
npm error path /tmp/it-main/deps/cloudxr/nvidia-cloudxr-6.3.0-rc4.tgz
npm error enoent ENOENT: no such file or directory, open '.../nvidia-cloudxr-6.3.0-rc4.tgz'
```

Exit code 254. `ls deps/cloudxr/*.tgz` showed only `nvidia-cloudxr-6.3.0.tgz`. As a control, overriding the version back to `6.3.0-rc4` on the same tree installed cleanly (976 packages), which isolates the version string as the mechanism.

Note that CI does not cover this path: `.github/actions/build-cloudxr-web-client/action.yml` runs `npm install "../nvidia-cloudxr-${SDK_VERSION}.tgz"`, and passing the tarball explicitly rewrites the dependency spec so the pin in `package.json` is never read. A clean-tree bare `npm install` on this branch is the confirming test; I have not been able to run it on this machine (no Node toolchain), so it is worth a second pair of eyes before merge.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CloudXR WebXR package to the 6.3.0 release.
  * Switched to the stable CloudXR dependency archive.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->