### PR TITLE
docs(ecosystem): add release tags, and update the Noitom entries

### DIFF
--- a/docs/source/_data/devices.yaml
+++ b/docs/source/_data/devices.yaml
@@ -210,6 +210,20 @@ devices:
         - One BLE device per glove
         - Plugin off by default — enable at build time
 
+  # Noitom Robotics integrates Isaac Teleop; the suit streams through Noitom Ltd's Axis
+  # Studio and Hybrid Data Server, which is what the plugin reads. The row names the
+  # partner, so it links to them and not to the parent company's product pages.
+  - id: noitom
+    name: Noitom Robotics Motion Capture
+    url: https://www.noitomrobotics.com
+    group: peripheral
+    modes: Full-body motion capture
+    since: main
+    details:
+      setup:
+        - label: Noitom Mocap Plugin
+          url: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/noitom_mocap
+
   # The plugin is named generically because any 3-axis HID pedal goes through it.
   - id: logitech-rudder-pedals
     name: Logitech Rudder Pedals
@@ -269,16 +283,18 @@ devices:
     group: data_factory
     modes: Ego data capture, simulation assets
 
-  - id: noitom
-    name: Noitom Motion Capture
-    url: https://www.noitom.com/
+  # No `since`: the datasets are a service, with nothing in this repository to date it
+  # against. ModalityNet is the platform the datasets come from, so it earns a label of
+  # its own rather than a second bare link off the name.
+  - id: noitom-robotics
+    name: Noitom Robotics
+    url: https://www.noitomrobotics.com
     group: data_factory
-    modes: Full-body motion capture
-    since: main
+    modes: Human-centric datasets
     details:
-      setup:
-        - label: Noitom Mocap Plugin
-          url: https://github.com/NVIDIA/IsaacTeleop/tree/main/src/plugins/noitom_mocap
+      acquire:
+        - label: ModalityNet
+          url: https://www.modalitynet.com
 
   # ------------------------------------------------------------------- cloud --
   - id: volcano-engine

--- a/docs/source/_data/devices.yaml
+++ b/docs/source/_data/devices.yaml
@@ -19,11 +19,14 @@
 #   since    optional; the earliest release carrying the device, rendered under the
 #            Details panel's columns as a tag linking to that release -- so a row without
 #            `details` cannot have one. A release tag spelled as the repository spells it
-#            ("v1.3.131", and the unprefixed "0.1.0" of the first two releases; the page
-#            shows every one with a "v"), or `main` for a device no release carries yet.
+#            ("v1.3.131"), or `main` for a device no release carries yet.
 #            Derive it, never date it: walk the release tags oldest-first and take the
 #            first whose tree carries the device's plugin or guide, as in
 #            ``git cat-file -e v1.4.142:src/plugins/oglo_tactile``; `main` when none does.
+#            ``ecosystem_grid.SINCE_FLOOR`` is the oldest release this page names, and a
+#            device an earlier release carried is listed from the floor instead -- the
+#            build rejects anything older, so do not "correct" such a row back to what
+#            the walk returned.
 #            Ask the tree, not the ancestry -- release branches are maintained by
 #            cherry-pick, so a change has a different commit on each branch and
 #            ``git tag --contains`` answers "no tag" for every device. Dates mislead too:
@@ -148,7 +151,8 @@ devices:
     url: https://www.manus-meta.com/products/metagloves-pro
     group: peripheral
     modes: High-fidelity finger tracking
-    since: "0.1.0"
+    # The plugin shipped in 0.1.0, below the floor.
+    since: v1.0.191
     company:
       name: MANUS
       logo: manus.svg

--- a/docs/source/_data/devices.yaml
+++ b/docs/source/_data/devices.yaml
@@ -16,6 +16,19 @@
 #   modes    the second column. Its heading is per section: "Input modes" for input
 #            devices, where the modes decide the available retargeters and control
 #            schemes, and "Provides" for the rest. One short phrase, not a sentence.
