### PR TITLE
feat(webclient): add SONIC application route

### DIFF
--- a/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
+++ b/deps/cloudxr/webxr_client/helpers/TeleopProjects.ts
@@ -99,6 +99,7 @@ export const TELEOP_PROJECTS: TeleopProjectRegistry = {
         children: {
           headless: { label: 'Headless', settings: { headless: true } },
           video: { label: 'Video streaming' },
+          sonic: { label: 'SONIC' },
         },
       },
     },


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Add a `SONIC` teleop application route under Real Robot in the CloudXR.js web client picker.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

Tested locally on Ubuntu/Linux:

- `git diff --check`
- `SKIP=check-copyright-year pre-commit run --all-files`

Jest was not run because this checkout does not have `node_modules`, and the local CloudXR SDK tarball referenced by `deps/cloudxr/webxr_client/package.json` is not present.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)