### PR TITLE
docs: correct the viz agent notes and Televiz page against the code

### DIFF
--- a/docs/source/getting_started/televiz.rst
+++ b/docs/source/getting_started/televiz.rst
@@ -38,8 +38,10 @@ The published wheels (Linux x86_64 / aarch64, CPython 3.11–3.13) bundle the co
    import isaacteleop.viz as televiz
 
 You only need to :doc:`build from source </getting_started/build_from_source/index>` when
-developing Isaac Teleop itself — that build enables Televiz automatically when Vulkan, the CUDA
-Toolkit, and ``glslangValidator`` are present.
+developing Isaac Teleop itself — that build enables Televiz automatically when Vulkan and the
+CUDA Toolkit are detected. ``glslangValidator`` is additionally required to compile the shaders:
+if it is missing, configuration fails rather than quietly dropping the module — install it, or
+pass ``-DBUILD_VIZ=OFF``.
 
 Overview
 --------
@@ -138,10 +140,11 @@ Session configuration
      - Default
      - Description
    * - ``mode``
-     - —
-     - ``DisplayMode.kXr`` / ``kWindow`` / ``kOffscreen``. Required.
+     - ``DisplayMode.kOffscreen``
+     - ``DisplayMode.kXr`` / ``kWindow`` / ``kOffscreen``. Set it explicitly; the default is
+       offscreen.
    * - ``window_width`` / ``window_height``
-     - —
+     - ``1024``
      - Render size for window and offscreen modes. Ignored in XR (the runtime dictates per-eye
        resolution; query it with ``get_recommended_resolution()``).
    * - ``app_name``
@@ -153,16 +156,17 @@ Session configuration
        components (e.g. ``TeleopSession`` trackers) need them. Televiz already enables its own
        rendering extensions. See `Sharing the XR session`_.
    * - ``xr_near_z`` / ``xr_far_z``
-     - —
+     - ``0.05`` / ``100.0``
      - Near / far planes for the XR projection.
    * - ``xr_system_wait_seconds``
-     - —
+     - ``0``
      - How long to wait for the OpenXR system (headset) to become available at create time.
+       Zero fails fast when no headset is present.
    * - ``clear_color``
-     - —
-     - Background color as an ``(r, g, b, a)`` sequence in ``[0, 1]``.
+     - ``(0, 0, 0, 0)``
+     - Background color as an ``(r, g, b, a)`` sequence in ``[0, 1]``. Transparent by default.
    * - ``gpu_timing``
-     - —
+     - ``False``
      - Enable GPU timestamp queries, surfaced via ``get_gpu_timing()``.
 
 Construct the session with the factory; never call the class directly:
@@ -242,7 +246,8 @@ Shared configuration
      - Source texture size, a ``Resolution``. Submitted buffers must match it.
    * - ``format``
      - —
-     - ``PixelFormat`` of the source (typically ``kRGBA8``).
+     - ``PixelFormat`` of the source. ``kRGBA8`` is the only value texture layers accept;
+       anything else raises ``ValueError``.
    * - ``placement``
      - —
      - Where and how big the surface is. Each layer has its own placement type describing its own

--- a/src/viz/AGENTS.md
+++ b/src/viz/AGENTS.md
@@ -13,7 +13,7 @@ mandatory **`AGENTS.md` preflight** in [`../../AGENTS.md`](../../AGENTS.md)
 
 `src/viz/` mirrors **`src/core/`**: a peer container of sub-modules, not a
 single sub-module. Each sub-module is its own static library. Tests live under
-[`../../../tests/`](../../../tests/) — see [`tests/AGENTS.md`](../../../tests/AGENTS.md).
+[`../../tests/`](../../tests/) — see [`tests/AGENTS.md`](../../tests/AGENTS.md).
 
 - **`viz/core/`** — foundational types + Vulkan/CUDA infrastructure.
   Library: `viz_core`. Today: `VkContext`, `VizBuffer`, `Pose3D`,
@@ -33,36 +33,45 @@ single sub-module. Each sub-module is its own static library. Tests live under
   from GLM 1.0.1 (FetchContent in `deps/third_party/`); use
   `glm::value_ptr(mat)` to get a raw `float*` for Vulkan / CUDA upload
   (POD-equivalent layout, no copy). CUDA-Vulkan interop requires CUDA
-  Toolkit at link time (`CUDAToolkit::cudart`). `VkContext::init()`
+  Toolkit at link time (`CUDA::cudart_static` — statically linked, so
+  consumers carry no runtime `libcudart` dependency). `VkContext::init()`
   matches the current CUDA device to the chosen Vulkan physical
   device by UUID — every viz_core type can assume CUDA and Vulkan
   are talking to the same GPU without re-doing the match.
