### PR TITLE
[release/1.4.x] fix(webxr): constrain React to the Fiber-compatible 19.2 minor

### DIFF
--- a/deps/cloudxr/webxr_client/AGENTS.md
+++ b/deps/cloudxr/webxr_client/AGENTS.md
@@ -1,0 +1,10 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# WebXR client dependencies
+
+Keep `react` and `react-dom` on the same minor release supported by
+`@react-three/fiber`. Validate dependency-range changes with a clean npm install;
+do not bypass peer checks with `--force` or `--legacy-peer-deps`.

--- a/deps/cloudxr/webxr_client/package.json
+++ b/deps/cloudxr/webxr_client/package.json
@@ -46,8 +46,8 @@
     "@react-three/uikit": "^1.0.64",
     "@react-three/uikit-default": "^1.0.64",
     "@react-three/xr": "^6.6.29",
-    "react": "^19.2.5",
-    "react-dom": "^19.2.5",
+    "react": "~19.2.5",
+    "react-dom": "~19.2.5",
     "three": "^0.184.0",
     "uuid": "^14.0.0"
   },


### PR DESCRIPTION
## Description

Backport of #1091 to `release/1.4.x`, cherry-picked from `86d379f731328d66c768b9aa54cbd93080642048` without conflicts.

Constrain React and React DOM to `~19.2.5`. The previous caret ranges allow React 19.3, which conflicts with Fiber 9.7.0's `>=19 <19.3` peer requirements and breaks fresh installs with `ERESOLVE`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Dependency manifest matches the validated #1091 change: clean install resolves React/React DOM 19.2.8 and Fiber 9.7.0 without bypassing peer checks.
- Release-branch tests: `npm test -- --runInBand` — 7 suites, 102 tests passed, reusing that dependency installation.
- Release-branch production build: `USE_LOCAL_WEBXR_ASSETS=0 npm run build` passed with webpack asset-size/performance warnings.
- `SKIP=check-copyright-year pre-commit run --all-files` passed.
- Only the two files from #1091 are changed relative to `release/1.4.x`.

## Checklist

- [x] Read the contribution guidelines.
- [x] Ran pre-commit.
- [x] Included the dependency guidance from #1091.
- [x] Validated the dependency-only change with existing tests and build.
- [x] Signed off the cherry-pick per the DCO.
