### PR TITLE
sensing: add CUDA IPC transport and a camera_viz source for it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,7 @@ option(BUILD_PLUGIN_OAK_CAMERA "Build OAK camera plugin (requires vcpkg for Dept
 option(BUILD_PLUGIN_NOITOM_MOCAP "Build Noitom mocap plugin (downloads MocapApi SDK)" OFF)
 option(BUILD_PLUGIN_OGLO "Build OGLO tactile glove plugin (BLE, Linux only; fetches SimpleBLE + nlohmann/json)" OFF)
 option(BUILD_PLUGIN_WUJI_GLOVE "Build Wuji glove plugin (requires the wuji_sdk C SDK)" OFF)
+option(BUILD_PLUGIN_SENSING "Build SENSING GMSL camera plugin (Jetson only)" OFF)
 option(BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_EXAMPLE_TELEOP_ROS2 "Build only the teleop_ros2 ROS 2 reference integration (e.g. for Docker)" OFF)
 option(BUILD_TESTING "Build unit tests" ON)

--- a/examples/camera_viz/README.md
+++ b/examples/camera_viz/README.md
@@ -21,6 +21,7 @@ SPDX-License-Identifier: Apache-2.0
 | `oakd`      | OAK-D RGB / LEFT / RIGHT; mono or `stereo: true` (GRAY8 over USB, GPU-broadcast to RGBA; `stereo_rgb` for color). Needs the Luxonis udev rule — see below |
 | `zed`       | ZED 2 / Mini / X One; mono or `stereo: true` (per-eye SDK retrieve, zero-copy GPU) |
 | `video`     | Video-file replay (anything OpenCV/FFmpeg reads) — preview / testing without a camera. Loops by default; `stereo: true` splits side-by-side files into eyes (viewer only) |
+| `cuda_ipc`  | RGBA8 frames mapped straight out of another process's CUDA memory — no encode, no host copy. See [below](#cuda_ipc-frames-from-another-process) |
 
 In XR mode the viewer **attaches to the CloudXR runtime + WSS proxy**, starting a background service if none is serving — nothing to start separately (`--accept-eula` for the first run; `camera_viz.py --help` for the rest). Output: XR headset (default) or desktop window (`run CONFIG --mode window`); one surface per camera — a flat plane (default), a cylinder arc, or an equirect sphere (`placements.<name>.shape`, XR only for the curved shapes). Stereo cameras render true SBS in XR; window mode shows the left eye. XR placements: `world` / `head` / `lazy` / `gimbal`.
 
@@ -140,6 +141,41 @@ display:                      # camera_viz only
 ```
 
 Multiple cameras → multiple `cameras:` entries; each gets its own `rtp.port` (plus `port_right` if stereo) and renders as its own plane.
+
+## `cuda_ipc` — frames from another process
+
+A producer on the same machine publishes captured frames as CUDA device
+memory; camera_viz maps that memory once and renders from it. Nothing is
+encoded and nothing crosses host RAM, so the cost per frame is one 24-byte
+socket message. Measured on an AGX Orin at 1920×1080: **~1 ms** from producer
+timestamp to consumer receipt, sustained at 60 fps.
+
+```yaml
+cameras:
+  - name: left
+    type: cuda_ipc
+    socket: /tmp/s0.sock   # must match the producer's ipc= path
+    width: 2560            # must match what the producer serves
+    height: 1984
+```
+
+Start either side first — the source retries until the socket appears, and
+survives the producer restarting under it. `width`/`height` are checked during
+the handshake and a mismatch is refused rather than rendered at the wrong
+stride.
+
+Any process can be the producer — the wire format is a 24-byte message and a
+CUDA VMM handle over `SCM_RIGHTS`. An animated test pattern ships with it, so
+the consumer can be developed and tested with no camera and no capture SDK:
+
+```bash
+cmake --build build --target sensing_ipc_testsrc
+./build/src/plugins/sensing/tools/sensing_ipc_testsrc --socket=/tmp/s0.sock \
+    --width=2560 --height=1984
+```
+
+**One consumer at a time.** The producer serves whoever connected most
+recently, so a second camera_viz silently takes the feed from the first.
 
 ## Known issues
 

--- a/examples/camera_viz/configs/cuda_ipc.yaml
+++ b/examples/camera_viz/configs/cuda_ipc.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# CUDA IPC source — frames arrive as GPU memory mapped straight out of the
+# producer process. No encode, no decode, no host copy.
+#
+# Producer is the sensing plugin:
+#   camera_plugin_sensing --add-stream=sensor=0,ipc=/tmp/s0.sock \
+#                         --add-stream=sensor=1,ipc=/tmp/s1.sock
+#
+# Or, with no camera attached:
+#   sensing_ipc_testsrc --socket=/tmp/s0.sock --width=2560 --height=1984
+#
+# Then, in a second terminal:
+#   export DISPLAY=:1     # :99 is Xvfb; Tegra EGL cannot drive it
+#   ./camera_viz.sh run configs/cuda_ipc.yaml --mode window   # desktop window
+#   ./camera_viz.sh run configs/cuda_ipc.yaml                 # XR headset
+#
+# ``width``/``height`` must match what the producer serves; the handshake
+# rejects a mismatch rather than rendering garbage. Order does not matter —
+# the source retries until the socket appears, and survives it restarting.
+
+source: local
+
+cameras:
+  - name: left
+    enabled: true
+    type: cuda_ipc
+    socket: /tmp/s0.sock
+    width: 2560
+    height: 1984
+  - name: right
+    enabled: true
+    type: cuda_ipc
+    socket: /tmp/s1.sock
+    width: 2560
+    height: 1984
+
+display:
+  mode: xr                      # xr | window (xr is the default)
+  window:
+    width: 1920
+    height: 1080
+  xr:
+    near_z: 0.05
+    far_z: 100.0
+  clear_color: [0.0, 0.0, 0.0, 0.0]
+  placements:
+    left:
+      lock_mode: lazy
+      distance: 1.0
+      # Orin + CloudXR experimental runtime: the default OpenXR compositor
+      # draws the plane but leaves its contents black. Ignored in window mode.
+      compositor: televiz
+    right:
+      lock_mode: lazy
+      distance: 1.0
+      compositor: televiz

--- a/examples/camera_viz/pipeline/interface.py
+++ b/examples/camera_viz/pipeline/interface.py
@@ -38,6 +38,14 @@ class Frame:
 
     Stereo: ``image`` is the left eye; ``image_right`` carries the
     right eye when paired (both from the same capture instant).
+
+    ``image`` may be *borrowed* rather than owned: a source is allowed to
+    hand back a view onto memory it will reuse (``cuda_ipc`` maps producer
+    memory directly). A borrowed frame stays valid only until the next
+    ``latest()`` on the source that produced it, so a consumer must finish
+    reading — or copy — before polling again, and must not retain a Frame
+    across polls. ``ImageLayerBase::submit`` upholds this by synchronizing
+    its copy before returning; keep that guarantee if you change it.
     """
 
     image: Any

--- a/examples/camera_viz/sources/__init__.py
+++ b/examples/camera_viz/sources/__init__.py
@@ -14,6 +14,7 @@ from typing import List
 from pipeline import FrameSource
 
 from ._helpers import PairedFrameSource, set_verbose
+from .cuda_ipc import CudaIpcSource
 from .oakd import OakdSource
 from .rtp_h264 import RtpH264Source
 from .synthetic import SyntheticSource, SyntheticStereoSource
@@ -22,6 +23,7 @@ from .video_file import VideoFileSource
 from .zed import ZedSource
 
 __all__ = [
+    "CudaIpcSource",
     "OakdSource",
     "PairedFrameSource",
     "RtpH264Source",
@@ -94,6 +96,22 @@ def build_local_camera(spec: dict) -> List[FrameSource]:
                 fourcc=spec.get("fourcc"),
             )
         ]
+    if kind == "cuda_ipc":
+        if stereo:
+            # Each publisher serves one sensor, so a stereo rig is two
+            # cameras: entries here, paired by the caller.
+            raise ValueError(
+                f"build_local_camera: cuda_ipc camera {name!r} cannot be stereo — "
+                "declare one entry per socket."
+            )
+        return [
+            CudaIpcSource(
+                name=name,
+                socket_path=spec["socket"],
+                width=int(spec["width"]),
+                height=int(spec["height"]),
+            )
+        ]
     if kind == "oakd":
         # ``stereo: true`` shorthand for ``mode: stereo``; explicit mode wins.
         mode = spec.get("mode", "stereo" if stereo else "mono")
@@ -157,5 +175,5 @@ def build_local_camera(spec: dict) -> List[FrameSource]:
         return eyes
     raise ValueError(
         f"build_local_camera: unknown camera type {kind!r} "
-        "(known: synthetic, v4l2, oakd, zed, video)"
+        "(known: synthetic, v4l2, cuda_ipc, oakd, zed, video)"
     )

--- a/examples/camera_viz/sources/_cuda_vmm.py
+++ b/examples/camera_viz/sources/_cuda_vmm.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Minimal ctypes binding for the CUDA virtual-memory-management API.
+
+Only what importing a shared device allocation needs. ``libcuda.so.1`` ships
+with the driver, so this keeps the ``cuda_ipc`` source free of any new Python
+dependency — CuPy alone is not enough, as it exposes no ``cuMemImport*``.
+
+Legacy CUDA IPC (``cudaIpcOpenMemHandle``) is not an option here: on Tegra it
+fails with ``cudaErrorInvalidValue`` even though the producer's
+``cudaIpcGetMemHandle`` succeeded. The VMM path is the one that works.
+"""
+
+from __future__ import annotations
+
+import ctypes
+
+# CUmemAllocationHandleType
+CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR = 1
+# CUmemLocationType
+CU_MEM_LOCATION_TYPE_DEVICE = 1
+# CUmemAccess_flags
+CU_MEM_ACCESS_FLAGS_PROT_READWRITE = 3
+
+
+class _CUmemLocation(ctypes.Structure):
+    _fields_ = [("type", ctypes.c_int), ("id", ctypes.c_int)]
+
+
+class CUmemAccessDesc(ctypes.Structure):
+    _fields_ = [("location", _CUmemLocation), ("flags", ctypes.c_int)]
+
+
+class CudaDriverError(RuntimeError):
+    pass
+
+
+class CudaDriver:
+    """Lazily-loaded handle onto the few driver entry points we need."""
+
+    def __init__(self) -> None:
+        try:
+            self._lib = ctypes.CDLL("libcuda.so.1")
+        except OSError as e:
+            raise CudaDriverError(
+                "libcuda.so.1 not found — the NVIDIA driver is not installed "
+                "or not visible in this container."
+            ) from e
+
+        # cuMemImportFromShareableHandle takes the fd by value in a void*, not
+        # a pointer to it; passing &fd yields CUDA_ERROR_INVALID_VALUE.
+        self._lib.cuMemImportFromShareableHandle.argtypes = [
+            ctypes.POINTER(ctypes.c_ulonglong),
+            ctypes.c_void_p,
+            ctypes.c_int,
+        ]
+        self._lib.cuMemAddressReserve.argtypes = [
+            ctypes.POINTER(ctypes.c_ulonglong),
+            ctypes.c_size_t,
+            ctypes.c_size_t,
+            ctypes.c_ulonglong,
+            ctypes.c_ulonglong,
+        ]
+        self._lib.cuMemMap.argtypes = [
+            ctypes.c_ulonglong,
+            ctypes.c_size_t,
+            ctypes.c_size_t,
+            ctypes.c_ulonglong,
+            ctypes.c_ulonglong,
+        ]
+        self._lib.cuMemSetAccess.argtypes = [
+            ctypes.c_ulonglong,
+            ctypes.c_size_t,
+            ctypes.POINTER(CUmemAccessDesc),
+            ctypes.c_size_t,
+        ]
+        self._lib.cuMemUnmap.argtypes = [ctypes.c_ulonglong, ctypes.c_size_t]
+        self._lib.cuMemAddressFree.argtypes = [ctypes.c_ulonglong, ctypes.c_size_t]
+        self._lib.cuMemRelease.argtypes = [ctypes.c_ulonglong]
+        self._lib.cuDevicePrimaryCtxRetain.argtypes = [
+            ctypes.POINTER(ctypes.c_void_p),
+            ctypes.c_int,
+        ]
+        self._lib.cuDevicePrimaryCtxRelease.argtypes = [ctypes.c_int]
+        self._lib.cuCtxSetCurrent.argtypes = [ctypes.c_void_p]
+        self._lib.cuInit.argtypes = [ctypes.c_uint]
+        self._lib.cuGetErrorName.argtypes = [
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_char_p),
+        ]
+
+        self._check(self._lib.cuInit(0), "cuInit")
+
+    def _check(self, result: int, what: str) -> None:
+        if result == 0:
+            return
+        name = ctypes.c_char_p()
+        self._lib.cuGetErrorName(result, ctypes.byref(name))
+        detail = name.value.decode() if name.value else f"code {result}"
+        raise CudaDriverError(f"{what} failed: {detail}")
+
+    # ── context ───────────────────────────────────────────────────────
+
+    def primary_ctx_retain(self, device_id: int) -> int:
+        ctx = ctypes.c_void_p()
+        self._check(
+            self._lib.cuDevicePrimaryCtxRetain(ctypes.byref(ctx), device_id),
+            "cuDevicePrimaryCtxRetain",
+        )
+        return ctx.value or 0
+
+    def primary_ctx_release(self, device_id: int) -> None:
+        self._lib.cuDevicePrimaryCtxRelease(device_id)
+
+    def ctx_set_current(self, ctx: int) -> None:
+        self._check(self._lib.cuCtxSetCurrent(ctypes.c_void_p(ctx)), "cuCtxSetCurrent")
+
+    # ── shared allocation ─────────────────────────────────────────────
+
+    def import_fd(self, fd: int) -> int:
+        """Import a POSIX fd exported by ``cuMemExportToShareableHandle``."""
+        handle = ctypes.c_ulonglong()
+        self._check(
+            self._lib.cuMemImportFromShareableHandle(
+                ctypes.byref(handle),
+                ctypes.c_void_p(fd),
+                CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR,
+            ),
+            "cuMemImportFromShareableHandle",
+        )
+        return handle.value
+
+    def map_readwrite(self, handle: int, size: int, device_id: int) -> int:
+        """Reserve VA, map the handle into it, and grant this device access.
+
+        Returns the device pointer. On failure everything already acquired is
+        rolled back, so the caller never has to unwind a partial mapping.
+        """
+        ptr = ctypes.c_ulonglong()
+        self._check(
+            self._lib.cuMemAddressReserve(ctypes.byref(ptr), size, 0, 0, 0),
+            "cuMemAddressReserve",
+        )
+        try:
+            self._check(self._lib.cuMemMap(ptr, size, 0, handle, 0), "cuMemMap")
+        except CudaDriverError:
+            self._lib.cuMemAddressFree(ptr, size)
+            raise
+
+        desc = CUmemAccessDesc()
+        desc.location.type = CU_MEM_LOCATION_TYPE_DEVICE
+        desc.location.id = device_id
+        desc.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE
+        try:
+            self._check(
+                self._lib.cuMemSetAccess(ptr, size, ctypes.byref(desc), 1),
+                "cuMemSetAccess",
+            )
+        except CudaDriverError:
+            self._lib.cuMemUnmap(ptr, size)
+            self._lib.cuMemAddressFree(ptr, size)
+            raise
+
+        return ptr.value
+
+    def unmap(self, ptr: int, size: int, handle: int) -> list:
+        """Tear down a ``map_readwrite`` mapping. Idempotent.
+
+        Returns the name of each step that failed rather than raising, so a
+        caller unwinding after an error still completes the rest. Silence here
+        would turn a failed release into a slow leak, so callers should log
+        whatever comes back.
+        """
+        failures = []
+        if ptr:
+            for name, fn in (
+                ("cuMemUnmap", self._lib.cuMemUnmap),
+                ("cuMemAddressFree", self._lib.cuMemAddressFree),
+            ):
+                if fn(ptr, size) != 0:
+                    failures.append(name)
+        if handle and self._lib.cuMemRelease(handle) != 0:
+            failures.append("cuMemRelease")
+        return failures
+
+
+_driver: CudaDriver | None = None
+
+
+def driver() -> CudaDriver:
+    """Process-wide driver handle; ``cuInit`` runs once."""
+    global _driver
+    if _driver is None:
+        _driver = CudaDriver()
+    return _driver

--- a/examples/camera_viz/sources/cuda_ipc.py
+++ b/examples/camera_viz/sources/cuda_ipc.py
@@ -1,0 +1,421 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Zero-copy CUDA frame source over a Unix socket.
+
+Consumes frames published by the sensing plugin's ``CudaIpcPublisher``
+(``src/plugins/sensing/core/cuda_ipc_publisher.cpp``). The producer exports one
+CUDA allocation holding a ring of RGBA8 slots; this source maps it once and
+hands the renderer a CuPy view straight onto producer memory. No encode, no
+decode, no host round-trip — the only per-frame traffic on the socket is a
+24-byte ready message.
+
+Unlike every other source here, the pixels are *not* ours: a slot stays valid
+only until we release it. ``latest()`` therefore releases the previously
+returned slot, which is safe because the viz layer copies during ``submit()``
+before the next poll comes round.
+
+Wire format mirrors ``core/cuda_ipc_protocol.hpp``; the struct format strings
+below are that file's layout and must change with it.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import threading
+import time
+from typing import Optional
+
+from pipeline import Frame, FrameSource, SourceSpec
+
+from ._cuda_vmm import CudaDriverError, driver
+from ._helpers import notify, notify_verbose
+
+# core/cuda_ipc_protocol.hpp. '<' pins little-endian and kills native padding;
+# the C++ side is checked against these sizes by static_assert.
+_HELLO_FMT = "<8I3Q"
+_HELLO_SIZE = struct.calcsize(_HELLO_FMT)
+_FRAME_FMT = "<2I2Q"
+_FRAME_SIZE = struct.calcsize(_FRAME_FMT)
+_RELEASE_FMT = "<2I"
+
+_HELLO_MAGIC = 0x44554349
+_FRAME_MAGIC = 0x4D524649
+_RELEASE_MAGIC = 0x4C455249
+_PROTOCOL_VERSION = 1
+_FORMAT_RGBA8 = 0
+
+# A producer that answers but disagrees (geometry, protocol version, pixel
+# format) is a config error, not a race, so back off hard. Retrying at the
+# normal cadence would evict a correctly-configured consumer once a second,
+# since the producer serves whoever connected last.
+_REJECT_DELAY_S = 5.0
+
+# A retired mapping is freed only after the renderer has provably stopped
+# touching it. The mailbox is cleared first, so one poll interval is enough;
+# a quarter second is many intervals and still bounds the memory held.
+_RETIRE_GRACE_S = 0.25
+
+
+class CudaIpcSource(FrameSource):
+    """RGBA8 frames mapped directly from a producer process's CUDA memory."""
+
+    _kind = "cuda_ipc"
+
+    def __init__(
+        self,
+        name: str,
+        socket_path: str,
+        width: int,
+        height: int,
+        reconnect_delay_s: float = 1.0,
+    ) -> None:
+        try:
+            import cupy as cp
+        except ImportError as e:
+            raise RuntimeError(
+                "cuda_ipc source requires CuPy (cupy-cuda12x). "
+                "Install via `uv pip install cupy-cuda12x`."
+            ) from e
+
+        self._cp = cp
+        self._spec = SourceSpec(
+            name=name, width=width, height=height, pixel_format="rgba8"
+        )
+        self._socket_path = socket_path
+        self._reconnect_delay_s = float(reconnect_delay_s)
+
+        self._sock: Optional[socket.socket] = None
+        self._send_lock = threading.Lock()
+
+        # Mapping state, replaced wholesale on every (re)connect.
+        self._slots: list = []
+        self._ptr = 0
+        self._size = 0
+        self._handle = 0
+        self._device_id = 0
+        self._ctx = 0
+
+        # Mailbox. ``_pending`` is published-but-unconsumed, ``_inflight`` is
+        # the slot the renderer received last and may still be reading.
+        self._lock = threading.Lock()
+        self._pending: Optional[tuple] = None
+        self._inflight: Optional[int] = None
+
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+        self._frame_count = 0
+        self._last_report_s = 0.0
+
+    # ── FrameSource interface ─────────────────────────────────────────
+
+    @property
+    def spec(self) -> SourceSpec:
+        return self._spec
+
+    def start(self) -> None:
+        if self._thread is not None:
+            return
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._reader_loop,
+            name=f"cuda_ipc_{self._spec.name}",
+            daemon=False,
+        )
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            if self._thread.is_alive():
+                notify(self._kind, "reader thread did not exit; leaking mapping")
+                return
+            self._thread = None
+        self._teardown()
+
+    def latest(self) -> Optional[Frame]:
+        """Newest published frame, or None.
+
+        The returned Frame *borrows* producer memory: this call releases the
+        slot handed out by the previous call, so the previous Frame is invalid
+        once this returns. Copy before polling again; never hold two.
+        """
+        with self._lock:
+            if self._pending is None:
+                return None
+            slot, sequence, timestamp_ns = self._pending
+            self._pending = None
+            previous, self._inflight = self._inflight, slot
+            slots = self._slots
+            if slot >= len(slots):
+                return None  # torn down between publish and poll
+            image = slots[slot]
+
+        # The renderer asking for a new frame means it is done with the last
+        # one, so its slot can go back to the producer.
+        if previous is not None and previous != slot:
+            self._release(previous)
+
+        self._frame_count += 1
+        now = time.monotonic()
+        if now - self._last_report_s >= 5.0:
+            notify_verbose(self._kind, f"{self._frame_count} frames, seq={sequence}")
+            self._last_report_s = now
+
+        # stream=0: the producer synchronized its copy stream before telling us
+        # the slot was ready, so the pixels are complete on any stream we read from.
+        return Frame(
+            image=image,
+            timestamp_ns=timestamp_ns,
+            source_id=self._spec.name,
+            stream=0,
+        )
+
+    # ── reader thread ─────────────────────────────────────────────────
+
+    def _reader_loop(self) -> None:
+        opening_notified = False
+        while not self._stop.is_set():
+            try:
+                self._connect()
+            except (ValueError, CudaDriverError) as e:
+                # The producer is there and we could not agree with it. Say so
+                # every time: unlike a missing socket, this will not fix itself.
+                self._teardown()
+                notify(self._kind, f"rejected producer on {self._socket_path}: {e}")
+                self._stop.wait(timeout=_REJECT_DELAY_S)
+                continue
+            except OSError as e:
+                self._teardown()
+                if not opening_notified:
+                    notify(
+                        self._kind, f"waiting for producer on {self._socket_path} ({e})"
+                    )
+                    opening_notified = True
+                self._stop.wait(timeout=self._reconnect_delay_s)
+                continue
+
+            notify(
+                self._kind,
+                f"attached to {self._socket_path} "
+                f"({self._spec.width}x{self._spec.height}, {len(self._slots)} slots)",
+            )
+            opening_notified = False
+            self._pump()
+            self._teardown()
+
+    def _connect(self) -> None:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(2.0)
+        sock.connect(self._socket_path)
+        # Short timeout so stop() is responsive while blocked in recv.
+        sock.settimeout(0.5)
+
+        fd = -1
+        try:
+            msg, fds, _flags, _addr = socket.recv_fds(sock, _HELLO_SIZE, 1)
+            if not fds:
+                raise ValueError("producer sent no memory handle")
+            fd = fds[0]
+            if len(msg) < _HELLO_SIZE:
+                # Ancillary data rides the first byte, so a short read still
+                # carries the fd; finish the header before using it.
+                msg += _recv_exact(sock, _HELLO_SIZE - len(msg))
+            self._handshake(sock, msg, fd)
+        except BaseException:
+            sock.close()
+            raise
+        finally:
+            # cuMemImportFromShareableHandle dups what it needs; holding the fd
+            # open past the import would pin the producer's allocation after it
+            # exits.
+            if fd >= 0:
+                os.close(fd)
+
+    def _handshake(self, sock: socket.socket, msg: bytes, fd: int) -> None:
+        (
+            magic,
+            version,
+            width,
+            height,
+            pixel_format,
+            slot_count,
+            device_id,
+            _sensor_id,
+            pitch,
+            slot_stride,
+            total_bytes,
+        ) = struct.unpack(_HELLO_FMT, msg)
+
+        if magic != _HELLO_MAGIC:
+            raise ValueError(f"bad handshake magic 0x{magic:08x}")
+        if version != _PROTOCOL_VERSION:
+            raise ValueError(
+                f"producer speaks protocol v{version}, this source speaks "
+                f"v{_PROTOCOL_VERSION} — rebuild both sides"
+            )
+        if pixel_format != _FORMAT_RGBA8:
+            raise ValueError(
+                f"unsupported pixel format {pixel_format} (expected RGBA8)"
+            )
+        if (width, height) != (self._spec.width, self._spec.height):
+            raise ValueError(
+                f"producer serves {width}x{height} but the config declares "
+                f"{self._spec.width}x{self._spec.height}"
+            )
+        if pitch != width * 4:
+            raise ValueError(f"expected tightly packed rows, got pitch {pitch}")
+        # These size the mapping and the per-slot views, so a producer that
+        # disagrees with itself must be rejected here rather than turned into
+        # out-of-bounds device pointers.
+        if not 2 <= slot_count <= 64:
+            raise ValueError(f"implausible slot count {slot_count}")
+        if slot_stride < height * pitch:
+            raise ValueError(
+                f"slot stride {slot_stride} is smaller than a {width}x{height} frame"
+            )
+        if slot_count * slot_stride > total_bytes:
+            raise ValueError(
+                f"{slot_count} slots of {slot_stride} B overrun the "
+                f"{total_bytes} B allocation"
+            )
+
+        cp = self._cp
+        # Import into the primary context, which is the one CuPy allocates and
+        # launches on; a pointer from any other context would fault on use.
+        cp.cuda.Device(device_id).use()
+        drv = driver()
+        self._ctx = drv.primary_ctx_retain(device_id)
+        drv.ctx_set_current(self._ctx)
+        self._device_id = device_id
+
+        self._handle = drv.import_fd(fd)
+        self._ptr = drv.map_readwrite(self._handle, total_bytes, device_id)
+        self._size = total_bytes
+
+        # One CuPy view per slot, built once. ``owner=self`` keeps this source
+        # alive for as long as any handed-out frame references its memory.
+        self._slots = []
+        for i in range(slot_count):
+            mem = cp.cuda.UnownedMemory(
+                self._ptr + i * slot_stride,
+                height * pitch,
+                self,
+                device_id,
+            )
+            self._slots.append(
+                cp.ndarray(
+                    (height, width, 4),
+                    dtype=cp.uint8,
+                    memptr=cp.cuda.MemoryPointer(mem, 0),
+                )
+            )
+
+        self._sock = sock
+
+    def _pump(self) -> None:
+        """Read ready messages until the producer goes away or we're stopped."""
+        sock = self._sock
+        assert sock is not None
+        while not self._stop.is_set():
+            try:
+                header = _recv_exact(sock, _FRAME_SIZE)
+            except socket.timeout:
+                continue
+            except OSError as e:
+                notify(self._kind, f"producer connection lost ({e})")
+                return
+            except EOFError:
+                notify(self._kind, "producer disconnected")
+                return
+
+            magic, slot, sequence, timestamp_ns = struct.unpack(_FRAME_FMT, header)
+            if magic != _FRAME_MAGIC or slot >= len(self._slots):
+                notify(self._kind, "protocol desync; reconnecting")
+                return
+
+            with self._lock:
+                superseded = self._pending
+                self._pending = (slot, sequence, timestamp_ns)
+
+            # A frame the renderer never picked up is dropped here rather than
+            # queued: this is a mailbox, and a stale frame is worth less than
+            # the slot it occupies.
+            if superseded is not None and superseded[0] != slot:
+                self._release(superseded[0])
+
+    # ── plumbing ──────────────────────────────────────────────────────
+
+    def _release(self, slot: int) -> None:
+        sock = self._sock
+        if sock is None:
+            return
+        payload = struct.pack(_RELEASE_FMT, _RELEASE_MAGIC, slot)
+        try:
+            with self._send_lock:
+                sock.sendall(payload)
+        except OSError:
+            # Producer is gone; _pump will notice and reconnect.
+            pass
+
+    def _teardown(self) -> None:
+        with self._lock:
+            self._pending = None
+            self._inflight = None
+        if self._sock is not None:
+            try:
+                self._sock.close()
+            except OSError:
+                pass
+            self._sock = None
+
+        # The context is retained before the mapping exists, so release it even
+        # when a connect failed partway — otherwise every retry adds a
+        # reference the primary context is never destroyed under.
+        if not self._ctx:
+            return
+
+        if self._ptr:
+            # Drop the views before unmapping, then wait out any submit()
+            # already in flight on the render thread — freeing under it would
+            # fault.
+            self._slots = []
+            time.sleep(_RETIRE_GRACE_S)
+
+        drv = driver()
+        drv.ctx_set_current(self._ctx)
+        failures = drv.unmap(self._ptr, self._size, self._handle)
+        if failures:
+            notify(self._kind, f"leaked shared mapping: {', '.join(failures)} failed")
+        self._slots = []
+        self._ptr = 0
+        self._size = 0
+        self._handle = 0
+        drv.primary_ctx_release(self._device_id)
+        self._ctx = 0
+
+
+def _recv_exact(sock: socket.socket, count: int) -> bytes:
+    """Read exactly ``count`` bytes. SOCK_STREAM may split any message.
+
+    The socket carries a short timeout so the reader stays responsive to
+    stop(). That timeout may only surface *between* messages: abandoning a
+    half-read one would leave the stream misaligned, so once any byte has
+    arrived this keeps waiting for the rest.
+    """
+    chunks = []
+    remaining = count
+    while remaining:
+        try:
+            chunk = sock.recv(remaining)
+        except socket.timeout:
+            if remaining == count:
+                raise
+            continue
+        if not chunk:
+            raise EOFError("peer closed the connection")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)

--- a/src/plugins/CMakeLists.txt
+++ b/src/plugins/CMakeLists.txt
@@ -35,3 +35,7 @@ endif()
 if(BUILD_PLUGIN_WUJI_GLOVE)
     add_subdirectory(wuji_glove)
 endif()
+# Gated: Jetson only -- the Tegra CUDA and NVENC entry points are L4T-only.
+if(BUILD_PLUGIN_SENSING)
+    add_subdirectory(sensing)
+endif()

--- a/src/plugins/sensing/CMakeLists.txt
+++ b/src/plugins/sensing/CMakeLists.txt
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ==============================================================================
+# SENSING camera plugin — CUDA IPC transport
+# ==============================================================================
+# Two leaf targets, one per directory (cmake/cmake-structure.md rule 1):
+#   cuda_ipc/  sensing_cuda_ipc     — publisher + wire format, CUDA only
+#   tools/     sensing_ipc_testsrc  — synthetic producer for the same protocol
+#
+# Neither needs a camera, a capture SDK or an encoder: the transport is CUDA and
+# a Unix socket. Keep the capture-side SDK checks in the directories that need
+# them so this half stays buildable on its own.
+#
+# Configure with:
+#   cmake -B build -DBUILD_PLUGIN_SENSING=ON
+# ==============================================================================
+
+enable_language(CUDA)
+
+if(NOT DEFINED CMAKE_CUDA_ARCHITECTURES)
+    # Orin is 87, Thor is 101; the rest cover desktop dev boxes.
+    set(CMAKE_CUDA_ARCHITECTURES "80;86;87;89;90")
+endif()
+
+find_package(CUDAToolkit REQUIRED)
+
+add_subdirectory(cuda_ipc)
+add_subdirectory(tools)

--- a/src/plugins/sensing/cuda_ipc/CMakeLists.txt
+++ b/src/plugins/sensing/cuda_ipc/CMakeLists.txt
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# CUDA IPC publisher and its wire format. Deliberately depends on CUDA alone so
+# tools/ can build a producer without SIPL or the V4L2 encoder.
+add_library(sensing_cuda_ipc STATIC
+    cuda_ipc_publisher.cpp
+)
+add_library(sensing::cuda_ipc ALIAS sensing_cuda_ipc)
+
+target_include_directories(sensing_cuda_ipc PUBLIC inc)
+
+target_link_libraries(sensing_cuda_ipc
+    PUBLIC
+        CUDA::cudart
+        CUDA::cuda_driver
+)

--- a/src/plugins/sensing/cuda_ipc/cuda_ipc_publisher.cpp
+++ b/src/plugins/sensing/cuda_ipc/cuda_ipc_publisher.cpp
@@ -1,0 +1,365 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <sensing_cuda_ipc/cuda_ipc_publisher.hpp>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+
+#include <cstring>
+#include <cuda_runtime_api.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <iostream>
+#include <sstream>
+#include <stdexcept>
+#include <unistd.h>
+
+namespace plugins
+{
+namespace sensing
+{
+namespace
+{
+
+void check_cuda(CUresult result, const char* what)
+{
+    if (result == CUDA_SUCCESS)
+        return;
+
+    const char* name = nullptr;
+    const char* text = nullptr;
+    cuGetErrorName(result, &name);
+    cuGetErrorString(result, &text);
+    std::ostringstream oss;
+    oss << "CudaIpcPublisher: " << what << " failed";
+    if (name)
+        oss << ": " << name;
+    if (text)
+        oss << " (" << text << ")";
+    throw std::runtime_error(oss.str());
+}
+
+void check_runtime(cudaError_t result, const char* what)
+{
+    if (result != cudaSuccess)
+    {
+        std::ostringstream oss;
+        oss << "CudaIpcPublisher: " << what << " failed: " << cudaGetErrorString(result);
+        throw std::runtime_error(oss.str());
+    }
+}
+
+size_t round_up(size_t value, size_t multiple)
+{
+    return ((value + multiple - 1) / multiple) * multiple;
+}
+
+/// Send a fixed-size record, optionally with one fd attached. Non-blocking:
+/// returns false on EAGAIN so a wedged consumer never stalls capture.
+bool send_record(int fd, const void* data, size_t size, int passed_fd)
+{
+    iovec io{ const_cast<void*>(data), size };
+    msghdr msg{};
+    msg.msg_iov = &io;
+    msg.msg_iovlen = 1;
+
+    // CMSG_SPACE is not constexpr-friendly on all libcs; size for exactly one fd.
+    alignas(cmsghdr) char control[CMSG_SPACE(sizeof(int))];
+    if (passed_fd >= 0)
+    {
+        std::memset(control, 0, sizeof(control));
+        msg.msg_control = control;
+        msg.msg_controllen = sizeof(control);
+        cmsghdr* cmsg = CMSG_FIRSTHDR(&msg);
+        cmsg->cmsg_level = SOL_SOCKET;
+        cmsg->cmsg_type = SCM_RIGHTS;
+        cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+        std::memcpy(CMSG_DATA(cmsg), &passed_fd, sizeof(int));
+    }
+
+    // MSG_NOSIGNAL: a consumer that exits mid-send must not SIGPIPE the plugin.
+    ssize_t sent = ::sendmsg(fd, &msg, MSG_NOSIGNAL);
+    return sent == static_cast<ssize_t>(size);
+}
+
+} // namespace
+
+CudaIpcPublisher::CudaIpcPublisher(const CudaIpcConfig& config) : m_config(config)
+{
+    if (m_config.socket_path.empty())
+        throw std::runtime_error("CudaIpcPublisher: socket path is empty");
+    if (m_config.slot_count < 2 || m_config.slot_count > 64)
+        throw std::runtime_error("CudaIpcPublisher: slot_count must be in [2, 64]");
+
+    check_cuda(cuInit(0), "cuInit");
+    check_cuda(cuDeviceGet(&m_device, m_config.gpu_id), "cuDeviceGet");
+    check_cuda(cuDevicePrimaryCtxRetain(&m_context, m_device), "cuDevicePrimaryCtxRetain");
+    m_context_retained = true;
+    check_cuda(cuCtxSetCurrent(m_context), "cuCtxSetCurrent");
+    check_cuda(cuStreamCreate(&m_stream, CU_STREAM_NON_BLOCKING), "cuStreamCreate");
+
+    allocate_slots();
+    open_socket();
+
+    std::cout << "CUDA IPC: sensor " << m_config.sensor_id << " serving " << m_config.width << "x" << m_config.height
+              << " RGBA8 on " << m_config.socket_path << " (" << m_config.slot_count << " slots, "
+              << (m_reserved_bytes >> 20) << " MiB)" << std::endl;
+}
+
+CudaIpcPublisher::~CudaIpcPublisher()
+{
+    if (m_client_fd >= 0)
+        ::close(m_client_fd);
+    if (m_listen_fd >= 0)
+        ::close(m_listen_fd);
+    if (m_socket_bound)
+        ::unlink(m_config.socket_path.c_str());
+    if (m_export_fd >= 0)
+        ::close(m_export_fd);
+
+    if (m_base_ptr)
+    {
+        cuMemUnmap(m_base_ptr, m_reserved_bytes);
+        cuMemAddressFree(m_base_ptr, m_reserved_bytes);
+    }
+    if (m_alloc_handle)
+        cuMemRelease(m_alloc_handle);
+    if (m_stream)
+        cuStreamDestroy(m_stream);
+    if (m_context_retained)
+        cuDevicePrimaryCtxRelease(m_device);
+}
+
+void CudaIpcPublisher::allocate_slots()
+{
+    CUmemAllocationProp prop{};
+    prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+    prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+    prop.location.id = m_config.gpu_id;
+    prop.requestedHandleTypes = CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR;
+
+    size_t granularity = 0;
+    check_cuda(cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_RECOMMENDED),
+               "cuMemGetAllocationGranularity");
+
+    // Rows are tightly packed so the consumer can wrap a slot as a plain
+    // contiguous HxWx4 array. Slots are 256-byte aligned to keep every slot
+    // base at CUDA's texture alignment.
+    m_pitch = static_cast<size_t>(m_config.width) * 4;
+    m_slot_stride = round_up(m_pitch * m_config.height, 256);
+    m_reserved_bytes = round_up(m_slot_stride * m_config.slot_count, granularity);
+
+    check_cuda(cuMemCreate(&m_alloc_handle, m_reserved_bytes, &prop, 0), "cuMemCreate");
+    check_cuda(cuMemExportToShareableHandle(&m_export_fd, m_alloc_handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0),
+               "cuMemExportToShareableHandle");
+    check_cuda(cuMemAddressReserve(&m_base_ptr, m_reserved_bytes, 0, 0, 0), "cuMemAddressReserve");
+    check_cuda(cuMemMap(m_base_ptr, m_reserved_bytes, 0, m_alloc_handle, 0), "cuMemMap");
+
+    CUmemAccessDesc access{};
+    access.location = prop.location;
+    access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+    check_cuda(cuMemSetAccess(m_base_ptr, m_reserved_bytes, &access, 1), "cuMemSetAccess");
+
+    // Opaque memory starts undefined; a consumer that attaches before the
+    // first frame would otherwise render whatever the allocator handed back.
+    check_runtime(cudaMemset(reinterpret_cast<void*>(m_base_ptr), 0, m_reserved_bytes), "cudaMemset");
+
+    m_slot_sequence.assign(m_config.slot_count, 0);
+}
+
+void CudaIpcPublisher::open_socket()
+{
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    if (m_config.socket_path.size() >= sizeof(addr.sun_path))
+    {
+        throw std::runtime_error("CudaIpcPublisher: socket path exceeds " + std::to_string(sizeof(addr.sun_path) - 1) +
+                                 " bytes: " + m_config.socket_path);
+    }
+    std::memcpy(addr.sun_path, m_config.socket_path.c_str(), m_config.socket_path.size());
+
+    m_listen_fd = ::socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC, 0);
+    if (m_listen_fd < 0)
+        throw std::runtime_error(std::string("CudaIpcPublisher: socket() failed: ") + std::strerror(errno));
+
+    // A previous run that died on SIGKILL leaves the node behind and bind()
+    // would fail with EADDRINUSE.
+    ::unlink(m_config.socket_path.c_str());
+
+    if (::bind(m_listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0)
+    {
+        std::string err = std::strerror(errno);
+        ::close(m_listen_fd);
+        m_listen_fd = -1;
+        throw std::runtime_error("CudaIpcPublisher: bind(" + m_config.socket_path + ") failed: " + err);
+    }
+    m_socket_bound = true;
+
+    if (::listen(m_listen_fd, 1) < 0)
+        throw std::runtime_error(std::string("CudaIpcPublisher: listen() failed: ") + std::strerror(errno));
+}
+
+void CudaIpcPublisher::accept_client()
+{
+    int fd = ::accept4(m_listen_fd, nullptr, nullptr, SOCK_NONBLOCK | SOCK_CLOEXEC);
+    if (fd < 0)
+        return; // EAGAIN: nobody waiting.
+
+    if (m_client_fd >= 0)
+    {
+        // Last connect wins, so restarting the viewer does not need a plugin
+        // restart. The old consumer sees EOF.
+        std::cout << "CUDA IPC: sensor " << m_config.sensor_id << " replacing consumer" << std::endl;
+        ::close(m_client_fd);
+        m_client_fd = -1;
+        m_unreleased = 0;
+    }
+
+    ipc::Hello hello{};
+    hello.magic = ipc::kHelloMagic;
+    hello.version = ipc::kProtocolVersion;
+    hello.width = m_config.width;
+    hello.height = m_config.height;
+    hello.format = static_cast<uint32_t>(ipc::PixelFormat::Rgba8);
+    hello.slot_count = m_config.slot_count;
+    hello.device_id = static_cast<uint32_t>(m_config.gpu_id);
+    hello.sensor_id = m_config.sensor_id;
+    hello.pitch = m_pitch;
+    hello.slot_stride = m_slot_stride;
+    hello.total_bytes = m_reserved_bytes;
+
+    if (!send_record(fd, &hello, sizeof(hello), m_export_fd))
+    {
+        std::cerr << "CUDA IPC: sensor " << m_config.sensor_id << " handshake send failed: " << std::strerror(errno)
+                  << std::endl;
+        ::close(fd);
+        return;
+    }
+
+    m_client_fd = fd;
+    std::cout << "CUDA IPC: sensor " << m_config.sensor_id << " consumer attached" << std::endl;
+}
+
+void CudaIpcPublisher::drain_releases()
+{
+    if (m_client_fd < 0)
+        return;
+
+    ipc::SlotRelease release{};
+    while (true)
+    {
+        ssize_t got = ::recv(m_client_fd, &release, sizeof(release), MSG_DONTWAIT);
+        if (got == 0)
+        {
+            drop_client("consumer disconnected");
+            return;
+        }
+        if (got < 0)
+        {
+            if (errno == EAGAIN || errno == EWOULDBLOCK)
+                return;
+            drop_client(std::strerror(errno));
+            return;
+        }
+        if (got != sizeof(release) || release.magic != ipc::kReleaseMagic)
+        {
+            drop_client("protocol desync on release message");
+            return;
+        }
+        if (release.slot >= m_config.slot_count)
+        {
+            drop_client("release named an out-of-range slot");
+            return;
+        }
+        m_unreleased &= ~(uint64_t{ 1 } << release.slot);
+    }
+}
+
+void CudaIpcPublisher::drop_client(const char* reason)
+{
+    if (m_client_fd < 0)
+        return;
+    std::cout << "CUDA IPC: sensor " << m_config.sensor_id << " consumer detached (" << reason << ")" << std::endl;
+    ::close(m_client_fd);
+    m_client_fd = -1;
+    m_unreleased = 0;
+}
+
+void CudaIpcPublisher::poll()
+{
+    drain_releases();
+    accept_client();
+}
+
+int CudaIpcPublisher::pick_slot() const
+{
+    int best = -1;
+    uint64_t best_sequence = UINT64_MAX;
+    for (uint32_t i = 0; i < m_config.slot_count; ++i)
+    {
+        if (m_unreleased & (uint64_t{ 1 } << i))
+            continue;
+        if (m_slot_sequence[i] < best_sequence)
+        {
+            best_sequence = m_slot_sequence[i];
+            best = static_cast<int>(i);
+        }
+    }
+    return best;
+}
+
+bool CudaIpcPublisher::publish(uintptr_t src_ptr, size_t src_pitch, uint64_t timestamp_ns)
+{
+    if (m_client_fd < 0 || src_ptr == 0)
+        return false;
+
+    const int slot = pick_slot();
+    if (slot < 0)
+    {
+        ++m_dropped;
+        return false;
+    }
+
+    check_cuda(cuCtxSetCurrent(m_context), "cuCtxSetCurrent publish");
+
+    void* dst = reinterpret_cast<void*>(m_base_ptr + static_cast<size_t>(slot) * m_slot_stride);
+    check_runtime(cudaMemcpy2DAsync(dst, m_pitch, reinterpret_cast<const void*>(src_ptr), src_pitch, m_pitch,
+                                    m_config.height, cudaMemcpyDeviceToDevice, m_stream),
+                  "cudaMemcpy2DAsync");
+
+    // The consumer reads on its own context and stream and has no way to wait
+    // on ours, so the copy must be complete before it is told the slot is
+    // ready. Without this it renders a torn frame.
+    check_runtime(cudaStreamSynchronize(m_stream), "cudaStreamSynchronize");
+
+    ++m_sequence;
+    m_slot_sequence[slot] = m_sequence;
+    m_unreleased |= uint64_t{ 1 } << slot;
+
+    ipc::FrameReady ready{};
+    ready.magic = ipc::kFrameMagic;
+    ready.slot = static_cast<uint32_t>(slot);
+    ready.sequence = m_sequence;
+    ready.timestamp_ns = timestamp_ns;
+
+    if (!send_record(m_client_fd, &ready, sizeof(ready), -1))
+    {
+        if (errno == EAGAIN || errno == EWOULDBLOCK)
+        {
+            // Consumer is behind and its socket buffer is full. Dropping the
+            // notification is the mailbox-correct outcome: it will pick up the
+            // next frame instead of falling further behind.
+            m_unreleased &= ~(uint64_t{ 1 } << slot);
+            ++m_dropped;
+            return false;
+        }
+        drop_client(std::strerror(errno));
+        return false;
+    }
+
+    return true;
+}
+
+} // namespace sensing
+} // namespace plugins

--- a/src/plugins/sensing/cuda_ipc/inc/sensing_cuda_ipc/cuda_ipc_protocol.hpp
+++ b/src/plugins/sensing/cuda_ipc/inc/sensing_cuda_ipc/cuda_ipc_protocol.hpp
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Wire format for the CUDA frame IPC socket.
+//
+// The Python consumer decodes these with struct.unpack in
+// examples/camera_viz/sources/cuda_ipc.py. Both sides hardcode the layout, so
+// any change here is a wire break: bump kProtocolVersion and update the
+// consumer's format strings in the same commit.
+//
+// Layout is fixed little-endian with explicit padding rather than whatever the
+// compiler picks, so the Python side can spell it as a plain struct format.
+
+#pragma once
+
+#include <cstdint>
+
+namespace plugins
+{
+namespace sensing
+{
+namespace ipc
+{
+
+constexpr uint32_t kHelloMagic = 0x44554349; // 'ICUD'
+constexpr uint32_t kFrameMagic = 0x4d524649; // 'IFRM'
+constexpr uint32_t kReleaseMagic = 0x4c455249; // 'IREL'
+constexpr uint32_t kProtocolVersion = 1;
+
+/// Pixel format tag carried in Hello::format.
+enum class PixelFormat : uint32_t
+{
+    Rgba8 = 0,
+};
+
+/**
+ * @brief Sent once on connect, alongside the export fd via SCM_RIGHTS.
+ *
+ * The single fd maps one allocation holding `slot_count` frames; slot i starts
+ * at `i * slot_stride` and each row is `pitch` bytes.
+ */
+struct Hello
+{
+    uint32_t magic;
+    uint32_t version;
+    uint32_t width;
+    uint32_t height;
+    uint32_t format;
+    uint32_t slot_count;
+    uint32_t device_id;
+    uint32_t sensor_id;
+    uint64_t pitch;
+    uint64_t slot_stride;
+    /// Total mapped size, already rounded up to the CUDA allocation granularity.
+    uint64_t total_bytes;
+};
+static_assert(sizeof(Hello) == 56, "Hello layout is wire format; see cuda_ipc.py");
+
+/// Sent per published frame. The named slot is the consumer's until it releases it.
+struct FrameReady
+{
+    uint32_t magic;
+    uint32_t slot;
+    uint64_t sequence;
+    uint64_t timestamp_ns;
+};
+static_assert(sizeof(FrameReady) == 24, "FrameReady layout is wire format; see cuda_ipc.py");
+
+/// Consumer -> producer: the slot is done being read and may be overwritten.
+struct SlotRelease
+{
+    uint32_t magic;
+    uint32_t slot;
+};
+static_assert(sizeof(SlotRelease) == 8, "SlotRelease layout is wire format; see cuda_ipc.py");
+
+} // namespace ipc
+} // namespace sensing
+} // namespace plugins

--- a/src/plugins/sensing/cuda_ipc/inc/sensing_cuda_ipc/cuda_ipc_publisher.hpp
+++ b/src/plugins/sensing/cuda_ipc/inc/sensing_cuda_ipc/cuda_ipc_publisher.hpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Publishes captured frames to another process as CUDA device memory, with no
+// encode and no host round-trip.
+//
+// Legacy CUDA IPC (cudaIpcGetMemHandle) does not work here. On Orin the
+// producer-side call returns cudaSuccess and the consumer's
+// cudaIpcOpenMemHandle then fails with cudaErrorInvalidValue, so the failure
+// only shows up in the far process. The working route on Tegra is the virtual
+// memory management API: cuMemCreate exports a POSIX file descriptor that the
+// consumer maps with cuMemImportFromShareableHandle. Do not "simplify" this
+// back to cudaIpcMemHandle_t.
+//
+// Wire protocol lives in cuda_ipc_protocol.hpp, shared with the Python
+// consumer in examples/camera_viz/sources/cuda_ipc.py.
+
+#pragma once
+
+#include <sensing_cuda_ipc/cuda_ipc_protocol.hpp>
+
+#include <cstdint>
+#include <cuda.h>
+#include <string>
+#include <vector>
+
+namespace plugins
+{
+namespace sensing
+{
+
+struct CudaIpcConfig
+{
+    /// Unix domain socket path the consumer connects to.
+    std::string socket_path;
+    uint32_t width = 1920;
+    uint32_t height = 1080;
+    uint32_t sensor_id = 0;
+    int gpu_id = 0;
+    /// Ring depth. One slot is held by the consumer while it renders, so
+    /// three is the minimum that lets the producer keep writing; four leaves
+    /// headroom for a consumer that briefly stalls.
+    uint32_t slot_count = 4;
+};
+
+/**
+ * @brief Serves RGBA8 frames to one consumer process over CUDA VMM + a Unix socket.
+ *
+ * Single-threaded and non-blocking throughout: poll() accepts connections and
+ * reaps slot releases, publish() copies into a free slot and notifies. Neither
+ * ever blocks the capture loop, so a stalled or absent consumer costs the
+ * pipeline nothing.
+ *
+ * One consumer at a time. A second connection replaces the first, so
+ * restarting the viewer does not require restarting the plugin.
+ */
+class CudaIpcPublisher
+{
+public:
+    explicit CudaIpcPublisher(const CudaIpcConfig& config);
+    ~CudaIpcPublisher();
+
+    CudaIpcPublisher(const CudaIpcPublisher&) = delete;
+    CudaIpcPublisher& operator=(const CudaIpcPublisher&) = delete;
+
+    /** @brief Accept a pending consumer and reap released slots. Never blocks. */
+    void poll();
+
+    /**
+     * @brief Copy one RGBA8 frame into a free slot and publish it.
+     *
+     * @param src_ptr    Device pointer to RGBA8 source (e.g. SiplCamera's
+     *                   converted buffer).
+     * @param src_pitch  Source row stride in bytes.
+     * @return false if no consumer is attached, or the frame was dropped.
+     */
+    bool publish(uintptr_t src_ptr, size_t src_pitch, uint64_t timestamp_ns);
+
+    bool has_consumer() const
+    {
+        return m_client_fd >= 0;
+    }
+    uint64_t published_count() const
+    {
+        return m_sequence;
+    }
+    uint64_t dropped_count() const
+    {
+        return m_dropped;
+    }
+
+private:
+    void allocate_slots();
+    void open_socket();
+    void accept_client();
+    void drain_releases();
+    void drop_client(const char* reason);
+    /// Least-recently-published slot the consumer has released, or -1.
+    int pick_slot() const;
+
+    CudaIpcConfig m_config;
+
+    CUdevice m_device = 0;
+    CUcontext m_context = nullptr;
+    bool m_context_retained = false;
+    CUstream m_stream = nullptr;
+
+    /// One allocation carrying every slot; one fd exports the lot.
+    CUmemGenericAllocationHandle m_alloc_handle = 0;
+    CUdeviceptr m_base_ptr = 0;
+    size_t m_reserved_bytes = 0;
+    int m_export_fd = -1;
+
+    size_t m_pitch = 0;
+    size_t m_slot_stride = 0;
+
+    /// Publish sequence each slot last carried; 0 means never written.
+    std::vector<uint64_t> m_slot_sequence;
+    /// Bit i set while slot i is published but not yet released by the
+    /// consumer. Overwriting one of these would tear the frame it is reading,
+    /// so publish() drops instead. Caps slot_count at 64.
+    uint64_t m_unreleased = 0;
+
+    int m_listen_fd = -1;
+    int m_client_fd = -1;
+    bool m_socket_bound = false;
+
+    uint64_t m_sequence = 0;
+    uint64_t m_dropped = 0;
+};
+
+} // namespace sensing
+} // namespace plugins

--- a/src/plugins/sensing/tools/CMakeLists.txt
+++ b/src/plugins/sensing/tools/CMakeLists.txt
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Animated test pattern on the IPC socket, so a consumer can be exercised with
+# no camera attached. Links sensing::cuda_ipc only, so the binary needs CUDA at
+# runtime and neither SIPL nor the encoder. Configuring this directory still
+# goes through the plugin's Jetson SDK checks in ../CMakeLists.txt.
+add_executable(sensing_ipc_testsrc ipc_testsrc.cu)
+
+set_target_properties(sensing_ipc_testsrc PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    INSTALL_RPATH "$ORIGIN"
+)
+
+target_link_libraries(sensing_ipc_testsrc PRIVATE sensing::cuda_ipc)

--- a/src/plugins/sensing/tools/ipc_testsrc.cu
+++ b/src/plugins/sensing/tools/ipc_testsrc.cu
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Animated RGBA test pattern on the CUDA IPC socket, with no camera attached.
+//
+// Lets the consumer side be developed and tested with no camera attached. Also
+// the quickest way to tell a broken consumer from a broken camera: if the
+// pattern animates here and the camera does not, the fault is upstream of the
+// IPC.
+//
+//   ./sensing_ipc_testsrc --socket=/tmp/sensing0.sock --width=1920 --height=1080
+//   ./camera_viz.sh run configs/cuda_ipc.yaml
+
+#include <sensing_cuda_ipc/cuda_ipc_publisher.hpp>
+
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <cuda_runtime.h>
+#include <iostream>
+#include <string>
+#include <thread>
+
+namespace
+{
+
+std::sig_atomic_t volatile g_stop = 0;
+
+void on_signal(int)
+{
+    g_stop = 1;
+}
+
+/// Scrolling colour bars plus a box tracking the frame counter, so a stale or
+/// torn frame is obvious on screen rather than merely plausible.
+__global__ void test_pattern(uint8_t* out, int width, int height, size_t pitch, float t, unsigned frame)
+{
+    const int x = blockIdx.x * blockDim.x + threadIdx.x;
+    const int y = blockIdx.y * blockDim.y + threadIdx.y;
+    if (x >= width || y >= height)
+        return;
+
+    const float u = static_cast<float>(x) / width;
+    const float v = static_cast<float>(y) / height;
+
+    uint8_t r = static_cast<uint8_t>(255.0f * fminf(1.0f, fmaxf(0.0f, 0.5f + 0.5f * __sinf(6.2831f * (u + t)))));
+    uint8_t g = static_cast<uint8_t>(255.0f * v);
+    uint8_t b = static_cast<uint8_t>(255.0f * fminf(1.0f, fmaxf(0.0f, 0.5f + 0.5f * __cosf(6.2831f * (v - t)))));
+
+    // A white square orbiting the centre: any duplicated frame freezes it.
+    const float cx = 0.5f + 0.3f * __cosf(6.2831f * t);
+    const float cy = 0.5f + 0.3f * __sinf(6.2831f * t);
+    if (fabsf(u - cx) < 0.04f && fabsf(v - cy) < 0.04f * width / height)
+    {
+        r = g = b = 255;
+    }
+
+    // Top-left binary readout of the frame counter, 16 bits, 24px cells.
+    if (y < 24 && x < 16 * 24)
+    {
+        const unsigned bit = static_cast<unsigned>(x / 24);
+        const bool on = (frame >> (15u - bit)) & 1u;
+        r = g = b = on ? 255 : 0;
+    }
+
+    uint8_t* px = out + static_cast<size_t>(y) * pitch + static_cast<size_t>(x) * 4;
+    px[0] = r;
+    px[1] = g;
+    px[2] = b;
+    px[3] = 255;
+}
+
+uint64_t monotonic_ns()
+{
+    timespec ts{};
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<uint64_t>(ts.tv_sec) * 1'000'000'000ull + static_cast<uint64_t>(ts.tv_nsec);
+}
+
+bool match(const std::string& arg, const char* key, std::string& value)
+{
+    const std::string prefix = std::string("--") + key + "=";
+    if (arg.rfind(prefix, 0) != 0)
+        return false;
+    value = arg.substr(prefix.size());
+    return true;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+try
+{
+    plugins::sensing::CudaIpcConfig config;
+    config.socket_path = "/tmp/sensing_cuda0.sock";
+    double fps = 30.0;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        std::string value;
+        if (arg == "--help" || arg == "-h")
+        {
+            std::cout << "Usage: " << argv[0] << " [--socket=PATH] [--width=N] [--height=N]\n"
+                      << "       [--fps=N] [--sensor=N] [--gpu-id=N] [--slots=N]\n";
+            return 0;
+        }
+        else if (match(arg, "socket", value))
+            config.socket_path = value;
+        else if (match(arg, "width", value))
+            config.width = static_cast<uint32_t>(std::stoul(value));
+        else if (match(arg, "height", value))
+            config.height = static_cast<uint32_t>(std::stoul(value));
+        else if (match(arg, "sensor", value))
+            config.sensor_id = static_cast<uint32_t>(std::stoul(value));
+        else if (match(arg, "gpu-id", value))
+            config.gpu_id = std::stoi(value);
+        else if (match(arg, "slots", value))
+            config.slot_count = static_cast<uint32_t>(std::stoul(value));
+        else if (match(arg, "fps", value))
+            fps = std::stod(value);
+        else
+        {
+            std::cerr << "Unknown option: " << arg << std::endl;
+            return 1;
+        }
+    }
+    if (fps <= 0.0)
+        fps = 30.0;
+
+    std::signal(SIGINT, on_signal);
+    std::signal(SIGTERM, on_signal);
+
+    plugins::sensing::CudaIpcPublisher publisher(config);
+
+    // Scratch frame standing in for the camera's converted RGBA output, so the
+    // publisher's copy path is exercised exactly as it is in the plugin.
+    uint8_t* scratch = nullptr;
+    size_t scratch_pitch = 0;
+    if (cudaMallocPitch(&scratch, &scratch_pitch, static_cast<size_t>(config.width) * 4, config.height) != cudaSuccess)
+        throw std::runtime_error("cudaMallocPitch failed");
+
+    const dim3 block(16, 16);
+    const dim3 grid((config.width + block.x - 1) / block.x, (config.height + block.y - 1) / block.y);
+    const auto period = std::chrono::nanoseconds(static_cast<int64_t>(1e9 / fps));
+
+    std::cout << "Test source running at " << fps << " fps. Ctrl+C to stop." << std::endl;
+
+    auto next = std::chrono::steady_clock::now();
+    auto last_report = std::chrono::steady_clock::now();
+    unsigned frame = 0;
+
+    while (!g_stop)
+    {
+        publisher.poll();
+
+        if (publisher.has_consumer())
+        {
+            const float t = static_cast<float>(frame % 120) / 120.0f;
+            test_pattern<<<grid, block>>>(scratch, config.width, config.height, scratch_pitch, t, frame);
+            if (cudaGetLastError() != cudaSuccess)
+                throw std::runtime_error("test_pattern launch failed");
+            cudaStreamSynchronize(0);
+            publisher.publish(reinterpret_cast<uintptr_t>(scratch), scratch_pitch, monotonic_ns());
+            ++frame;
+        }
+
+        auto now = std::chrono::steady_clock::now();
+        if (now - last_report >= std::chrono::seconds(5))
+        {
+            std::cout << "  published=" << publisher.published_count() << " dropped=" << publisher.dropped_count()
+                      << (publisher.has_consumer() ? " (consumer attached)" : " (waiting for consumer)") << std::endl;
+            last_report = now;
+        }
+
+        next += period;
+        if (next > now)
+            std::this_thread::sleep_until(next);
+        else
+            next = now; // Fell behind; do not spiral trying to catch up.
+    }
+
+    std::cout << "\nStopped. published=" << publisher.published_count() << " dropped=" << publisher.dropped_count()
+              << std::endl;
+    cudaFree(scratch);
+    return 0;
+}
+catch (const std::exception& e)
+{
+    std::cerr << argv[0] << ": " << e.what() << std::endl;
+    return 1;
+}

--- a/src/viz/layers/cpp/image_layer_base.cpp
+++ b/src/viz/layers/cpp/image_layer_base.cpp
@@ -221,6 +221,11 @@ void ImageLayerBase::submit(const VizBuffer& src, cudaStream_t stream)
     // mailbox and overwrite src.data while our async memcpy is still
     // reading from it. Cost is ~0.5 ms per 1080p submit on the caller's
     // thread; the render path is unaffected.
+    //
+    // This sync is load-bearing for borrowed-frame sources, which map producer
+    // memory rather than owning it: see the Frame docstring in
+    // examples/camera_viz/pipeline/interface.py and sources/cuda_ipc.py.
+    // Removing it corrupts those sources only, and only on device.
     check_cuda(cudaStreamSynchronize(stream), layer_type_.c_str(), "cudaStreamSynchronize(submit)");
 
     // memory_order_release pairs with the renderer's acquire load.

--- a/tests/python/examples/camera_viz/test_cuda_ipc_source.py
+++ b/tests/python/examples/camera_viz/test_cuda_ipc_source.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the CUDA IPC source (``type: cuda_ipc``).
+
+Wire-format and config checks run everywhere. The end-to-end tests drive the
+real producer, ``sensing_ipc_testsrc``, and skip unless it has been built and a
+CUDA device is present:
+
+    cmake --build build --target sensing_ipc_testsrc
+
+``sensing_ipc_testsrc`` paints a 16-bit frame counter into the top-left of
+every frame, so a test can tell a fresh frame from a stale or torn one by
+reading pixels rather than trusting the sequence number the producer sends.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import struct
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from repo_paths import repo_root  # noqa: E402
+from sources import build_local_camera  # noqa: E402
+from sources.cuda_ipc import (  # noqa: E402
+    _FRAME_FMT,
+    _HELLO_FMT,
+    _RELEASE_FMT,
+    CudaIpcSource,
+)
+
+_REPO_ROOT = repo_root()
+_TESTSRC_REL = "src/plugins/sensing/tools/sensing_ipc_testsrc"
+
+
+def _find_testsrc() -> Path | None:
+    override = os.environ.get("SENSING_IPC_TESTSRC")
+    if override:
+        p = Path(override)
+        return p if p.is_file() else None
+    for build_dir in (_REPO_ROOT / "build", _REPO_ROOT / "cmake-build-debug"):
+        candidate = build_dir / _TESTSRC_REL
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+def _cuda_available() -> bool:
+    try:
+        import cupy as cp
+    except ImportError:
+        return False
+    try:
+        return cp.cuda.runtime.getDeviceCount() > 0
+    except Exception:
+        return False
+
+
+_testsrc = _find_testsrc()
+
+requires_producer = pytest.mark.skipif(
+    _testsrc is None or not _cuda_available(),
+    reason="needs cupy + a CUDA device + a built sensing_ipc_testsrc",
+)
+
+
+# ── wire format ───────────────────────────────────────────────────────
+
+
+def test_struct_sizes_match_the_cpp_static_asserts():
+    """core/cuda_ipc_protocol.hpp static_asserts these exact sizes."""
+    assert struct.calcsize(_HELLO_FMT) == 56
+    assert struct.calcsize(_FRAME_FMT) == 24
+    assert struct.calcsize(_RELEASE_FMT) == 8
+
+
+def test_magics_are_the_ascii_tags_the_producer_sends():
+    from sources import cuda_ipc
+
+    assert struct.pack("<I", cuda_ipc._HELLO_MAGIC) == b"ICUD"
+    assert struct.pack("<I", cuda_ipc._FRAME_MAGIC) == b"IFRM"
+    assert struct.pack("<I", cuda_ipc._RELEASE_MAGIC) == b"IREL"
+
+
+# ── config plumbing ───────────────────────────────────────────────────
+
+
+def test_build_local_camera_rejects_stereo():
+    spec = {
+        "type": "cuda_ipc",
+        "name": "cam",
+        "socket": "/tmp/nope.sock",
+        "width": 640,
+        "height": 480,
+        "stereo": True,
+    }
+    with pytest.raises(ValueError, match="cannot be stereo"):
+        build_local_camera(spec)
+
+
+def test_shipped_config_parses():
+    yaml = pytest.importorskip("yaml")
+    cfg_path = _REPO_ROOT / "examples" / "camera_viz" / "configs" / "cuda_ipc.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text())
+    (cam,) = [c for c in cfg["cameras"] if c.get("enabled", True)]
+    assert cam["type"] == "cuda_ipc"
+    assert cam["socket"] and cam["width"] and cam["height"]
+
+
+# ── end to end ────────────────────────────────────────────────────────
+
+
+class _Producer:
+    """Runs sensing_ipc_testsrc for the duration of a `with` block."""
+
+    def __init__(self, socket_path: str, width: int, height: int, fps: int = 60):
+        self._argv = [
+            str(_testsrc),
+            f"--socket={socket_path}",
+            f"--width={width}",
+            f"--height={height}",
+            f"--fps={fps}",
+        ]
+        self._proc: subprocess.Popen | None = None
+
+    def __enter__(self) -> "_Producer":
+        self._proc = subprocess.Popen(
+            self._argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+        )
+        time.sleep(1.5)  # let it allocate + bind before anyone connects
+        assert self._proc.poll() is None, "producer exited during startup"
+        return self
+
+    def stop(self) -> None:
+        if self._proc is not None and self._proc.poll() is None:
+            self._proc.send_signal(signal.SIGINT)
+            try:
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self._proc.kill()
+        self._proc = None
+
+    def __exit__(self, *exc) -> None:
+        self.stop()
+
+
+def _frame_counter(image) -> int:
+    """Read the producer's 16-bit counter bar: 16 cells, 24 px each."""
+    import cupy as cp
+
+    centres = cp.asnumpy(image[12, 12 : 16 * 24 : 24, 0])
+    return int("".join("1" if v > 127 else "0" for v in centres), 2)
+
+
+def _collect(source: CudaIpcSource, want: int, timeout_s: float = 15.0) -> list:
+    counters = []
+    deadline = time.monotonic() + timeout_s
+    while len(counters) < want and time.monotonic() < deadline:
+        frame = source.latest()
+        if frame is None:
+            time.sleep(0.002)
+            continue
+        counters.append(_frame_counter(frame.image))
+    return counters
+
+
+@requires_producer
+def test_frames_arrive_and_always_advance(tmp_path):
+    """The headline property: every frame handed out is fresh, never torn.
+
+    A slot the producer reused while we were reading it would show a counter
+    that stalls or goes backwards.
+    """
+    sock = str(tmp_path / "ipc.sock")
+    with _Producer(sock, 640, 480) as producer:
+        source = CudaIpcSource(name="cam", socket_path=sock, width=640, height=480)
+        source.start()
+        try:
+            counters = _collect(source, 60)
+        finally:
+            source.stop()
+        producer.stop()
+
+    assert len(counters) >= 60, f"only {len(counters)} frames arrived"
+    deltas = [b - a for a, b in zip(counters, counters[1:])]
+    assert all(d > 0 for d in deltas), f"stale or torn frame: deltas={deltas}"
+
+
+@requires_producer
+def test_image_is_a_gpu_rgba_view_of_the_declared_size(tmp_path):
+    import cupy as cp
+
+    sock = str(tmp_path / "ipc.sock")
+    with _Producer(sock, 320, 240) as producer:
+        source = CudaIpcSource(name="cam", socket_path=sock, width=320, height=240)
+        source.start()
+        try:
+            deadline = time.monotonic() + 10.0
+            frame = None
+            while frame is None and time.monotonic() < deadline:
+                frame = source.latest()
+                if frame is None:
+                    time.sleep(0.002)
+            assert frame is not None, "no frame within 10s"
+            assert frame.image.shape == (240, 320, 4)
+            assert frame.image.dtype == cp.uint8
+            assert hasattr(frame.image, "__cuda_array_interface__")
+            assert frame.source_id == "cam"
+            assert frame.timestamp_ns > 0
+        finally:
+            source.stop()
+        producer.stop()
+
+
+@requires_producer
+def test_waits_for_a_late_producer_then_recovers_from_its_restart(tmp_path):
+    sock = str(tmp_path / "ipc.sock")
+    source = CudaIpcSource(name="cam", socket_path=sock, width=320, height=240)
+    source.start()
+    try:
+        # Started before any producer exists: must idle, not raise.
+        time.sleep(1.0)
+        assert source.latest() is None
+
+        with _Producer(sock, 320, 240):
+            assert len(_collect(source, 10)) >= 10
+
+        # Producer gone; the source should be idle again rather than serving
+        # pixels out of an allocation that no longer has an owner.
+        time.sleep(1.0)
+
+        with _Producer(sock, 320, 240):
+            assert len(_collect(source, 10)) >= 10, "did not recover"
+    finally:
+        source.stop()
+
+
+@requires_producer
+def test_geometry_mismatch_is_refused(tmp_path):
+    """A config that disagrees with the producer must yield no frames rather
+    than reinterpreting its bytes at the wrong stride."""
+    sock = str(tmp_path / "ipc.sock")
+    with _Producer(sock, 320, 240):
+        source = CudaIpcSource(name="cam", socket_path=sock, width=640, height=480)
+        source.start()
+        try:
+            time.sleep(3.0)
+            assert source.latest() is None
+        finally:
+            source.stop()


### PR DESCRIPTION
## Description

**Stack 2/3** — depends on #1077. Follow-up: #998 (the SIPL plugin).

Zero-copy handoff of camera frames from a capture process to a Python consumer on the same Jetson. The publisher exports CUDA VMM allocations and passes the OS handles over a unix socket with `SCM_RIGHTS`; camera_viz gains a matching `type: cuda_ipc` source that maps them directly, so frames never round-trip through host memory.

The VMM-plus-socket shape is not a preference: the legacy `cudaIpcGetMemHandle` path does not work on Tegra.

No SIPL and no camera dependency — the transport builds and is tested on its own. `sensing_ipc_testsrc` publishes a synthetic pattern with the frame number stamped into the pixels, so a stale or misordered buffer slot fails the test rather than looking plausible.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Testing

AGX Orin, JetPack 7.2.1 / L4T R39.2.1:

- `sensing_ipc_testsrc` → camera_viz `cuda_ipc` source, rendered in window mode.
- `test_cuda_ipc_source.py` drives the publisher and asserts the stamped frame numbers.
- Configured and built with the SIPL SDK absent, confirming the transport pulls in no camera headers.
- `SKIP=check-copyright-year pre-commit run --all-files` passes.

## Checklist

- [x] I have read and understood the [contribution guidelines](../CONTRIBUTING.md)
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the [DCO](../CONTRIBUTING.md#signing-your-work)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional CUDA IPC camera streaming between local producer and consumer processes.
  - Added support for zero-copy GPU RGBA frames, producer reconnection, and frame geometry validation.
  - Added an animated CUDA test-pattern source for development without a camera.
  - Added a ready-to-use camera visualization configuration for multiple streams.
  - Added an opt-in SENSING camera plugin build option.

- **Documentation**
  - Documented CUDA IPC setup, socket behavior, frame lifetime, synchronization, and usage requirements.

- **Tests**
  - Added protocol, configuration, recovery, frame delivery, and GPU image validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->