### PR TITLE
🍒 fix(web): prevent scrolling from changing server port (backport of #1052)

### DIFF
--- a/deps/cloudxr/webxr_client/src/index.html
+++ b/deps/cloudxr/webxr_client/src/index.html
@@ -900,11 +900,10 @@ limitations under the License.
               <input
                 id="portInput"
                 class="ui-input"
-                type="number"
+                type="text"
+                inputmode="numeric"
                 placeholder="Port (default: 49100)"
                 spellcheck="false"
-                min="1"
-                max="65535"
               />
               <div id="certAcceptanceLink" class="cert-acceptance-link" style="display: none">
                 <span class="cert-icon">🔒</span>


### PR DESCRIPTION
## Summary

Cherry-picks #1052 into `release/1.4.x`.

- render the CloudXR server port as a text field so mouse-wheel scrolling cannot step and persist a different port
- retain the numeric virtual keyboard hint with `inputmode="numeric"`
- preserve source provenance with `cherry-pick -x` from `9fba23c4a3bd5b6de732cac77a47f471fca25276`

## Validation

- `SKIP=check-copyright-year pre-commit run --all-files`
- `npm test -- --runInBand` (102 tests)
- `npm run build`
- `npx prettier --check src/index.html`
- parsed `src/index.html` with JSDOM and verified `portInput` has `type=text` and `inputMode=numeric`