### PR TITLE
ROS: separate hand provider from plugin lifecycle

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -850,7 +850,7 @@ jobs:
           -e PYTHONUNBUFFERED=1 \
           -e ACCEPT_CLOUDXR_EULA=Y \
           --entrypoint bash "$IMAGE" -c \
-          "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$MODE -p hand_retargeter:=$HAND_RETARGETER -p hand_tracking_provider:=$HAND_TRACKING_PROVIDER -p start_hand_tracking_plugin:=true -p cloudxr_accept_eula:=true" >/dev/null
+          "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$MODE -p hand_retargeter:=$HAND_RETARGETER -p hand_tracking_provider:=$HAND_TRACKING_PROVIDER -p cloudxr_accept_eula:=true" >/dev/null
 
         fail() {
           echo "Error: $1"

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -715,18 +715,20 @@ jobs:
           "source /usr/local/bin/teleop-env-setup && exec /opt/isaacteleop/install/examples/teleop_ros2/cpp/integration_tests/teleop_ros2_mcap_generator '$REPLAY_MCAP'"
 
         scenarios=(
-          "controller_teleop mode_default"
-          "hand_teleop mode_default"
-          "controller_raw mode_default"
-          "full_body mode_default"
-          "controller_teleop pink_ik"
-          "controller_teleop wuji"
-          "hand_teleop wuji"
+          "controller_teleop mode_default native"
+          "hand_teleop mode_default native"
+          "controller_raw mode_default native"
+          "full_body mode_default native"
+          "controller_teleop pink_ik native"
+          "controller_teleop wuji native"
+          "hand_teleop wuji native"
+          "controller_teleop dexpilot manus"
+          "controller_teleop dexpilot wuji"
         )
         for scenario in "${scenarios[@]}"; do
-          read -r mode hand_retargeter <<< "$scenario"
-          scenario_name="${mode}_${hand_retargeter}"
-          echo "Testing mode: $mode (hand_retargeter=$hand_retargeter)"
+          read -r mode hand_retargeter hand_tracking_provider <<< "$scenario"
+          scenario_name="${mode}_${hand_retargeter}_${hand_tracking_provider}"
+          echo "Testing mode: $mode (hand_retargeter=$hand_retargeter, hand_tracking_provider=$hand_tracking_provider)"
           LOG_FILE="${LOG_FILE_BASE}_${scenario_name}.log"
           RUN_NAME="teleop-ros2-${PROJECT_NAME}-${scenario_name//_/-}"
           verifier_rc=0
@@ -741,7 +743,7 @@ jobs:
             -v /tmp:/tmp \
             -e PYTHONUNBUFFERED=1 \
             --entrypoint bash teleop_ros2_ref:${{ env.ROS_DISTRO }} -c \
-            "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$mode -p hand_retargeter:=$hand_retargeter -p mcap_replay_path:=$REPLAY_MCAP" >/dev/null
+            "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$mode -p hand_retargeter:=$hand_retargeter -p hand_tracking_provider:=$hand_tracking_provider -p mcap_replay_path:=$REPLAY_MCAP" >/dev/null
 
           deadline=$((SECONDS + READINESS_TIMEOUT_SEC))
           while [ "$SECONDS" -lt "$deadline" ]; do
@@ -767,7 +769,7 @@ jobs:
             if docker exec \
               -e PYTHONUNBUFFERED=1 \
               "$RUN_NAME" bash -c \
-              "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync python -m integration_tests.teleop_ros2_topic_verifier --mode $mode --hand-retargeter $hand_retargeter"; then
+              "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync python -m integration_tests.teleop_ros2_topic_verifier --mode $mode --hand-retargeter $hand_retargeter --hand-tracking-provider $hand_tracking_provider"; then
               verifier_rc=0
             else
               verifier_rc=$?
@@ -816,7 +818,7 @@ jobs:
         LOG_FILE="/tmp/ros2_cloudxr_output_${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}_${{ matrix.arch }}_${{ env.ROS_DISTRO }}.log"
         MODE="controller_teleop"
         HAND_RETARGETER="dexpilot"
-        HAND_TRACKING_PLUGIN="wuji"
+        HAND_TRACKING_PROVIDER="wuji"
 
         # The node logs this after CloudXRLauncher returns: runtime ready + WSS
         # proxy up. This is the primary bring-up marker.
@@ -848,7 +850,7 @@ jobs:
           -e PYTHONUNBUFFERED=1 \
           -e ACCEPT_CLOUDXR_EULA=Y \
           --entrypoint bash "$IMAGE" -c \
-          "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$MODE -p hand_retargeter:=$HAND_RETARGETER -p hand_tracking_plugin:=$HAND_TRACKING_PLUGIN -p cloudxr_accept_eula:=true" >/dev/null
+          "source /usr/local/bin/teleop-env-setup && exec uv run --no-sync teleop_ros2_node.py --ros-args -p mode:=$MODE -p hand_retargeter:=$HAND_RETARGETER -p hand_tracking_provider:=$HAND_TRACKING_PROVIDER -p start_hand_tracking_plugin:=true -p cloudxr_accept_eula:=true" >/dev/null
 
         fail() {
           echo "Error: $1"

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -46,10 +46,12 @@ parameter:
   firmware-order joints named `left_thumb_j0` through
   `left_pinky_j3` and `right_thumb_j0` through `right_pinky_j3`.
 
-In `controller_teleop`, explicitly setting `hand_retargeter:=dexpilot`,
-`hand_retargeter:=pink_ik` or `hand_retargeter:=wuji` keeps XR controllers
-responsible for EE poses, wrist TFs, locomotion, and `controller_data`, while
-OpenXR/Manus/Wuji hand data drives `xr_teleop/hand` and `xr_teleop/finger_joints`.
+In `controller_teleop`, `hand_retargeter` selects the finger-joint mapping.
+With `hand_tracking_provider:=native`, EE poses and wrist TFs come from XR
+controller aim poses. With `hand_tracking_provider:=manus`, they come from
+controller aim poses with the MANUS controller-to-hand calibration. With
+`hand_tracking_provider:=wuji`, they come from the provider-injected OpenXR
+wrists. Controllers continue to provide locomotion and `controller_data`.
 
 The Docker build fetches the pinned official Sharpa Wave URDFs and installs them
 at `/opt/isaacteleop/install/examples/teleop_ros2/assets/urdf/sharpa_standalone/`.
@@ -64,15 +66,13 @@ Robot assets are never downloaded by `teleop_ros2_node.py` at runtime.
 ### OpenXR hand input sources
 
 The DexPilot, Pink IK, and Wuji hand retargeters can use native OpenXR hand
-tracking, MANUS gloves, or Wuji gloves. Choose the retargeter for the robot hand
-independently from the OpenXR input source, and use only one input source at a
-time. Native OpenXR hand tracking needs no additional input plugin.
+tracking, MANUS gloves, or Wuji gloves. Set `hand_tracking_provider` to
+`native` (default), `manus`, or `wuji`. Use only one provider at a time.
 
-Set `hand_tracking_plugin` to `wuji` or `manus` to have the ROS node manage that
-plugin with its live teleoperation session. The default `none` keeps native
-OpenXR hand tracking or the manual plugin workflow below. Managed plugins require
-`hand_teleop`, or `controller_teleop` with `dexpilot`, `pink_ik`, or `wuji`, and
-are not launched during MCAP replay.
+`start_hand_tracking_plugin` defaults to `false`. Set it to `true` to have the
+ROS node start the selected MANUS or Wuji plugin with a live session. A
+non-native provider requires `hand_teleop`, or `controller_teleop` with
+`dexpilot`, `pink_ik`, or `wuji`. `native` cannot be started as a plugin.
 
 When launching a plugin manually, the plugin and node must use the same CloudXR
 runtime path and network namespace, and the glove must be reachable from the
@@ -83,9 +83,10 @@ plugin environment.
 Follow the [MANUS device guide](../../docs/source/device/manus.rst) to install
 host USB permissions, the MANUS SDK, and the MANUS plugin.
 
-Start the ROS node first so its CloudXR runtime is available. Then, from the
-IsaacTeleop repository root in the environment where the MANUS plugin was built,
-attach the plugin to that runtime:
+Start the ROS node with `hand_tracking_provider:=manus` and
+`start_hand_tracking_plugin:=false` so its CloudXR runtime is available. Then,
+from the IsaacTeleop repository root in the environment where the MANUS plugin
+was built, attach the plugin to that runtime:
 
 ```bash
 source "$HOME/.cloudxr/run/cloudxr.env"
@@ -100,7 +101,9 @@ Build the Wuji glove plugin from the repository root:
 ./src/plugins/wuji_glove/install.sh
 ```
 
-After starting the ROS node, attach the plugin to the same CloudXR runtime:
+Start the ROS node with `hand_tracking_provider:=wuji` and
+`start_hand_tracking_plugin:=false`. Then attach the plugin to the same CloudXR
+runtime:
 
 ```bash
 source "$HOME/.cloudxr/run/cloudxr.env"
@@ -183,12 +186,13 @@ docker run --rm --gpus all --net=host --ipc=host \
   teleop_ros2_ref --ros-args -p cloudxr_accept_eula:=true
 ```
 
-Select the managed input plugin independently from the robot-hand retargeter:
+Select the hand provider independently from the robot-hand retargeter. Set
+`start_hand_tracking_plugin:=true` to start its plugin with the node:
 
 - Wuji gloves driving Sharpa hands:
-  `-p hand_tracking_plugin:=wuji -p hand_retargeter:=dexpilot`
+  `-p hand_tracking_provider:=wuji -p start_hand_tracking_plugin:=true -p hand_retargeter:=dexpilot`
 - MANUS gloves driving Wuji Hand 2:
-  `-p hand_tracking_plugin:=manus -p hand_retargeter:=wuji -p wuji_hand_model:=wuji_hand_2`
+  `-p hand_tracking_provider:=manus -p start_hand_tracking_plugin:=true -p hand_retargeter:=wuji -p wuji_hand_model:=wuji_hand_2`
 
 Wuji gloves must be reachable through the container's host network. Pass Wuji
 configuration overrides into the container with `docker run -e <name>=<value>`.
@@ -212,7 +216,7 @@ docker run --rm --gpus all --net=host --ipc=host \
   -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `hand_tracking_plugin`, `wuji_hand_model`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `hand_tracking_provider`, `start_hand_tracking_plugin`, `wuji_hand_model`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 
@@ -224,7 +228,7 @@ The `mode` parameter selects the teleoperation scenario and which topics are pub
 
 | Mode | Topics published |
 |------|------------------|
-| `controller_teleop` (default) | `ee_poses`, `root_twist`, `root_pose`, `head_pose`, `finger_joints`, `controller_data`, and `tf`; TriHand uses controller-derived finger joints and EE poses, explicit Sharpa retargeters add `hand` and use controller-derived EE poses with the MANUS mount transform, and Wuji adds `hand` while using the plugin-injected OpenXR wrist for EE poses and wrist TFs |
+| `controller_teleop` (default) | `ee_poses`, `root_twist`, `root_pose`, `head_pose`, `finger_joints`, `controller_data`, and `tf`; TriHand uses controller-derived finger joints and EE poses. Explicit Sharpa or Wuji retargeters add `hand`; `native` uses controller aim for EE poses, `manus` applies the MANUS calibration to controller aim, and `wuji` uses provider-injected wrist poses |
 | `hand_teleop` | `ee_poses` (from hand tracking wrists), `hand` (named left and right joint poses), `finger_joints` (finger joints in joint space), `root_twist`, `root_pose`, `head_pose`, `tf` (from hand tracking wrists and head pose); locomotion comes from the configured foot pedal collection |
 | `controller_raw` | `controller_data` only |
 | `full_body` | `full_body` and `controller_data` |

--- a/examples/teleop_ros2/README.md
+++ b/examples/teleop_ros2/README.md
@@ -69,24 +69,20 @@ The DexPilot, Pink IK, and Wuji hand retargeters can use native OpenXR hand
 tracking, MANUS gloves, or Wuji gloves. Set `hand_tracking_provider` to
 `native` (default), `manus`, or `wuji`. Use only one provider at a time.
 
-`start_hand_tracking_plugin` defaults to `false`. Set it to `true` to have the
-ROS node start the selected MANUS or Wuji plugin with a live session. A
-non-native provider requires `hand_teleop`, or `controller_teleop` with
-`dexpilot`, `pink_ik`, or `wuji`. `native` cannot be started as a plugin.
-
-When launching a plugin manually, the plugin and node must use the same CloudXR
-runtime path and network namespace, and the glove must be reachable from the
-plugin environment.
+When `mcap_replay_path` is unset, the ROS node starts the selected MANUS or Wuji
+plugin by default. For manual launch, set
+`use_external_hand_tracking_plugin:=true`; the plugin and node must use the same
+CloudXR runtime path and network namespace, and the glove must be reachable from
+the plugin environment. A non-native provider requires `hand_teleop`, or
+`controller_teleop` with `dexpilot`, `pink_ik`, or `wuji`.
 
 #### MANUS glove input
 
 Follow the [MANUS device guide](../../docs/source/device/manus.rst) to install
 host USB permissions, the MANUS SDK, and the MANUS plugin.
 
-Start the ROS node with `hand_tracking_provider:=manus` and
-`start_hand_tracking_plugin:=false` so its CloudXR runtime is available. Then,
-from the IsaacTeleop repository root in the environment where the MANUS plugin
-was built, attach the plugin to that runtime:
+After the ROS node starts, run the following from the IsaacTeleop repository
+root in the environment where the MANUS plugin was built:
 
 ```bash
 source "$HOME/.cloudxr/run/cloudxr.env"
@@ -101,9 +97,7 @@ Build the Wuji glove plugin from the repository root:
 ./src/plugins/wuji_glove/install.sh
 ```
 
-Start the ROS node with `hand_tracking_provider:=wuji` and
-`start_hand_tracking_plugin:=false`. Then attach the plugin to the same CloudXR
-runtime:
+After the ROS node starts, attach the plugin to the same CloudXR runtime:
 
 ```bash
 source "$HOME/.cloudxr/run/cloudxr.env"
@@ -186,13 +180,13 @@ docker run --rm --gpus all --net=host --ipc=host \
   teleop_ros2_ref --ros-args -p cloudxr_accept_eula:=true
 ```
 
-Select the hand provider independently from the robot-hand retargeter. Set
-`start_hand_tracking_plugin:=true` to start its plugin with the node:
+Select the hand provider independently from the robot-hand retargeter. The node
+starts the selected plugin automatically:
 
 - Wuji gloves driving Sharpa hands:
-  `-p hand_tracking_provider:=wuji -p start_hand_tracking_plugin:=true -p hand_retargeter:=dexpilot`
+  `-p hand_tracking_provider:=wuji -p hand_retargeter:=dexpilot`
 - MANUS gloves driving Wuji Hand 2:
-  `-p hand_tracking_provider:=manus -p start_hand_tracking_plugin:=true -p hand_retargeter:=wuji -p wuji_hand_model:=wuji_hand_2`
+  `-p hand_tracking_provider:=manus -p hand_retargeter:=wuji -p wuji_hand_model:=wuji_hand_2`
 
 Wuji gloves must be reachable through the container's host network. Pass Wuji
 configuration overrides into the container with `docker run -e <name>=<value>`.
@@ -216,7 +210,7 @@ docker run --rm --gpus all --net=host --ipc=host \
   -r xr_teleop/ee_poses:=my_robot/ee_poses
 ```
 
-Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `hand_tracking_provider`, `start_hand_tracking_plugin`, `wuji_hand_model`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
+Available parameters: `rate_hz`, `mode`, `hand_retargeter`, `hand_tracking_provider`, `use_external_hand_tracking_plugin`, `wuji_hand_model`, `config_asset_root`, `cloudxr_install_dir`, `cloudxr_env_config`, `cloudxr_client_route`, `cloudxr_accept_eula`, `cloudxr_setup_oob`, `cloudxr_usb_local`, `pedal_collection_id`, `world_frame`, `right_wrist_frame`, `left_wrist_frame`, `head_frame`, `left_finger_joint_names`, `right_finger_joint_names`. Use `ros2 param list /teleop_ros2_node` and `ros2 param describe /teleop_ros2_node <param>` (with the node running) for the full set.
 
 By default, `left_finger_joint_names` and `right_finger_joint_names` use the selected mode's retargeter joint names. They can be overridden to publish robot-specific names on `xr_teleop/finger_joints`, but each override must provide the same number of names as the joints emitted by that mode's retargeter.
 

--- a/examples/teleop_ros2/python/constants.py
+++ b/examples/teleop_ros2/python/constants.py
@@ -20,8 +20,8 @@ class HandRetargeter(StrEnum):
     WUJI = "wuji"
 
 
-class HandTrackingPlugin(StrEnum):
-    NONE = "none"
+class HandTrackingProvider(StrEnum):
+    NATIVE = "native"
     MANUS = "manus"
     WUJI = "wuji"
 
@@ -40,7 +40,7 @@ HAND_POSE_JOINT_INDICES = tuple(
 )
 HAND_POSE_NAMES = [joint.name for joint in HAND_POSE_JOINT_INDICES]
 HAND_RETARGETERS = tuple(retargeter.value for retargeter in HandRetargeter)
-HAND_TRACKING_PLUGINS = tuple(plugin.value for plugin in HandTrackingPlugin)
+HAND_TRACKING_PROVIDERS = tuple(provider.value for provider in HandTrackingProvider)
 SHARPA_HAND_RETARGETERS = (HandRetargeter.PINK_IK, HandRetargeter.DEXPILOT)
 TRACKED_HAND_RETARGETERS = (*SHARPA_HAND_RETARGETERS, HandRetargeter.WUJI)
 TELEOP_MODES = tuple(mode.value for mode in TeleopMode)

--- a/examples/teleop_ros2/python/geometry.py
+++ b/examples/teleop_ros2/python/geometry.py
@@ -22,7 +22,6 @@ def apply_manus_controller_to_hand_pose(pose: Pose, side: str) -> Pose:
     if side not in ("left", "right"):
         raise ValueError(f"side must be 'left' or 'right', got {side!r}")
 
-    # All MANUS calibration data is intentionally kept in this one function.
     hand_left_pico_rotation = np.array(
         [
             [-0.91777945, -0.18672461, -0.35044942],
@@ -54,14 +53,12 @@ def apply_manus_controller_to_hand_pose(pose: Pose, side: str) -> Pose:
             pose.orientation.w,
         ]
     )
-
     controller_to_hand_rot = Rotation.from_matrix(controller_to_hand_rot_mat)
 
     world_hand_pos = world_controller_pos + world_controller_rot.apply(
         controller_to_hand_trans
     )
     world_hand_rot = world_controller_rot * controller_to_hand_rot
-
     return to_pose(world_hand_pos, world_hand_rot.as_quat())
 
 

--- a/examples/teleop_ros2/python/geometry.py
+++ b/examples/teleop_ros2/python/geometry.py
@@ -22,6 +22,7 @@ def apply_manus_controller_to_hand_pose(pose: Pose, side: str) -> Pose:
     if side not in ("left", "right"):
         raise ValueError(f"side must be 'left' or 'right', got {side!r}")
 
+    # All MANUS calibration data is intentionally kept in this one function.
     hand_left_pico_rotation = np.array(
         [
             [-0.91777945, -0.18672461, -0.35044942],
@@ -53,12 +54,14 @@ def apply_manus_controller_to_hand_pose(pose: Pose, side: str) -> Pose:
             pose.orientation.w,
         ]
     )
+
     controller_to_hand_rot = Rotation.from_matrix(controller_to_hand_rot_mat)
 
     world_hand_pos = world_controller_pos + world_controller_rot.apply(
         controller_to_hand_trans
     )
     world_hand_rot = world_controller_rot * controller_to_hand_rot
+
     return to_pose(world_hand_pos, world_hand_rot.as_quat())
 
 

--- a/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
+++ b/examples/teleop_ros2/python/integration_tests/teleop_ros2_topic_verifier.py
@@ -18,6 +18,7 @@ import msgpack
 import rclpy
 from constants import (
     HAND_RETARGETERS,
+    HAND_TRACKING_PROVIDERS,
     LEFT_SHARPA_WAVE_JOINT_NAMES,
     LEFT_WUJI_HAND_JOINT_NAMES,
     RIGHT_SHARPA_WAVE_JOINT_NAMES,
@@ -134,11 +135,39 @@ def _assert_noncollinear_positions(
     raise ValueError(f"{label} positions are collinear")
 
 
-def _assert_ee_poses_array(msg: NamedPoseArray) -> None:
+def _assert_ee_poses_array(
+    msg: NamedPoseArray,
+    *,
+    mode: str,
+    hand_tracking_provider: str,
+) -> None:
     _assert_named_pose_array(msg, ["left", "right"])
     if not all(bool(is_valid) for is_valid in msg.is_valid):
         raise ValueError("EE pose array contains an invalid entry")
     _assert_nonzero_pose_positions(msg, "EE pose")
+
+    if mode != "controller_teleop" or hand_tracking_provider == "wuji":
+        expected_xy = ((-0.25, 1.10), (0.25, 1.10))
+    elif hand_tracking_provider == "manus":
+        expected_xy = (
+            (-0.1896684528, 1.255536544),
+            (0.2103315472, 1.144463456),
+        )
+    else:
+        expected_xy = ((-0.20, 1.20), (0.20, 1.20))
+    for side, pose, (expected_x, expected_y) in zip(
+        ("left", "right"), msg.pose, expected_xy, strict=True
+    ):
+        if not math.isclose(pose.position.x, expected_x, abs_tol=1e-5):
+            raise ValueError(
+                f"{side} EE pose x={pose.position.x} does not match "
+                f"the {hand_tracking_provider} provider fixture value {expected_x}"
+            )
+        if not math.isclose(pose.position.y, expected_y, abs_tol=1e-5):
+            raise ValueError(
+                f"{side} EE pose y={pose.position.y} does not match "
+                f"the {hand_tracking_provider} provider fixture value {expected_y}"
+            )
 
 
 def _assert_hand_pose_array(msg: NamedPoseArray) -> None:
@@ -314,14 +343,19 @@ def _finger_joint_validator(hand_retargeter: str) -> Callable:
 class TopicVerifier(Node):
     """Small ROS 2 node that waits for mode-specific verified messages."""
 
-    def __init__(self, mode: str, hand_retargeter: str) -> None:
+    def __init__(
+        self,
+        mode: str,
+        hand_retargeter: str,
+        hand_tracking_provider: str,
+    ) -> None:
         super().__init__("teleop_ros2_topic_verifier")
         self._pending: set[str] = set()
         self._errors: dict[str, str] = {}
         self._seen_tf_frames: set[str] = set()
 
         for name, topic, msg_type, validator in self._expected_subscriptions(
-            mode, hand_retargeter
+            mode, hand_retargeter, hand_tracking_provider
         ):
             self._pending.add(name)
             self.create_subscription(
@@ -368,15 +402,23 @@ class TopicVerifier(Node):
         self._pending.discard("tf")
 
     def _expected_subscriptions(
-        self, mode: str, hand_retargeter: str
+        self,
+        mode: str,
+        hand_retargeter: str,
+        hand_tracking_provider: str,
     ) -> list[tuple[str, str, type, Callable]]:
+        ee_validator = partial(
+            _assert_ee_poses_array,
+            mode=mode,
+            hand_tracking_provider=hand_tracking_provider,
+        )
         if mode == "controller_teleop":
             subscriptions = [
                 (
                     "ee_poses",
                     "xr_teleop/ee_poses",
                     NamedPoseArray,
-                    _assert_ee_poses_array,
+                    ee_validator,
                 ),
                 ("root_twist", "xr_teleop/root_twist", TwistStamped, _assert_twist),
                 ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_pose_stamped),
@@ -417,7 +459,7 @@ class TopicVerifier(Node):
                     "ee_poses",
                     "xr_teleop/ee_poses",
                     NamedPoseArray,
-                    _assert_ee_poses_array,
+                    ee_validator,
                 ),
                 ("root_twist", "xr_teleop/root_twist", TwistStamped, _assert_twist),
                 ("root_pose", "xr_teleop/root_pose", PoseStamped, _assert_pose_stamped),
@@ -464,6 +506,11 @@ def _parse_args() -> argparse.Namespace:
         choices=HAND_RETARGETERS,
         default="mode_default",
     )
+    parser.add_argument(
+        "--hand-tracking-provider",
+        choices=HAND_TRACKING_PROVIDERS,
+        default="native",
+    )
     parser.add_argument("--timeout", type=float, default=20.0)
     return parser.parse_args()
 
@@ -471,7 +518,11 @@ def _parse_args() -> argparse.Namespace:
 def main() -> int:
     args = _parse_args()
     rclpy.init()
-    verifier = TopicVerifier(args.mode, args.hand_retargeter)
+    verifier = TopicVerifier(
+        args.mode,
+        args.hand_retargeter,
+        args.hand_tracking_provider,
+    )
     try:
         deadline = time.monotonic() + args.timeout
         while verifier.pending and time.monotonic() < deadline:
@@ -488,7 +539,8 @@ def main() -> int:
 
         print(
             "Verified teleop_ros2 topics for "
-            f"mode {args.mode} and hand retargeter {args.hand_retargeter}"
+            f"mode {args.mode}, hand retargeter {args.hand_retargeter}, "
+            f"and hand-tracking provider {args.hand_tracking_provider}"
         )
         return 0
     finally:

--- a/examples/teleop_ros2/python/messages.py
+++ b/examples/teleop_ros2/python/messages.py
@@ -67,7 +67,7 @@ def _compute_ee_pose_from_controller(
     side: str,
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
-    apply_manus_controller_to_hand_transform: bool = False,
+    apply_manus_controller_mount_offset: bool = False,
 ) -> Pose | None:
     if not controller_aim_is_valid(ctrl):
         return None
@@ -79,7 +79,7 @@ def _compute_ee_pose_from_controller(
     if transform_rot is not None or transform_trans is not None:
         pose = apply_transform_to_pose(pose, transform_rot, transform_trans)
 
-    if apply_manus_controller_to_hand_transform:
+    if apply_manus_controller_mount_offset:
         pose = apply_manus_controller_to_hand_pose(pose, side)
 
     return pose
@@ -244,7 +244,7 @@ def build_ee_output_from_controllers(
     right_wrist_frame: str,
     transform_rot: Rotation | None = None,
     transform_trans: Sequence[float] | None = None,
-    apply_manus_controller_to_hand_transform: bool = False,
+    apply_manus_controller_mount_offset: bool = False,
 ) -> tuple[NamedPoseArray, list[TransformStamped]]:
     """Build the controller-derived EE message and its valid wrist TFs."""
     left_pose = _compute_ee_pose_from_controller(
@@ -252,14 +252,14 @@ def build_ee_output_from_controllers(
         "left",
         transform_rot,
         transform_trans,
-        apply_manus_controller_to_hand_transform,
+        apply_manus_controller_mount_offset,
     )
     right_pose = _compute_ee_pose_from_controller(
         right_ctrl,
         "right",
         transform_rot,
         transform_trans,
-        apply_manus_controller_to_hand_transform,
+        apply_manus_controller_mount_offset,
     )
     ee_msg = _compose_ee_msg(left_pose, right_pose, now, frame_id)
     return ee_msg, _wrist_tfs_from_ee_msg(

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -21,12 +21,12 @@ from pathlib import Path
 import numpy as np
 from constants import (
     HAND_RETARGETERS,
-    HAND_TRACKING_PLUGINS,
+    HAND_TRACKING_PROVIDERS,
     TELEOP_MODES,
     TRACKED_HAND_RETARGETERS,
     WUJI_HAND_MODELS,
     HandRetargeter,
-    HandTrackingPlugin,
+    HandTrackingProvider,
     TeleopMode,
     resolve_hand_retargeter,
 )
@@ -66,7 +66,8 @@ class NodeParameters:
     sleep_period_s: float
     hand_retargeter: HandRetargeter
     resolved_hand_retargeter: HandRetargeter
-    hand_tracking_plugin: HandTrackingPlugin
+    hand_tracking_provider: HandTrackingProvider
+    start_hand_tracking_plugin: bool
     plugin_search_paths: tuple[Path, ...]
     wuji_hand_model: str
     config_asset_root: Path
@@ -344,73 +345,94 @@ def _load_hand_retargeter(
     return hand_retargeter, resolved_hand_retargeter
 
 
-def _load_hand_tracking_plugin(
+def _load_hand_tracking_provider(
     node: Node,
     mode: TeleopMode,
     resolved_hand_retargeter: HandRetargeter,
     session_mode: SessionMode,
-) -> tuple[HandTrackingPlugin, tuple[Path, ...]]:
+) -> tuple[HandTrackingProvider, bool, tuple[Path, ...]]:
     node.declare_parameter(
-        "hand_tracking_plugin",
-        HandTrackingPlugin.NONE.value,
+        "hand_tracking_provider",
+        HandTrackingProvider.NATIVE.value,
         ParameterDescriptor(
             description=(
-                "Optional hand-tracking input plugin managed by this node. "
-                "Use 'none' for native OpenXR or a manually launched plugin. "
-                "Valid managed plugins: 'manus' or 'wuji'."
+                "Hand-tracking data provider. Use 'native' for native OpenXR "
+                "hand tracking, or 'manus'/'wuji' for glove-provided OpenXR hands."
             ),
-            additional_constraints=f"Must be one of {HAND_TRACKING_PLUGINS}.",
+            additional_constraints=f"Must be one of {HAND_TRACKING_PROVIDERS}.",
         ),
     )
-    raw_plugin = (
-        node.get_parameter("hand_tracking_plugin")
+    node.declare_parameter(
+        "start_hand_tracking_plugin",
+        False,
+        ParameterDescriptor(
+            description=(
+                "Start the selected MANUS or Wuji provider plugin with the session. "
+                "Leave false when the provider is native or externally managed."
+            )
+        ),
+    )
+
+    raw_provider = (
+        node.get_parameter("hand_tracking_provider")
         .get_parameter_value()
         .string_value.strip()
     )
     try:
-        plugin = HandTrackingPlugin(raw_plugin)
+        provider = HandTrackingProvider(raw_provider)
     except ValueError as exc:
         raise ValueError(
-            f"Parameter 'hand_tracking_plugin' must be one of "
-            f"{HAND_TRACKING_PLUGINS}, got {raw_plugin!r}"
+            f"Parameter 'hand_tracking_provider' must be one of "
+            f"{HAND_TRACKING_PROVIDERS}, got {raw_provider!r}"
         ) from exc
 
-    search_paths = tuple(
-        dict.fromkeys(
-            Path(value).expanduser().resolve()
-            for value in os.environ.get("ISAAC_TELEOP_PLUGIN_PATH", "").split(
-                os.pathsep
-            )
-            if value.strip()
-        )
+    start_plugin = (
+        node.get_parameter("start_hand_tracking_plugin")
+        .get_parameter_value()
+        .bool_value
     )
-    if plugin == HandTrackingPlugin.NONE:
-        return plugin, search_paths
-
-    if session_mode == SessionMode.REPLAY:
-        node.get_logger().info(
-            f"Ignoring hand_tracking_plugin:={plugin} during MCAP replay."
-        )
-        return HandTrackingPlugin.NONE, search_paths
 
     consumes_tracked_hands = mode == TeleopMode.HAND_TELEOP or (
         mode == TeleopMode.CONTROLLER_TELEOP
         and resolved_hand_retargeter in TRACKED_HAND_RETARGETERS
     )
-    if not consumes_tracked_hands:
+    if provider != HandTrackingProvider.NATIVE and not consumes_tracked_hands:
         raise ValueError(
-            f"hand_tracking_plugin:={plugin} requires a tracked-hand mode; "
+            f"hand_tracking_provider:={provider} requires a tracked-hand mode; "
             f"mode:={mode} with hand_retargeter:={resolved_hand_retargeter} "
             "does not consume OpenXR hand tracking"
         )
 
-    if not any(path.is_dir() for path in search_paths):
-        raise FileNotFoundError(
-            "No existing plugin search directory was found in ISAAC_TELEOP_PLUGIN_PATH"
+    if start_plugin and provider == HandTrackingProvider.NATIVE:
+        raise ValueError(
+            "Parameter 'start_hand_tracking_plugin' requires "
+            "hand_tracking_provider:=manus or hand_tracking_provider:=wuji"
+        )
+    if start_plugin and session_mode == SessionMode.REPLAY:
+        raise ValueError(
+            "Parameter 'start_hand_tracking_plugin' must be false during MCAP replay"
         )
 
-    node.get_logger().info(f"Managed hand-tracking plugin: {plugin}")
-    return plugin, search_paths
+    search_paths: tuple[Path, ...] = ()
+    if start_plugin:
+        search_paths = tuple(
+            dict.fromkeys(
+                Path(value).expanduser().resolve()
+                for value in os.environ.get("ISAAC_TELEOP_PLUGIN_PATH", "").split(
+                    os.pathsep
+                )
+                if value.strip()
+            )
+        )
+        if not any(path.is_dir() for path in search_paths):
+            raise FileNotFoundError(
+                "No existing plugin search directory was found in "
+                "ISAAC_TELEOP_PLUGIN_PATH"
+            )
+        node.get_logger().info(f"Managed hand-tracking plugin provider: {provider}")
+    elif provider != HandTrackingProvider.NATIVE:
+        node.get_logger().info(f"External hand-tracking provider: {provider}")
+    return provider, start_plugin, search_paths
 
 
 def _load_mcap_replay(
@@ -583,7 +605,11 @@ def create_node_parameters(node: Node) -> NodeParameters:
     wuji_hand_model = _load_wuji_hand_model(node)
     config_asset_root = _load_config_asset_root(node)
     session_mode, mcap_config = _load_mcap_replay(node)
-    hand_tracking_plugin, plugin_search_paths = _load_hand_tracking_plugin(
+    (
+        hand_tracking_provider,
+        start_hand_tracking_plugin,
+        plugin_search_paths,
+    ) = _load_hand_tracking_provider(
         node,
         mode,
         resolved_hand_retargeter,
@@ -602,7 +628,8 @@ def create_node_parameters(node: Node) -> NodeParameters:
         sleep_period_s=1.0 / rate_hz,
         hand_retargeter=hand_retargeter,
         resolved_hand_retargeter=resolved_hand_retargeter,
-        hand_tracking_plugin=hand_tracking_plugin,
+        hand_tracking_provider=hand_tracking_provider,
+        start_hand_tracking_plugin=start_hand_tracking_plugin,
         plugin_search_paths=plugin_search_paths,
         wuji_hand_model=wuji_hand_model,
         config_asset_root=config_asset_root,

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -406,17 +406,6 @@ def _load_hand_tracking_provider(
             "does not consume OpenXR hand tracking"
         )
 
-    if use_external_plugin and provider == HandTrackingProvider.NATIVE:
-        raise ValueError(
-            "Parameter 'use_external_hand_tracking_plugin' requires "
-            "hand_tracking_provider:=manus or hand_tracking_provider:=wuji"
-        )
-    if use_external_plugin and session_mode == SessionMode.REPLAY:
-        raise ValueError(
-            "Parameter 'use_external_hand_tracking_plugin' must be false "
-            "during MCAP replay"
-        )
-
     start_plugin = (
         provider != HandTrackingProvider.NATIVE
         and session_mode == SessionMode.LIVE
@@ -439,7 +428,7 @@ def _load_hand_tracking_provider(
                 "ISAAC_TELEOP_PLUGIN_PATH"
             )
         node.get_logger().info(f"Managed hand-tracking plugin provider: {provider}")
-    elif use_external_plugin:
+    elif use_external_plugin and provider != HandTrackingProvider.NATIVE:
         node.get_logger().info(f"External hand-tracking provider: {provider}")
     return provider, use_external_plugin, search_paths
 

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -67,7 +67,7 @@ class NodeParameters:
     hand_retargeter: HandRetargeter
     resolved_hand_retargeter: HandRetargeter
     hand_tracking_provider: HandTrackingProvider
-    start_hand_tracking_plugin: bool
+    use_external_hand_tracking_plugin: bool
     plugin_search_paths: tuple[Path, ...]
     wuji_hand_model: str
     config_asset_root: Path
@@ -363,12 +363,13 @@ def _load_hand_tracking_provider(
         ),
     )
     node.declare_parameter(
-        "start_hand_tracking_plugin",
+        "use_external_hand_tracking_plugin",
         False,
         ParameterDescriptor(
             description=(
-                "Start the selected MANUS or Wuji provider plugin with the session. "
-                "Leave false when the provider is native or externally managed."
+                "Use a MANUS or Wuji provider plugin started outside this node. "
+                "Leave false to start the selected provider plugin automatically "
+                "with a live session."
             )
         ),
     )
@@ -386,8 +387,8 @@ def _load_hand_tracking_provider(
             f"{HAND_TRACKING_PROVIDERS}, got {raw_provider!r}"
         ) from exc
 
-    start_plugin = (
-        node.get_parameter("start_hand_tracking_plugin")
+    use_external_plugin = (
+        node.get_parameter("use_external_hand_tracking_plugin")
         .get_parameter_value()
         .bool_value
     )
@@ -403,16 +404,22 @@ def _load_hand_tracking_provider(
             "does not consume OpenXR hand tracking"
         )
 
-    if start_plugin and provider == HandTrackingProvider.NATIVE:
+    if use_external_plugin and provider == HandTrackingProvider.NATIVE:
         raise ValueError(
-            "Parameter 'start_hand_tracking_plugin' requires "
+            "Parameter 'use_external_hand_tracking_plugin' requires "
             "hand_tracking_provider:=manus or hand_tracking_provider:=wuji"
         )
-    if start_plugin and session_mode == SessionMode.REPLAY:
+    if use_external_plugin and session_mode == SessionMode.REPLAY:
         raise ValueError(
-            "Parameter 'start_hand_tracking_plugin' must be false during MCAP replay"
+            "Parameter 'use_external_hand_tracking_plugin' must be false "
+            "during MCAP replay"
         )
 
+    start_plugin = (
+        provider != HandTrackingProvider.NATIVE
+        and session_mode == SessionMode.LIVE
+        and not use_external_plugin
+    )
     search_paths: tuple[Path, ...] = ()
     if start_plugin:
         search_paths = tuple(
@@ -430,9 +437,9 @@ def _load_hand_tracking_provider(
                 "ISAAC_TELEOP_PLUGIN_PATH"
             )
         node.get_logger().info(f"Managed hand-tracking plugin provider: {provider}")
-    elif provider != HandTrackingProvider.NATIVE:
+    elif use_external_plugin:
         node.get_logger().info(f"External hand-tracking provider: {provider}")
-    return provider, start_plugin, search_paths
+    return provider, use_external_plugin, search_paths
 
 
 def _load_mcap_replay(
@@ -607,7 +614,7 @@ def create_node_parameters(node: Node) -> NodeParameters:
     session_mode, mcap_config = _load_mcap_replay(node)
     (
         hand_tracking_provider,
-        start_hand_tracking_plugin,
+        use_external_hand_tracking_plugin,
         plugin_search_paths,
     ) = _load_hand_tracking_provider(
         node,
@@ -629,7 +636,7 @@ def create_node_parameters(node: Node) -> NodeParameters:
         hand_retargeter=hand_retargeter,
         resolved_hand_retargeter=resolved_hand_retargeter,
         hand_tracking_provider=hand_tracking_provider,
-        start_hand_tracking_plugin=start_hand_tracking_plugin,
+        use_external_hand_tracking_plugin=use_external_hand_tracking_plugin,
         plugin_search_paths=plugin_search_paths,
         wuji_hand_model=wuji_hand_model,
         config_asset_root=config_asset_root,

--- a/examples/teleop_ros2/python/node_parameters.py
+++ b/examples/teleop_ros2/python/node_parameters.py
@@ -356,8 +356,10 @@ def _load_hand_tracking_provider(
         HandTrackingProvider.NATIVE.value,
         ParameterDescriptor(
             description=(
-                "Hand-tracking data provider. Use 'native' for native OpenXR "
-                "hand tracking, or 'manus'/'wuji' for glove-provided OpenXR hands."
+                "Hand-tracking data provider. 'native' uses runtime-provided "
+                "OpenXR hands, starts no plugin, and has no effect when tracked "
+                "hands are not consumed. 'manus'/'wuji' use glove-provided "
+                "OpenXR hands."
             ),
             additional_constraints=f"Must be one of {HAND_TRACKING_PROVIDERS}.",
         ),

--- a/examples/teleop_ros2/python/session_config.py
+++ b/examples/teleop_ros2/python/session_config.py
@@ -23,7 +23,7 @@ from constants import (
     TRACKED_HAND_RETARGETERS,
     WUJI_HAND_JOINT_COUNT,
     HandRetargeter,
-    HandTrackingPlugin,
+    HandTrackingProvider,
     TeleopMode,
 )
 from isaacteleop.retargeters import (
@@ -46,7 +46,6 @@ from isaacteleop.retargeting_engine.deviceio_source_nodes import (
 from isaacteleop.retargeting_engine.interface import OutputCombiner
 from isaacteleop.teleop_session_manager import (
     PluginConfig,
-    SessionMode,
     TeleopSessionConfig,
 )
 from node_parameters import NodeParameters
@@ -111,13 +110,10 @@ def _maybe_gate_hand_joints_on_tracking(
 def _resolve_hand_tracking_plugin_configs(
     params: NodeParameters,
 ) -> list[PluginConfig]:
-    if (
-        params.hand_tracking_plugin == HandTrackingPlugin.NONE
-        or params.session_mode == SessionMode.REPLAY
-    ):
+    if not params.start_hand_tracking_plugin:
         return []
 
-    if params.hand_tracking_plugin == HandTrackingPlugin.MANUS:
+    if params.hand_tracking_provider == HandTrackingProvider.MANUS:
         return [
             PluginConfig(
                 plugin_name="manus_hand_plugin",
@@ -127,7 +123,7 @@ def _resolve_hand_tracking_plugin_configs(
                 required=True,
             )
         ]
-    if params.hand_tracking_plugin == HandTrackingPlugin.WUJI:
+    if params.hand_tracking_provider == HandTrackingProvider.WUJI:
         return [
             PluginConfig(
                 plugin_name="wuji_glove_plugin",
@@ -137,7 +133,8 @@ def _resolve_hand_tracking_plugin_configs(
             )
         ]
     raise ValueError(
-        f"Unsupported hand-tracking plugin {params.hand_tracking_plugin!r}"
+        f"Cannot start a plugin for hand-tracking provider "
+        f"{params.hand_tracking_provider!r}"
     )
 
 

--- a/examples/teleop_ros2/python/session_config.py
+++ b/examples/teleop_ros2/python/session_config.py
@@ -46,6 +46,7 @@ from isaacteleop.retargeting_engine.deviceio_source_nodes import (
 from isaacteleop.retargeting_engine.interface import OutputCombiner
 from isaacteleop.teleop_session_manager import (
     PluginConfig,
+    SessionMode,
     TeleopSessionConfig,
 )
 from node_parameters import NodeParameters
@@ -110,7 +111,11 @@ def _maybe_gate_hand_joints_on_tracking(
 def _resolve_hand_tracking_plugin_configs(
     params: NodeParameters,
 ) -> list[PluginConfig]:
-    if not params.start_hand_tracking_plugin:
+    if (
+        params.session_mode == SessionMode.REPLAY
+        or params.hand_tracking_provider == HandTrackingProvider.NATIVE
+        or params.use_external_hand_tracking_plugin
+    ):
         return []
 
     if params.hand_tracking_provider == HandTrackingProvider.MANUS:

--- a/examples/teleop_ros2/python/teleop_profiles.py
+++ b/examples/teleop_ros2/python/teleop_profiles.py
@@ -5,13 +5,13 @@
 """Resolved runtime profiles for teleoperation session results and publishing."""
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TypedDict, cast
 
 from constants import (
-    SHARPA_HAND_RETARGETERS,
+    TRACKED_HAND_RETARGETERS,
     HandRetargeter,
-    HandTrackingPlugin,
+    HandTrackingProvider,
     StrEnum,
     TeleopMode,
 )
@@ -34,6 +34,7 @@ class TeleopProfile(StrEnum):
     CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE = (
         "controller_teleop_with_hand_controller_ee"
     )
+    CONTROLLER_TELEOP_WITH_HAND_MANUS_EE = "controller_teleop_with_hand_manus_ee"
     CONTROLLER_TELEOP_WITH_HAND_WRIST_EE = "controller_teleop_with_hand_wrist_ee"
     HAND_TELEOP = "hand_teleop"
     CONTROLLER_RAW = "controller_raw"
@@ -62,6 +63,33 @@ class TeleopProfileSpec:
     apply_manus_controller_to_hand_transform: bool = False
 
 
+_CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE_SPEC = TeleopProfileSpec(
+    mode=TeleopMode.CONTROLLER_TELEOP,
+    required_result_keys=frozenset(
+        {
+            "controller_left",
+            "controller_right",
+            "finger_joints_left",
+            "finger_joints_right",
+            "hand_left",
+            "hand_right",
+            "head",
+            "root_command",
+        }
+    ),
+    publish_types=frozenset(
+        {
+            PublishType.CONTROLLER_PAYLOAD,
+            PublishType.EE_FROM_CONTROLLERS,
+            PublishType.FINGER_JOINTS,
+            PublishType.HAND_POSES,
+            PublishType.HEAD,
+            PublishType.ROOT_COMMAND,
+        }
+    ),
+)
+
+
 TELEOP_PROFILE_SPECS = {
     TeleopProfile.CONTROLLER_TELEOP: TeleopProfileSpec(
         mode=TeleopMode.CONTROLLER_TELEOP,
@@ -85,30 +113,11 @@ TELEOP_PROFILE_SPECS = {
             }
         ),
     ),
-    TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE: TeleopProfileSpec(
-        mode=TeleopMode.CONTROLLER_TELEOP,
-        required_result_keys=frozenset(
-            {
-                "controller_left",
-                "controller_right",
-                "finger_joints_left",
-                "finger_joints_right",
-                "hand_left",
-                "hand_right",
-                "head",
-                "root_command",
-            }
-        ),
-        publish_types=frozenset(
-            {
-                PublishType.CONTROLLER_PAYLOAD,
-                PublishType.EE_FROM_CONTROLLERS,
-                PublishType.FINGER_JOINTS,
-                PublishType.HAND_POSES,
-                PublishType.HEAD,
-                PublishType.ROOT_COMMAND,
-            }
-        ),
+    TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE: (
+        _CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE_SPEC
+    ),
+    TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_MANUS_EE: replace(
+        _CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE_SPEC,
         apply_manus_controller_to_hand_transform=True,
     ),
     TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE: TeleopProfileSpec(
@@ -181,22 +190,19 @@ TELEOP_PROFILE_SPECS = {
 def resolve_teleop_profile_spec(
     mode: TeleopMode,
     resolved_hand_retargeter: HandRetargeter,
-    hand_tracking_plugin: HandTrackingPlugin = HandTrackingPlugin.NONE,
+    hand_tracking_provider: HandTrackingProvider = HandTrackingProvider.NATIVE,
 ) -> TeleopProfileSpec:
     """Resolve user-facing settings to one complete immutable runtime profile."""
-    if mode == TeleopMode.CONTROLLER_TELEOP and (
-        resolved_hand_retargeter == HandRetargeter.WUJI
-        or (
-            resolved_hand_retargeter in SHARPA_HAND_RETARGETERS
-            and hand_tracking_plugin == HandTrackingPlugin.WUJI
-        )
-    ):
-        profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE
-    elif (
+    if (
         mode == TeleopMode.CONTROLLER_TELEOP
-        and resolved_hand_retargeter in SHARPA_HAND_RETARGETERS
+        and resolved_hand_retargeter in TRACKED_HAND_RETARGETERS
     ):
-        profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE
+        if hand_tracking_provider == HandTrackingProvider.MANUS:
+            profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_MANUS_EE
+        elif hand_tracking_provider == HandTrackingProvider.WUJI:
+            profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE
+        else:
+            profile = TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE
     else:
         profile = TeleopProfile(mode.value)
     return TELEOP_PROFILE_SPECS[profile]

--- a/examples/teleop_ros2/python/teleop_profiles.py
+++ b/examples/teleop_ros2/python/teleop_profiles.py
@@ -60,7 +60,7 @@ class TeleopProfileSpec:
     mode: TeleopMode
     required_result_keys: frozenset[str]
     publish_types: frozenset[PublishType]
-    apply_manus_controller_to_hand_transform: bool = False
+    apply_manus_controller_mount_offset: bool = False
 
 
 _CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE_SPEC = TeleopProfileSpec(
@@ -118,7 +118,7 @@ TELEOP_PROFILE_SPECS = {
     ),
     TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_MANUS_EE: replace(
         _CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE_SPEC,
-        apply_manus_controller_to_hand_transform=True,
+        apply_manus_controller_mount_offset=True,
     ),
     TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE: TeleopProfileSpec(
         mode=TeleopMode.CONTROLLER_TELEOP,

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -10,7 +10,9 @@ Publishes teleoperation data over ROS2 topics using isaacteleop TeleopSession.
 The `mode` parameter selects the teleoperation scenario and which topics are
 published:
 
-  - controller_teleop (default): ee_poses (from controller aim poses),
+  - controller_teleop (default): ee_poses (from controller aim poses for native
+                       or MANUS input, with MANUS calibration when selected; from
+                       provider wrist poses for Wuji input),
                        root_twist, root_pose, finger_joints
                        (retargeted TriHand angles), controller_data, head_pose,
                        and TF transforms for left/right wrists and head
@@ -87,7 +89,7 @@ class TeleopRos2Node(Node):
         self._profile_spec = resolve_teleop_profile_spec(
             self._params.mode,
             self._params.resolved_hand_retargeter,
-            self._params.hand_tracking_plugin,
+            self._params.hand_tracking_provider,
         )
         if self._profile_spec.apply_manus_controller_to_hand_transform:
             self.get_logger().info(

--- a/examples/teleop_ros2/python/teleop_ros2_node.py
+++ b/examples/teleop_ros2/python/teleop_ros2_node.py
@@ -91,9 +91,9 @@ class TeleopRos2Node(Node):
             self._params.resolved_hand_retargeter,
             self._params.hand_tracking_provider,
         )
-        if self._profile_spec.apply_manus_controller_to_hand_transform:
+        if self._profile_spec.apply_manus_controller_mount_offset:
             self.get_logger().info(
-                "Applying MANUS controller-to-hand transform after pose transform."
+                "Applying MANUS controller mount offset after pose transform."
             )
         self._tf_broadcaster = TransformBroadcaster(self)
         self._create_publishers()
@@ -131,7 +131,7 @@ class TeleopRos2Node(Node):
             self._params.right_wrist_frame,
             self._params.transform_rotation,
             self._params.transform_translation,
-            self._profile_spec.apply_manus_controller_to_hand_transform,
+            self._profile_spec.apply_manus_controller_mount_offset,
         )
         self._pub_ee_poses.publish(ee_poses_msg)
         if wrist_tfs:

--- a/tests/python/examples/teleop_ros2/test_geometry.py
+++ b/tests/python/examples/teleop_ros2/test_geometry.py
@@ -64,19 +64,47 @@ def test_apply_transform_returns_a_new_pose_without_mutating_input() -> None:
     np.testing.assert_allclose(_position(transformed), [5.0, 7.0, 9.0])
 
 
-def test_manus_calibration_is_side_specific_and_finite() -> None:
-    controller_pose = to_pose([0.1, 0.2, 0.3], [0.0, 0.0, 0.0, 1.0])
+@pytest.mark.parametrize(
+    ("side", "expected_position", "expected_orientation"),
+    (
+        (
+            "left",
+            [0.0103315472, 0.055536544, -0.0566476072],
+            [
+                -0.1315856570103413,
+                -0.3586609382547703,
+                0.9111816820492541,
+                -0.15425786377769118,
+            ],
+        ),
+        (
+            "right",
+            [0.0103315472, -0.055536544, -0.0566476072],
+            [
+                -0.1315856570103413,
+                0.3586609382547703,
+                0.9111816820492541,
+                0.15425786377769118,
+            ],
+        ),
+    ),
+)
+def test_manus_controller_calibration_matches_known_good_transform(
+    side: str,
+    expected_position: list[float],
+    expected_orientation: list[float],
+) -> None:
+    controller_pose = to_pose([0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0])
 
-    left_hand = apply_manus_controller_to_hand_pose(controller_pose, "left")
-    right_hand = apply_manus_controller_to_hand_pose(controller_pose, "right")
+    calibrated_pose = apply_manus_controller_to_hand_pose(controller_pose, side)
 
-    assert np.isfinite(_position(left_hand)).all()
-    assert np.isfinite(_orientation(left_hand)).all()
-    assert np.isfinite(_position(right_hand)).all()
-    assert np.isfinite(_orientation(right_hand)).all()
-    assert not np.allclose(_orientation(left_hand), _orientation(right_hand))
+    np.testing.assert_allclose(_position(calibrated_pose), expected_position)
+    np.testing.assert_allclose(_orientation(calibrated_pose), expected_orientation)
 
 
-def test_manus_calibration_rejects_unknown_side() -> None:
+def test_manus_controller_calibration_rejects_unknown_side() -> None:
     with pytest.raises(ValueError, match="side must be 'left' or 'right'"):
-        apply_manus_controller_to_hand_pose(to_pose([0.0, 0.0, 0.0]), "center")
+        apply_manus_controller_to_hand_pose(
+            to_pose([0.0, 0.0, 0.0]),
+            "center",
+        )

--- a/tests/python/examples/teleop_ros2/test_messages.py
+++ b/tests/python/examples/teleop_ros2/test_messages.py
@@ -222,7 +222,7 @@ def test_build_ee_output_from_controllers_preserves_manus_calibration() -> None:
         "world",
         "left_wrist",
         "right_wrist",
-        apply_manus_controller_to_hand_transform=True,
+        apply_manus_controller_mount_offset=True,
     )
 
     expected_position = [4.0103315472, 5.055536544, 5.9433523928]

--- a/tests/python/examples/teleop_ros2/test_messages.py
+++ b/tests/python/examples/teleop_ros2/test_messages.py
@@ -214,6 +214,54 @@ def test_build_ee_output_from_controllers_keeps_message_and_tfs_consistent() -> 
     assert transform.transform.rotation.w == 1.0
 
 
+def test_build_ee_output_from_controllers_preserves_manus_calibration() -> None:
+    msg, transforms = build_ee_output_from_controllers(
+        _active_controller(),
+        OptionalTensorGroup(ControllerInput()),
+        Time(),
+        "world",
+        "left_wrist",
+        "right_wrist",
+        apply_manus_controller_to_hand_transform=True,
+    )
+
+    expected_position = [4.0103315472, 5.055536544, 5.9433523928]
+    expected_orientation = [
+        -0.1315856570103413,
+        -0.3586609382547703,
+        0.9111816820492541,
+        -0.15425786377769118,
+    ]
+    actual_pose = msg.pose[0]
+    actual_transform = transforms[0].transform
+
+    np.testing.assert_allclose(
+        [
+            actual_pose.position.x,
+            actual_pose.position.y,
+            actual_pose.position.z,
+        ],
+        expected_position,
+    )
+    np.testing.assert_allclose(
+        [
+            actual_pose.orientation.x,
+            actual_pose.orientation.y,
+            actual_pose.orientation.z,
+            actual_pose.orientation.w,
+        ],
+        expected_orientation,
+    )
+    np.testing.assert_allclose(
+        [
+            actual_transform.translation.x,
+            actual_transform.translation.y,
+            actual_transform.translation.z,
+        ],
+        expected_position,
+    )
+
+
 def test_build_ee_output_from_hands_uses_valid_wrist_entries() -> None:
     msg, transforms = build_ee_output_from_hands(
         _active_hand(),

--- a/tests/python/examples/teleop_ros2/test_node_parameters.py
+++ b/tests/python/examples/teleop_ros2/test_node_parameters.py
@@ -70,37 +70,40 @@ def test_replay_preserves_provider_without_starting_plugin() -> None:
     assert not use_external_plugin
 
 
-def test_external_plugin_requires_non_native_provider() -> None:
+def test_external_plugin_setting_is_ignored_for_native() -> None:
     node = _Node(
         hand_tracking_provider="native",
         use_external_hand_tracking_plugin=True,
     )
 
-    with pytest.raises(
-        ValueError,
-        match="requires hand_tracking_provider:=manus or hand_tracking_provider:=wuji",
-    ):
-        _load_hand_tracking_provider(
-            node,
-            TeleopMode.CONTROLLER_TELEOP,
-            HandRetargeter.DEXPILOT,
-            SessionMode.LIVE,
-        )
+    provider, use_external_plugin, search_paths = _load_hand_tracking_provider(
+        node,
+        TeleopMode.CONTROLLER_TELEOP,
+        HandRetargeter.DEXPILOT,
+        SessionMode.LIVE,
+    )
+
+    assert provider == HandTrackingProvider.NATIVE
+    assert use_external_plugin
+    assert search_paths == ()
 
 
-def test_replay_rejects_external_plugin() -> None:
+def test_external_plugin_setting_is_ignored_for_replay() -> None:
     node = _Node(
         hand_tracking_provider="wuji",
         use_external_hand_tracking_plugin=True,
     )
 
-    with pytest.raises(ValueError, match="must be false.*during MCAP replay"):
-        _load_hand_tracking_provider(
-            node,
-            TeleopMode.CONTROLLER_TELEOP,
-            HandRetargeter.WUJI,
-            SessionMode.REPLAY,
-        )
+    provider, use_external_plugin, search_paths = _load_hand_tracking_provider(
+        node,
+        TeleopMode.CONTROLLER_TELEOP,
+        HandRetargeter.WUJI,
+        SessionMode.REPLAY,
+    )
+
+    assert provider == HandTrackingProvider.WUJI
+    assert use_external_plugin
+    assert search_paths == ()
 
 
 def test_non_native_provider_requires_tracked_hand_mode() -> None:

--- a/tests/python/examples/teleop_ros2/test_node_parameters.py
+++ b/tests/python/examples/teleop_ros2/test_node_parameters.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for hand-tracking provider parameter validation."""
+
+from types import SimpleNamespace
+
+import pytest
+from constants import HandRetargeter, HandTrackingProvider, TeleopMode
+from isaacteleop.teleop_session_manager import SessionMode
+from node_parameters import _load_hand_tracking_provider
+
+
+class _Logger:
+    def info(self, _message: str) -> None:
+        pass
+
+
+class _Node:
+    def __init__(self, **overrides) -> None:
+        self._parameters = dict(overrides)
+        self._logger = _Logger()
+
+    def declare_parameter(self, name, default, _descriptor=None):
+        self._parameters.setdefault(name, default)
+
+    def get_parameter(self, name):
+        value = self._parameters[name]
+        parameter_value = SimpleNamespace(
+            string_value=value if isinstance(value, str) else "",
+            bool_value=value if isinstance(value, bool) else False,
+        )
+        return SimpleNamespace(get_parameter_value=lambda: parameter_value)
+
+    def get_logger(self):
+        return self._logger
+
+
+def test_external_provider_is_preserved_without_plugin_paths(monkeypatch) -> None:
+    monkeypatch.delenv("ISAAC_TELEOP_PLUGIN_PATH", raising=False)
+    node = _Node(
+        hand_tracking_provider="manus",
+        start_hand_tracking_plugin=False,
+    )
+
+    provider, start_plugin, search_paths = _load_hand_tracking_provider(
+        node,
+        TeleopMode.CONTROLLER_TELEOP,
+        HandRetargeter.DEXPILOT,
+        SessionMode.LIVE,
+    )
+
+    assert provider == HandTrackingProvider.MANUS
+    assert not start_plugin
+    assert search_paths == ()
+
+
+def test_replay_preserves_provider_when_plugin_startup_is_disabled() -> None:
+    node = _Node(
+        hand_tracking_provider="wuji",
+        start_hand_tracking_plugin=False,
+    )
+
+    provider, start_plugin, _search_paths = _load_hand_tracking_provider(
+        node,
+        TeleopMode.CONTROLLER_TELEOP,
+        HandRetargeter.WUJI,
+        SessionMode.REPLAY,
+    )
+
+    assert provider == HandTrackingProvider.WUJI
+    assert not start_plugin
+
+
+def test_managed_plugin_requires_non_native_provider() -> None:
+    node = _Node(
+        hand_tracking_provider="native",
+        start_hand_tracking_plugin=True,
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="requires hand_tracking_provider:=manus or hand_tracking_provider:=wuji",
+    ):
+        _load_hand_tracking_provider(
+            node,
+            TeleopMode.CONTROLLER_TELEOP,
+            HandRetargeter.DEXPILOT,
+            SessionMode.LIVE,
+        )
+
+
+def test_replay_rejects_managed_plugin_startup() -> None:
+    node = _Node(
+        hand_tracking_provider="wuji",
+        start_hand_tracking_plugin=True,
+    )
+
+    with pytest.raises(ValueError, match="must be false during MCAP replay"):
+        _load_hand_tracking_provider(
+            node,
+            TeleopMode.CONTROLLER_TELEOP,
+            HandRetargeter.WUJI,
+            SessionMode.REPLAY,
+        )
+
+
+def test_non_native_provider_requires_tracked_hand_mode() -> None:
+    node = _Node(
+        hand_tracking_provider="manus",
+        start_hand_tracking_plugin=False,
+    )
+
+    with pytest.raises(ValueError, match="requires a tracked-hand mode"):
+        _load_hand_tracking_provider(
+            node,
+            TeleopMode.CONTROLLER_TELEOP,
+            HandRetargeter.TRIHAND,
+            SessionMode.LIVE,
+        )
+
+
+def test_managed_provider_requires_and_returns_plugin_paths(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.setenv("ISAAC_TELEOP_PLUGIN_PATH", str(tmp_path))
+    node = _Node(
+        hand_tracking_provider="wuji",
+        start_hand_tracking_plugin=True,
+    )
+
+    provider, start_plugin, search_paths = _load_hand_tracking_provider(
+        node,
+        TeleopMode.HAND_TELEOP,
+        HandRetargeter.DEXPILOT,
+        SessionMode.LIVE,
+    )
+
+    assert provider == HandTrackingProvider.WUJI
+    assert start_plugin
+    assert search_paths == (tmp_path.resolve(),)
+
+
+def test_managed_provider_requires_plugin_path(monkeypatch) -> None:
+    monkeypatch.delenv("ISAAC_TELEOP_PLUGIN_PATH", raising=False)
+    node = _Node(
+        hand_tracking_provider="manus",
+        start_hand_tracking_plugin=True,
+    )
+
+    with pytest.raises(FileNotFoundError, match="ISAAC_TELEOP_PLUGIN_PATH"):
+        _load_hand_tracking_provider(
+            node,
+            TeleopMode.HAND_TELEOP,
+            HandRetargeter.DEXPILOT,
+            SessionMode.LIVE,
+        )

--- a/tests/python/examples/teleop_ros2/test_node_parameters.py
+++ b/tests/python/examples/teleop_ros2/test_node_parameters.py
@@ -41,10 +41,10 @@ def test_external_provider_is_preserved_without_plugin_paths(monkeypatch) -> Non
     monkeypatch.delenv("ISAAC_TELEOP_PLUGIN_PATH", raising=False)
     node = _Node(
         hand_tracking_provider="manus",
-        start_hand_tracking_plugin=False,
+        use_external_hand_tracking_plugin=True,
     )
 
-    provider, start_plugin, search_paths = _load_hand_tracking_provider(
+    provider, use_external_plugin, search_paths = _load_hand_tracking_provider(
         node,
         TeleopMode.CONTROLLER_TELEOP,
         HandRetargeter.DEXPILOT,
@@ -52,17 +52,14 @@ def test_external_provider_is_preserved_without_plugin_paths(monkeypatch) -> Non
     )
 
     assert provider == HandTrackingProvider.MANUS
-    assert not start_plugin
+    assert use_external_plugin
     assert search_paths == ()
 
 
-def test_replay_preserves_provider_when_plugin_startup_is_disabled() -> None:
-    node = _Node(
-        hand_tracking_provider="wuji",
-        start_hand_tracking_plugin=False,
-    )
+def test_replay_preserves_provider_without_starting_plugin() -> None:
+    node = _Node(hand_tracking_provider="wuji")
 
-    provider, start_plugin, _search_paths = _load_hand_tracking_provider(
+    provider, use_external_plugin, _search_paths = _load_hand_tracking_provider(
         node,
         TeleopMode.CONTROLLER_TELEOP,
         HandRetargeter.WUJI,
@@ -70,13 +67,13 @@ def test_replay_preserves_provider_when_plugin_startup_is_disabled() -> None:
     )
 
     assert provider == HandTrackingProvider.WUJI
-    assert not start_plugin
+    assert not use_external_plugin
 
 
-def test_managed_plugin_requires_non_native_provider() -> None:
+def test_external_plugin_requires_non_native_provider() -> None:
     node = _Node(
         hand_tracking_provider="native",
-        start_hand_tracking_plugin=True,
+        use_external_hand_tracking_plugin=True,
     )
 
     with pytest.raises(
@@ -91,13 +88,13 @@ def test_managed_plugin_requires_non_native_provider() -> None:
         )
 
 
-def test_replay_rejects_managed_plugin_startup() -> None:
+def test_replay_rejects_external_plugin() -> None:
     node = _Node(
         hand_tracking_provider="wuji",
-        start_hand_tracking_plugin=True,
+        use_external_hand_tracking_plugin=True,
     )
 
-    with pytest.raises(ValueError, match="must be false during MCAP replay"):
+    with pytest.raises(ValueError, match="must be false.*during MCAP replay"):
         _load_hand_tracking_provider(
             node,
             TeleopMode.CONTROLLER_TELEOP,
@@ -109,7 +106,7 @@ def test_replay_rejects_managed_plugin_startup() -> None:
 def test_non_native_provider_requires_tracked_hand_mode() -> None:
     node = _Node(
         hand_tracking_provider="manus",
-        start_hand_tracking_plugin=False,
+        use_external_hand_tracking_plugin=True,
     )
 
     with pytest.raises(ValueError, match="requires a tracked-hand mode"):
@@ -127,10 +124,9 @@ def test_managed_provider_requires_and_returns_plugin_paths(
     monkeypatch.setenv("ISAAC_TELEOP_PLUGIN_PATH", str(tmp_path))
     node = _Node(
         hand_tracking_provider="wuji",
-        start_hand_tracking_plugin=True,
     )
 
-    provider, start_plugin, search_paths = _load_hand_tracking_provider(
+    provider, use_external_plugin, search_paths = _load_hand_tracking_provider(
         node,
         TeleopMode.HAND_TELEOP,
         HandRetargeter.DEXPILOT,
@@ -138,16 +134,13 @@ def test_managed_provider_requires_and_returns_plugin_paths(
     )
 
     assert provider == HandTrackingProvider.WUJI
-    assert start_plugin
+    assert not use_external_plugin
     assert search_paths == (tmp_path.resolve(),)
 
 
 def test_managed_provider_requires_plugin_path(monkeypatch) -> None:
     monkeypatch.delenv("ISAAC_TELEOP_PLUGIN_PATH", raising=False)
-    node = _Node(
-        hand_tracking_provider="manus",
-        start_hand_tracking_plugin=True,
-    )
+    node = _Node(hand_tracking_provider="manus")
 
     with pytest.raises(FileNotFoundError, match="ISAAC_TELEOP_PLUGIN_PATH"):
         _load_hand_tracking_provider(

--- a/tests/python/examples/teleop_ros2/test_teleop_profiles.py
+++ b/tests/python/examples/teleop_ros2/test_teleop_profiles.py
@@ -92,7 +92,7 @@ def test_controller_profile_spec_is_resolved_for_selected_retargeter() -> None:
     assert PublishType.EE_FROM_HANDS not in wuji_spec.publish_types
     assert PublishType.EE_FROM_CONTROLLERS in manus_spec.publish_types
     assert PublishType.EE_FROM_HANDS not in manus_spec.publish_types
-    assert manus_spec.apply_manus_controller_to_hand_transform
+    assert manus_spec.apply_manus_controller_mount_offset
     assert (
         manus_spec
         is TELEOP_PROFILE_SPECS[TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_MANUS_EE]
@@ -160,7 +160,7 @@ def test_controller_manus_provider_uses_known_good_transform_for_every_retargete
         profile_spec
         is TELEOP_PROFILE_SPECS[TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_MANUS_EE]
     )
-    assert profile_spec.apply_manus_controller_to_hand_transform
+    assert profile_spec.apply_manus_controller_mount_offset
 
 
 @pytest.mark.parametrize("profile", list(TeleopProfile))
@@ -216,7 +216,7 @@ def test_hand_teleop_always_uses_hand_wrist(
     )
 
     assert profile_spec is TELEOP_PROFILE_SPECS[TeleopProfile.HAND_TELEOP]
-    assert not profile_spec.apply_manus_controller_to_hand_transform
+    assert not profile_spec.apply_manus_controller_mount_offset
 
 
 def test_managed_plugin_config_is_inferred_from_provider(tmp_path) -> None:

--- a/tests/python/examples/teleop_ros2/test_teleop_profiles.py
+++ b/tests/python/examples/teleop_ros2/test_teleop_profiles.py
@@ -14,10 +14,11 @@ from constants import (
     TELEOP_MODES,
     WUJI_HAND_JOINT_COUNT,
     HandRetargeter,
-    HandTrackingPlugin,
+    HandTrackingProvider,
     TeleopMode,
     resolve_hand_retargeter,
 )
+from isaacteleop.teleop_session_manager import SessionMode
 from teleop_profiles import (
     TELEOP_PROFILE_SPECS,
     PublishType,
@@ -73,6 +74,11 @@ def test_controller_profile_spec_is_resolved_for_selected_retargeter() -> None:
     wuji_spec = resolve_teleop_profile_spec(
         TeleopMode.CONTROLLER_TELEOP, HandRetargeter.WUJI
     )
+    manus_spec = resolve_teleop_profile_spec(
+        TeleopMode.CONTROLLER_TELEOP,
+        HandRetargeter.WUJI,
+        HandTrackingProvider.MANUS,
+    )
 
     assert "hand_left" not in controller_spec.required_result_keys
     assert "hand_right" not in controller_spec.required_result_keys
@@ -80,9 +86,17 @@ def test_controller_profile_spec_is_resolved_for_selected_retargeter() -> None:
 
     assert {"hand_left", "hand_right"} <= hands_spec.required_result_keys
     assert PublishType.HAND_POSES in hands_spec.publish_types
+    assert PublishType.EE_FROM_CONTROLLERS in hands_spec.publish_types
     assert {"hand_left", "hand_right"} <= wuji_spec.required_result_keys
-    assert PublishType.EE_FROM_HANDS in wuji_spec.publish_types
-    assert PublishType.EE_FROM_CONTROLLERS not in wuji_spec.publish_types
+    assert PublishType.EE_FROM_CONTROLLERS in wuji_spec.publish_types
+    assert PublishType.EE_FROM_HANDS not in wuji_spec.publish_types
+    assert PublishType.EE_FROM_CONTROLLERS in manus_spec.publish_types
+    assert PublishType.EE_FROM_HANDS not in manus_spec.publish_types
+    assert manus_spec.apply_manus_controller_to_hand_transform
+    assert (
+        manus_spec
+        is TELEOP_PROFILE_SPECS[TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_MANUS_EE]
+    )
 
 
 @pytest.mark.parametrize(
@@ -99,7 +113,7 @@ def test_controller_profile_spec_is_resolved_for_selected_retargeter() -> None:
         ),
         (
             HandRetargeter.WUJI,
-            TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE,
+            TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_CONTROLLER_EE,
         ),
     ),
 )
@@ -108,6 +122,45 @@ def test_controller_profile_spec_resolution(
 ) -> None:
     profile_spec = resolve_teleop_profile_spec(TeleopMode.CONTROLLER_TELEOP, retargeter)
     assert profile_spec is TELEOP_PROFILE_SPECS[expected_profile]
+
+
+@pytest.mark.parametrize(
+    "retargeter",
+    (HandRetargeter.DEXPILOT, HandRetargeter.PINK_IK, HandRetargeter.WUJI),
+)
+def test_controller_wuji_provider_uses_provider_wrist_for_every_retargeter(
+    retargeter: HandRetargeter,
+) -> None:
+    profile_spec = resolve_teleop_profile_spec(
+        TeleopMode.CONTROLLER_TELEOP,
+        retargeter,
+        HandTrackingProvider.WUJI,
+    )
+
+    assert (
+        profile_spec
+        is TELEOP_PROFILE_SPECS[TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_WRIST_EE]
+    )
+
+
+@pytest.mark.parametrize(
+    "retargeter",
+    (HandRetargeter.DEXPILOT, HandRetargeter.PINK_IK, HandRetargeter.WUJI),
+)
+def test_controller_manus_provider_uses_known_good_transform_for_every_retargeter(
+    retargeter: HandRetargeter,
+) -> None:
+    profile_spec = resolve_teleop_profile_spec(
+        TeleopMode.CONTROLLER_TELEOP,
+        retargeter,
+        HandTrackingProvider.MANUS,
+    )
+
+    assert (
+        profile_spec
+        is TELEOP_PROFILE_SPECS[TeleopProfile.CONTROLLER_TELEOP_WITH_HAND_MANUS_EE]
+    )
+    assert profile_spec.apply_manus_controller_to_hand_transform
 
 
 @pytest.mark.parametrize("profile", list(TeleopProfile))
@@ -149,26 +202,55 @@ def test_trihand_is_rejected_for_hand_teleop() -> None:
         resolve_hand_retargeter(TeleopMode.HAND_TELEOP, HandRetargeter.TRIHAND)
 
 
-def test_manus_transform_is_resolved_with_controller_ee_profile() -> None:
-    dexpilot_spec = resolve_teleop_profile_spec(
-        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.DEXPILOT
-    )
-    pink_ik_spec = resolve_teleop_profile_spec(
-        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.PINK_IK
-    )
-    wuji_spec = resolve_teleop_profile_spec(
-        TeleopMode.CONTROLLER_TELEOP, HandRetargeter.WUJI
-    )
-    wuji_input_spec = resolve_teleop_profile_spec(
-        TeleopMode.CONTROLLER_TELEOP,
+@pytest.mark.parametrize(
+    "provider",
+    list(HandTrackingProvider),
+)
+def test_hand_teleop_always_uses_hand_wrist(
+    provider: HandTrackingProvider,
+) -> None:
+    profile_spec = resolve_teleop_profile_spec(
+        TeleopMode.HAND_TELEOP,
         HandRetargeter.DEXPILOT,
-        HandTrackingPlugin.WUJI,
+        provider,
     )
 
-    assert dexpilot_spec.apply_manus_controller_to_hand_transform
-    assert pink_ik_spec.apply_manus_controller_to_hand_transform
-    assert not wuji_spec.apply_manus_controller_to_hand_transform
-    assert not wuji_input_spec.apply_manus_controller_to_hand_transform
+    assert profile_spec is TELEOP_PROFILE_SPECS[TeleopProfile.HAND_TELEOP]
+    assert not profile_spec.apply_manus_controller_to_hand_transform
+
+
+def test_managed_plugin_config_is_inferred_from_provider(tmp_path) -> None:
+    manus_params = SimpleNamespace(
+        hand_tracking_provider=HandTrackingProvider.MANUS,
+        start_hand_tracking_plugin=True,
+        session_mode=SessionMode.LIVE,
+        plugin_search_paths=(tmp_path,),
+    )
+    wuji_params = SimpleNamespace(
+        hand_tracking_provider=HandTrackingProvider.WUJI,
+        start_hand_tracking_plugin=True,
+        session_mode=SessionMode.LIVE,
+        plugin_search_paths=(tmp_path,),
+    )
+
+    manus_config = session_config._resolve_hand_tracking_plugin_configs(manus_params)[0]
+    wuji_config = session_config._resolve_hand_tracking_plugin_configs(wuji_params)[0]
+
+    assert manus_config.plugin_name == "manus_hand_plugin"
+    assert manus_config.plugin_args == ["--datasets=human"]
+    assert wuji_config.plugin_name == "wuji_glove_plugin"
+    assert wuji_config.plugin_args == []
+
+
+def test_plugin_config_is_empty_when_start_is_false(tmp_path) -> None:
+    external_params = SimpleNamespace(
+        hand_tracking_provider=HandTrackingProvider.MANUS,
+        start_hand_tracking_plugin=False,
+        session_mode=SessionMode.LIVE,
+        plugin_search_paths=(tmp_path,),
+    )
+
+    assert session_config._resolve_hand_tracking_plugin_configs(external_params) == []
 
 
 def test_joint_alias_count_validation() -> None:

--- a/tests/python/examples/teleop_ros2/test_teleop_profiles.py
+++ b/tests/python/examples/teleop_ros2/test_teleop_profiles.py
@@ -222,13 +222,13 @@ def test_hand_teleop_always_uses_hand_wrist(
 def test_managed_plugin_config_is_inferred_from_provider(tmp_path) -> None:
     manus_params = SimpleNamespace(
         hand_tracking_provider=HandTrackingProvider.MANUS,
-        start_hand_tracking_plugin=True,
+        use_external_hand_tracking_plugin=False,
         session_mode=SessionMode.LIVE,
         plugin_search_paths=(tmp_path,),
     )
     wuji_params = SimpleNamespace(
         hand_tracking_provider=HandTrackingProvider.WUJI,
-        start_hand_tracking_plugin=True,
+        use_external_hand_tracking_plugin=False,
         session_mode=SessionMode.LIVE,
         plugin_search_paths=(tmp_path,),
     )
@@ -242,15 +242,22 @@ def test_managed_plugin_config_is_inferred_from_provider(tmp_path) -> None:
     assert wuji_config.plugin_args == []
 
 
-def test_plugin_config_is_empty_when_start_is_false(tmp_path) -> None:
+def test_plugin_config_is_empty_for_external_provider_or_replay(tmp_path) -> None:
     external_params = SimpleNamespace(
         hand_tracking_provider=HandTrackingProvider.MANUS,
-        start_hand_tracking_plugin=False,
+        use_external_hand_tracking_plugin=True,
         session_mode=SessionMode.LIVE,
+        plugin_search_paths=(tmp_path,),
+    )
+    replay_params = SimpleNamespace(
+        hand_tracking_provider=HandTrackingProvider.WUJI,
+        use_external_hand_tracking_plugin=False,
+        session_mode=SessionMode.REPLAY,
         plugin_search_paths=(tmp_path,),
     )
 
     assert session_config._resolve_hand_tracking_plugin_configs(external_params) == []
+    assert session_config._resolve_hand_tracking_plugin_configs(replay_params) == []
 
 
 def test_joint_alias_count_validation() -> None:


### PR DESCRIPTION
## Description

Separate hand-tracking provider identity from plugin process lifecycle. Native tracking uses controller aim poses for controller teleop, while MANUS and Wuji use their provider-injected wrist poses so provider-owned calibration is preserved.

Replace `hand_tracking_plugin` with `hand_tracking_provider` and `start_hand_tracking_plugin`, preserve provider selection during MCAP replay, reject plugin startup during replay, and require plugin search paths only for managed startup. Update the MCAP matrix and verifier to validate provider-specific EE routing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update

## Testing

- Built `examples/teleop_ros2/Dockerfile` with the `test` target.
- Ran the full teleop ROS 2 test suite: 60 passed.
- Ran all 9 MCAP scenarios, including native, MANUS, and Wuji provider routing.
- Verified formatting, Python syntax, and `git diff --check`.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix/feature works
- [x] I have signed off all my commits per the DCO

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added separate hand-tracking provider selection for Native, Manus, and Wuji tracking.
  - Added independent control over whether the hand-tracking plugin starts.
  - Updated teleoperation profiles and topic verification for provider-specific wrist and hand end-effector behavior.
  - Expanded ROS2 replay and live CloudXR scenarios across supported providers.

- **Documentation**
  - Updated teleoperation setup instructions, parameters, Docker examples, and Manus/Wuji startup guidance.

- **Bug Fixes**
  - Added validation for incompatible provider, replay, tracking-mode, and plugin-path configurations.
  - Preserved Manus calibration in controller end-effector output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->