+#   since    optional; the earliest release carrying the device, rendered under the
+#            Details panel's columns as a tag linking to that release -- so a row without
+#            `details` cannot have one. A release tag spelled as the repository spells it
+#            ("v1.3.131", and the unprefixed "0.1.0" of the first two releases; the page
+#            shows every one with a "v"), or `main` for a device no release carries yet.
+#            Derive it, never date it: walk the release tags oldest-first and take the
+#            first whose tree carries the device's plugin or guide, as in
+#            ``git cat-file -e v1.4.142:src/plugins/oglo_tactile``; `main` when none does.
+#            Ask the tree, not the ancestry -- release branches are maintained by
+#            cherry-pick, so a change has a different commit on each branch and
+#            ``git tag --contains`` answers "no tag" for every device. Dates mislead too:
+#            v1.3.131 (2026-06-30) does not carry the LeRobot integration merged on
+#            2026-06-27, which first shipped in v1.4.142.
 #   company  optional; the mark of the company behind the device. A mark and nothing
 #            else -- no category and no copy, so the table stays the reference it is.
 #            `name` and `logo` are both required, `name` being the alt text; add
@@ -55,6 +68,7 @@ devices:
     url: https://www.apple.com/apple-vision-pro/
     group: xr
     modes: Hand tracking (26 joints), spatial controllers
+    since: v1.0.191
     details:
       setup:
         - label: Sample Client
@@ -72,6 +86,7 @@ devices:
     url: https://www.meta.com/quest/
     group: xr
     modes: Motion controllers, hand tracking
+    since: v1.0.191
     details:
       setup:
         - label: How To Connect
@@ -88,6 +103,7 @@ devices:
     url: https://www.picoxr.com/products/pico4-ultra
     group: xr
     modes: Motion controllers, hand tracking
+    since: v1.0.191
     company:
       name: PICO
       logo: pico.svg
@@ -110,6 +126,7 @@ devices:
     url: https://www.picoxr.com/global/products/pico-motion-tracker
     group: xr
     modes: Full body tracking
+    since: v1.3.131
     details:
       setup:
         - label: Body Tracking guide
@@ -131,6 +148,7 @@ devices:
     url: https://www.manus-meta.com/products/metagloves-pro
     group: peripheral
     modes: High-fidelity finger tracking
+    since: "0.1.0"
     company:
       name: MANUS
       logo: manus.svg
@@ -154,6 +172,7 @@ devices:
     url: https://haptikos.tech/product/haptikos/
     group: peripheral
     modes: Finger tracking, haptic feedback
+    since: v1.3.131
     company:
       name: Haptikos
       logo: haptikos.png
@@ -175,6 +194,7 @@ devices:
     url: https://www.opengraphlabs.com/
     group: peripheral
     modes: Tactile contact sensing (80 taxels), 6-axis IMU
+    since: v1.4.142
     company:
       name: OpenGraph Labs
       logo: opengraph-labs.svg
@@ -196,6 +216,7 @@ devices:
     url: https://www.logitechg.com/en-us/products/flight/flight-simulator-rudder-pedals.html
     group: peripheral
     modes: 3-axis foot pedal
+    since: v1.0.191
     details:
       setup:
         - label: Generic 3-axis Pedal Plugin
@@ -211,6 +232,7 @@ devices:
     url: https://shop.luxonis.com/products/oak-d
     group: peripheral
     modes: Offline data recording
+    since: v1.0.191
     details:
       setup:
         - label: OAK-D Camera Plugin
@@ -229,6 +251,7 @@ devices:
     url: https://huggingface.co/docs/lerobot
     group: data_factory
     modes: Robot learning framework, dataset collection
+    since: v1.4.142
     company:
       name: Hugging Face
       logo: hugging-face.svg
@@ -251,6 +274,7 @@ devices:
     url: https://www.noitom.com/
     group: data_factory
     modes: Full-body motion capture
+    since: main
     details:
       setup:
         - label: Noitom Mocap Plugin

--- a/docs/source/_ext/ecosystem_grid.py
+++ b/docs/source/_ext/ecosystem_grid.py
@@ -26,6 +26,9 @@ from sphinx.util.docutils import SphinxRole
 DEVICE_DATA = "_data/devices.yaml"
 DEVICE_LOGO_DIR = "_static/logos"
 
