### PR TITLE
fix(webxr): constrain React to the Fiber-compatible 19.2 minor

### DIFF
--- a/deps/cloudxr/webxr_client/AGENTS.md
+++ b/deps/cloudxr/webxr_client/AGENTS.md
@@ -1,0 +1,10 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# WebXR client dependencies
+
+Keep `react` and `react-dom` on the same minor release supported by
+`@react-three/fiber`. Validate dependency-range changes with a clean npm install;
+do not bypass peer checks with `--force` or `--legacy-peer-deps`.

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -46,8 +46,8 @@
     "@react-three/uikit": "^1.0.64",
     "@react-three/uikit-default": "^1.0.64",
     "@react-three/xr": "^6.6.29",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
+    "react": "~19.2.5",
+    "react-dom": "~19.2.5",
     "three": "^0.184.0",
     "uuid": "^14.0.0"
   },


### PR DESCRIPTION
## Description

Fresh web-client installs select React 19.3.0 from `^19.2.5`, but `@react-three/fiber@9.7.0` requires React and React DOM `>=19 <19.3`, causing `ERESOLVE` in CI.

Constrain both `react` and `react-dom` to `~19.2.5` so compatible 19.2 patch updates remain allowed. Add a local dependency note to keep their minor release within Fiber's supported range and validate clean installs without bypassing peer checks.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Reproduced the reported `ERESOLVE` on unchanged `main` using clean dependency resolution.
- Clean `npm install --ignore-scripts --no-audit --no-fund --package-lock=false` passed with peer checks enabled: React 19.2.8, React DOM 19.2.8, Fiber 9.7.0.
- `USE_LOCAL_WEBXR_ASSETS=0 npm run build` passed (webpack asset-size/performance warnings).
- `npm test -- --runInBand`: 7 suites, 102 tests passed.
- `SKIP=check-copyright-year pre-commit run --all-files` passed.

## Checklist

- [x] Read the contribution guidelines.
- [x] Ran pre-commit.
- [x] Documented the dependency constraint locally.
- [x] Verified clean installation and existing build/tests; no new test code is needed for this version-range change.
- [x] Signed off the commit per the DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal WebXR client configuration to maintain consistent React version compatibility.
  * Added contributor guidance for validating clean installations and supported package combinations.

* **Documentation**
  * Documented WebXR client setup and compatibility requirements for maintainers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->