### PR TITLE
ci: keep prerelease wheels off PyPI via Kitmaker mirroring_strategy

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1128,6 +1128,9 @@ jobs:
         ARTIFACTORY_REPO: ${{ secrets.ARTIFACTORY_REPO }}
         WHEEL_PATHS: ${{ needs.publish-wheel.outputs.wheel_paths }}
         KITMAKER_UPLOAD: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v') }}
+        # Only a vX.Y.Z tag is a final version and mirrors to PyPI.
+        # release/*.*.x builds are rc versions and stay on DevZone.
+        KITMAKER_MIRRORING: ${{ startsWith(github.ref, 'refs/tags/v') && 'upload-both' || 'claim-project' }}
       run: |
         set -euo pipefail
 
@@ -1165,7 +1168,8 @@ jobs:
             --arg pic "${KITMAKER_PIC_EMAIL}" \
             --arg url "${wheel_url}" \
             --argjson upload "${KITMAKER_UPLOAD}" \
-            '{pic: $pic, job_type: "wheel-release-job", publish_to: "both_devzone_pypi", url: $url, size: "small", upload: $upload}')")
+            --arg mirroring "${KITMAKER_MIRRORING}" \
+            '{pic: $pic, job_type: "wheel-release-job", mirroring_strategy: $mirroring, url: $url, size: "small", upload: $upload}')")
           done <<< "${WHEEL_PATHS}"
 
         if (( ${#payload_items[@]} == 0 )); then


### PR DESCRIPTION
## Problem

Every push to a `release/*.*.x` branch mirrors a release candidate to **public PyPI**.

`KITMAKER_UPLOAD` is true for release branches, and the Kitmaker payload hardcoded `publish_to: "both_devzone_pypi"` for every submission, so there was no path that reached Kitmaker without also requesting PyPI. Combined with `sync-release-branches.yml` fast-forwarding `release/1.5.x` on every push to `main`, this means **every merge to main publishes an rc to PyPI** with no human in the loop.

The result: **139 of the 145 versions on PyPI are prereleases**, all `rcN`, starting with `1.4.63rc1` on 2026-07-17.

## Fix

Kitmaker's updated API replaces `publish_to` with `mirroring_strategy`:

- `claim-project` — DevZone only → `release/*.*.x` builds (rc versions)
- `upload-both` — DevZone + PyPI → `vX.Y.Z` tags (final versions)

| ref | version | `upload` | `mirroring_strategy` | lands on |
|---|---|---|---|---|
| pull request | dev | *job skipped* | — | — |
| push `main` | `X.Y.Z.dev0+label` | `false` | `claim-project` | nothing (dry run) |
| push `release/X.Y.x` | `X.Y.ZrcN` | `true` | `claim-project` | DevZone only |
| tag `vX.Y.Z` | `X.Y.Z` | `true` | `upload-both` | DevZone + PyPI |

Keying the strategy on the ref is safe because ref and version cannot disagree: `cmake/IsaacTeleopVersion.cmake` hard-fails a tag that is not `vMAJOR.MINOR.PATCH` and forces `rcN` on `release/X.Y.x`.

## Verification

`build-ubuntu.yml` parses, `publish_to` no longer appears in the file, and the generated payloads are:

```json
{"pic":"…","job_type":"wheel-release-job","mirroring_strategy":"claim-project","url":"…isaacteleop-1.5.141rc1-cp312.whl","size":"small","upload":true}
{"pic":"…","job_type":"wheel-release-job","mirroring_strategy":"upload-both","url":"…isaacteleop-1.5.141-cp312.whl","size":"small","upload":true}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Kitmaker submissions to use the appropriate mirroring strategy for version tags and release builds.
  * Ensured submission payloads reflect the selected mirroring configuration instead of a fixed destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->