### PR TITLE
docs(televiz): document Orin XR compositor for QuadLayer

### DIFF
--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -130,8 +130,8 @@ layer setup is identical; you just drive a frame loop (see `Frame loop`_) rather
 .. note::
 
    **Jetson Orin, XR.** The default ``openxr_composition = True`` path presents a solid
-   color, or black, in place of the submitted image. Set ``openxr_composition = False``
-   so Televiz composites the quad itself:
+   color, or black, in place of the submitted image. Until this is addressed in a future
+   release, set ``openxr_composition = False`` so Televiz composites the quad itself:
 
    .. code-block:: python
 

--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -125,6 +125,21 @@ For a window or headset, set ``mode`` to ``DisplayMode.kWindow`` or ``DisplayMod
 layer setup is identical; you just drive a frame loop (see `Frame loop`_) rather than the one-shot
 ``readback_to_host()``, which is offscreen-only.
 
+.. _orin-openxr-composition:
+
+.. note::
+
+   **Jetson Orin, XR.** The default ``openxr_composition = True`` path presents a solid
+   color, or black, in place of the submitted image. Set ``openxr_composition = False``
+   so Televiz composites the quad itself:
+
+   .. code-block:: python
+
+      layer_cfg.openxr_composition = False
+
+   Cylinder and equirect layers cannot opt out. In :doc:`/references/camera_streaming` the
+   same switch is YAML ``compositor: televiz`` (quads only).
+
 Session configuration
 ---------------------
 
@@ -218,7 +233,8 @@ Three consequences, in rough order of how often they bite:
 ``QuadLayer`` is the one layer with a choice, which is why ``openxr_composition`` and
 ``generate_mipmaps`` appear on its config and on no other. Set ``openxr_composition = False`` to
 draw the quad with Televiz's built-in compositor instead, where 3D-placed quads depth-test against
-each other in a shared render target — the way out of the no-depth constraint above. Cylinder and
+each other in a shared render target — the way out of the no-depth constraint above, and the
+setting to use on Jetson Orin in XR (see :ref:`Jetson Orin, XR <orin-openxr-composition>`). Cylinder and
 equirect layers have no such switch: they exist only as native runtime layers, and therefore only in
 XR. Window and offscreen modes always use the built-in compositor.
 
@@ -328,7 +344,8 @@ because the quad is the only layer that can be drawn either way:
    * - ``openxr_composition``
      - ``True``
      - ``True`` = the OpenXR runtime composites the quad, ``False`` = Televiz's built-in
-       compositor. See `Composition model`_.
+       compositor. On Jetson Orin in XR, set ``False`` (see :ref:`Jetson Orin, XR <orin-openxr-composition>`).
+       See `Composition model`_.
 
 Its placement is a ``QuadLayerPlacement`` — a ``pose`` plus ``size_meters``. It is optional:
 a quad with no placement fills the window in window mode.

--- a/docs/source/references/camera_streaming.rst
+++ b/docs/source/references/camera_streaming.rst
@@ -265,7 +265,8 @@ CloudXR stream them efficiently (see
 :ref:`OpenXR composition layers <openxr-composition-layers>`). For flat planes only,
 ``compositor: televiz`` opts a camera back into Televiz's built-in compositor. On Jetson Orin
 (CloudXR experimental runtime), set ``compositor: televiz`` so the plane is not left black; see
-Troubleshooting below.
+Troubleshooting below. On the Televiz 2D API the same switch is
+``openxr_composition = False`` (see :ref:`Jetson Orin, XR <orin-openxr-composition>`).
 
 CloudXR runtime flags
 ---------------------

--- a/src/viz/python/layers_bindings.cpp
+++ b/src/viz/python/layers_bindings.cpp
@@ -131,7 +131,9 @@ void bind_layers(py::module_& m)
                        "the projection layer entirely. Set False to composite into the shared "
                        "render target instead, where 3D-placed quads depth-test against each "
                        "other (native quads carry no depth: flat billboard, submission-order "
-                       "composited). Ignored outside kXr "
+                       "composited). Set False on Jetson Orin in kXr, where the native path "
+                       "presents a solid color in place of the submitted image. "
+                       "Ignored outside kXr "
                        "(window/offscreen always composite). Stereo emits one quad per eye.")
         .def_readwrite(
             "alpha_blend", &viz::QuadLayer::Config::alpha_blend,


### PR DESCRIPTION
## Description

On Jetson Orin in XR, the default `QuadLayer` path (`openxr_composition = True`) presents a solid color or black instead of the submitted image. That limitation was already documented for `camera_viz` as YAML `compositor: televiz`, but not next to the Televiz 2D API default.

This adds the Orin compositor note to the Televiz XR quick start, the `openxr_composition` default, and `help(QuadLayerConfig)`, and points camera streaming at the same switch.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

Docs and a Python binding docstring only. Ran `SKIP=check-copyright-year pre-commit run --all-files` in this worktree; all hooks passed.

No runtime tests: behavior is unchanged. The pages record the existing Orin XR compositor setting (`openxr_composition = False` / `compositor: televiz`).

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Jetson Orin guidance for configuring quad layers with Televiz’s built-in compositor.
  * Documented equivalent 2D API and YAML settings for disabling native OpenXR composition.
  * Clarified that native OpenXR quad composition may display a solid color instead of the submitted image in `kXr`.
  * Noted that cylinder and equirectangular layers cannot disable native composition.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->