-- **`viz/layers/`** — `LayerBase` and concrete layers. Library:
-  `viz_layers` (STATIC). Depends on `viz_core` + `viz_shaders`. Today:
-  `QuadLayer` (textured fullscreen quad, CUDA-fed via a 3-slot
-  mailbox of `DeviceImage`s; producer side is `submit(VizBuffer)` and
-  the renderer always samples the most recently published slot).
+- **`viz/layers/`** — the concrete layers. `LayerBase` itself lives in
+  `viz/session/`. Library: `viz_layers` (STATIC). Depends PUBLIC on
+  `viz::core` + `viz::session`, PRIVATE on `viz::shaders`. Today:
+  `ImageLayerBase` plus `QuadLayer`, `CylinderLayer` and
+  `EquirectLayer` on top of it, and `ProjectionLayer` directly on
+  `LayerBase`. The three image layers are CUDA-fed via a mailbox of
+  `DeviceImage`s owned by the shared `ImageLayerBase`, sized
+  `kSlotCount = kMaxFramesInFlight + 2`; producer side is
+  `submit(VizBuffer)` and the renderer always samples the most
+  recently published slot.
   Pipelines built per-layer using the driver-side `VkPipelineCache`
   from `VkContext`. **Deferred:** a zero-copy `acquire`/`release`
   variant for producers that can write directly into a tiled
   `cudaArray_t` (NVDEC, custom CUDA kernels). The mailbox internals
   already track slot ownership, so the addition is local to
-  `QuadLayer`; revisit when a real producer demands it. Open design
-  questions are captured under "Future: zero-copy acquire/release"
-  in `DESIGN.md`.
+  `ImageLayerBase` and the layers built on it; revisit when a real
+  producer demands it.
   Test-only fixture layers (`ClearRectLayer`, `ThrowingLayer`) live in
   `tests/cpp/viz/support/layers_testing/inc/viz/layers/testing/` and are exposed via
   the `viz::layers_testing` static library — used by `viz_session_tests`
   to compose into a `VizSession`.
 - **`viz/session/`** — `VizSession`, `VizCompositor`, `FrameInfo`,
-  `FrameTimingStats`, `SessionState`, display backends (today: offscreen
-  only; window/XR added by their respective backends). Library:
-  `viz_session`. Depends on `viz_core`, `viz_layers`. Public API for the
+  `FrameTimingStats`, `SessionState`, `LayerBase`, `Swapchain`,
+  `TileLayout`, and the display backends (offscreen, window/GLFW, and
+  XR). Library: `viz_session`. Links `viz::core`, `viz::xr`,
+  `oxr::oxr_utils`, `glfw`. Public API for the
   whole module — applications interact with Televiz through
   `VizSession::create()`.
