### PR TITLE
docs(ecosystem): note Meta Quest lacks full-body robot control support

### DIFF
--- a/docs/source/_data/devices.yaml
+++ b/docs/source/_data/devices.yaml
@@ -79,10 +79,6 @@ devices:
         - Isaac Teleop Web Client — runs in the headset browser
       requirements:
         - No additional software
-        - Not supported for full-body robot control
-        - label: Body Tracking guide
-          doc: /device/body_tracking
-          note: for full-body teleoperation, use equipment with Motion Trackers
       acquire:
         - label: meta.com
           url: https://www.meta.com/quest/

--- a/docs/source/_data/devices.yaml
+++ b/docs/source/_data/devices.yaml
@@ -79,6 +79,10 @@ devices:
         - Isaac Teleop Web Client — runs in the headset browser
       requirements:
         - No additional software
+        - Not supported for full-body robot control
+        - label: Body Tracking guide
+          doc: /device/body_tracking
+          note: for full-body teleoperation, use equipment with Motion Trackers
       acquire:
         - label: meta.com
           url: https://www.meta.com/quest/

--- a/docs/source/device/body_tracking.rst
+++ b/docs/source/device/body_tracking.rst
@@ -28,9 +28,7 @@ and the BD skeleton format used on the server.
 
    Meta Quest 3/3S also expose body tracking to WebXR via inside-out body
    tracking (IOBT), and the CloudXR client will stream it under the WebXR
-   Body Tracking extension. However, this can not currently be used for full
-   body control as a retargetting of the WebXR skeleton to the robot's full
-   body skeleton is inaccurate and not currently supported.
+   Body Tracking extension.
 
 .. seealso::
 

--- a/docs/source/device/body_tracking.rst
+++ b/docs/source/device/body_tracking.rst
@@ -27,10 +27,10 @@ and the BD skeleton format used on the server.
 .. note::
 
    Meta Quest 3/3S also expose body tracking to WebXR via inside-out body
-   tracking (IOBT), and the CloudXR client will stream it. However the Quest
-   skeleton is mapped to the PICO BD 24-joint layout in the current version,
-   and accuracy is lower since there are no physical trackers. See
-   `Quest Body Tracking (Limited Support)`_ for details.
+   tracking (IOBT), and the CloudXR client will stream it under the WebXR
+   Body Tracking extension. However, this can not currently be used for full
+   body control as a retargetting of the WebXR skeleton to the robot's full
+   body skeleton is inaccurate and not currently supported.
 
 .. seealso::
 
@@ -252,21 +252,3 @@ timestamped take into ``examples/mcap_record_replay/recordings/``, where
    :class: no-image-zoom
 
    ``replay_full_body.py`` visualizing a recorded BD 24-joint skeleton in viser.
-
-Quest Body Tracking (Limited Support)
--------------------------------------
-
-Meta Quest headsets expose inside-out body tracking (IOBT) to WebXR sessions.
-The CloudXR WebXR client will stream this data when the Quest browser grants the
-``body-tracking`` feature.
-
-However, in the current version the Quest IOBT skeleton is mapped to the PICO BD
-24-joint layout before being sent to the server. This means the server always
-receives data in the ``XR_BD_body_tracking`` joint format regardless of the
-source headset.
-
-.. note::
-
-   Quest body tracking does not require external trackers. It uses the
-   headset's built-in cameras. Tracking quality may differ from the
-   tracker-based PICO solution, particularly for lower-body joints.


### PR DESCRIPTION
## Summary
Modified 2 major documentation pages available to the public:
https://nvidia.github.io/IsaacTeleop/main/overview/ecosystem.html
- The Meta Quest 2/3/3S entry on the ecosystem/devices page did not call out that it tracks head and hands only, not full-body.
- Adds a requirements line noting it's not supported for full-body robot control, with a link to the Body Tracking guide for equipment with Motion Trackers.

https://nvidia.github.io/IsaacTeleop/main/device/body_tracking.html
- Changed the note at the top discussing the Meta skeleton and that no translation exists from it's WebXR Skeletal format.
- Remove the "Quest Body Tracking (Limited Support)" section entirely.

## Test plan
- [ ] Build docs and check the Requirements panel for the Meta Quest 2 / 3 / 3S row renders as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Meta Quest compatibility guidance, noting it is not supported for full-body robot control.
  * Linked to the Body Tracking guide and recommended Motion Trackers for full-body teleoperation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->