+# A device no release carries yet, so the only way to get it is to build main.
+SINCE_MAIN = "main"
+
 # A link into the docs site or into the IsaacTeleop repository stays inside this
 # project, so it carries no external marker -- arrow or screen-reader label. Every
 # other domain gets one, including other GitHub organizations such as isaac-sim.
@@ -104,8 +107,13 @@ def _depart_eco_block(self, node):
     self.body.append(f"</{node.get('html_tag', 'div')}>\n")
 
 
-class eco_inline(nodes.Inline, nodes.Element):
-    """``eco_block``'s inline twin, for elements that sit inside a paragraph."""
+class eco_inline(nodes.Inline, nodes.TextElement):
+    """``eco_block``'s inline twin, for elements that sit inside a paragraph.
+
+    ``TextElement`` and not ``Element``: Sphinx's HTML writer treats a reference whose
+    parent is not one as an image reference, and asserts that its only child is an
+    image. A link nested in this span would crash the build.
+    """
 
 
 def _element(tag: str, classes: list[str], *, inline: bool = False, **attributes):
@@ -121,6 +129,9 @@ def _passthrough(self, node):
 
 _ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _ISSUE_RE = re.compile(r"/(?:issues|pull)/(\d+)/?$")
+# A release tag exactly as the repository spells it, because the link resolves it: the
+# first two releases predate the "v" prefix, so both "v1.0.191" and "0.1.0" occur.
+_SINCE_RE = re.compile(r"^v?\d+\.\d+\.\d+$")
 _TEL_RE = re.compile(r"[^\d+]")
 
 # A stroked glyph rather than U+2197: the Unicode arrow renders far heavier than the
@@ -140,7 +151,7 @@ def _fail(source: str, record: str | None, message: str) -> None:
 
 
 _DEVICE_REQUIRED = ("id", "name", "url", "group", "modes")
-_DEVICE_KNOWN = _DEVICE_REQUIRED + ("details", "company")
+_DEVICE_KNOWN = _DEVICE_REQUIRED + ("since", "details", "company")
 _COMPANY_REQUIRED = ("name", "logo")
 _COMPANY_KNOWN = _COMPANY_REQUIRED + ("logo_dark",)
 _PLANNED_REQUIRED = ("id", "name", "url", "note", "tracking")
@@ -226,6 +237,29 @@ def _validate_details(details, source: str, name: str) -> None:
             _validate_entry(entry, source, name, f"details.{key}")
 
 
+def _validate_since(since, source: str, name: str, details) -> None:
+    """A release tag, or ``main``: both name something the tag can link to.
+
+    Rejecting anything else keeps the field derivable rather than editorial -- a date, a
+    release line, or "latest" would all make the tag a claim nobody can check, and none
+    of them resolve to a page the link can point at.
+    """
+    if since != SINCE_MAIN and not _SINCE_RE.match(str(since)):
+        _fail(
+            source,
+            name,
+            f"since must be {SINCE_MAIN!r} or a release tag such as 'v1.3.131', "
+            f"not {since!r}",
+        )
+    if not details:
+        _fail(
+            source,
+            name,
+            "since renders inside the Details panel, and this row has no 'details' to "
+            "open, so the tag would never appear",
+        )
+
+
 def _validate_company(company, source: str, name: str, confdir: str) -> None:
     """The panel header renders a mark and nothing else, so the schema carries no copy.
 
@@ -296,6 +330,9 @@ def _validate_devices(
 
         if record.get("details") is not None:
             _validate_details(record["details"], source, name)
+
+        if record.get("since") is not None:
+            _validate_since(record["since"], source, name, record.get("details"))
 
         if record.get("company") is not None:
             _validate_company(record["company"], source, name, confdir)
@@ -461,6 +498,34 @@ def _disclosure(panel_id: str) -> nodes.Element:
     return cell
 
 
+def _since_tag(since: str) -> nodes.Element:
+    """The earliest release carrying the device, linked to that release.
+
+    A release takes the word "Since", which the number alone does not say: on its own it
+    reads as a version of the device rather than of what runs it. ``main`` takes no word,
+    because it is not a floor -- it is the moving tip, and nothing is available "since"
+    it. The bare chip, in the theme's primary color against the other rows' "Since",
+    carries that on its own, and it points at the branch because there is no release for
+    it to point at.
+
+    The label restores the "v" the first two releases were tagged without, so the chips
+    read as one series; the link keeps the spelling the repository actually uses.
+    """
+    group = _element("span", ["device-since"], inline=True)
+    classes = ["device-since-branch"]
+    if since == SINCE_MAIN:
+        label = SINCE_MAIN
+        target = f"{PROJECT_REPO}/tree/{SINCE_MAIN}"
+        classes.append("is-main")
+    else:
+        group += nodes.inline("", "Since", classes=["device-since-label"])
+        label = since if since.startswith("v") else f"v{since}"
+        target = f"{PROJECT_REPO}/releases/tag/{since}"
+    # Into the project's own repository, so no external marker: see PROJECT_REPO.
+    group += nodes.reference("", label, refuri=target, classes=classes)
+    return group
+
+
 def _company_head(company: dict) -> nodes.Element:
     """The mark of the company behind the device, above the panel's columns.
 