-- **`viz/xr/`** — OpenXR backend (instance/session, swapchain wrapping,
-  frame loop, type conversion). Library: `viz_xr`. **Optional** behind
-  `BUILD_VIZ_XR`. Depends on `viz_core` + OpenXR.
+- **`viz/xr/`** — OpenXR instance/session lifecycle, event polling, and
+  the `xrWaitFrame`/`xrBeginFrame`/`xrEndFrame` loop. Swapchain wrapping
+  and OpenXR↔`viz` type conversion live in `viz_session`'s `XrBackend`.
+  Library: `viz_xr`. Always built under `BUILD_VIZ` — `viz_core` and
+  `viz_session` both require the OpenXR loader. Depends on `viz_core` +
+  OpenXR.
 - **`viz/python/`** — pybind11 module `_viz`, exposed as `isaacteleop.viz`.
 - **`viz/shaders/`** — GLSL → SPIR-V at build time. Library: `viz_shaders`
   (INTERFACE — exposes generated headers `viz/shaders/<name>.spv.h`,
@@ -81,10 +90,11 @@ and `tests/python/viz/` respectively (one Catch2 executable per sub-module:
 sub-module sub-directories. Sub-module `CMakeLists.txt` files build the
 actual libraries.
 
-The whole module is gated by **`BUILD_VIZ`** (default `OFF`) at the top
-level — viz requires Vulkan headers/loader, so it's opt-in to keep the
-default build path lightweight (matches the convention used by
-`BUILD_PLUGIN_OAK_CAMERA`, which also pulls in extra system deps).
+The whole module is gated by **`BUILD_VIZ`** at the top level, which
+defaults to `ON` when `find_package(Vulkan)` and `find_package(CUDAToolkit)`
+both succeed and `OFF` otherwise — a machine that cannot build viz still
+configures. Override with `-DBUILD_VIZ=ON/OFF`. Note this is *not* the
+`BUILD_PLUGIN_OAK_CAMERA` convention, which is a hard `OFF`.
 Build paths that ship viz (the wheel CI on Linux + Windows) pass
 `-DBUILD_VIZ=ON` explicitly. Lean Dockerfiles
 (`examples/teleop_ros2/Dockerfile`) get viz-free builds for free.
@@ -102,8 +112,9 @@ When `BUILD_VIZ=ON` the build machine must have:
 
 ## Code conventions
 
-- **C++ namespace:** all Televiz symbols in `viz`. Internal helpers
-  in `viz::detail`. Test infrastructure in `viz::testing`.
+- **C++ namespace:** all Televiz symbols in `viz`. Internal helpers go in
+  an anonymous namespace in the `.cpp` that needs them — there is no
+  `viz::detail`. Test infrastructure in `viz::testing`.
   This is shared across all sub-modules — no per-module nested namespace.
 - **Naming:** types `PascalCase`, methods/functions/variables
   `snake_case` (matches `src/core/`). Private members use trailing
@@ -111,7 +122,7 @@ When `BUILD_VIZ=ON` the build machine must have:
 - **Include paths:** mirror the on-disk nesting since sub-modules are
   *children* of `viz/`, not peers of each other:
   `<viz/core/vk_context.hpp>`, `<viz/layers/quad_layer.hpp>`,
-  `<viz/session/viz_session.hpp>`, `<viz/xr/xr_backend.hpp>`. Each
+  `<viz/session/viz_session.hpp>`, `<viz/xr/openxr_session.hpp>`. Each
   sub-module's `inc/viz/<sub-module>/` lives under that sub-module's
   `cpp/`, so per-library isolation is preserved (linking only `viz::core`
   exposes only `viz/core/...` headers, not other sub-modules).
@@ -133,8 +144,9 @@ When `BUILD_VIZ=ON` the build machine must have:
   required, must skip cleanly via `viz::testing::is_gpu_available`
   when no GPU), **`[xr]`** (OpenXR runtime required, manual-only).
 - `catch_discover_tests(<target> ADD_TAGS_AS_LABELS)` — exposes Catch2
-  tags as CTest labels. CI uses `ctest -L unit` and `ctest -L gpu` for
-  selection.
+  tags as CTest labels. CI uses `ctest -L unit` for CPU selection; the GPU
+  job runs each packaged `viz_*_tests` binary directly with the Catch2
+  `[gpu]` filter, because it downloads bare executables with no build tree.
 - GPU tests **must** use `GpuFixture` or call `is_gpu_available()` and
   `SKIP()` if false. Never assume a GPU is present.
 
@@ -193,9 +205,8 @@ the package step globs `viz_*_tests` and the runner loops over them.
 - **Public API surface (in `viz_core`, `viz_layers`, `viz_session`)
   must not expose OpenXR types.** Convert `XrPosef`/`XrFovf` to
   `viz::Pose3D`/`Fov` at the boundary. The conversion lives in
-  `viz::detail` inside `viz_xr` (where OpenXR headers are
-  available). This keeps `BUILD_VIZ_XR=OFF` viable for window/offscreen
-  builds without requiring OpenXR headers.
+  an anonymous namespace in `viz_session`'s `xr_backend.cpp`, where the
+  OpenXR headers are already in scope.
 - **Vulkan types are exposed** in the public API where functionally
   necessary (`VkCommandBuffer`, `VkRenderPass`, `VkImage` for custom
   layer authoring). This is intentional — Vulkan is the contract for


### PR DESCRIPTION
Seventeen claims across two viz docs that the code contradicts. Each was checked against the tree at `2a0854c16`; none needed an author decision. Two commits, one per file, so either can be dropped cleanly.

## Why now

The 2026-08-22 doc audit found 13 of 68 falsifiable claims false in `src/viz/AGENTS.md` and deliberately left them — viz was mid-refactor and a correction would have gone stale before review. That refactor has been quiet since 2026-08-24 and the file has not been touched since, so the findings were re-verified against today's code: **12 still stood, 1 had self-healed, and 5 more turned up.**

`televiz.rst` was nominally in scope of that audit but produced one incidental finding. 729 lines describing a module whose own agent notes were 19% false is not credible as clean, so it was re-read on its own rather than batched. ~170 claims checked, 5 defects — 3 here, 2 held back below.

## `src/viz/AGENTS.md` (14)

**Build and CI** — misleads anyone reasoning about either:

- `BUILD_VIZ` documented as a hard default `OFF` "matching `BUILD_PLUGIN_OAK_CAMERA`". It auto-detects — `ON` when Vulkan and CUDAToolkit are both found (`CMakeLists.txt:74-86`) — and the cited analogue is the opposite convention (`:62`).
- `BUILD_VIZ_XR` documented as the option gating `viz_xr`, in two places. **No such option exists**; `add_subdirectory(xr)` is unconditional (`src/viz/CMakeLists.txt:35`).
- CI documented as running `ctest -L gpu`. It never has — the GPU job invokes each packaged binary with the Catch2 `[gpu]` filter (`build-ubuntu.yml:435,440`) because it downloads bare executables with no build tree. This **contradicted the file's own CI section**.

**Module boundaries and the dependency DAG** — what an agent consults this file for before touching a `CMakeLists`:

- `viz_layers` links PUBLIC `viz::core` + `viz::session`, PRIVATE `viz::shaders` (`layers/cpp/CMakeLists.txt:29-35`). The doc had the edge running the other way and placed `LayerBase` in `viz/layers/`; it is in `viz/session/`.
- `viz_session` is not offscreen-only and does not link `viz_layers`. Offscreen + window/GLFW + XR, plus `Swapchain` and `TileLayout`; links `viz::core`, `viz::xr`, `oxr::oxr_utils`, `glfw`.
- `viz_xr` does not do swapchain wrapping or type conversion — both live in `viz_session`'s `XrBackend`. It does own the frame loop.
- `viz/xr/` does not expose `xr_backend.hpp`; that is a `viz_session` header.
- There is **no `viz::detail` namespace** anywhere under `src/viz`.
- CUDA links `CUDA::cudart_static`, not `CUDAToolkit::cudart` — the static choice is deliberate, so the reason is now stated.

**Layers** — left behind by the `ImageLayerBase` refactor:

- Five types ship, not one. The mailbox moved off `QuadLayer` onto the shared `ImageLayerBase` and is `kSlotCount = kMaxFramesInFlight + 2`, not three slots. `ProjectionLayer` sits directly on `LayerBase`.
- The deferred zero-copy note said the change would be "local to `QuadLayer`"; it would now touch `ImageLayerBase` and the layers on it.
- It pointed at `DESIGN.md` for open questions. No such file exists.

**One broken link introduced by #980** while it fixed the fixture-layer paths: `../../../tests/` is above the repo root from `src/viz/`. Two occurrences, now `../../tests/`, matching what `src/core/AGENTS.md:8` already uses.

## `docs/source/getting_started/televiz.rst` (3)

- The `VizSessionConfig` table showed "—" for seven Defaults and marked `mode` "Required." All seven have working in-class defaults and a bare `VizSessionConfig()` yields a valid 1024×1024 offscreen session. The table already showed real defaults for two other fields, so the dashes read as "no default" by contrast.
- `format` described as "typically `kRGBA8`". It is the **only** accepted value — anything else throws (`image_layer_base.cpp:59-62`), and `PixelFormat` has two enumerators. The page's own "Submitting frames" bullet already said flatly RGBA8.
- The install section listed `glslangValidator` as part of the `BUILD_VIZ` auto-enable condition. Only Vulkan and CUDA gate the default; a missing `glslangValidator` **fails configuration outright** rather than dropping the module (`CheckBuildDeps.cmake:60-63,90-91`). The sentence inverted the failure mode and contradicted this page's own C++ section.

## Held back — these need an author call, not a doc fix

Two findings from the same pass are **not** in this PR, because in each case the doc describes something the code does not do and only the owner knows whether that is unfinished or abandoned:

- **`FrameTimingStats`**: four of its six fields are never written. `update_timing_stats` assigns only `avg_frame_time_ms` and `render_fps` (`viz_session.cpp:315-326`), so `target_fps`, `missed_frames`, `gpu_time_ms` and `stale_layers` are permanently `0` — and the page's worked example branches on two of them. `examples/camera_viz/pipeline/runner.py:261-264` already guards all four with truthiness tests.
- **`SessionState`**: `kStopping` and `kLost` are never assigned. `state_` is set in exactly three places — `kReady`, `kRunning`, `kDestroyed`. The XR state machine is tracked inside `OpenXrSession` and never propagated, so an XR app polling `get_state()` for session loss, as the page instructs, will never see it.

Raising both separately.

## Verification

`sphinx-build -W --keep-going` over `docs/source` — the command `make current-docs` and CI run: **build succeeded, zero warnings.** Repo pre-commit suite passes on both commits. Docs only; no code, no build config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated build instructions to note the `glslangValidator` requirement and the option to disable VIZ builds when unavailable.
  - Documented default display, window, XR, clear-color, and GPU-timing settings.
  - Clarified supported texture layer formats and resulting validation behavior.
  - Expanded contributor guidance for VIZ modules, dependencies, build detection, namespaces, include paths, CI, and OpenXR integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->