### PR TITLE
Fix docs dependencies after switching to main configuration

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -143,6 +143,8 @@ jobs:
           # does not load come out as raw text, and its CSS is dropped. This step
           # deploys the whole site, so take the docs config from main either way.
           git -C "$GITHUB_WORKSPACE" checkout origin/main -- docs
+          # Main's extensions may require dependencies absent from the triggering ref.
+          python -m pip install -r requirements.txt
           make multi-docs
 
       - name: Upload docs artifact


### PR DESCRIPTION
## Description

The v1.4.142 tag's [docs workflow failed](https://github.com/NVIDIA/IsaacTeleop/actions/runs/33413482317) with `Could not import extension ecosystem_grid (exception: No module named 'yaml')`. The workflow installed the tag's requirements before replacing `docs/` with main's configuration, whose extensions require additional dependencies. The client build succeeded, but the shared deployment was skipped, leaving `/client/stable/` pointing at v1.3.131.

Install the matching requirements immediately after checking out main's docs and before running `make multi-docs`.

Later multi-version docs deployments have published `/v1.4.142/index.html`; they do not rebuild the tagged client at `/client/v1.4.142/`. This fix needs to reach release branches before future tags are created. Recovering the existing tagged client requires a separate deployment; rerunning the old tag still uses its original workflow.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- `SKIP=check-copyright-year pre-commit run --all-files` passed.
- `git diff --check` passed.
- Verified the failed tag run and a later successful multi-version docs run. Full tag deployment was not run locally; pull-request CI does not execute the deploy-only multi-version step.
- No new tests: this adds a dependency installation command to the existing CI sequence.

## Checklist

- [x] I have read and understood the contribution guidelines
- [x] I have run the linter and formatter with `SKIP=check-copyright-year pre-commit run --all-files`
- [x] I have made corresponding changes to the documentation (inline workflow explanation)
- [x] I have added tests that prove my fix/feature works (or explained why not)
- [x] I have signed off all my commits (`git commit -s`) per the DCO


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the multi-version documentation build to install the required dependencies before generating documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->