@@ -485,6 +550,19 @@ def _company_head(company: dict) -> nodes.Element:
     return head
 
 
+def _since_foot(since: str) -> nodes.Element:
+    """Under the panel's columns rather than over them.
+
+    Fewer than half the rows carry a company mark, so sharing the mark's row left the
+    rest with a chip against an empty half -- and a row holding only a chip is a row
+    spent on nothing. Below the columns it also reads as what it is: a note on the
+    listing, not a heading over it.
+    """
+    foot = _line(["device-panel-foot"])
+    foot += _since_tag(since)
+    return foot
+
+
 def _device_panel(record: dict, panel_id: str, docname: str) -> nodes.Element:
     panel = _element("div", ["device-panel"])
     panel["ids"] = [panel_id]
@@ -501,6 +579,9 @@ def _device_panel(record: dict, panel_id: str, docname: str) -> nodes.Element:
         for entry in entries:
             column += _detail_line(entry, docname)
         panel += column
+    since = record.get("since")
+    if since:
+        panel += _since_foot(since)
     return panel
 
 

--- a/docs/source/_ext/ecosystem_grid.py
+++ b/docs/source/_ext/ecosystem_grid.py
@@ -244,7 +244,7 @@ def _validate_since(since, source: str, name: str, details) -> None:
     release line, or "latest" would all make the tag a claim nobody can check, and none
     of them resolve to a page the link can point at.
     """
-    if since != SINCE_MAIN and not _SINCE_RE.match(str(since)):
+    if since != SINCE_MAIN and not _SINCE_RE.fullmatch(str(since)):
         _fail(
             source,
             name,

--- a/docs/source/_ext/ecosystem_grid.py
+++ b/docs/source/_ext/ecosystem_grid.py
@@ -29,6 +29,10 @@ DEVICE_LOGO_DIR = "_static/logos"
 # A device no release carries yet, so the only way to get it is to build main.
 SINCE_MAIN = "main"
 
+# The first stable release; everything before 1.0 was a pre-release. A device carried by
+# an earlier tag is listed from here rather than from a 0.x version.
+SINCE_FLOOR = "v1.0.191"
+
 # A link into the docs site or into the IsaacTeleop repository stays inside this
 # project, so it carries no external marker -- arrow or screen-reader label. Every
 # other domain gets one, including other GitHub organizations such as isaac-sim.
@@ -129,8 +133,10 @@ def _passthrough(self, node):
 
 _ID_RE = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
 _ISSUE_RE = re.compile(r"/(?:issues|pull)/(\d+)/?$")
-# A release tag exactly as the repository spells it, because the link resolves it: the
-# first two releases predate the "v" prefix, so both "v1.0.191" and "0.1.0" occur.
+# A release tag exactly as the repository spells it, because the link resolves it. Every
+# tag from SINCE_FLOOR on carries the "v", and only the releases below it drop the
+# prefix; matching those too lets the floor explain itself rather than reading as a
+# misspelling.
 _SINCE_RE = re.compile(r"^v?\d+\.\d+\.\d+$")
 _TEL_RE = re.compile(r"[^\d+]")
 
@@ -237,6 +243,11 @@ def _validate_details(details, source: str, name: str) -> None:
             _validate_entry(entry, source, name, f"details.{key}")
 
 
+def _release_order(tag: str) -> tuple:
+    """Sortable form of a release tag, whose "v" is optional in the oldest ones."""
+    return tuple(int(part) for part in tag.lstrip("v").split("."))
+
+
 def _validate_since(since, source: str, name: str, details) -> None:
     """A release tag, or ``main``: both name something the tag can link to.
 
