### PR TITLE
Update MANUS plugin and installer for SDK 3.2.0

### DIFF
--- a/docs/source/device/manus.rst
+++ b/docs/source/device/manus.rst
@@ -30,7 +30,7 @@ Components
 Prerequisites
 -------------
 
-- **Linux** — x86_64 (tested on Ubuntu 22.04 / 24.04).
+- **Linux** — x86_64 or aarch64 (tested on Ubuntu 22.04 / 24.04).
 - **Manus SDK** for Linux — downloaded automatically by the install script.
 - **System dependencies** — the install script installs required packages automatically.
 
@@ -74,8 +74,8 @@ directory.
 The script will:
 
 1. Install the required system packages for MANUS Core Integrated.
-2. Download MANUS SDK v3.1.1.
-3. Extract and place the SDK in the correct location.
+2. Download MANUS SDK v3.2.0.
+3. Extract and place the SDK for the host architecture in the correct location.
 4. Build the plugin and the diagnostic tool.
 
 When run inside a container, ``install_manus.sh`` skips the udev step and
@@ -83,17 +83,23 @@ reminds you to run ``install_udev_rules.sh`` on the host. Pass ``--container``
 when the build environment does not expose standard container markers, such as
 during a Docker BuildKit build.
 
-Manual installation
-~~~~~~~~~~~~~~~~~~~
+Manual installation (fallback only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you prefer to install manually:
+Steps 1 and 2 above are the supported path — most users should never need
+this section. Only follow it if ``install_manus.sh`` fails (for example, the
+SDK download is unreachable from your network) and you need to place the SDK
+by hand.
 
 1. Download the MANUS Core SDK from
-   `MANUS Downloads <https://docs.manus-meta.com/3.1.1/Resources/>`_.
-2. Extract and place the ``ManusSDK`` folder inside ``src/plugins/manus/``, or
-   point CMake at a different path by setting ``MANUS_SDK_ROOT``.
+   `MANUS Downloads <https://docs.manus-meta.com/3.2.0/Resources/>`_.
+2. From ``C++/SDKClient/ManusSDK`` in the archive, place ``include/`` and the
+   library for your architecture (``lib/amd64/libManusSDK-amd64.so`` or
+   ``lib/aarch64/libManusSDK-aarch64.so``, renamed to ``lib/libManusSDK.so``)
+   into a ``ManusSDK`` folder inside ``src/plugins/manus/``, or point CMake at a
+   different path by setting ``MANUS_SDK_ROOT``.
 3. Follow the
-   `MANUS Getting Started guide for Linux <https://docs.manus-meta.com/3.1.1/Plugins/SDK/Linux/>`_
+   `MANUS Getting Started guide for Linux <https://docs.manus-meta.com/3.2.0/Plugins/SDK/Linux/>`_
    to install the dependencies and configure device permissions.
 
 Expected directory layout after placing the SDK:
@@ -113,6 +119,7 @@ Expected directory layout after placing the SDK:
      ManusSDK/        <-- placed here
        include/
        lib/
+         libManusSDK.so
 
 Then build from the root:
 
@@ -265,6 +272,16 @@ Troubleshooting
      - Resolution
    * - SDK download fails
      - Check your internet connection and re-run the install script.
+   * - ``uv not found. Please install uv: ...``
+     - Install uv and re-run: ``curl -LsSf https://astral.sh/uv/install.sh | sh``.
+       It installs to ``~/.local/bin``, so also add that to ``PATH`` for the
+       current shell (and ``~/.bashrc``, to make it stick):
+       ``export PATH="$HOME/.local/bin:$PATH"``.
+   * - ``Missing build tools: ... patchelf ...``
+     - CMake's dependency preflight lists every missing tool and the exact
+       install command in the same message, e.g.
+       ``sudo apt-get install -y patchelf``. Run the printed command and
+       re-run the install script.
    * - Manus SDK not found at build time
      - With manual installation, ensure ``ManusSDK`` is inside
        ``src/plugins/manus/`` or set ``MANUS_SDK_ROOT`` to your installation path.

--- a/src/plugins/manus/.gitignore
+++ b/src/plugins/manus/.gitignore
@@ -6,3 +6,4 @@ ManusSDK/
 
 # Downloaded SDK archive (kept locally to avoid re-downloading)
 MANUS_Core_*_SDK.zip
+MANUS_Core_*_SDK_Linux.tar.gz

--- a/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
+++ b/src/plugins/manus/core/manus_hand_tracking_plugin.cpp
@@ -1,6 +1,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// Bridges MANUS Core (integrated mode) to the IsaacTeleop DeviceIO layer for a
+// pair of MANUS gloves.
+//
+// MANUS SDK callbacks fire on SDK threads and only cache state: skeleton joints,
+// the glove ids discovered from the landscape, and raw flex-sensor transforms.
+// All consumption happens on the plugin tick in update(), which drives three
+// independently switchable datasets (see ManusPluginConfig):
+//   human   - cached joints are anchored to a wrist pose from the OpenXR xdev
+//             hand trackers, or a controller aim pose when xdev is unavailable,
+//             and injected as XR_EXT_hand_tracking joints.
+//   sensors - cached sensor transforms are pushed as JointState flatbuffers.
+//   haptic  - inbound HapticCommands are forwarded to the glove finger motors.
+//
+// ManusTracker is a singleton because the SDK's C callbacks carry no user
+// pointer and must reach the instance through instance().
+
 #include "inc/manus/manus_hand_tracking_plugin.hpp"
 
 #include "inc/manus/manus_glove_collection.hpp"
@@ -61,12 +77,7 @@ bool is_openxr_extension_supported(const char* ext_name)
 
 SDKReturnCode get_raw_skeleton_node_count(uint32_t glove_id, uint32_t& node_count)
 {
-#if defined(__aarch64__) || defined(__arm__) || defined(_M_ARM64) || defined(_M_ARM)
-    // Manus SDK 3.1.1 ships different declarations for this call across architectures.
     return CoreSdk_GetRawSkeletonNodeCount(glove_id, &node_count);
-#else
-    return CoreSdk_GetRawSkeletonNodeCount(glove_id, node_count);
-#endif
 }
 
 // Must agree with JointStateTracker::DEFAULT_MAX_FLATBUFFER_SIZE on the consumer side.

--- a/src/plugins/manus/install_manus.sh
+++ b/src/plugins/manus/install_manus.sh
@@ -44,13 +44,26 @@ EOF
 done
 
 # --- Configuration -------------------------------------------------------
-MANUS_SDK_VERSION="3.1.1"
-MANUS_SDK_URL="https://static.manus-meta.com/resources/manus_core_3/sdk/MANUS_Core_${MANUS_SDK_VERSION}_SDK.zip"
-MANUS_SDK_ZIP="MANUS_Core_${MANUS_SDK_VERSION}_SDK.zip"
+MANUS_SDK_VERSION="3.2.0"
+# Since 3.2 the SDK ships per-platform; the Linux package is a tarball.
+MANUS_SDK_ARCHIVE="MANUS_Core_${MANUS_SDK_VERSION}_SDK_Linux.tar.gz"
+MANUS_SDK_URL="https://static.manus-meta.com/resources/manus_core_3/sdk/${MANUS_SDK_ARCHIVE}"
 MANUS_SDK_SHA256_ACCEPTED=(
-    "c5ccd3c42a501107ec79f70d8450a486fbc3925c5c1e18e606114d09f2d9d24a"
-    "23fa74e507f3781668b50bbfc01141c495ffc93a5213d148c192220623b482fc"
+    "02821f0b6d1f45645ffb63fdc5b5c312211b3a9cfbcd9b701584fd2feed0a432"
 )
+# Directory inside the tarball that holds include/ and lib/<arch>/.
+MANUS_SDK_TAR_PREFIX="C++/SDKClient/ManusSDK"
+
+HOST_ARCH="$(uname -m)"
+case "$HOST_ARCH" in
+    x86_64) MANUS_SDK_ARCH="amd64" ;;
+    aarch64|arm64) MANUS_SDK_ARCH="aarch64" ;;
+    *)
+        echo "Unsupported architecture: $HOST_ARCH (MANUS SDK supports x86_64 and aarch64)" >&2
+        exit 1
+        ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TELEOP_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
 BUILD_DIR="${BUILD_DIR:-$TELEOP_ROOT/build}"
