### PR TITLE
viz: preview a second arm, the reBot DevArm

### DIFF
--- a/examples/robot_viz/README.md
+++ b/examples/robot_viz/README.md
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 # Robot Viz
 
-A robot twin rendered stereoscopically into an Isaac Teleop Televiz XR session: an SO-101 follower arm the operator drags around by hand, and an SO-101 leader gripper that replaces it once the clutch engages. One process, one OpenXR session, two threads — `TeleopSession` creates the session the trackers and the compositor share and runs the twin's frame loop on a thread of its own.
+A robot twin rendered stereoscopically into an Isaac Teleop Televiz XR session: a follower arm the operator drags around by hand (`--arm`, SO-101 by default), and a gripper ghost that replaces it once the clutch engages. One process, one OpenXR session, two threads — `TeleopSession` creates the session the trackers and the compositor share and runs the twin's frame loop on a thread of its own.
 
 `isaacteleop.viz.robot` holds no `mjModel` and no `mjData`: it addresses the scene by name and publishes what moved, and `twin.py` applies the lot on the render thread. That bound is what lets the backend link against a MuJoCo the user's environment knows nothing about, and is why this example is pure Python — no compiled extension, no ABI tag, no `mujoco` pin.
 
@@ -32,9 +32,9 @@ The XR half — everything downstream of the readback — has never executed any
 
 ## Scope
 
-Renderer + MuJoCo + rig, and one scene: `src/python/isaacteleop/viz/robot/assets/scene.xml`, an SO-101 follower arm and an SO-101 leader gripper ghost, exactly one drawn at a time. No table, no blocks, no ground plane: this is an AR scene and passthrough is the background.
+Renderer + MuJoCo + rig, and two scenes — one per follower in `viz.robot.PREVIEW_ARMS`, selected with `--arm`: `assets/scene.xml` (SO-101, the default) and `assets/scene_rebot.xml` (reBot DevArm, RobStride build). Each pairs its follower arm with a gripper ghost on the operator's hand, exactly one drawn at a time: the SO-101 shows its LEADER's gripper, and the reBot — which has no leader hardware — its own follower gripper. No table, no blocks, no ground plane: this is an AR scene and passthrough is the background.
 
-The ghost is a real mesh assembly (4 fetched STLs, so it exercises the `mjGEOM_MESH` path). Its trigger is driven by the shipped `SO101GripperRetargeter` as a graph edge — a `BaseRetargeter` node inside `_build_pipeline()`, whose closedness output reaches `mjData` and therefore the screen. Its pose is the safety harness's output, not the controller's.
+Each ghost is a real mesh assembly of fetched STLs, so it exercises the `mjGEOM_MESH` path — the SO-101's is four with a hinged trigger, the reBot's seven with two rack-and-pinion fingers (`viz.robot.ghost` holds both specs). Closedness is driven by the shipped `SO101GripperRetargeter` as a graph edge — a `BaseRetargeter` node inside `_build_pipeline()`, whose closedness output reaches `mjData` and therefore the screen. Its pose is the safety harness's output, not the controller's.
 
 Two calibrations, different in kind. `src/viz/robot_twin/cpp/frames.hpp` is a convention fixed by two specs and cannot be wrong at runtime. `EULER_HAND_FROM_GHOST_DEG` / `POS_HAND_FROM_GHOST` in `viz.robot.so101_ghost` are a measurement of how a hand holds a tool, taken on a headset and checkable nowhere else.
 
@@ -83,7 +83,7 @@ python -m isaacteleop_examples.robot_viz --no-launch-cloudxr-runtime           #
 
 Omitting `--no-launch-cloudxr-runtime` makes the app start its own runtime, which is right when nothing else has and fatal when something has (the runtime is a host singleton on WSS port 48322). Pass it with no runtime running and the failure comes out of `VizSession.create` as an OpenXR error before any of this example's code runs — no `[robot_viz]` lines at all is the tell.
 
-There is one scene and no flag to change it; `assets/scene.xml` is package data beside the module. There is no desktop or headless display mode.
+`--arm` picks the scene, from the profiles in `viz.robot.PREVIEW_ARMS`; each scene's MJCF wrappers are package data beside the module. There is no desktop or headless display mode.
 
 ## The harness the ghost renders
 
@@ -232,6 +232,10 @@ Visibility is `model.geom_group`, from Python. Group 2 draws and group 3 does no
 Pass MuJoCo an absolute scene path. Measured on mujoco 3.11.0, a relative model path mis-composes an `<include>`d file's paths and fails with `Error opening file '<a path that exists>'`; with the follower's nested include it composes the directory onto itself and opens `<dir>/<dir>/so101_new_calib.xml`. `assets.ensure_so101_scene()` returns an absolute path for this reason.
 
 The 17 STLs are fetched, not vendored: `viz.robot.assets.ensure_so101_scene()` fetches them on the first run into `~/.cache/isaacteleop/so101-assets/`, checksum-verified against a pinned commit, and `ISAACTELEOP_SO101_ASSETS` overrides the destination for a host with no route to GitHub. Nothing fetches at build time — an isolated PEP-517 wheel build must not reach the network. Everything lands flat in one directory, because MuJoCo drops an included file's own `meshdir`; `sts3215_03a_v1.stl` is fetched twice rather than aliased, because the leader fragment names its copy `STS3215_03a.stl`. The three MJCF wrappers (`follower_arm.xml`, `leader_gripper.xml`, `scene.xml`) are tracked package data re-copied into the cache on every call, so editing one takes effect on the next launch. `joints_properties.xml` is deliberately not fetched: upstream inlines its `<default>` block rather than `<include>`ing it.
+
+The reBot's scene works the same way, in its own cache directory (`~/.cache/isaacteleop/rebot-devarm-assets/`, `ISAACTELEOP_REBOT_ASSETS` to move it): `ensure_rebot_devarm_scene()` fetches MuJoCo Menagerie's `seeed_rebot_devarm` — 115 meshes and its MJCF, ~15 MB — plus the same ghost meshes, since every scene draws the ghost. The set is pinned by one `REBOT_MANIFEST_SHA256` over the sorted per-file digests rather than a 117-row table or a hash of the repo tarball: content, not archive framing, and 15 MB instead of the 400 MB a tarball costs. Which meshes to fetch is read out of the MJCF, so one added upstream cannot be silently left behind — the manifest digest is what pins the set. Menagerie's own `scene.xml` is not used; it has a ground plane, skybox and haze.
+
+The reBot's 92 collision meshes are fetched and compiled although the twin never draws them: MuJoCo must resolve every mesh the MJCF names, and the file is not edited.
 
 `follower_arm.xml` wraps upstream's `so101_new_calib.xml`, fetched verbatim and never edited. `so101_new_calib.urdf` is pulled too, as the source of the trigger's hinge and its 0..100° travel. Three of the leader's four meshes are leader-specific print parts; the fourth is the STS3215 servo, shared with the follower and not decoration — `wrist_roll` is a C-shaped bracket that wraps it.
 