@@ -250,6 +261,13 @@ def _validate_since(since, source: str, name: str, details) -> None:
             name,
             f"since must be {SINCE_MAIN!r} or a release tag such as 'v1.3.131', "
             f"not {since!r}",
+        )
+    if since != SINCE_MAIN and _release_order(since) < _release_order(SINCE_FLOOR):
+        _fail(
+            source,
+            name,
+            f"since is {since!r}, older than {SINCE_FLOOR!r}; a device carried by an "
+            f"earlier release is listed from {SINCE_FLOOR!r} instead",
         )
     if not details:
         _fail(

--- a/docs/source/_static/css/ecosystem.css
+++ b/docs/source/_static/css/ecosystem.css
@@ -363,7 +363,7 @@ html[data-theme="dark"] .device-toggle {
     }
 }
 
-/* ---- company mark ---- */
+/* ---- company mark and version tag ---- */
 
 /* Spans the panel's columns so they keep their own alignment underneath. No rule under
    it: with the mark alone, a divider reads as a header whose text failed to load. */
@@ -378,6 +378,58 @@ html[data-theme="dark"] .device-toggle {
     height: 1.25rem;
     width: auto;
     max-width: 9rem;
+}
+
+/* Below the columns, spanning them, and right-aligned: a note on the listing rather
+   than a fourth column of it. */
+.device-panel p.device-panel-foot {
+    display: flex;
+    grid-column: 1 / -1;
+    margin: 0;
+}
+
+/* Right-aligned by its own margin, so it does not depend on how its parent distributes
+   free space. Its own gap, tighter than the panel's, keeps the word with the branch. */
+.device-since {
+    display: flex;
+    align-items: center;
+    flex: none;
+    gap: 0.375rem;
+    margin-left: auto;
+}
+
+/* The panel's column headings, so the word reads as a label rather than as content. */
+.device-since-label {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--pst-color-text-muted);
+}
+
+/* Monospace because the label is a ref -- a release tag, or the branch name -- which is
+   the string the reader is about to check out. */
+.device-panel a.device-since-branch {
+    padding: 0.0625rem 0.5rem;
+    border: 1px solid var(--pst-color-border);
+    border-radius: 999px;
+    font-family: var(--pst-font-family-monospace);
+    font-size: 0.6875rem;
+    color: var(--pst-color-text-muted);
+    white-space: nowrap;
+    text-decoration: none;
+}
+
+.device-panel a.device-since-branch:hover,
+.device-panel a.device-since-branch:focus-visible {
+    border-color: currentcolor;
+    color: var(--pst-color-link-hover);
+}
+
+/* No release branch has it yet, which is the one case a reader has to act on. */
+.device-panel a.device-since-branch.is-main {
+    border-color: var(--pst-color-primary);
+    color: var(--pst-color-primary);
 }
 
 .device-panel h4.device-panel-heading {


### PR DESCRIPTION
## Description

- Add a tag showing the earliest release that supports each device.
- Update the Noitom entries: the mocap suit moves to the device table as Noitom
  Robotics Motion Capture, and their datasets get a Data Factory row.

## Type of change

- [x] Documentation update

## Testing

    cd docs && make current-docs
    SKIP=check-copyright-year pre-commit run --all-files

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added release-version metadata to device listings, including links to relevant repository branches or tags.
  * Added Noitom Robotics motion-capture support with plugin setup details.
  * Added Logitech Rudder Pedals, OAK-D Camera, and LeRobot release information.
  * Added Noitom Robotics human-centric datasets and ModalityNet acquisition details.

* **Documentation**
  * Documented how optional release metadata is interpreted, including `main` branch semantics and version-tag formatting.
  * Improved device panel styling to clearly display release information and links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->