@@ -60,7 +73,14 @@ fi
 
 # --- Output helpers ------------------------------------------------------
 LOG_FILE=$(mktemp -t manus_install.XXXXXX.log)
-trap 'rm -f "$LOG_FILE"' EXIT
+TMP_EXTRACT_DIR=""
+TMP_ARCHIVE=""
+cleanup() {
+    rm -f "$LOG_FILE"
+    if [[ -n "$TMP_ARCHIVE" ]]; then rm -f "$TMP_ARCHIVE"; fi
+    if [[ -n "$TMP_EXTRACT_DIR" ]]; then rm -rf "$TMP_EXTRACT_DIR"; fi
+}
+trap cleanup EXIT
 
 # ANSI colors, but only when stdout is a TTY so logs/pipes stay clean.
 if [[ -t 1 ]]; then
@@ -99,7 +119,7 @@ in_container() {
 
 # --- Banner --------------------------------------------------------------
 echo "=== MANUS SDK Installation ==="
-echo "Architecture: $(uname -m)"
+echo "Architecture: $HOST_ARCH (SDK library: $MANUS_SDK_ARCH)"
 if [[ "$FORCE_CONTAINER" -eq 1 ]] || in_container; then
     CONTAINER=1
     echo "Environment:  container (udev step will be skipped)"
@@ -122,15 +142,14 @@ if ! sudo -n true 2>/dev/null; then
 fi
 
 # --- 1. System dependencies ---------------------------------------------
+# gRPC and protobuf are statically linked into libManusSDK.so since MANUS Core
+# 3.2, so their build dependencies are no longer installed here.
 APT_PACKAGES=(
     build-essential
     cmake
     curl
     git
-    libssl-dev
-    unzip
-    zlib1g-dev
-    libc-ares-dev
+    tar
     libzmq3-dev
     libncurses-dev
     libudev-dev
@@ -170,31 +189,30 @@ fi
 step "[3/4] Downloading and extracting MANUS SDK v${MANUS_SDK_VERSION}"
 cd "$SCRIPT_DIR"
 
-if [[ -f "$MANUS_SDK_ZIP" ]]; then
+if [[ -f "$MANUS_SDK_ARCHIVE" ]]; then
     echo "    SDK archive already exists. Skipping download."
 else
     # Download to a .tmp path and rename on success so a partial/aborted
     # download never leaves a file that looks complete on the next run.
-    MANUS_SDK_ZIP_TMP="${MANUS_SDK_ZIP}.tmp"
-    trap 'rm -f "$LOG_FILE" "$MANUS_SDK_ZIP_TMP"' EXIT
+    TMP_ARCHIVE="$SCRIPT_DIR/${MANUS_SDK_ARCHIVE}.tmp"
     if command -v curl &> /dev/null; then
         if [[ "$VERBOSE" -eq 1 ]]; then
             # -f: fail on HTTP errors (4xx/5xx), -L: follow redirects
-            curl -fL "$MANUS_SDK_URL" -o "$MANUS_SDK_ZIP_TMP" || die "SDK download failed"
+            curl -fL "$MANUS_SDK_URL" -o "$TMP_ARCHIVE" || die "SDK download failed"
         else
             # -fsSL: silent but show errors, follow redirects
-            curl -fsSL "$MANUS_SDK_URL" -o "$MANUS_SDK_ZIP_TMP" || die "SDK download failed"
+            curl -fsSL "$MANUS_SDK_URL" -o "$TMP_ARCHIVE" || die "SDK download failed"
         fi
     elif command -v wget &> /dev/null; then
-        run wget -q "$MANUS_SDK_URL" -O "$MANUS_SDK_ZIP_TMP" || die "SDK download failed"
+        run wget -q "$MANUS_SDK_URL" -O "$TMP_ARCHIVE" || die "SDK download failed"
     else
         die "Neither curl nor wget found"
     fi
-    mv "$MANUS_SDK_ZIP_TMP" "$MANUS_SDK_ZIP"
-    trap 'rm -f "$LOG_FILE"' EXIT
+    mv "$TMP_ARCHIVE" "$MANUS_SDK_ARCHIVE"
+    TMP_ARCHIVE=""
 fi
 
-ACTUAL_SHA256=$(sha256sum "$MANUS_SDK_ZIP" | awk '{print $1}')
+ACTUAL_SHA256=$(sha256sum "$MANUS_SDK_ARCHIVE" | awk '{print $1}')
 sha_match=0
 for expected in "${MANUS_SDK_SHA256_ACCEPTED[@]}"; do
     if [[ "$ACTUAL_SHA256" = "$expected" ]]; then
@@ -203,25 +221,31 @@ for expected in "${MANUS_SDK_SHA256_ACCEPTED[@]}"; do
     fi
 done
 if [[ "$sha_match" -ne 1 ]]; then
-    rm -f "$MANUS_SDK_ZIP"
+    rm -f "$MANUS_SDK_ARCHIVE"
     die "SHA-256 mismatch (got $ACTUAL_SHA256; accepted: ${MANUS_SDK_SHA256_ACCEPTED[*]})"
 fi
 
-if [[ -d "$SCRIPT_DIR/ManusSDK" ]]; then
-    rm -rf "$SCRIPT_DIR/ManusSDK"
-fi
-run unzip -oq "$MANUS_SDK_ZIP" || die "unzip failed"
+# The tarball also carries the Python/ROS2/dashboard packages; only unpack the
+# C++ headers and the shared library for this architecture.
+TMP_EXTRACT_DIR=$(mktemp -d -t manus_sdk.XXXXXX)
+run tar -xzf "$MANUS_SDK_ARCHIVE" -C "$TMP_EXTRACT_DIR" \
+    "$MANUS_SDK_TAR_PREFIX/include" "$MANUS_SDK_TAR_PREFIX/lib/$MANUS_SDK_ARCH" \
+    || die "extraction failed"
 
-EXTRACTED_DIR=$(find . -maxdepth 1 -type d -name "ManusSDK_v*" | head -n 1)
-[[ -n "$EXTRACTED_DIR" ]] || die "Could not find extracted SDK directory"
+SDK_SRC="$TMP_EXTRACT_DIR/$MANUS_SDK_TAR_PREFIX"
+SDK_LIB_SRC="$SDK_SRC/lib/$MANUS_SDK_ARCH/libManusSDK-${MANUS_SDK_ARCH}.so"
+[[ -f "$SDK_SRC/include/ManusSDK.h" ]] || die "ManusSDK.h not found in $MANUS_SDK_ARCHIVE"
+[[ -f "$SDK_LIB_SRC" ]] || die "No $MANUS_SDK_ARCH library found in $MANUS_SDK_ARCHIVE"
 
-SDK_CLIENT_DIR="SDKClient_Linux"
-[[ -d "$EXTRACTED_DIR/$SDK_CLIENT_DIR/ManusSDK" ]] || \
-    die "ManusSDK folder not found in $EXTRACTED_DIR/$SDK_CLIENT_DIR"
-
-cp -r "$EXTRACTED_DIR/$SDK_CLIENT_DIR/ManusSDK" "$SCRIPT_DIR/"
-# Keep the zip for re-runs; SHA-256 verification above guards against corruption.
-rm -rf "$EXTRACTED_DIR"
+rm -rf "$SCRIPT_DIR/ManusSDK"
+mkdir -p "$SCRIPT_DIR/ManusSDK/lib"
+cp -r "$SDK_SRC/include" "$SCRIPT_DIR/ManusSDK/"
+# Drop the arch suffix: the build expects a single lib/libManusSDK.so, which
+# since 3.2 serves both integrated and remote modes.
+cp "$SDK_LIB_SRC" "$SCRIPT_DIR/ManusSDK/lib/libManusSDK.so"
+rm -rf "$TMP_EXTRACT_DIR"
+TMP_EXTRACT_DIR=""
+# Keep the archive for re-runs; SHA-256 verification above guards against corruption.
 done_ok
 
 # --- 4. Build the plugin ------------------------------------------------
@@ -229,6 +253,7 @@ step "[4/4] Building Manus plugin"
 cd "$TELEOP_ROOT"
 run cmake -S . -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -DBUILD_PLUGINS=ON \
     -DBUILD_VIZ=OFF -DENABLE_CLANG_FORMAT_CHECK=OFF \
+    -DMANUS_SDK_ROOT="$SCRIPT_DIR/ManusSDK" \
     || die "cmake configure failed"
 run cmake --build "$BUILD_DIR" \
     --target manus_hand_plugin manus_hand_tracker_printer -j"$(nproc)" \


### PR DESCRIPTION
## Summary
- Updates MANUS device docs for SDK 3.2.0 (x86_64 + aarch64 support, updated manual-install fallback steps, updated download links)
- `install_manus.sh` now downloads/extracts the SDK 3.2.0 Linux tarball, selects and verifies the library for the host architecture, and pins the plugin build to the freshly installed SDK via `-DMANUS_SDK_ROOT` so a stale cached path from a prior build directory can't be used. The downloaded archive is kept locally (unchanged from before) so re-runs on unreliable networks don't need to re-download it.
- Simplifies `manus_hand_tracking_plugin.cpp` now that the SDK 3.2.0 API is consistent across architectures.

## Test plan
- [ ] Run `install_manus.sh` end-to-end and confirm the plugin builds and installs against the freshly installed SDK
- [ ] Confirm a stale build directory with a cached `MANUS_SDK_ROOT` pointing at an older SDK still picks up the newly installed 3.2 SDK
- [ ] Confirm the downloaded archive is left in place after a successful run, for reuse on a subsequent re-run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MANUS SDK 3.2.0 support for both x86_64 and aarch64 Linux systems.
  - Improved automatic installation with architecture detection and clearer SDK setup.
  - Added troubleshooting guidance for missing `uv` and build tools.
  - Documented hand-tracking callbacks, wrist-pose fallbacks, haptic forwarding, and SDK behavior.

- **Bug Fixes**
  - Standardized the installed SDK library name to `libManusSDK.so`.
  - Pinned the plugin build to the freshly installed SDK, avoiding stale cached SDK paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
