### PR TITLE
🍒 fix(cloudxr): pin webxr_client to the 6.3.0 web SDK tarball (1.4.x)

### DIFF
--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudxr-isaac-lab-teleop",
-  "version": "6.3.0-rc4",
+  "version": "6.3.0",
   "private": true,
   "description": "NVIDIA Isaac Teleop Web Client",
   "author": "NVIDIA Corporation",
@@ -38,7 +38,7 @@
     ]
   },
   "dependencies": {
-    "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.3.0-rc4.tgz",
+    "@nvidia/cloudxr": "file:../nvidia-cloudxr-6.3.0.tgz",
     "@preact/signals-react": "^3.10.0",
     "@react-three/drei": "^10.7.7",
     "@react-three/fiber": "^9.6.0",


### PR DESCRIPTION
## Description

Cherry-pick of #1058 onto `release/1.4.x` (`-x` reference to `8990018f0`).

#1057 brought the `CXR_WEB_SDK_VERSION=6.3.0` bump onto this branch but left `deps/cloudxr/webxr_client/package.json` pinned to the rc4 tarball, so `release/1.4.x` currently has the same mismatch as `main`: `scripts/download_cloudxr_sdk.sh` writes `nvidia-cloudxr-6.3.0.tgz` while `package.json` asks for `file:../nvidia-cloudxr-6.3.0-rc4.tgz`, and the bare `npm install` documented in `webxr.rst` fails on a clean tree.

Worth landing before 1.4 ships, since it breaks the documented from-source web client build.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Clean cherry-pick, no conflicts; diff is identical to #1058. See #1058 for the reproduction (Linux / Node 22, clean clone, ENOENT with exit 254, and the rc4-override control that installs cleanly).

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)