### PR TITLE
ci: keep prerelease wheels off PyPI via Kitmaker mirroring_strategy (1.4.x)

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -1008,6 +1008,9 @@ jobs:
         ARTIFACTORY_REPO: ${{ secrets.ARTIFACTORY_REPO }}
         WHEEL_PATHS: ${{ needs.publish-wheel.outputs.wheel_paths }}
         KITMAKER_UPLOAD: ${{ startsWith(github.ref, 'refs/heads/release/') || startsWith(github.ref, 'refs/tags/v') }}
+        # Only a vX.Y.Z tag is a final version and mirrors to PyPI.
+        # release/*.*.x builds are rc versions and stay on DevZone.
+        KITMAKER_MIRRORING: ${{ startsWith(github.ref, 'refs/tags/v') && 'upload-both' || 'claim-project' }}
       run: |
         set -euo pipefail
 
@@ -1045,7 +1048,8 @@ jobs:
             --arg pic "${KITMAKER_PIC_EMAIL}" \
             --arg url "${wheel_url}" \
             --argjson upload "${KITMAKER_UPLOAD}" \
-            '{pic: $pic, job_type: "wheel-release-job", publish_to: "both_devzone_pypi", url: $url, size: "small", upload: $upload}')")
+            --arg mirroring "${KITMAKER_MIRRORING}" \
+            '{pic: $pic, job_type: "wheel-release-job", mirroring_strategy: $mirroring, url: $url, size: "small", upload: $upload}')")
           done <<< "${WHEEL_PATHS}"
 
         if (( ${#payload_items[@]} == 0 )); then


### PR DESCRIPTION
Cherry-pick of c0dad278e onto `release/1.4.x`. Applied cleanly, no conflicts.

Rationale, ref → strategy table and verification are in the main PR: #1069

`release/1.4.x` still receives pushes (backports and cherry-picks), and each one builds a `1.4.PATCHrc1` and submits with `upload: true`, so the branch leaks to PyPI independently of `main` until this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)