--- a/examples/robot_viz/python/isaacteleop_examples/robot_viz/app.py
+++ b/examples/robot_viz/python/isaacteleop_examples/robot_viz/app.py
@@ -44,13 +44,14 @@ from isaacteleop.retargeters.SO101.gripper_retargeter import (
 from isaacteleop.teleop_session_manager import TeleopSession, TeleopSessionConfig
 from isaacteleop.teleop_session_manager.config import TwinRenderConfig
 from isaacteleop.viz.robot import (
+    PREVIEW_ARMS,
     VIEW_COUNT,
     ClutchPreview,
     EngageGate,
     InterventionMonitor,
     PreviewArm,
+    PreviewArmProfile,
     SceneTwin,
-    assets,
     frames,
 )
 from isaacteleop.viz.robot.clutch_preview import (
@@ -140,7 +141,7 @@ def _build_pipeline(  # noqa: N803
     )
 
 
-def _log_startup(scene_path, resolution, backend: str, gl_device: int) -> None:
+def _log_startup(arm, scene_path, resolution, backend: str, gl_device: int) -> None:
     """One block naming every assumption that is invisible at runtime."""
     try:
         version = importlib.metadata.version("isaacteleop")
@@ -148,6 +149,7 @@ def _log_startup(scene_path, resolution, backend: str, gl_device: int) -> None:
         version = "<not installed as a distribution>"
     trans = frames.TRANS_MJ_FROM_XR
 
+    LOG.info("arm:        %s", arm)
     LOG.info("scene:      %s", scene_path)
     # Several examples ship their own .venv, and picking up the wrong isaacteleop is
     # invisible without this line.
@@ -178,17 +180,19 @@ def _log_startup(scene_path, resolution, backend: str, gl_device: int) -> None:
 EXIT_TWIN_STUCK = 1
 
 
-def run() -> int:
-    scene_path = assets.ensure_so101_scene()
+def run(profile: PreviewArmProfile) -> int:
+    scene_path = profile.scene()
     twin = SceneTwin(scene_path)
     # Before the Renderer, which uploads geometry once: the follower repoints geom
     # materials and poses its joints here. Not placed until the first head pose.
-    arm = PreviewArm(twin)
+    arm = PreviewArm(twin, profile)
     monitor = InterventionMonitor(twin)
 
     # The clutch's home is pushed every non-ENGAGED frame, so this constructor value
     # only has to be well-formed -- nothing can latch before the anchor exists.
-    pipeline, clutch = _build_pipeline(pose_from_ghost_body(*arm.gripper_pose_mj()))
+    pipeline, clutch = _build_pipeline(
+        pose_from_ghost_body(*arm.gripper_pose_mj(), arm.hand_from_ghost)
+    )
     gate = EngageGate(app_conjunct=("limiter", "still catching up"))
     preview = ClutchPreview(twin, monitor, arm, clutch, gate)
 
@@ -203,6 +207,7 @@ def run() -> int:
     )
     with TeleopSession(teleop_config) as teleop_session:
         _log_startup(
+            profile.label,
             scene_path,
             teleop_session.twin_resolution,
             twin.backend_version,
@@ -284,6 +289,12 @@ def main(argv: list[str]) -> int:
         description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument("--verbose", action="store_true", help="Debug-level logging.")
+    parser.add_argument(
+        "--arm",
+        choices=sorted(PREVIEW_ARMS),
+        default="so101",
+        help="Which follower to preview. Each fetches its own scene on first use.",
+    )
     CloudXRLauncher.add_launcher_arguments(parser)
     args = parser.parse_args(argv[1:])
 
@@ -297,7 +308,7 @@ def main(argv: list[str]) -> int:
         if launcher.owns_runtime:
             LOG.info("CloudXR runtime started (WSS log: %s)", launcher.wss_log_path)
         try:
-            code = run()
+            code = run(PREVIEW_ARMS[args.arm])
         except KeyboardInterrupt:
             LOG.info("interrupted")
             return 0

--- a/src/python/isaacteleop/viz/robot/__init__.py
+++ b/src/python/isaacteleop/viz/robot/__init__.py
@@ -26,14 +26,16 @@ from .twin import RobotTwinPublisher
 if TYPE_CHECKING:
     from . import assets, clutch_preview, frames, so101_ghost
     from .clutch_preview import ClutchPreview
-    from .preview_arm import PreviewArm
+    from .preview_arm import PREVIEW_ARMS, PreviewArm, PreviewArmProfile
     from .scene import SceneTwin
 
 # Resolved on first access: everything below reaches `frames` or `scene`, and those need
 # the compiled `_robot_twin` a Windows Televiz build has no copy of.
 _LAZY = {
     "ClutchPreview": ".clutch_preview",
+    "PREVIEW_ARMS": ".preview_arm",
     "PreviewArm": ".preview_arm",
+    "PreviewArmProfile": ".preview_arm",
     "SceneTwin": ".scene",
     "assets": ".assets",
     "clutch_preview": ".clutch_preview",
@@ -84,7 +86,9 @@ __all__ = [
     "GateVerdict",
     "InterventionMonitor",
     "OperatorFrame",
+    "PREVIEW_ARMS",
     "PreviewArm",
+    "PreviewArmProfile",
     "RobotTwinPublisher",
     "SceneTwin",
     "XrTwinSession",

--- a/src/python/isaacteleop/viz/robot/assets.py
+++ b/src/python/isaacteleop/viz/robot/assets.py
@@ -1,39 +1,44 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""The SO-101 scene the preview arm and the leader ghost are drawn from.
+"""The scenes each preview arm and its ghost gripper are drawn from, one per arm.
 
-The three MJCF files are tracked package data; the 18 MB of upstream mesh and MJCF they
-name is fetched, not vendored. :func:`ensure_so101_scene` assembles both halves into one
-cache directory and returns the scene path.
+The MJCF wrappers are tracked package data; the upstream mesh and MJCF they name is
+fetched, not vendored. Each ``ensure_*_scene`` assembles both halves into its own cache
+directory and returns the scene path, gripper the ghost draws included.
 
-Downloads are checksum-verified against a pinned commit: a raw.githubusercontent path is
-not immutable in practice, and a substituted mesh renders as a broken arm rather than an
-error. Everything lands flat, because MuJoCo drops an included file's own ``meshdir``; the
-leader's servo is fetched under its own name so it cannot collide with the follower's copy.
+Downloads are verified against a pinned commit: a raw.githubusercontent path is not
+immutable in practice, and a substituted mesh renders as a broken arm rather than an error.
+Everything lands flat, because MuJoCo drops an included file's own ``meshdir``; where a
+ghost and its follower share a mesh, one of the two is named apart so the flat directory and
+MuJoCo's global asset names can both hold them.
 """
 
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
+import re
 import shutil
 import urllib.request
 from pathlib import Path
+
+LOG = logging.getLogger(__name__)
 
 #: Bump this and the checksums together, or the download is refused.
 SO_ARM_REPO = "TheRobotStudio/SO-ARM100"
 SO_ARM_COMMIT = "fda892cba81032c46c40976a48c9ceadbf40a9ca"
 
-#: ``(upstream path, destination name, sha256)``. The destination is per entry because
-#: ``sts3215_03a_v1.stl`` is fetched twice -- the leader fragment names its copy
-#: ``STS3215_03a.stl`` -- and a flat directory cannot alias the two.
+#: The SO-101 leader gripper, as ``(upstream path, destination name, sha256)``: the ghost
+#: its own scene draws, and no other's -- the reBot has no leader, so it puts its own
+#: follower gripper on the hand from meshes it already fetches. The destination is per entry
+#: because ``sts3215_03a_v1.stl`` is fetched twice (the leader fragment names its copy
+#: ``STS3215_03a.stl``) and a flat directory cannot alias the two.
 #:
 #: ``so101_new_calib.urdf`` is not drawn; it is on disk to check :mod:`.so101_ghost`'s
-#: trigger hinge and travel against. ``joints_properties.xml`` is deliberately absent:
-#: upstream inlines its ``<default>`` block, so the file is never read.
-SO_ARM_ASSETS: tuple[tuple[str, str, str], ...] = (
-    # The leader gripper ghost.
+#: trigger hinge and travel against.
+GHOST_ASSETS: tuple[tuple[str, str, str], ...] = (
     (
         "STL/SO101/Individual/Wrist_Roll_SO101.stl",
         "Wrist_Roll_SO101.stl",
@@ -64,7 +69,11 @@ SO_ARM_ASSETS: tuple[tuple[str, str, str], ...] = (
         "LICENSE",
         "c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4",
     ),
-    # The follower arm.
+)
+
+#: The SO-101 follower arm. ``joints_properties.xml`` is deliberately absent: upstream
+#: inlines its ``<default>`` block, so the file is never read.
+SO101_ARM_ASSETS: tuple[tuple[str, str, str], ...] = (
     (
         "Simulation/SO101/so101_new_calib.xml",
         "so101_new_calib.xml",
@@ -137,6 +146,8 @@ SO_ARM_ASSETS: tuple[tuple[str, str, str], ...] = (
     ),
 )
 
+SO_ARM_ASSETS: tuple[tuple[str, str, str], ...] = GHOST_ASSETS + SO101_ARM_ASSETS
+
 #: The tracked wrappers. Re-copied on every call rather than gated on the completeness
 #: marker, so editing one takes effect on the next run with no cache to clear.
 SCENE_FILE = "scene.xml"
@@ -146,6 +157,26 @@ _WRAPPERS = (SCENE_FILE, "follower_arm.xml", "leader_gripper.xml")
 #: with no route to GitHub.
 CACHE_ENV_VAR = "ISAACTELEOP_SO101_ASSETS"
 
+#: The reBot DevArm, RobStride build, from MuJoCo Menagerie. Upstream derives it from the
+#: same Seeed URDF LeRobot's IK solves against and validates against it link by link, and
+#: builds it around RS-06/RS-00 actuators -- so it is the RS arm, not the Damiao one, whose
+#: geometry differs.
+MENAGERIE_REPO = "google-deepmind/mujoco_menagerie"
+MENAGERIE_COMMIT = "8161bba264d7fa7c99ca301e91e7fb44737676ad"
+REBOT_MODEL_DIR = "seeed_rebot_devarm"
+REBOT_SCENE_FILE = "scene_rebot.xml"
+_REBOT_WRAPPERS = (REBOT_SCENE_FILE, "rebot_arm.xml", "rebot_gripper.xml")
+REBOT_CACHE_ENV_VAR = "ISAACTELEOP_REBOT_ASSETS"
+
+#: sha256 over the sorted ``"<name> <sha256>\n"`` lines of everything fetched from
+#: Menagerie -- 117 files, so one constant rather than a table nobody reads. Content, not
+#: archive framing: a repo tarball is 400 MB for 15 MB of arm, and its bytes are not
+#: promised to be stable. Bump it and MENAGERIE_COMMIT together, or the download is
+#: refused.
+REBOT_MANIFEST_SHA256 = (
+    "5164271c8fc098add8c1905e52198c759239dda73831231112d70359a78874ba"
+)
+
 
 def _sha256(path: Path) -> str:
     digest = hashlib.sha256()
@@ -153,6 +184,48 @@ def _sha256(path: Path) -> str:
         for block in iter(lambda: handle.read(1 << 20), b""):
             digest.update(block)
     return digest.hexdigest()
+
+
+def _cache_dir(env_var: str, name: str) -> Path:
+    override = os.environ.get(env_var, "").strip()
+    if override:
+        dest = Path(override)
+    else:
+        root = os.environ.get("XDG_CACHE_HOME", "").strip() or str(
+            Path.home() / ".cache"
+        )
+        dest = Path(root) / "isaacteleop" / name
+    dest.mkdir(parents=True, exist_ok=True)
+    return dest
+
+
+def _copy_wrappers(dest: Path, wrappers: tuple[str, ...]) -> None:
+    source = Path(__file__).parent / "assets"
+    for wrapper in wrappers:
+        shutil.copyfile(source / wrapper, dest / wrapper)
+
+
+def _fetch(url: str) -> bytes:
+    with urllib.request.urlopen(url, timeout=120) as response:  # nosec B310
+        return response.read()
+
+
+def _fetch_checksummed(dest: Path, entries: tuple[tuple[str, str, str], ...]) -> None:
+    """Fetch ``(remote, name, sha256)`` entries from SO-ARM100 that are not already
+    cached under their own hash."""
+    for remote, name, sha in entries:
+        target = dest / name
+        if target.is_file() and _sha256(target) == sha:
+            continue
+        payload = _fetch(
+            f"https://raw.githubusercontent.com/{SO_ARM_REPO}/{SO_ARM_COMMIT}/{remote}"
+        )
+        if hashlib.sha256(payload).hexdigest() != sha:
+            raise RuntimeError(
+                f"robot twin: checksum mismatch for {remote}. Upstream changed, or "
+                "SO_ARM_COMMIT and the hashes in SO_ARM_ASSETS disagree."
+            )
+        target.write_bytes(payload)
 
 
 def ensure_so101_scene() -> Path:
@@ -166,37 +239,100 @@ def ensure_so101_scene() -> Path:
         RuntimeError: If a download's checksum does not match :data:`SO_ARM_ASSETS`.
         OSError: If the files cannot be fetched or written.
     """
-    override = os.environ.get(CACHE_ENV_VAR, "").strip()
-    if override:
-        dest = Path(override)
-    else:
-        root = os.environ.get("XDG_CACHE_HOME", "").strip() or str(
-            Path.home() / ".cache"
-        )
-        dest = Path(root) / "isaacteleop" / "so101-assets"
-    dest.mkdir(parents=True, exist_ok=True)
-
-    source = Path(__file__).parent / "assets"
-    for wrapper in _WRAPPERS:
-        shutil.copyfile(source / wrapper, dest / wrapper)
+    dest = _cache_dir(CACHE_ENV_VAR, "so101-assets")
+    _copy_wrappers(dest, _WRAPPERS)
 
     marker = dest / ".fetch_complete"
     if not marker.exists():
-        for remote, name, sha in SO_ARM_ASSETS:
-            target = dest / name
-            if target.is_file() and _sha256(target) == sha:
-                continue
-            url = f"https://raw.githubusercontent.com/{SO_ARM_REPO}/{SO_ARM_COMMIT}/{remote}"
-            with urllib.request.urlopen(url, timeout=120) as response:  # nosec B310
-                payload = response.read()
-            if hashlib.sha256(payload).hexdigest() != sha:
-                raise RuntimeError(
-                    f"robot twin: checksum mismatch for {remote}. Upstream changed, or "
-                    "SO_ARM_COMMIT and the hashes in SO_ARM_ASSETS disagree."
-                )
-            target.write_bytes(payload)
+        _fetch_checksummed(dest, SO_ARM_ASSETS)
         marker.touch()
 
     # Absolute: on mujoco 3.11 a relative model path mis-composes an <include>d file's
     # path and fails naming a file that exists.
     return (dest / SCENE_FILE).resolve()
+
+
+def _menagerie_rebot_files() -> tuple[str, ...]:
+    """The model file, its licence, and every mesh it names. Read out of the MJCF rather
+    than listed, so a mesh added upstream cannot be silently left behind -- the manifest
+    digest is what pins the set."""
+    model = _fetch(
+        f"https://raw.githubusercontent.com/{MENAGERIE_REPO}/{MENAGERIE_COMMIT}/"
+        f"{REBOT_MODEL_DIR}/{REBOT_MODEL_DIR}.xml"
+    ).decode()
+    meshes = sorted(set(re.findall(r'file="([^"]+)"', model)))
+    return (f"{REBOT_MODEL_DIR}.xml", "LICENSE", *meshes)
+
+
+def _rebot_cached_digest(dest: Path) -> str | None:
+    """The manifest digest of what is already in ``dest``, or ``None`` if it cannot be read.
+
+    Derived from the directory and never from the network: REBOT_CACHE_ENV_VAR exists so a
+    host with no route to GitHub can be pointed at a pre-populated cache, and that cache has
+    to be checkable there. The tracked wrappers are excluded because they are package data,
+    not fetched, and so are not in the manifest.
+    """
+    wrappers = set(_REBOT_WRAPPERS)
+    lines = []
+    try:
+        for path in sorted(dest.iterdir()):
+            if not path.is_file() or path.name.startswith(".") or path.name in wrappers:
+                continue
+            lines.append(f"{path.name} {_sha256(path)}\n")
+    except OSError:
+        return None
+    return hashlib.sha256("".join(sorted(lines)).encode()).hexdigest()
+
+
+def ensure_rebot_devarm_rs_scene() -> Path:
+    """Assemble the reBot DevArm (RobStride) scene into its cache directory and return its path.
+
+    Same completeness-marker rule as :func:`ensure_so101_scene`. Nothing from SO-ARM100 is
+    fetched: this arm's ghost is its own gripper, drawn from the meshes below.
+
+    Raises:
+        RuntimeError: If the fetched set does not hash to :data:`REBOT_MANIFEST_SHA256`.
+        OSError: If the files cannot be fetched or written.
+    """
+    dest = _cache_dir(REBOT_CACHE_ENV_VAR, "rebot-devarm-rs-assets")
+    _copy_wrappers(dest, _REBOT_WRAPPERS)
+
+    marker = dest / ".fetch_complete"
+    if marker.exists() and _rebot_cached_digest(dest) != REBOT_MANIFEST_SHA256:
+        # The marker claims a verified fetch; the bytes on disk say otherwise. Re-fetch
+        # rather than compile them -- a truncated or substituted mesh draws as a broken arm
+        # instead of raising, which is the failure the digest exists to catch.
+        LOG.warning(
+            "Robot twin: the cached reBot assets in %s do not match "
+            "REBOT_MANIFEST_SHA256; re-fetching them.",
+            dest,
+        )
+        marker.unlink(missing_ok=True)
+    if not marker.exists():
+        base = (
+            f"https://raw.githubusercontent.com/{MENAGERIE_REPO}/{MENAGERIE_COMMIT}/"
+            f"{REBOT_MODEL_DIR}"
+        )
+        manifest = []
+        for name in _menagerie_rebot_files():
+            # Everything lands flat: MuJoCo drops an included file's own meshdir, so
+            # upstream's meshdir="assets" is inert once rebot_arm.xml includes it.
+            flat = Path(name).name
+            remote = (
+                f"{base}/assets/{flat}"
+                if flat.lower().endswith(".stl")
+                else f"{base}/{flat}"
+            )
+            payload = _fetch(remote)
+            (dest / flat).write_bytes(payload)
+            manifest.append(f"{flat} {hashlib.sha256(payload).hexdigest()}\n")
+        digest = hashlib.sha256("".join(sorted(manifest)).encode()).hexdigest()
+        if digest != REBOT_MANIFEST_SHA256:
+            raise RuntimeError(
+                f"robot twin: reBot manifest is {digest}, expected "
+                f"{REBOT_MANIFEST_SHA256}. Upstream changed, or MENAGERIE_COMMIT and "
+                "REBOT_MANIFEST_SHA256 disagree."
+            )
+        marker.touch()
+
+    return (dest / REBOT_SCENE_FILE).resolve()

--- a/src/python/isaacteleop/viz/robot/assets/rebot_arm.xml
+++ b/src/python/isaacteleop/viz/robot/assets/rebot_arm.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+The reBot DevArm follower, RobStride build: what the operator drags before the
+clutch engages. The Damiao build of the same arm has different geometry and is
+not this model.
+
+A wrapper around upstream's own MJCF, which is fetched verbatim and NEVER
+edited -- assets.py hashes the whole fetched set, so an edit is a fetch failure
+on the next run.
+
+Provenance: google-deepmind/mujoco_menagerie at commit
+8161bba264d7fa7c99ca301e91e7fb44737676ad, MIT. Upstream derives it from
+Seeed-Projects/reBot-Isaacsim's URDF -- the same URDF LeRobot's IK solves
+against. The 115 meshes land FLAT beside this file: MuJoCo drops an included
+file's own `meshdir`, so upstream's `meshdir="assets"` is inert here.
+
+Upstream's own scene.xml is deliberately NOT used: it carries a ground plane,
+skybox and haze, and this is an AR scene where passthrough is the background.
+
+preview_arm.py repoints EVERY arm geom's `geom_matid` at this material at
+startup, replacing upstream's three (alum/lime/black). One material is what lets
+the whole arm change colour in one write.
+
+The gripper's two fingers are `slide` joints coupled by an <equality>. The twin
+addresses hinges only, so they are held at their authored pose -- the preview
+jaw does not articulate on either arm.
+
+Translucent and grey to match follower_arm.xml; see there for why.
+-->
+<mujoco model="rebot devarm follower arm">
+  <asset>
+    <material name="follower_arm" rgba="0.45 0.45 0.45 0.6"/>
+  </asset>
+
+  <include file="seeed_rebot_devarm.xml"/>
+</mujoco>

--- a/src/python/isaacteleop/viz/robot/assets/rebot_gripper.xml
+++ b/src/python/isaacteleop/viz/robot/assets/rebot_gripper.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+The reBot DevArm (RobStride) gripper, locked to the operator's hand: what replaces the
+preview arm once the clutch engages. leader_gripper.xml's counterpart, and the
+same idea -- the operator holds the tool the follower will move.
+
+The reBot has no leader hardware, so unlike the SO-101's this is the FOLLOWER's
+own gripper drawn at the hand, from the same meshes rebot_arm.xml draws. They
+are re-declared here under ghost_ names because that file names them too and
+MuJoCo asset names are global; the STLs themselves are fetched once and land
+flat beside this file.
+
+No `scale`: Menagerie authors in METRES, where the SO-ARM print STLs
+leader_gripper.xml names are in millimetres.
+
+Three mocap bodies, because the two fingers articulate independently -- a
+jointed child of a mocap body honours a written qpos but mj_step integrates
+gravity into it. The fingers' geoms carry their body transform from
+seeed_rebot_devarm.xml baked in, so ghost.py translates each mocap body along
+the slide axis rather than reproducing that transform.
+
+Opaque, like the leader ghost; see leader_gripper.xml's header for why.
+-->
+<mujoco model="rebot devarm gripper ghost">
+  <asset>
+    <mesh name="ghost_pla7_green" file="pla7_green.STL"/>
+    <mesh name="ghost_cnc7" file="cnc7.STL"/>
+    <mesh name="ghost_motor_7" file="motor_7.STL"/>
+    <mesh name="ghost_pla_left" file="pla_left.STL"/>
+    <mesh name="ghost_cnc_left" file="cnc_left.STL"/>
+    <mesh name="ghost_pla_right" file="pla_right.STL"/>
+    <mesh name="ghost_cnc_right" file="cnc_right.STL"/>
+    <material name="leader_ghost" rgba="0.55 0.80 1.00 1"/>
+  </asset>
+
+  <worldbody>
+    <!-- The gripper_end assembly. `pos` parks it clear of the scene until the
+         first valid controller sample, so "not moved yet" reads differently
+         from "broken". Its frame IS gripper_end's, which is the frame
+         preview_arm's gripper_body and the hand calibration both work in. -->
+    <body name="rebot_ghost" mocap="true" pos="0.12 0.16 0.22"
+          quat="0.5 0.5 -0.5 -0.5">
+      <geom name="rebot_ghost_pla7" type="mesh" mesh="ghost_pla7_green"
+            material="leader_ghost" contype="0" conaffinity="0" mass="0" group="2"/>
+      <geom name="rebot_ghost_cnc7" type="mesh" mesh="ghost_cnc7"
+            material="leader_ghost" contype="0" conaffinity="0" mass="0" group="2"/>
+      <geom name="rebot_ghost_motor" type="mesh" mesh="ghost_motor_7"
+            material="leader_ghost" contype="0" conaffinity="0" mass="0" group="2"/>
+    </body>
+
+    <!-- The two fingers. `pos`/`quat` match rebot_ghost above: ghost.py slides
+         these bodies along the jaw axis from there, so the finger transform
+         lives in the geoms and in exactly one place. -->
+    <body name="rebot_ghost_left" mocap="true" pos="0.12 0.16 0.22"
+          quat="0.5 0.5 -0.5 -0.5">
+      <geom name="rebot_ghost_pla_left" type="mesh" mesh="ghost_pla_left"
+            material="leader_ghost" pos="-0.041939 -0.000073385 0"
+            quat="0.5 0.5 -0.5 0.5"
+            contype="0" conaffinity="0" mass="0" group="2"/>
+      <geom name="rebot_ghost_cnc_left" type="mesh" mesh="ghost_cnc_left"
+            material="leader_ghost" pos="-0.041939 -0.000073385 0"
+            quat="0.5 0.5 -0.5 0.5"
+            contype="0" conaffinity="0" mass="0" group="2"/>
+    </body>
+
+    <body name="rebot_ghost_right" mocap="true" pos="0.12 0.16 0.22"
+          quat="0.5 0.5 -0.5 -0.5">
+      <geom name="rebot_ghost_pla_right" type="mesh" mesh="ghost_pla_right"
+            material="leader_ghost" pos="-0.041939 0.000073385 0"
+            quat="0.5 -0.5 -0.5 -0.5"
+            contype="0" conaffinity="0" mass="0" group="2"/>
+      <geom name="rebot_ghost_cnc_right" type="mesh" mesh="ghost_cnc_right"
+            material="leader_ghost" pos="-0.041939 0.000073385 0"
+            quat="0.5 -0.5 -0.5 -0.5"
+            contype="0" conaffinity="0" mass="0" group="2"/>
+    </body>
+  </worldbody>
+</mujoco>

--- a/src/python/isaacteleop/viz/robot/assets/scene_rebot.xml
+++ b/src/python/isaacteleop/viz/robot/assets/scene_rebot.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+scene.xml's reBot counterpart: the reBot DevArm follower and, on the operator's
+hand, that same arm's own gripper. The SO-101 pairs a follower with its LEADER's
+gripper; the reBot has no leader hardware, so the hand holds the follower's.
+
+See scene.xml for the headlight rationale and the no-ground-plane rule; this
+file differs from it only in which two fragments it includes.
+-->
+<mujoco model="robot_viz_scene_rebot">
+  <visual>
+    <headlight ambient="0.4 0.4 0.4" diffuse="0.4 0.4 0.4" specular="0.3 0.3 0.3"/>
+  </visual>
+
+  <include file="rebot_arm.xml"/>
+  <include file="rebot_gripper.xml"/>
+</mujoco>

--- a/src/python/isaacteleop/viz/robot/clutch_preview.py
+++ b/src/python/isaacteleop/viz/robot/clutch_preview.py
@@ -39,12 +39,10 @@ from .engage_gate import KEY_ENGAGED, GateVerdict
 from .harness import HarnessBand
 from .preview_arm import deflection
 from .quaternion import conjugate, from_axis_angle, multiply, rotate, to_matrix
+from .ghost import GHOST_GROUP, ghost_bodies
 from .so101_ghost import (
     GHOST_POINTING_AXIS,
     POS_HAND_FROM_GHOST,
-    GHOST_GEOMS,
-    GHOST_GROUP,
-    ghost_bodies,
     ghost_body_from_pose,
     grip_quat_from_ghost_body,
     pose_from_ghost_body,
@@ -234,7 +232,8 @@ def log_grip_posture(arm) -> tuple[float, float]:
         frames.xr_from_mj_pos(p_body + ghost_axis) - frames.xr_from_mj_pos(p_body)
     )
     hand_axis = in_operator_frame(
-        pose_from_ghost_body(p_body, q_body)[:3, :3] @ _HAND_REPORT_AXIS
+        pose_from_ghost_body(p_body, q_body, arm.hand_from_ghost)[:3, :3]
+        @ _HAND_REPORT_AXIS
     )
 
     def ahead(direction):
@@ -310,7 +309,7 @@ class ClutchPreview:
         self._recentered = False
         self._ghost_pose_key = str(ghost_pose_key)
         # Named rather than discovered, so a renamed geom is an error.
-        twin.declare_group(GHOST_GROUP, geoms=GHOST_GEOMS)
+        twin.declare_group(GHOST_GROUP, geoms=arm.ghost.geoms)
         self.phases = PhaseMachine()
         # The gate's own pre-first-step verdict, which reports that nothing has been
         # judged rather than reading as engageable.
@@ -369,7 +368,11 @@ class ClutchPreview:
             and self._hand_body_mj is not None
         ):
             self._clutch.set_home_base_T_ee(
-                pose_from_ghost_body(self._hand_body_mj, self._arm.gripper_pose_mj()[1])
+                pose_from_ghost_body(
+                    self._hand_body_mj,
+                    self._arm.gripper_pose_mj()[1],
+                    self._arm.hand_from_ghost,
+                )
             )
         # The reset pulse re-seeds the limiter's baseline on the first frame after a
         # disengage; without it the limiter rejects for ~30 frames (0.92 s). execution_state
@@ -437,7 +440,9 @@ class ClutchPreview:
             self._closedness = float(result[GRIPPER_COMMAND_KEY][0])
             # Taken from the hand rather than read back off the arm, so the grip offset
             # cannot leak into an engagement the clutch composes as a delta.
-            self._hand_body_mj = ghost_body_from_pose(hand)[0]
+            self._hand_body_mj = ghost_body_from_pose(hand, self._arm.hand_from_ghost)[
+                0
+            ]
 
         if not self._frames_logged:
             self._frames_logged = _log_hand_frames(result)
@@ -469,7 +474,13 @@ class ClutchPreview:
         if drawn is not None:
             # The body needs no tracking-loss gate: the clutch emits its held pose on
             # every disarm path. The jaw does, hence the latch above.
-            self._twin.publish(bodies=ghost_bodies(drawn, self._closedness))
+            self._twin.publish(
+                bodies=ghost_bodies(
+                    self._arm.ghost,
+                    *ghost_body_from_pose(drawn, self._arm.hand_from_ghost),
+                    self._closedness,
+                )
+            )
         if commanded is not None and governed is not None:
             # Classified on every governed frame, painted only while the ghost is the
             # tool on show: the band needs an unbroken baseline to tell a refused frame
@@ -498,7 +509,9 @@ class ClutchPreview:
         """
         reference = None
         if q_gripper_wxyz is not None:
-            q_xyzw = grip_quat_from_ghost_body(q_gripper_wxyz)
+            q_xyzw = grip_quat_from_ghost_body(
+                q_gripper_wxyz, self._arm.hand_from_ghost
+            )
             reference = to_matrix(np.array([q_xyzw[3], *q_xyzw[:3]]))
         return self._gate.update(
             None if hand is None else hand[3:7],

--- a/src/python/isaacteleop/viz/robot/ghost.py
+++ b/src/python/isaacteleop/viz/robot/ghost.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Which gripper rides on the operator's hand, and how its jaw opens.
+
+One spec per preview arm, selected through :class:`~.preview_arm.PreviewArmProfile`. The
+frame algebra that places the thing is arm-independent and lives in :mod:`.so101_ghost`;
+only the bodies, the geoms and the jaw's kinematics differ.
+
+The two jaw kinds are not interchangeable: the SO-101's leader trigger is one hinge, the
+reBot's gripper two rack-and-pinion slides. Both are driven by the same closedness in
+[0, 1], 1 being squeezed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from .quaternion import from_axis_angle, multiply, rotate
+
+#: The twin's name for every ghost geom, hidden as a set whenever the follower is the tool
+#: on show. One group for every arm; which geoms are in it is per-spec.
+GHOST_GROUP = "ghost"
+
+
+@dataclass(frozen=True)
+class GhostHinge:
+    """A jaw that swings, as the SO-101 leader's trigger does."""
+
+    body: str
+    pivot: np.ndarray
+    """Metres, in the ghost body's frame. Rotated ABOUT, not placed at."""
+    axis: np.ndarray
+    """Unit, in the ghost body's frame."""
+    released_rad: float
+    squeezed_rad: float
+
+
+@dataclass(frozen=True)
+class GhostSlide:
+    """A jaw finger that translates, as each of the reBot's two do."""
+
+    body: str
+    axis: np.ndarray
+    """Unit, in the ghost body's frame: the direction this finger opens along."""
+    released_m: float
+    squeezed_m: float
+
+
+@dataclass(frozen=True)
+class GhostSpec:
+    """The gripper on the hand for one arm."""
+
+    body: str
+    """The mocap body the hand calibration places; its frame is the ghost frame."""
+
+    geoms: tuple[str, ...]
+    """Every geom to declare as :data:`GHOST_GROUP`."""
+
+    jaw: tuple[GhostHinge | GhostSlide, ...]
+    """The moving parts, each on its own mocap body."""
+
+
+def ghost_bodies(spec: GhostSpec, p_body, q_body, closedness: float) -> dict:
+    """Where this ghost's mocap bodies go, given its root pose and jaw closedness.
+
+    The root pose comes from :func:`.so101_ghost.ghost_body_from_pose`. Both arguments must
+    be held frozen by the caller on an untracked frame: (0, 0, 0) is the scene origin, and
+    a jaw articulating on a frozen body reads as an actuated gripper.
+    """
+    bodies = {spec.body: (p_body, q_body)}
+    for part in spec.jaw:
+        if isinstance(part, GhostHinge):
+            angle = part.released_rad + closedness * (
+                part.squeezed_rad - part.released_rad
+            )
+            q_hinge = from_axis_angle(part.axis, angle)
+            # Rotating the ghost frame about the pivot maps 0 to (pivot - R_hinge.pivot).
+            swung = rotate(part.pivot, q_hinge)
+            offset = rotate(part.pivot - swung, q_body)
+            bodies[part.body] = (p_body + offset, multiply(q_body, q_hinge))
+        else:
+            travel = part.released_m + closedness * (part.squeezed_m - part.released_m)
+            bodies[part.body] = (
+                p_body + rotate(part.axis * travel, q_body),
+                q_body,
+            )
+    return bodies
+
+
+#: The reBot's: its FOLLOWER's own gripper, since the arm has no leader hardware. The two
+#: fingers are one rack and pinion, so they travel together and opposite. Measured off the
+#: compiled model: gripper_end's -Y and +Y, closed at the slide's 0 and open at its 0.05.
+REBOT_GHOST = GhostSpec(
+    body="rebot_ghost",
+    geoms=(
+        "rebot_ghost_pla7",
+        "rebot_ghost_cnc7",
+        "rebot_ghost_motor",
+        "rebot_ghost_pla_left",
+        "rebot_ghost_cnc_left",
+        "rebot_ghost_pla_right",
+        "rebot_ghost_cnc_right",
+    ),
+    jaw=(
+        GhostSlide(
+            body="rebot_ghost_left",
+            axis=np.array((0.0, -1.0, 0.0)),
+            released_m=0.05,
+            squeezed_m=0.0,
+        ),
+        GhostSlide(
+            body="rebot_ghost_right",
+            axis=np.array((0.0, 1.0, 0.0)),
+            released_m=0.05,
+            squeezed_m=0.0,
+        ),
+    ),
+)

--- a/src/python/isaacteleop/viz/robot/joint_map.py
+++ b/src/python/isaacteleop/viz/robot/joint_map.py
@@ -20,7 +20,12 @@ class JointMap:
     """
 
     def __init__(
-        self, names: Sequence[str], addresses: Sequence[int], *, width: int
+        self,
+        names: Sequence[str],
+        addresses: Sequence[int],
+        *,
+        width: int,
+        skipped: Sequence[str] = (),
     ) -> None:
         """Bind names to addresses and reject a mapping nothing could scatter through.
 
@@ -28,6 +33,8 @@ class JointMap:
             names: Motor names, in the order a published snapshot carries them.
             addresses: Where each name's position sits, parallel to ``names``.
             width: Total length of the state vector the addresses index into.
+            skipped: Joints the scene carries that this map deliberately does not
+                address, so :meth:`require`'s error can tell "absent" from "held".
 
         Raises:
             ValueError: If the two sequences disagree in length, either carries a
@@ -36,6 +43,7 @@ class JointMap:
         self._names = tuple(names)
         self._addresses = np.asarray(addresses, dtype=np.int32)
         self._width = int(width)
+        self._skipped = tuple(skipped)
 
         if len(self._names) != self._addresses.size:
             raise ValueError(
@@ -64,6 +72,11 @@ class JointMap:
         """The motor names, in the order a published snapshot carries them."""
         return self._names
 
+    @property
+    def skipped(self) -> tuple[str, ...]:
+        """Joints the scene carries that nothing writes; they hold their authored pose."""
+        return self._skipped
+
     def require(self, expected: Sequence[str]) -> None:
         """Fail unless the scene declares exactly ``expected``, in that order.
 
@@ -80,6 +93,8 @@ class JointMap:
             if missing or extra
             else f"same joints in a different order: {self._names}"
         )
+        if missing and self._skipped:
+            detail += f" (held, not addressed: {list(self._skipped)})"
         raise RuntimeError(
             f"the scene's joints are not the {len(expected)} this was authored "
             f"against ({detail}); a snapshot would pose the wrong joints. Expected "

--- a/src/python/isaacteleop/viz/robot/preview_arm.py
+++ b/src/python/isaacteleop/viz/robot/preview_arm.py
@@ -1,66 +1,208 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""The SO-101 arm the operator drags by hand before the clutch engages.
+"""The arm the operator drags by hand before the clutch engages.
 
-The joints are written once, to :data:`Q_HOME`, and the arm is moved as a rigid body:
-:meth:`PreviewArm._place` is the one place its base pose is published, and every other
-frame on the arm is that pose composed with a constant measured at :data:`Q_HOME`. This
+The joints are written once, to the profile's ``q_home``, and the arm is moved as a rigid
+body: :meth:`PreviewArm._place` is the one place its base pose is published, and every
+other frame on the arm is that pose composed with a constant measured at that pose. This
 module must not learn the leader ghost's grip calibration, which is a claim about a hand
 holding a controller; :mod:`.so101_ghost` converts between the two.
+
+Which arm is profile data -- see :data:`PREVIEW_ARMS`. Each arm previews the pose its real
+follower parks at, and carries both the gripper it puts on the operator's hand and the
+calibration that places it, solved against that pose.
 """
 
 from __future__ import annotations
 
 import logging
 import math
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
 
 import numpy as np
 
 from . import frames
 from .anchor import anchor_from_head, yaw_of_direction
 from .quaternion import conjugate, multiply, rotate
+from .ghost import REBOT_GHOST, GhostSpec
 from .scene import WORLD_BODY
+from .so101_ghost import SO101_GHOST, quat_hand_from_ghost
 
 LOG = logging.getLogger(__name__)
 
-# Declared by assets/follower_arm.xml and repointed onto every follower geom
-# at startup, so the arm recolours in one write.
+# Declared by each profile's scene wrapper and repointed onto every follower geom at
+# startup, so the arm recolours in one write.
 FOLLOWER_MATERIAL = "follower_arm"
 
-BASE_BODY = "base"
-GRIPPER_BODY = "gripper"
+# Each arm previews the pose its real follower parks at on declutch, so the operator sees
+# the arm hold what the hardware will hold. These are LeRobot's RobotProfile.reset_pose for
+# the same arm, in that arm's own joint order; keep the two in step.
+#
+# The pose does NOT set the wrist the engage gate demands -- the arm's
+# euler_hand_from_ghost_deg does, and the two are solved together. Move a pose and the gate
+# follows it unless the calibration is re-solved with it (so101_ghost has the closed form).
 
-# Upstream's own tool frame, declared on the `gripper` body 98.4 mm out from its origin
-# and 3.8 mm off the closed jaw surface. The arm is placed by this point, so it is also the
-# axis the yaw turns about; placing by the gripper body instead swings the jaw on a 15.8 mm
-# arc across +-90 degrees of yaw.
-GRIPPER_SITE = "gripperframe"
-
-# Upstream's joint order, which is also the qpos order Q_HOME is written in. Asserted by
-# name at startup: a reordered upstream file would land Q_HOME's angles on the wrong
-# joints and still look like an arm.
-ARM_JOINTS = (
-    "shoulder_pan",
-    "shoulder_lift",
-    "elbow_flex",
-    "wrist_flex",
-    "wrist_roll",
-)
-GRIPPER_JOINT = "gripper"
-
-# The configuration the arm holds for the whole session, written to qpos once at
-# construction. This pose is the wrist posture the engage gate demands, so re-solve
-# _EULER_HAND_FROM_GHOST_DEG whenever it changes. J4 stops at +-95 degrees.
+# SO-101, in motor order -- here the URDF joint names, the motor names and the qpos order
+# all coincide. J4 stops at +-95 degrees.
+#
+# wrist_roll is the one joint whose zero the arm's calibration does not pin: LeRobot forces
+# its range to a full turn, so normalized 0 is wherever the wrist sat at the homing prompt
+# rather than a mechanical feature. Measured across two calibrations of one arm: every other
+# joint's zero reproduced within 2 deg, wrist_roll moved 90. So if the preview's gripper
+# looks rolled against the hardware, recalibrate holding the wrist where this pose puts it
+# -- do not "fix" the number below, which is right for a correctly homed arm and wrong for
+# the next one.
 Q_HOME_DEG = (
     0.00,  # J1 shoulder_pan  -- base yaw
     -45.00,  # J2 shoulder_lift -- first segment elevation
     45.00,  # J3 elbow_flex    -- second segment elevation
     90.00,  # J4 wrist_flex    -- wrist up/down
-    -90.00,  # J5 wrist_roll    -- spin about the tool axis
-    00.00,  # J6 gripper       -- jaw opening, 0 is the authored pose
+    0.00,  # J5 wrist_roll    -- spin about the tool axis
+    0.00,  # J6 gripper       -- jaw opening, 0 is the authored pose
 )
 Q_HOME = np.radians(Q_HOME_DEG)
+
+# reBot DevArm. jointN is the MJCF/URDF name; the motor it drives is named beside it, in
+# the positional order LeRobot's IK already maps by. The gripper is a pair of slides this
+# does not address.
+Q_HOME_REBOT_DEG = (
+    0.00,  # joint1 -- shoulder_pan
+    -5.00,  # joint2 -- shoulder_lift, 5 deg off the endpoint it calibrates at
+    -10.00,  # joint3 -- elbow_flex, 10 deg off its endpoint
+    0.00,  # joint4 -- wrist_flex
+    0.00,  # joint5 -- wrist_yaw
+    0.00,  # joint6 -- wrist_roll
+)
+Q_HOME_REBOT = np.radians(Q_HOME_REBOT_DEG)
+
+
+@dataclass(frozen=True)
+class PreviewArmProfile:
+    """One follower's scene and the names :class:`PreviewArm` addresses it by.
+
+    Adding an arm is an entry in :data:`PREVIEW_ARMS`, not a code change. Everything here
+    is read off the compiled model or authored in its scene; nothing is tuned by eye.
+    """
+
+    name: str
+    """The key this profile is selected by on a command line."""
+
+    label: str
+    """What the startup log calls the arm."""
+
+    scene: Callable[[], Path]
+    """Returns the scene path, fetching and caching it on first use."""
+
+    joints: tuple[str, ...]
+    """Every hinge the scene declares, in qpos order -- asserted by name at startup, since
+    a reordered upstream file would land ``q_home`` on the wrong joints and still look like
+    an arm. Slide joints are not addressed and so are not named here."""
+
+    q_home: np.ndarray
+    """Radians, parallel to :attr:`joints`. The one and only joint write."""
+
+    base_body: str
+    """The body the whole arm is moved by."""
+
+    gripper_body: str
+    """The gripper body, whose pose the ghost handoff is taken from."""
+
+    ghost: GhostSpec
+    """The gripper this arm puts on the operator's hand once the clutch engages."""
+
+    euler_hand_from_ghost_deg: tuple[float, float, float]
+    """Where the leader ghost sits on the hand, for this arm. Paired with :attr:`q_home`:
+    it turns that pose's gripper orientation into the hand the engage gate demands, so the
+    two move together. See :mod:`.so101_ghost` for the closed form."""
+
+    tool: str | tuple[str, np.ndarray, np.ndarray]
+    """The point the arm is placed by, and so the axis its yaw turns about: a site name, or
+    a ``(body, pos, quat)`` frame in that body's own frame for a scene that declares no
+    site. Placing by the gripper body instead swings the jaw on an arc across the yaw
+    range. The frame's +Z is the direction the jaw faces."""
+
+
+def _so101_scene() -> Path:
+    from . import assets
+
+    return assets.ensure_so101_scene()
+
+
+def _rebot_devarm_rs_scene() -> Path:
+    from . import assets
+
+    return assets.ensure_rebot_devarm_rs_scene()
+
+
+_PROFILES = (
+    PreviewArmProfile(
+        name="so101",
+        label="SO-101",
+        scene=_so101_scene,
+        joints=(
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_roll",
+            "gripper",
+        ),
+        q_home=Q_HOME,
+        base_body="base",
+        gripper_body="gripper",
+        ghost=SO101_GHOST,
+        # Unchanged by the move to a park-pose Q_HOME: wrist_roll rolls about the tool
+        # axis, and the clutch measures that bias at every engage, so the wrist the gate
+        # demands is the same at 0 as it was at -90.
+        euler_hand_from_ghost_deg=(270.0, 0.0, 90.0),
+        # Upstream's own tool frame, declared on the `gripper` body 98.4 mm out from its
+        # origin and 3.8 mm off the closed jaw surface.
+        tool="gripperframe",
+    ),
+    PreviewArmProfile(
+        # The build is in the name because it has to be: the B601 ships as a Damiao and a
+        # RobStride arm with the same joint topology and DIFFERENT geometry, and this model
+        # is the RobStride one. A Damiao arm has no profile here rather than a near-fit.
+        name="rebot_devarm_rs",
+        label="reBot DevArm (RobStride)",
+        scene=_rebot_devarm_rs_scene,
+        # The two gripper slides (joint_left/joint_right, one rack and pinion) are held at
+        # their authored pose, not addressed -- see SceneTwin._read_joint_map.
+        joints=("joint1", "joint2", "joint3", "joint4", "joint5", "joint6"),
+        q_home=Q_HOME_REBOT,
+        base_body="base_link",
+        gripper_body="gripper_end",
+        # This arm's own gripper, not the SO-101 leader's: the reBot has no leader, so
+        # showing one put a different robot's tool in the operator's hand.
+        ghost=REBOT_GHOST,
+        # Solved against Q_HOME_REBOT so this arm demands the wrist the SO-101 does, to
+        # 1e-6 deg. Five degrees off the SO-101's, absorbing the pitch this arm's park
+        # pose puts on its gripper.
+        euler_hand_from_ghost_deg=(-85.0, 0.0, 90.0),
+        # Menagerie's model declares no sites, so the frame is given here.
+        #
+        # The point is this arm's own: measured off the compiled finger meshes, the jaws
+        # run out to -88.6 mm along gripper_end's -X.
+        #
+        # The turn is gripperframe's own rotation off the SO-101's gripper body, reused
+        # rather than rederived from these meshes. Its only consumer is the facing (+Z)
+        # that sets the base-yaw bias, which the clutch measures at every engage, so what
+        # matters is that it is a fixed, non-vertical direction on the tool -- deriving one
+        # from these meshes puts it near vertical, where the yaw it feeds is degenerate.
+        tool=(
+            "gripper_end",
+            np.array([-0.0886, 0.0, 0.0]),
+            np.array([0.70710678, 0.0, 0.70710678, 0.0]),
+        ),
+    ),
+)
+
+#: The arms a session can preview. ``robot_viz --arm`` and LeRobot's ``RobotProfile`` both
+#: select by these keys.
+PREVIEW_ARMS: dict[str, PreviewArmProfile] = {p.name: p for p in _PROFILES}
 
 # Where the home gripper sits relative to the operator's head, in XR axes: 0.30 m below eye
 # level and 0.60 m ahead on the head's yaw-projected facing (anchor_from_head). Measured
@@ -78,13 +220,13 @@ GRIP_FROM_CONTROLLER_XR = np.array([0.0, -0.10, -0.25])
 # What the thumbstick does to the two horizontal terms above. Deflection is a rate, so the
 # offset holds where the stick left it: metres per second at full deflection, scaled by the
 # frame dt -- not per frame, or its feel would track the frame rate.
-_TUNE_RATE_M_S = 0.20
+_TUNE_RATE_M_S = 0.50
 # Sticks drift and the offset is latched, so a resting controller would walk the arm
 # away over a session.
 _STICK_DEADZONE = 0.15
 # Each tuned term, absolutely: a stuck stick must not push the arm out of sight. The
 # vertical term is not tuned, so it is not bounded.
-_TUNE_LIMIT_M = 0.60
+_TUNE_LIMIT_M = 1.00
 
 #: The twin's name for every geom on the arm, declared at construction.
 FOLLOWER_GROUP = "follower"
@@ -96,55 +238,55 @@ _ENGAGEABLE_RGB = (0.20, 0.85, 0.35)
 
 
 class PreviewArm:
-    """The SO-101 in one scene: posed once, drawn, and driven rigidly by the hand.
+    """One arm in one scene: posed once, drawn, and driven rigidly by the hand.
 
     :meth:`drive` moves it two independent ways: position from the controller plus a
-    thumbstick-trimmed offset, yaw from the wrist. Placed by :data:`GRIPPER_SITE`, so the
-    yaw turns about the jaw; the gripper body sits 98.4 mm short of it.
+    thumbstick-trimmed offset, yaw from the wrist. Placed by the profile's tool frame, so
+    the yaw turns about the jaw, not the gripper body behind it.
     """
 
-    def __init__(self, twin) -> None:
-        """Resolve the arm in ``twin``, pose it at :data:`Q_HOME`, and hide it. Every
-        geometric constant is measured here; the arm is rigid below Q_HOME.
+    def __init__(self, twin, profile: PreviewArmProfile | None = None) -> None:
+        """Resolve the arm in ``twin``, pose it at the profile's ``q_home``, and hide it.
+        Every geometric constant is measured here; the arm is rigid below ``q_home``.
         """
         self._twin = twin
+        self._profile = profile if profile is not None else PREVIEW_ARMS["so101"]
+        profile = self._profile
+        self._hand_from_ghost = quat_hand_from_ghost(profile.euler_hand_from_ghost_deg)
 
         included = (
-            "It must <include> assets/follower_arm.xml rather than "
+            "It must <include> the profile's own arm wrapper rather than "
             "upstream's MJCF directly."
         )
         # The follower must be the scene's only jointed body, in upstream's order, so a
-        # second one fails here rather than landing Q_HOME on somebody else's joints.
-        twin.joints.require(ARM_JOINTS + (GRIPPER_JOINT,))
+        # second one fails here rather than landing q_home on somebody else's joints.
+        twin.joints.require(profile.joints)
 
         # Upstream numbers its visual geoms 2 and its collision geoms 3; declare_group
         # raises on an empty set, so a renumbering is an error, not an invisible arm.
-        twin.declare_group(FOLLOWER_GROUP, body=BASE_BODY, drawn_only=True)
-        # One material for thirteen upstream ones, so the arm recolours in one write.
+        twin.declare_group(FOLLOWER_GROUP, body=profile.base_body, drawn_only=True)
+        # One material for every upstream one, so the arm recolours in one write.
         self._blocked_rgba = twin.declare_material(FOLLOWER_MATERIAL, hint=included)
         twin.repaint(FOLLOWER_GROUP, FOLLOWER_MATERIAL)
 
         # The one and only joint write. Everything after this moves the base.
-        twin.home(Q_HOME)
+        twin.home(profile.q_home)
 
         # The anchor composes its yaw onto the authored base quat rather than replacing
         # it, so a scene that authors a base tilt keeps it.
         self._base_pos, self._authored_base_quat = twin.body_offset(
-            BASE_BODY, relative_to=WORLD_BODY
+            profile.base_body, relative_to=WORLD_BODY
         )
         self._base_quat = self._authored_base_quat.copy()
 
-        # The two constants Q_HOME freezes, both in the base's own frame. Composing the
+        # The two constants q_home freezes, both in the base's own frame. Composing the
         # base's pose with them replaces every per-frame forward-kinematics read.
-        jaw_pos, jaw_quat = twin.site_offset(
-            GRIPPER_SITE,
-            relative_to=BASE_BODY,
-        )
+        jaw_pos, jaw_quat = self._tool_offset()
         self._jaw_from_base_local = jaw_pos
-        # The site's +Z is the direction the jaw faces; its +X is the tool axis.
+        # The tool frame's +Z is the direction the jaw faces; its +X is the tool axis.
         self._jaw_facing_local = rotate(np.array([0.0, 0.0, 1.0]), jaw_quat)
         self._gripper_from_base_local = twin.body_offset(
-            GRIPPER_BODY, relative_to=BASE_BODY
+            profile.gripper_body, relative_to=profile.base_body
         )
 
         # The live grip offset. This class is its only definition; app.py passes two raw
@@ -159,7 +301,32 @@ class PreviewArm:
         self._base_yaw_xr = np.array([1.0, 0.0, 0.0, 0.0])
         self.set_visible(False)
 
+    def _tool_offset(self) -> tuple[np.ndarray, np.ndarray]:
+        """The tool frame in the base's own frame, from a site or a body-plus-offset."""
+        tool = self._profile.tool
+        base = self._profile.base_body
+        if isinstance(tool, str):
+            return self._twin.site_offset(tool, relative_to=base)
+        body, offset, turn = tool
+        pos, quat = self._twin.body_offset(body, relative_to=base)
+        return pos + rotate(np.asarray(offset, dtype=float), quat), multiply(quat, turn)
+
     # ---------------------------------------------------------------- geometry
+
+    @property
+    def name(self) -> str:
+        """Which arm this is previewing, by profile key."""
+        return self._profile.name
+
+    @property
+    def ghost(self) -> GhostSpec:
+        """The gripper this arm puts on the hand."""
+        return self._profile.ghost
+
+    @property
+    def hand_from_ghost(self) -> np.ndarray:
+        """This arm's ghost calibration, for :mod:`.so101_ghost`'s conversions."""
+        return self._hand_from_ghost
 
     @property
     def anchored(self) -> bool:
@@ -217,7 +384,9 @@ class PreviewArm:
             np.array(frames.mj_from_xr_pos(list(grip_xr)), dtype=float)
             - self.jaw_from_base
         )
-        self._twin.publish(bodies={BASE_BODY: (self._base_pos, self._base_quat)})
+        self._twin.publish(
+            bodies={self._profile.base_body: (self._base_pos, self._base_quat)}
+        )
 
     @property
     def jaw_from_base(self) -> np.ndarray:
@@ -228,7 +397,7 @@ class PreviewArm:
 
     @property
     def jaw_yaw_xr(self) -> np.ndarray:
-        """The XR yaw (wxyz) the jaw faces along: :data:`GRIPPER_SITE`'s +Z. Not the
+        """The XR yaw (wxyz) the jaw faces along: the tool frame's +Z. Not the
         links' reach -- J5 rolls the jaw about the tool axis without moving them.
         """
         facing = rotate(self._jaw_facing_local, self._base_quat)
@@ -318,11 +487,12 @@ class PreviewArm:
     def log_placement(self) -> None:
         """One line naming the placement rule, before any head pose exists."""
         LOG.info(
-            "preview arm: SO-101 home grip %.2f m below and %.2f m in front of the HEAD, "
+            "preview arm: %s home grip %.2f m below and %.2f m in front of the HEAD, "
             "turned onto its facing, on the first frame carrying one. Hidden until then. "
             "After it: the JAW dragged rigidly by the controller at (%.2f, %.2f, %.2f) "
             "off it, turning about itself on the wrist's own yaw, with the right "
             "thumbstick trimming the horizontal pair to +-%.2f m.",
+            self._profile.label,
             -HOME_GRIP_FROM_HEAD_XR[1],
             -HOME_GRIP_FROM_HEAD_XR[2],
             *GRIP_FROM_CONTROLLER_XR,

--- a/src/python/isaacteleop/viz/robot/scene.py
+++ b/src/python/isaacteleop/viz/robot/scene.py
@@ -16,6 +16,7 @@ thread. The thread boundary is :meth:`SceneTwin.publish` -- after
 
 from __future__ import annotations
 
+import logging
 import threading
 from pathlib import Path
 from typing import Mapping, Sequence
@@ -24,6 +25,8 @@ import numpy as np
 
 from . import _robot_twin, quaternion
 from .joint_map import JointMap
+
+LOG = logging.getLogger(__name__)
 
 #: ``geom_group`` values a scene is expected to use. Robot MJCFs number their visual geoms
 #: 2 and their collision geoms 3, and only 2 is in the visualiser's default geomgroup mask,
@@ -351,15 +354,19 @@ class SceneTwin:
     def _read_joint_map(self) -> JointMap:
         """Every hinge in the scene, by name, mapped to its position address.
 
-        Hinges only: a ball or free joint occupies four or seven slots, which a snapshot
-        with one value per name could not fill.
+        Slide joints are left out rather than addressed: a snapshot is one value per name
+        in radians, and a slide's position is metres, so the same array would pose it
+        plausibly and wrongly. Out of the map nothing writes them and they hold their
+        authored pose. A ball or free joint still raises -- it occupies four or seven
+        slots, so no per-name snapshot could fill it either way.
 
         Raises:
-            RuntimeError: If the scene carries a joint that is not a hinge, or one with
-                no name -- an unnamed joint cannot be published or asserted.
+            RuntimeError: If the scene carries a ball or free joint, or one with no name
+                -- an unnamed joint cannot be published or asserted.
         """
         names: list[str] = []
         addresses: list[int] = []
+        skipped: list[str] = []
         types = self._scene.jnt_type
         for joint in range(self._scene.njnt):
             name = self._scene.name(_robot_twin.ObjType.JOINT, joint)
@@ -367,15 +374,23 @@ class SceneTwin:
                 raise RuntimeError(
                     f"robot twin: joint {joint} has no name, so nothing can address it."
                 )
+            if types[joint] == int(_robot_twin.JointType.SLIDE):
+                skipped.append(name)
+                continue
             if types[joint] != int(_robot_twin.JointType.HINGE):
-                # Also what licenses reading angles in radians: a slide joint's position
-                # is metres, and the same array would pose it plausibly and wrongly.
                 raise RuntimeError(
-                    f"robot twin: joint `{name}` is not a hinge; the twin poses hinges only."
+                    f"robot twin: joint `{name}` is neither a hinge nor a slide; the twin "
+                    "poses hinges and holds slides."
                 )
             names.append(name)
             addresses.append(int(self._scene.jnt_qposadr[joint]))
-        return JointMap(names, addresses, width=int(self._scene.nq))
+        if skipped:
+            LOG.info(
+                "robot twin: holding %d slide joint(s) at their authored pose: %s",
+                len(skipped),
+                ", ".join(skipped),
+            )
+        return JointMap(names, addresses, width=int(self._scene.nq), skipped=skipped)
 
     def _subtree_geoms(self, root: int) -> np.ndarray:
         """Every geom on ``root`` and its descendants, by geom id. ``body_rootid`` is the

--- a/src/python/isaacteleop/viz/robot/so101_ghost.py
+++ b/src/python/isaacteleop/viz/robot/so101_ghost.py
@@ -20,26 +20,26 @@ import math
 import numpy as np
 
 from . import frames
+from .ghost import GhostHinge, GhostSpec
 from .quaternion import conjugate, from_axis_angle, multiply, rotate, to_matrix
 
 # The two mocap bodies leader_gripper.xml declares.
 GHOST_BODY = "leader_ghost"
 GHOST_JAW_BODY = "leader_ghost_jaw"
 
-# The twin's name for the four ghost geoms, hidden as a set whenever the follower
-# is the tool on show.
-GHOST_GROUP = "ghost"
-GHOST_GEOMS = (
-    "leader_ghost_wrist_roll",
-    "leader_ghost_motor",
-    "leader_ghost_handle",
-    "leader_ghost_trigger",
-)
 
-# Where the ghost sits on the hand. Euler degrees, intrinsic XYZ, i.e. MuJoCo's `euler=`.
-# Solve it from Q_HOME -- the gripper's xquat at Q_HOME and base yaw 0, carried into XR by
-# _xr_from_mj_quat -- and re-solve when Q_HOME moves. Do not port a grip-measured value,
-# which demands a wrist pitch nobody chose.
+# Where the ghost sits on the hand, for an arm that names no calibration of its own. Euler
+# degrees, intrinsic XYZ, i.e. MuJoCo's `euler=`. It pairs with one q_home and no other: it
+# is what turns that pose's gripper orientation into the hand the gate demands, so moving
+# q_home without re-solving this rotates that demand by the same amount. Each preview arm
+# carries its own (PreviewArmProfile.euler_hand_from_ghost_deg); this is the SO-101's, kept
+# as the default so the functions below can still be called bare.
+#
+# Re-solve it against the arm's own q_home, never by eye, and compare in the OPERATOR's
+# frame (log_grip_posture's second number) -- the absolute demanded quaternion moves with
+# any roll about the tool axis while the wrist the operator must actually hold does not,
+# so matching the absolute one "preserves" a quantity nobody feels. Do not port a
+# grip-measured value, which demands a wrist pitch nobody chose.
 EULER_HAND_FROM_GHOST_DEG = (270, 0, 90)
 # Measured on a headset: a claim about a hand holding a CONTROLLER, so do not re-derive
 # it from the mesh. Relative to HAND_POSE; `_log_hand_frames` prints the replacement
@@ -77,11 +77,23 @@ def _quat_from_euler_deg(angles_deg) -> np.ndarray:
 _QUAT_HAND_FROM_GHOST = _quat_from_euler_deg(EULER_HAND_FROM_GHOST_DEG)
 
 
-def ghost_body_from_pose(pose: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+def quat_hand_from_ghost(euler_deg) -> np.ndarray:
+    """One arm's calibration as a quaternion, from its ``euler_deg``."""
+    return _quat_from_euler_deg(euler_deg)
+
+
+def _resolve(hand_from_ghost: np.ndarray | None) -> np.ndarray:
+    return _QUAT_HAND_FROM_GHOST if hand_from_ghost is None else hand_from_ghost
+
+
+def ghost_body_from_pose(
+    pose: np.ndarray, hand_from_ghost: np.ndarray | None = None
+) -> tuple[np.ndarray, np.ndarray]:
     """A 7-D XR hand pose -> where the leader ghost body goes in MuJoCo world.
 
-    _QUAT_HAND_FROM_GHOST right-multiplies because it is fixed in the gripper's frame;
-    left-multiplying swings the ghost around the room as the operator turns.
+    ``hand_from_ghost`` is the arm's own calibration, defaulting to the SO-101's. It
+    right-multiplies because it is fixed in the gripper's frame; left-multiplying swings the
+    ghost around the room as the operator turns.
     """
     p_xr = [float(pose[0]), float(pose[1]), float(pose[2])]
     q_xyzw = [float(pose[3]), float(pose[4]), float(pose[5]), float(pose[6])]
@@ -89,34 +101,40 @@ def ghost_body_from_pose(pose: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     q_grip = np.array(frames.mj_from_xr_quat(q_xyzw), dtype=float)
     p_grip = np.array(frames.mj_from_xr_pos(p_xr), dtype=float)
 
-    q_body = multiply(q_grip, _QUAT_HAND_FROM_GHOST)
+    q_body = multiply(q_grip, _resolve(hand_from_ghost))
     p_offset = rotate(POS_HAND_FROM_GHOST, q_grip)
     return p_grip + p_offset, q_body
 
 
-def _grip_quat_mj(q_body: np.ndarray) -> np.ndarray:
+def _grip_quat_mj(
+    q_body: np.ndarray, hand_from_ghost: np.ndarray | None = None
+) -> np.ndarray:
     """The MuJoCo grip orientation (wxyz) whose ghost body lands at ``q_body``."""
-    inverse = conjugate(_QUAT_HAND_FROM_GHOST)
+    inverse = conjugate(_resolve(hand_from_ghost))
     q_grip = multiply(np.asarray(q_body, dtype=float), inverse)
     return q_grip
 
 
-def grip_quat_from_ghost_body(q_body: np.ndarray) -> np.ndarray:
+def grip_quat_from_ghost_body(
+    q_body: np.ndarray, hand_from_ghost: np.ndarray | None = None
+) -> np.ndarray:
     """The XR hand orientation (xyzw) that would put the ghost body at ``q_body``.
 
     The engage gate's second operand. Both operands are xyzw in XR, which is what makes a
     geodesic angle meaningful.
     """
-    return frames.xr_from_mj_quat(_grip_quat_mj(q_body))
+    return frames.xr_from_mj_quat(_grip_quat_mj(q_body, hand_from_ghost))
 
 
-def pose_from_ghost_body(p_body: np.ndarray, q_body: np.ndarray) -> np.ndarray:
+def pose_from_ghost_body(
+    p_body: np.ndarray, q_body: np.ndarray, hand_from_ghost: np.ndarray | None = None
+) -> np.ndarray:
     """The exact inverse of :func:`ghost_body_from_pose`, as a 4x4 in the XR frame.
 
     4x4 for ``SO101ClutchRetargeter.set_home_base_T_ee``, and XR because the app does no
     rebase, so "base" is the XR anchor.
     """
-    q_grip = _grip_quat_mj(q_body)
+    q_grip = _grip_quat_mj(q_body, hand_from_ghost)
     p_offset = rotate(POS_HAND_FROM_GHOST, q_grip)
 
     transform = np.eye(4)
@@ -128,34 +146,28 @@ def pose_from_ghost_body(p_body: np.ndarray, q_body: np.ndarray) -> np.ndarray:
     return transform
 
 
-def ghost_bodies(pose: np.ndarray, closedness: float) -> dict:
-    """Where the leader gripper's two mocap bodies go, by name.
-
-    `pose` is the harness output, not the controller. Both arguments must be held frozen by
-    the caller on an untracked frame: (0, 0, 0) is the scene origin, and a jaw articulating
-    on a frozen body reads as an actuated gripper.
-    """
-    p_body, q_body = ghost_body_from_pose(pose)
-
-    # Rotated ABOUT the hinge, not placed at it: the jaw's XML rest pose equals the
-    # ghost's, so the pivot lives in exactly one place.
-    angle = TRIGGER_RELEASED_RAD + closedness * (
-        TRIGGER_SQUEEZED_RAD - TRIGGER_RELEASED_RAD
-    )
-    q_hinge = from_axis_angle(_TRIGGER_HINGE_AXIS, angle)
-    q_jaw = multiply(q_body, q_hinge)
-
-    # Rotating the ghost frame about the hinge maps 0 to (pivot - R_hinge.pivot).
-    swung = rotate(_TRIGGER_HINGE_POS, q_hinge)
-    offset = rotate(_TRIGGER_HINGE_POS - swung, q_body)
-
-    return {
-        GHOST_BODY: (p_body, q_body),
-        GHOST_JAW_BODY: (p_body + offset, q_jaw),
-    }
-
-
 # Handle centroid to wrist-roll centroid in the ghost body frame, measured on the fetched
 # meshes: (-56.9, -0.5, -63.2) mm -> (-4.3, -1.4, -13.2) mm. Rotated by the follower
 # `gripper` quaternion, since the handoff puts the ghost body on its orientation exactly.
 GHOST_POINTING_AXIS = np.array((0.7228, -0.0124, 0.6910))
+
+
+#: The SO-101's: its LEADER's gripper, whose trigger shares the follower's moving-jaw slot.
+SO101_GHOST = GhostSpec(
+    body=GHOST_BODY,
+    geoms=(
+        "leader_ghost_wrist_roll",
+        "leader_ghost_motor",
+        "leader_ghost_handle",
+        "leader_ghost_trigger",
+    ),
+    jaw=(
+        GhostHinge(
+            body=GHOST_JAW_BODY,
+            pivot=_TRIGGER_HINGE_POS,
+            axis=_TRIGGER_HINGE_AXIS,
+            released_rad=TRIGGER_RELEASED_RAD,
+            squeezed_rad=TRIGGER_SQUEEZED_RAD,
+        ),
+    ),
+)

--- a/tests/python/viz/test_preview_arm_profiles.py
+++ b/tests/python/viz/test_preview_arm_profiles.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""The preview-arm profiles, checked without a scene, a GPU or a headset.
+
+Adding an arm is profile data, so what is worth pinning here is that a profile could pose
+its scene at all -- a q_home that is the wrong length lands its angles on the wrong joints
+and still looks like an arm. Everything geometric needs the compiled model and belongs in
+an integration test.
+"""
+
+import numpy as np
+import pytest
+
+robot = pytest.importorskip(
+    "isaacteleop.viz.robot",
+    reason="needs the compiled scene backend (Linux, -DBUILD_VIZ=ON)",
+)
+
+
+def profiles():
+    return robot.PREVIEW_ARMS
+
+
+def test_the_documented_arms_are_present():
+    assert set(profiles()) == {"so101", "rebot_devarm_rs"}
+
+
+@pytest.mark.parametrize("key", sorted(profiles()))
+def test_profile_could_pose_its_scene(key):
+    profile = profiles()[key]
+    assert profile.name == key, "PREVIEW_ARMS is keyed by name; the two must agree"
+    assert len(profile.q_home) == len(profile.joints), (
+        "one angle per addressed joint, or q_home scatters onto the wrong joints"
+    )
+    assert len(set(profile.joints)) == len(profile.joints)
+    assert np.all(np.isfinite(profile.q_home))
+    assert profile.label and profile.base_body and profile.gripper_body
+
+
+@pytest.mark.parametrize("key", sorted(profiles()))
+def test_tool_frame_is_a_site_or_a_placed_frame(key):
+    tool = profiles()[key].tool
+    if isinstance(tool, str):
+        assert tool
+        return
+    body, offset, turn = tool
+    assert body
+    assert np.asarray(offset).shape == (3,)
+    quat = np.asarray(turn, dtype=float)
+    assert quat.shape == (4,)
+    # A non-unit quat silently scales the jaw's facing direction.
+    assert np.linalg.norm(quat) == pytest.approx(1.0)
+
+
+def test_so101_profile_names_upstreams_own_frames():
+    profile = profiles()["so101"]
+    assert profile.joints == (
+        "shoulder_pan",
+        "shoulder_lift",
+        "elbow_flex",
+        "wrist_flex",
+        "wrist_roll",
+        "gripper",
+    )
+    assert profile.base_body == "base"
+    assert profile.gripper_body == "gripper"
+    assert profile.tool == "gripperframe"
+
+
+# LeRobot's RobotProfile.reset_pose for the same arm, in that arm's own joint order. The
+# preview holds what the hardware parks at, so these move together; a mismatch means the
+# operator is shown a pose the robot will not adopt. LeRobot is not importable here, so the
+# values are pinned literally rather than read across.
+PARK_POSE_DEG = {
+    "so101": [0, -45, 45, 90, 0, 0],
+    "rebot_devarm_rs": [0, -5, -10, 0, 0, 0],
+}
+
+
+@pytest.mark.parametrize("key", sorted(PARK_POSE_DEG))
+def test_q_home_is_the_arms_park_pose(key):
+    assert np.degrees(profiles()[key].q_home) == pytest.approx(PARK_POSE_DEG[key])
+
+
+@pytest.mark.parametrize("key", sorted(profiles()))
+def test_each_arm_calibrates_its_own_ghost(key):
+    """Paired with q_home: it is what turns that pose's gripper orientation into the wrist
+    the engage gate demands, so neither can move without re-solving the other."""
+    euler = profiles()[key].euler_hand_from_ghost_deg
+    assert len(euler) == 3
+    assert all(isinstance(float(a), float) for a in euler)
+
+
+def test_rebot_gripper_slides_are_not_addressed():
+    """The two rack-and-pinion fingers are held, not posed -- SceneTwin leaves slide joints
+    out of the map, so naming them here would fail JointMap.require at startup."""
+    joints = profiles()["rebot_devarm_rs"].joints
+    assert "joint_left" not in joints and "joint_right" not in joints
+    assert joints == ("joint1", "joint2", "joint3", "joint4", "joint5", "joint6")
+
+
+@pytest.mark.parametrize("key", sorted(profiles()))
+def test_ghost_spec_is_addressable(key):
+    """Every geom and body the spec names is published or declared by name, so a typo is a
+    scene error at startup rather than an invisible ghost."""
+    ghost = profiles()[key].ghost
+    assert ghost.body
+    assert ghost.geoms and len(set(ghost.geoms)) == len(ghost.geoms)
+    jaw_bodies = [part.body for part in ghost.jaw]
+    assert jaw_bodies, "a ghost with no moving part cannot show the trigger"
+    assert len(set(jaw_bodies)) == len(jaw_bodies)
+    assert ghost.body not in jaw_bodies
+
+
+@pytest.mark.parametrize("key", sorted(profiles()))
+def test_ghost_jaw_travel_is_well_formed(key):
+    from isaacteleop.viz.robot.ghost import GhostSlide
+
+    for part in profiles()[key].ghost.jaw:
+        # Released and squeezed must differ, or closedness drives nothing.
+        released, squeezed = (
+            (part.released_m, part.squeezed_m)
+            if isinstance(part, GhostSlide)
+            else (part.released_rad, part.squeezed_rad)
+        )
+        assert released != squeezed
+        axis = np.asarray(part.axis, dtype=float)
+        assert np.linalg.norm(axis) == pytest.approx(1.0)
+
+
+def test_rebot_ghost_is_the_rebots_own_gripper():
+    """The reBot has no leader hardware, so its ghost is its own follower gripper -- not a
+    single SO-101 part."""
+    ghost = profiles()["rebot_devarm_rs"].ghost
+    assert not any("leader" in geom for geom in ghost.geoms)
+    assert len(ghost.jaw) == 2, "one rack and pinion, two fingers"


### PR DESCRIPTION
## What

The robot twin was SO-101 geometry throughout, so `robot_viz` could only ever preview one arm. This makes the arm profile data (`PreviewArmProfile` / `PREVIEW_ARMS`) and adds a second entry, MuJoCo Menagerie's `seeed_rebot_devarm`, selected with `python -m isaacteleop_examples.robot_viz --arm rebot_devarm_rs`.

The mechanism was never SO-101-specific — the arm is posed once at `q_home` and dragged as a rigid body, with no per-frame FK — so this is mostly constants moving into a dataclass.

## Two things the reBot needed

- **Slide joints.** Its gripper is a rack-and-pinion pair, and `SceneTwin` refused any scene carrying one. It now holds slide joints at their authored pose and leaves them out of the map, so a radians snapshot still cannot reach one — which is what the original guard protected. Ball and free joints still raise.
- **A tool frame without a site.** Menagerie's model declares none, so a profile may give `(body, pos, quat)` instead of a site name.

## Each arm previews the pose its follower parks at

Both preview poses were originally shaped by the shared ghost calibration rather than by the robot: the reBot's was solved to land its gripper on the SO-101's orientation, pinning its base yaw at −45.65° and hanging the arm 0.33 m off to the side, and the SO-101 held `wrist_roll` at −90° where its follower parks at 0.

Each arm now previews its own follower's park pose (LeRobot's `RobotProfile.reset_pose`) and carries its own `euler_hand_from_ghost_deg`, solved against that pose so the engage gate demands the wrist it always did — **both arms report a 0° hand.**

Solved in the operator's frame, not against the absolute demanded quaternion: the latter moves with any roll about the tool axis while the wrist the operator actually holds does not.

The finding worth recording: the SO-101's calibration comes out **unchanged** at `(270, 0, 90)`. `wrist_roll` rolls about the tool axis and the clutch measures that bias at every engage, so the −90 was never load-bearing.

## Each arm's own gripper on the hand

The ghost started as the SO-101's leader gripper for every arm, on the reasoning that it stands for the hand rather than the follower. A headset pass falsified that — a reBot session put a different robot's tool in the operator's hand. The reBot has no leader hardware, so it now shows its own follower gripper, from meshes the arm already fetches.

The jaw generalised with it: the SO-101's trigger is one hinge, the reBot's gripper two rack-and-pinion fingers sliding 0–50 mm along `gripper_end`'s ∓Y, closed at the slide's zero. Both are driven by the same closedness; `ghost.py` dispatches on which kind a spec names. The reBot scene now fetches nothing from SO-ARM100 — its ghost and its arm are the same 117 files, so the manifest digest is unchanged.

## Why the name carries the build

The B601 ships as a Damiao and a RobStride arm with the same joint topology and **different geometry**, and Menagerie's model is the RobStride one — built around RS-06/RS-00 actuators. A bare `rebot_devarm` would invite a Damiao owner to pick a model that is not their arm, so the profile is `rebot_devarm_rs`. `rebot_devarm` stays the family name, matching `src/plugins/rebot_devarm_leader`; the build is the axis that was missing. A Damiao arm gets no profile rather than a near-fit.

## Grip trim

`_TUNE_LIMIT_M` 0.60 → 1.00 and `_TUNE_RATE_M_S` 0.20 → 0.50 m/s, both from headset use. The bound is absolute rather than travel-relative, so from the `-0.25` default the old value ran out of forward travel 35 cm out while giving the full 0.60 m sideways — it read as a stuck control. The rate is multiplied by stick deflection, so raising the ceiling costs no precision at partial deflection.

## Assets

115 meshes and the MJCF, ~15 MB, into their own cache dir. Pinned by one digest over the sorted per-file hashes rather than a 117-row table or a hash of the repo tarball — that tarball is 400 MB for 15 MB of arm and its bytes are not promised to be stable.

## Testing

- Both arms verified against a real `SceneTwin` on an Orin: 0° demanded hand, no posture warning, 6 hinges mapped and both slides held, cold fetch + cache hit + digest verified.
- **The SO-101's preview does change**: its gripper rolls 90° and its jaw centres on the base plane. Its grip calibration, placement and gate behaviour do not — the `grip calib` line is identical to a pre-change run.
- Ghost verified against a real `SceneTwin`: every geom and body name resolves, the SO-101's hinge swings 47.4 mm → 0 and each reBot finger travels its full 50.0 mm → 0.
- `tests/python/viz/test_preview_arm_profiles.py`, 16 cases; `SKIP=check-copyright-year pre-commit run --all-files` clean.
- **Not yet run in a headset** — that is the next step, on both arms.